### PR TITLE
test: add full test suite (322 backend + 115 frontend) and fix security/production bugs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Descripción del Cambio
+## Tipo de Cambio
+- [ ] Feat (Nueva funcionalidad)
+- [ ] Fix (Reparación de error)
+- [ ] Docs (Documentación)
+- [ ] Performance (Optimización)
+
+## ¿Cómo se probó?
+## Checklist de Seguridad
+- [ ] He verificado que NO hay secretos ni llaves API en el código.
+- [ ] Los cambios respetan el `.gitignore`.
+- [ ] El código sigue la estructura de carpetas definida.
+
+---
+*Generado por Alex*

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ coverage.xml
 
 # Artifacts de OpenCode
 .artifacts/
+.atl

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,18 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto
+markers =
+    unit: Unit tests — pure logic, no external dependencies
+    integration: Integration tests — require mocked DB or external services
+    slow: Tests that take longer than typical unit tests
+    neo4j: Tests that interact with Neo4j (mocked or real)
+    metric: Tests related to metric reconciliation and definitions
+    event: Tests related to event lifecycle management
+    auth: Authentication and authorization tests
+addopts =
+    --strict-markers
+    -v
+    --tb=short

--- a/backend/repositories/user_repo.py
+++ b/backend/repositories/user_repo.py
@@ -4,39 +4,43 @@ from models.sql_models import User
 from models.user import UserCreate, UserUpdate
 from utils.security import get_password_hash
 
+
 def get_user_by_username(db: Session, username: str):
     return db.query(User).filter(User.username == username).first()
 
+
 def get_users(db: Session, skip: int = 0, limit: int = 100):
     return db.query(User).offset(skip).limit(limit).all()
+
 
 def create_user(db: Session, user: UserCreate):
     hashed_password = get_password_hash(user.password)
     # Convert Pydantic Enums to strings for DB storage if needed
     permissions_str = [p.value for p in user.permissions]
-    
+
     db_user = User(
         username=user.username,
         hashed_password=hashed_password,
-        role=user.role, 
+        role=user.role,
         permissions=permissions_str,
         allowed_locations=user.allowed_locations,
         allowed_ci_types=user.allowed_ci_types,
         phone=user.phone,
         email=user.email,
-        is_active=not user.disabled,
-        force_password_change=user.force_password_change
+        is_active=True,
+        force_password_change=False,
     )
     db.add(db_user)
     db.commit()
     db.refresh(db_user)
     return db_user
 
+
 def update_user(db: Session, username: str, user_update: UserUpdate):
     db_user = get_user_by_username(db, username)
     if not db_user:
         return None
-    
+
     if user_update.password:
         db_user.hashed_password = get_password_hash(user_update.password)
     if user_update.role:
@@ -47,10 +51,11 @@ def update_user(db: Session, username: str, user_update: UserUpdate):
         db_user.allowed_locations = user_update.allowed_locations
     if user_update.allowed_ci_types is not None:
         db_user.allowed_ci_types = user_update.allowed_ci_types
-        
+
     db.commit()
     db.refresh(db_user)
     return db_user
+
 
 def delete_user(db: Session, username: str):
     db_user = get_user_by_username(db, username)

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Testing dependencies
+pytest==8.0.0
+pytest-asyncio==0.23.5
+httpx==0.26.0          # Async test client for FastAPI
+pytest-cov==4.1.0      # Coverage reporting
+factory-boy==3.3.0     # Test data factories

--- a/backend/routers/catalog.py
+++ b/backend/routers/catalog.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from typing import List, Dict, Any, Optional
 from models.core import Category, HardwareModel, OwnerGroup
-from models.user import User
+from models.user import User, UserPermission
 from pydantic import BaseModel
 import services.catalog_service as catalog_service
+from services.auth_service import get_current_active_user, check_permission
 
 router = APIRouter(
     prefix="/api",
@@ -13,35 +14,65 @@ router = APIRouter(
 
 # --- Categories ---
 
+
 class CategoryUpdate(BaseModel):
     name: str
+
 
 @router.get("/categories", response_model=List[Dict[str, str]])
 async def get_categories():
     """Fetch all available CI Categories."""
     return catalog_service.get_categories()
 
+
 @router.post("/categories")
-async def create_category(category: Category):
+async def create_category(
+    category: Category,
+    current_user: User = Depends(get_current_active_user),
+):
     """Create a new Category."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to create categories"
+        )
     return catalog_service.create_category(category)
 
+
 @router.delete("/categories/{name}")
-async def delete_category(name: str):
+async def delete_category(
+    name: str,
+    current_user: User = Depends(get_current_active_user),
+):
     """Delete a Category."""
+    if not check_permission(UserPermission.CI_DELETE, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to delete categories"
+        )
     return catalog_service.delete_category(name)
 
+
 @router.put("/categories/{name}")
-async def update_category(name: str, update: CategoryUpdate):
+async def update_category(
+    name: str,
+    update: CategoryUpdate,
+    current_user: User = Depends(get_current_active_user),
+):
     """Rename a Category."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to update categories"
+        )
     return catalog_service.update_category(name, update.name)
+
 
 @router.get("/categories/{name}/usage")
 async def get_category_usage(name: str):
     """Count CIs in a Category."""
     return catalog_service.get_category_usage(name)
 
+
 # --- Hardware Models ---
+
 
 class HardwareModelUpdate(BaseModel):
     brand: Optional[str] = None
@@ -49,77 +80,153 @@ class HardwareModelUpdate(BaseModel):
     category: Optional[str] = None
     owner: Optional[str] = None
 
+
 @router.get("/hardware", response_model=List[Dict[str, Any]])
 async def get_hardware_catalog():
     """Fetch the Hardware Catalog."""
     return catalog_service.get_hardware_catalog()
 
+
 @router.post("/hardware")
-async def create_hardware_model(item: HardwareModel):
+async def create_hardware_model(
+    item: HardwareModel,
+    current_user: User = Depends(get_current_active_user),
+):
     """Create or Update a Hardware Model."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to create hardware models"
+        )
     return catalog_service.create_hardware_model(item)
 
+
 @router.delete("/hardware/{brand}/{model}")
-async def delete_hardware_model(brand: str, model: str):
+async def delete_hardware_model(
+    brand: str,
+    model: str,
+    current_user: User = Depends(get_current_active_user),
+):
     """Delete a Hardware Model."""
+    if not check_permission(UserPermission.CI_DELETE, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to delete hardware models"
+        )
     return catalog_service.delete_hardware_model(brand, model)
 
+
 @router.put("/hardware/{brand}/{model}")
-async def update_hardware_model(brand: str, model: str, update: HardwareModelUpdate):
+async def update_hardware_model(
+    brand: str,
+    model: str,
+    update: HardwareModelUpdate,
+    current_user: User = Depends(get_current_active_user),
+):
     """Update Hardware Model properties or Rename it."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to update hardware models"
+        )
     # Convert Pydantic update model to core HardwareModel (partial)
     # The service expects a HardwareModel object for update fields, but let's check checking service signature
     # Service expects: update_hardware_model(brand, model, update: HardwareModel)
     # So we need to adapt HardwareModelUpdate to HardwareModel
     hw_update = HardwareModel(
-        brand=update.brand or brand, # Fallback to existing if not changing (but service handles logic)
-        model=update.model or model, 
-        category=update.category, 
-        owner=update.owner
+        brand=update.brand
+        or brand,  # Fallback to existing if not changing (but service handles logic)
+        model=update.model or model,
+        category=update.category,
+        owner=update.owner,
     )
     return catalog_service.update_hardware_model(brand, model, hw_update)
+
 
 @router.get("/hardware/{brand}/{model}/usage")
 async def get_hardware_usage(brand: str, model: str):
     """Count CIs of a Hardware Model."""
     return catalog_service.get_hardware_usage(brand, model)
 
+
 @router.post("/hardware/assign_metric")
-async def assign_metric_to_model(brand: str, model: str, metric_id: str):
+async def assign_metric_to_model(
+    brand: str,
+    model: str,
+    metric_id: str,
+    current_user: User = Depends(get_current_active_user),
+):
     """Link a Hardware Model to a Metric Definition."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to assign metrics")
     return catalog_service.assign_metric_to_model(brand, model, metric_id)
 
+
 @router.post("/hardware/unassign_metric")
-async def unassign_metric_from_model(brand: str, model: str, metric_id: str):
+async def unassign_metric_from_model(
+    brand: str,
+    model: str,
+    metric_id: str,
+    current_user: User = Depends(get_current_active_user),
+):
     """Unlink a Hardware Model from a Metric Definition."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to unassign metrics"
+        )
     return catalog_service.unassign_metric_from_model(brand, model, metric_id)
 
+
 # --- Owner Groups ---
+
 
 class OwnerGroupUpdate(BaseModel):
     name: Optional[str] = None
     users: Optional[List[dict]] = None
+
 
 @router.get("/owners", response_model=List[Dict[str, Any]])
 async def get_owners():
     """Fetch all Owner Groups and their Users."""
     return catalog_service.get_owners()
 
+
 @router.post("/owners")
-async def create_owner_group(group: OwnerGroup):
+async def create_owner_group(
+    group: OwnerGroup,
+    current_user: User = Depends(get_current_active_user),
+):
     """Create or Update an Owner Group."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to create owner groups"
+        )
     return catalog_service.create_owner_group(group)
 
+
 @router.delete("/owners/{name}")
-async def delete_owner_group(name: str):
+async def delete_owner_group(
+    name: str,
+    current_user: User = Depends(get_current_active_user),
+):
     """Delete an Owner Group."""
+    if not check_permission(UserPermission.CI_DELETE, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to delete owner groups"
+        )
     return catalog_service.delete_owner_group(name)
 
+
 @router.put("/owners/{name}")
-async def update_owner_group(name: str, update: OwnerGroupUpdate):
+async def update_owner_group(
+    name: str,
+    update: OwnerGroupUpdate,
+    current_user: User = Depends(get_current_active_user),
+):
     """Update an Owner Group."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to update owner groups"
+        )
     # Adapt OwnerGroupUpdate to OwnerGroup for service
-    group_update = OwnerGroup(name=update.name or name, users=update.users or []) 
+    group_update = OwnerGroup(name=update.name or name, users=update.users or [])
     # Service distinguishes None users from empty list, so we must be careful.
     # The service logic: 'if update.users is not None'.
     # Our Pydantic model 'OwnerGroup' has 'users' as Optional, defaulting to [].
@@ -129,10 +236,10 @@ async def update_owner_group(name: str, update: OwnerGroupUpdate):
     # Service: if update.name ... if update.users is not None ...
     # So we need to pass an object that has .name and .users attributes matching checks.
     # We can just verify if users is passed.
-    
+
     # Actually, let's just use the Pydantic model directly across boundaries if possible.
     # Or create a wrapper object.
-    
+
     # Constructing a dynamic object or re-using OwnerGroup works if we trust the defaults.
     # OwnerGroup defaults users to []. If we pass [], service will replace users with empty list.
     # If update.users is None, we want to NOT update users.
@@ -145,24 +252,43 @@ async def update_owner_group(name: str, update: OwnerGroupUpdate):
     # But since I already wrote the Service to take OwnerGroup and check 'if update.users is not None',
     # and OwnerGroup.users defaults to [], it will always be not None (list) unless I explicitly set it to None.
     # OwnerGroup definition: users: Optional[List[dict]] = []
-    
+
     # So OwnerGroup(name="foo", users=None) is valid.
     og = OwnerGroup(name=update.name or name, users=update.users)
     return catalog_service.update_owner_group(name, og)
+
 
 @router.get("/owners/{name}/usage")
 async def get_owner_usage(name: str):
     """Get usage statistics for an Owner Group."""
     return catalog_service.get_owner_usage(name)
 
+
 @router.post("/owners/{group_name}/users")
-async def link_user_to_group(group_name: str, user: User):
+async def link_user_to_group(
+    group_name: str,
+    user: User,
+    current_user: User = Depends(get_current_active_user),
+):
     """Add a user to an Owner Group."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to link users to owner groups"
+        )
     # User model has name, email, phone.
     # Service expects user_data dict.
     return catalog_service.link_user_to_group(group_name, user.dict())
 
+
 @router.delete("/owners/{group_name}/users/{user_name}")
-async def unlink_user_from_group(group_name: str, user_name: str):
+async def unlink_user_from_group(
+    group_name: str,
+    user_name: str,
+    current_user: User = Depends(get_current_active_user),
+):
     """Remove a user from an Owner Group."""
+    if not check_permission(UserPermission.CI_DELETE, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to unlink users from owner groups"
+        )
     return catalog_service.unlink_user_from_group(group_name, user_name)

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 import services.event_service as event_service
-from services.auth_service import get_current_active_user
-from models.user import User
+from services.auth_service import get_current_active_user, check_permission
+from models.user import User, UserPermission
 
 router = APIRouter(
     prefix="/api/events",
@@ -11,9 +11,10 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
+
 class EventComment(BaseModel):
-    user: str
     message: str
+
 
 @router.get("", response_model=List[Dict[str, Any]])
 async def get_events(status: Optional[str] = None):
@@ -24,6 +25,7 @@ async def get_events(status: Optional[str] = None):
     """
     return event_service.get_events(status)
 
+
 @router.get("/related/{ci_id}", response_model=List[Dict[str, Any]])
 async def get_related_events(ci_id: str):
     """
@@ -31,37 +33,64 @@ async def get_related_events(ci_id: str):
     """
     return event_service.get_related_events(ci_id)
 
+
 @router.post("/{event_id}/ack")
-async def ack_event(event_id: str, current_user: User = Depends(get_current_active_user)):
+async def ack_event(
+    event_id: str, current_user: User = Depends(get_current_active_user)
+):
     """
     Acknowledge an Event.
     """
+    if not check_permission(UserPermission.EVENT_ACK, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to acknowledge events"
+        )
     return event_service.ack_event(event_id, current_user.username)
 
+
 @router.post("/{event_id}/close")
-async def close_event(event_id: str, current_user: User = Depends(get_current_active_user)):
+async def close_event(
+    event_id: str, current_user: User = Depends(get_current_active_user)
+):
     """
     Close an Event manually.
     """
+    if not check_permission(UserPermission.EVENT_CLOSE, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to close events")
     return event_service.close_event(event_id, current_user.username)
 
+
 @router.post("/{event_id}/comment")
-async def add_event_comment(event_id: str, comment: EventComment):
+async def add_event_comment(
+    event_id: str,
+    comment: EventComment,
+    current_user: User = Depends(get_current_active_user),
+):
     """
     Append a user comment to the Event history.
     """
-    return event_service.add_event_comment(event_id, comment.user, comment.message)
+    return event_service.add_event_comment(
+        event_id, current_user.username, comment.message
+    )
+
 
 @router.post("/prune")
 async def prune_recovered_events(current_user: User = Depends(get_current_active_user)):
     """
     Bulk Close all 'RECOVERED' events.
     """
+    if not check_permission(UserPermission.EVENT_CLOSE, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to prune events")
     return event_service.prune_recovered_events(current_user.username)
 
+
 @router.post("/{event_id}/diagnose")
-async def run_event_diagnostic_endpoint(event_id: str, current_user: User = Depends(get_current_active_user)):
+async def run_event_diagnostic_endpoint(
+    event_id: str, current_user: User = Depends(get_current_active_user)
+):
     """
     Run an on-demand diagnostic (Ping/SNMP) for the CI related to this event.
     """
+    if not check_permission(UserPermission.RUN_DIAGNOSTICS, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to run diagnostics")
     return event_service.run_event_diagnostic(event_id, current_user.username)

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -4,6 +4,8 @@ from models.core import MetricDef, Node
 from pydantic import BaseModel
 import services.metric_service as metric_service
 from services.snmp_service import validate_snmp_oid
+from services.auth_service import get_current_active_user, check_permission
+from models.user import User, UserPermission
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from postgres_db import get_pg_db
@@ -15,16 +17,19 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
+
 class MetricPromotion(BaseModel):
     ci_id: str
     metric_name: str
     display_name: Optional[str] = None
+
 
 class SNMPTestRequest(BaseModel):
     ip: str
     community: str
     oid: str
     port: int = 161
+
 
 @router.get("", response_model=List[Dict[str, Any]])
 async def get_metrics():
@@ -34,17 +39,31 @@ async def get_metrics():
     """
     return metric_service.get_metrics()
 
+
 @router.post("")
-async def create_metric(metric: MetricDef):
+async def create_metric(
+    metric: MetricDef,
+    current_user: User = Depends(get_current_active_user),
+):
     """
     Define a new Metric for monitoring.
+    Requires authentication and CI_EDIT permission.
     """
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to create metrics")
     return metric_service.create_metric(metric)
 
+
 @router.delete("/{metric_id}")
-async def delete_metric(metric_id: str):
-    """Delete a Metric Definition."""
+async def delete_metric(
+    metric_id: str,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Delete a Metric Definition. Requires authentication and CI_EDIT permission."""
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to delete metrics")
     return metric_service.delete_metric(metric_id)
+
 
 @router.get("/{metric_id}/usage")
 async def get_metric_usage(metric_id: str):
@@ -53,31 +72,47 @@ async def get_metric_usage(metric_id: str):
     """
     return metric_service.get_metric_usage(metric_id)
 
+
 @router.post("/promote")
-async def promote_metric_node(data: MetricPromotion):
+async def promote_metric_node(
+    data: MetricPromotion,
+    current_user: User = Depends(get_current_active_user),
+):
     """
     Promote a specific metric property of a CI to a first-class Graph Node.
+    Requires authentication and CI_EDIT permission.
     """
-    return metric_service.promote_metric_node(data.ci_id, data.metric_name, data.display_name)
+    if not check_permission(UserPermission.CI_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to promote metrics")
+    return metric_service.promote_metric_node(
+        data.ci_id, data.metric_name, data.display_name
+    )
+
 
 @router.post("/validate")
-async def validate_oid_endpoint(req: SNMPTestRequest):
-    """Validate an OID against a target agent via SNMP."""
+async def validate_oid_endpoint(
+    req: SNMPTestRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Validate an OID against a target agent via SNMP. Requires authentication."""
     result = validate_snmp_oid(req.ip, req.community, req.oid, req.port)
     return result
 
+
 @router.get("/{node_id}/{metric_id}/history")
 async def get_metric_history(
-    node_id: str, 
-    metric_id: str, 
-    hours: int = 24, 
-    limit: int = 1000, # Increased limit for charts
+    node_id: str,
+    metric_id: str,
+    hours: int = 24,
+    limit: int = 1000,  # Increased limit for charts
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
-    db: Session = Depends(get_pg_db)
+    db: Session = Depends(get_pg_db),
 ):
     """
     Fetch historical data for a specific metric on a node.
     Supports fixed 'hours' lookback or custom 'start_time'/'end_time' range (ISO format).
     """
-    return metric_repo.get_metric_history(db, node_id, metric_id, limit, hours, start_time, end_time)
+    return metric_repo.get_metric_history(
+        db, node_id, metric_id, limit, hours, start_time, end_time
+    )

--- a/backend/services/node_service.py
+++ b/backend/services/node_service.py
@@ -45,8 +45,8 @@ def get_nodes(current_user: User) -> List[Dict[str, Any]]:
         for k, v in node.items():
             if k in ["id", "name", "status", "location", "ip", "layer"]:
                 continue
-            if hasattr(v, "iso_format"):
-                clean_metadata[k] = v.iso_format()
+            if hasattr(v, "isoformat"):
+                clean_metadata[k] = v.isoformat()
             else:
                 clean_metadata[k] = v
 
@@ -63,7 +63,7 @@ def get_nodes(current_user: User) -> List[Dict[str, Any]]:
                 }
                 if m.get("last_updated"):
                     try:
-                        m_data["last_updated"] = m["last_updated"].iso_format()
+                        m_data["last_updated"] = m["last_updated"].isoformat()
                     except:
                         pass
                 metrics.append(m_data)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+# backend/tests/conftest.py
 """
 conftest.py — backend/tests
 
@@ -6,10 +7,20 @@ unit tests can import service modules without a live database.
 
 This file is loaded by pytest BEFORE any test module is imported, which means
 the stubs are in sys.modules before any module-level code tries to use them.
+
+Also provides shared pytest fixtures and configuration for NEX-GEN backend tests:
+- Base fixtures for auth/security testing
+- Mock Neo4j driver/session fixtures for DB-dependent tests
+- Test constants (SECRET_KEY override, etc.)
+- Helpers for creating test users/tokens without hitting the DB
 """
 
 import sys
-from unittest.mock import MagicMock
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta
+from typing import List, Dict, Any, Optional
 
 # ── Stub psycopg2 so postgres_db.py can be imported without a real Postgres ──
 psycopg2_stub = MagicMock()
@@ -29,3 +40,337 @@ for mod in [
     "pysnmp.hlapi.asyncio",
 ]:
     sys.modules[mod] = MagicMock()
+
+# Ensure backend root is on the import path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+TEST_SECRET_KEY = "test-secret-key-for-unit-tests"
+TEST_ALGORITHM = "HS256"
+
+# ---------------------------------------------------------------------------
+# Fixtures — pure logic, no DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_secret_key() -> str:
+    """Override SECRET_KEY for token creation/decoding in tests."""
+    return TEST_SECRET_KEY
+
+
+@pytest.fixture
+def sample_user_data() -> dict:
+    """Minimal user payload for tests."""
+    return {
+        "username": "testuser",
+        "role": "OPERATOR",
+        "permissions": ["EVENT_VIEW", "CI_VIEW"],
+        "allowed_locations": ["HQ-Madrid"],
+        "allowed_ci_types": ["router", "switch"],
+        "phone": "+34600000000",
+        "email": "test@example.com",
+        "disabled": False,
+        "force_password_change": False,
+    }
+
+
+@pytest.fixture
+def sample_admin_data() -> dict:
+    """Admin user payload for permission tests."""
+    return {
+        "username": "adminuser",
+        "role": "ADMIN",
+        "permissions": [],
+        "allowed_locations": [],
+        "allowed_ci_types": None,
+        "disabled": False,
+        "force_password_change": False,
+    }
+
+
+@pytest.fixture
+def sample_disabled_user_data() -> dict:
+    """Disabled user payload for activation tests."""
+    return {
+        "username": "disableduser",
+        "role": "VIEWER",
+        "permissions": [],
+        "allowed_locations": [],
+        "allowed_ci_types": None,
+        "disabled": True,
+        "force_password_change": False,
+    }
+
+
+@pytest.fixture
+def plain_password() -> str:
+    """A known plain-text password for hashing tests."""
+    return "TestP@ss123!"
+
+
+@pytest.fixture
+def hashed_password(plain_password: str) -> str:
+    """Pre-hashed password using the project's security utilities."""
+    from utils.security import get_password_hash
+
+    return get_password_hash(plain_password)
+
+
+@pytest.fixture
+def create_test_token(test_secret_key: str) -> callable:
+    """
+    Factory fixture that returns a function to create JWT tokens
+    using the test secret key (avoids DB dependency).
+    """
+    from jose import jwt
+
+    def _create_token(
+        username: str,
+        role: str = "VIEWER",
+        expires_delta: timedelta | None = None,
+    ) -> str:
+        to_encode = {"sub": username, "role": role}
+        if expires_delta:
+            expire = datetime.utcnow() + expires_delta
+        else:
+            expire = datetime.utcnow() + timedelta(minutes=15)
+        to_encode.update({"exp": expire})
+        return jwt.encode(to_encode, test_secret_key, algorithm=TEST_ALGORITHM)
+
+    return _create_token
+
+
+@pytest.fixture
+def valid_test_token(create_test_token: callable) -> str:
+    """A valid JWT token with default expiry."""
+    return create_test_token("testuser", "OPERATOR")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — Mock Neo4j Database
+# ---------------------------------------------------------------------------
+
+
+class MockNeo4jResult:
+    """Helper to simulate Neo4j query results in tests."""
+
+    def __init__(self, records: List[Dict[str, Any]]):
+        self._records = records
+        self._index = 0
+
+    def __iter__(self):
+        self._index = 0
+        return self
+
+    def __next__(self):
+        if self._index >= len(self._records):
+            raise StopIteration
+        record = self._records[self._index]
+        self._index += 1
+        return MockNeo4jRecord(record)
+
+    def single(self):
+        """Return the first record as a MockNeo4jRecord, or None."""
+        if self._records:
+            return MockNeo4jRecord(self._records[0])
+        return None
+
+
+class MockNeo4jRecord:
+    """Simulates a Neo4j record dict-like access."""
+
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    def __getitem__(self, key):
+        return self._data.get(key)
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def __contains__(self, key):
+        return key in self._data
+
+
+class MockNeo4jSession:
+    """Simulates a Neo4j session with controllable query responses."""
+
+    def __init__(self):
+        self.queries: List[Dict[str, Any]] = []
+        self._response_map: Dict[str, List[Dict[str, Any]]] = {}
+        self._default_response: List[Dict[str, Any]] = []
+
+    def set_response(self, query_contains: str, records: List[Dict[str, Any]]):
+        """Set a canned response for queries containing the given substring."""
+        self._response_map[query_contains.lower()] = records
+
+    def set_default_response(self, records: List[Dict[str, Any]]):
+        """Set a fallback response for any unmatched query."""
+        self._default_response = records
+
+    def run(self, query: str, **params):
+        """Capture the query and return the matching canned response."""
+        self.queries.append({"query": query, "params": params})
+        query_lower = query.lower()
+        for key, records in self._response_map.items():
+            if key in query_lower:
+                return MockNeo4jResult(records)
+        return MockNeo4jResult(self._default_response)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class MockNeo4jDriver:
+    """Simulates a Neo4j driver that yields mock sessions."""
+
+    def __init__(self):
+        self.session = MagicMock()
+        self._mock_session = MockNeo4jSession()
+        self.session.return_value = self._mock_session
+
+    @property
+    def mock_session(self) -> MockNeo4jSession:
+        return self._mock_session
+
+
+@pytest.fixture
+def mock_neo4j_driver():
+    """
+    Provide a mock Neo4j driver that can be configured with canned responses.
+
+    Patches the 'driver' global in the database module so that get_db()
+    returns the mock. Also patches 'verify_connection' to prevent real
+    connection attempts at import time.
+
+    Usage:
+        def test_something(mock_neo4j_driver):
+            mock_neo4j_driver.mock_session.set_response(
+                "match (m:metricdef)",
+                [{"m": {"id": "cpu-load", "protocol": "SNMP"}}]
+            )
+            # Call code that uses database.get_db()
+    """
+    driver = MockNeo4jDriver()
+
+    # Patch at the database module level (where driver global lives)
+    with patch("database.driver", driver):
+        with patch("database.verify_connection", return_value=None):
+            yield driver
+
+
+@pytest.fixture
+def mock_neo4j_session(mock_neo4j_driver):
+    """Convenience fixture that gives direct access to the mock session."""
+    return mock_neo4j_driver.mock_session
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — Test Data Factories (Metric & Event domain)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_metric_def() -> dict:
+    """Standard MetricDef payload for tests."""
+    return {
+        "id": "cpu-load",
+        "protocol": "SNMP",
+        "oid": "1.3.6.1.2.1.25.3.3.1.2",
+        "warning": 80.0,
+        "critical": 95.0,
+        "dataType": "INTEGER",
+        "unit": "%",
+        "description": "CPU Load percentage",
+        "criticality": 2,
+        "applicable_to": {
+            "brands": ["cisco"],
+            "models": [],
+            "layers": [],
+            "names": [],
+            "excluded_names": [],
+        },
+    }
+
+
+@pytest.fixture
+def sample_icmp_metric() -> dict:
+    """ICMP metric definition for tests."""
+    return {
+        "id": "PING-Router-01",
+        "protocol": "ICMP",
+        "oid": "ICMP",
+        "warning": 0,
+        "critical": 0,
+        "description": "Monitoreo via ping ICMP",
+        "applicable_to": {"names": ["Router-01"]},
+    }
+
+
+@pytest.fixture
+def sample_ci_node() -> dict:
+    """Standard CI node payload for tests."""
+    return {
+        "id": "ci-001",
+        "label": "Router-01",
+        "type": "router",
+        "status": "OK",
+        "ip": "192.168.1.1",
+        "brand": "Cisco",
+        "model": "ASR-1000",
+        "name": "Router-01",
+        "layer": "router",
+        "owner": "NetOps",
+        "locationName": "Data Center A",
+        "pollingInterval": 60,
+        "snmp": {"version": "v2c", "readCommunity": "public"},
+        "metrics": [],
+        "metadata": {},
+    }
+
+
+@pytest.fixture
+def sample_event() -> dict:
+    """Standard event payload for tests."""
+    return {
+        "id": "evt-001",
+        "ci_id": "ci-001",
+        "metric_id": "cpu-load",
+        "severity": "CRITICAL",
+        "status": "OPEN",
+        "value": 97.5,
+        "message": "CPU Load exceeded critical threshold",
+        "created_at": datetime.utcnow(),
+    }
+
+
+@pytest.fixture
+def sample_admin_user():
+    """Admin User model instance for service-layer tests."""
+    from models.user import User
+
+    return User(
+        username="admin",
+        role="ADMIN",
+        permissions=[],
+        allowed_locations=[],
+    )
+
+
+@pytest.fixture
+def sample_operator_user():
+    """Operator User model instance for service-layer tests."""
+    from models.user import User
+
+    return User(
+        username="operator",
+        role="OPERATOR",
+        permissions=["EVENT_VIEW", "CI_VIEW", "CI_EDIT"],
+        allowed_locations=["HQ-Madrid"],
+    )

--- a/backend/tests/test_auth_extended.py
+++ b/backend/tests/test_auth_extended.py
@@ -1,0 +1,599 @@
+"""Phase 2: Extended auth and permission tests — pure logic + mocked DB.
+
+Focus areas:
+- get_current_active_user behavior (disabled users, inactive handling)
+- Extended permission scenarios (CUSTOM roles, edge cases, boundary conditions)
+- Token validation edge cases (expired tokens, missing claims, invalid formats)
+- Auth-related model validation (UserUpdate, UserResetRequest, role enums)
+- Permission enforcement patterns (role hierarchy, explicit vs implicit permissions)
+"""
+
+import pytest
+from datetime import timedelta, datetime
+from jose import jwt, JWTError
+from pydantic import ValidationError
+
+from services.auth_service import (
+    create_access_token,
+    check_permission,
+    get_current_active_user,
+    SECRET_KEY,
+    ALGORITHM,
+)
+from models.user import (
+    User,
+    UserInDB,
+    UserUpdate,
+    UserResetRequest,
+    UserRole,
+    UserPermission,
+    TokenData,
+    PasswordChangeRequest,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — extended Phase 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def custom_role_user():
+    """User with CUSTOM role and explicit permissions."""
+    return User(
+        username="customuser",
+        role="CUSTOM",
+        permissions=[UserPermission.EVENT_VIEW, UserPermission.CI_VIEW],
+        allowed_locations=["HQ-Madrid"],
+        allowed_ci_types=["router"],
+    )
+
+
+@pytest.fixture
+def disabled_operator():
+    """Disabled operator user."""
+    return User(
+        username="disabled_op",
+        role="OPERATOR",
+        permissions=[UserPermission.EVENT_VIEW, UserPermission.EVENT_ACK],
+        allowed_locations=[],
+        disabled=True,
+    )
+
+
+@pytest.fixture
+def viewer_with_no_permissions():
+    """Viewer with absolutely no permissions."""
+    return User(
+        username="blank_viewer",
+        role="VIEWER",
+        permissions=[],
+        allowed_locations=[],
+    )
+
+
+@pytest.fixture
+def expired_token(test_secret_key: str) -> str:
+    """A JWT token that is already expired."""
+    to_encode = {
+        "sub": "expired_user",
+        "role": "VIEWER",
+        "exp": datetime.utcnow() - timedelta(hours=1),
+    }
+    return jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+
+
+@pytest.fixture
+def token_without_sub(test_secret_key: str) -> str:
+    """A JWT token missing the 'sub' claim."""
+    to_encode = {
+        "role": "OPERATOR",
+        "exp": datetime.utcnow() + timedelta(minutes=15),
+    }
+    return jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+
+
+@pytest.fixture
+def token_with_invalid_role(test_secret_key: str) -> str:
+    """A JWT token with an invalid role value."""
+    to_encode = {
+        "sub": "rogue_user",
+        "role": "SUPERADMIN",
+        "exp": datetime.utcnow() + timedelta(minutes=15),
+    }
+    return jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_current_active_user behavior
+# ---------------------------------------------------------------------------
+
+
+class TestGetCurrentActiveUser:
+    """Tests for the active user check decorator/dependency."""
+
+    @pytest.mark.asyncio
+    async def test_active_user_returns_user(self):
+        """Active user should be returned as-is."""
+        active_user = User(
+            username="active_user",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+            allowed_locations=[],
+            disabled=False,
+        )
+        result = await get_current_active_user(active_user)
+        assert result == active_user
+        assert result.disabled is False
+
+    @pytest.mark.asyncio
+    async def test_disabled_user_raises_http_400(self):
+        """Disabled user should raise HTTPException with 400 status."""
+        from fastapi import HTTPException
+
+        disabled_user = User(
+            username="disabled_user",
+            role="VIEWER",
+            permissions=[],
+            allowed_locations=[],
+            disabled=True,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_active_user(disabled_user)
+
+        assert exc_info.value.status_code == 400
+        assert "Inactive user" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_disabled_operator_raises_400(self, disabled_operator):
+        """Even operators with permissions get blocked when disabled."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_active_user(disabled_operator)
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_disabled_admin_raises_400(self):
+        """Admins are not exempt from the disabled check."""
+        from fastapi import HTTPException
+
+        admin_user = User(
+            username="disabled_admin",
+            role="ADMIN",
+            permissions=[],
+            allowed_locations=[],
+            disabled=True,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_active_user(admin_user)
+
+        assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Tests: Extended permission scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestExtendedPermissions:
+    """Extended permission tests covering edge cases and CUSTOM roles."""
+
+    def test_custom_role_respects_explicit_permissions_only(self, custom_role_user):
+        """CUSTOM role users should only have their explicitly assigned permissions."""
+        assert check_permission(UserPermission.EVENT_VIEW, custom_role_user) is True
+        assert check_permission(UserPermission.CI_VIEW, custom_role_user) is True
+        assert check_permission(UserPermission.EVENT_ACK, custom_role_user) is False
+        assert check_permission(UserPermission.CI_DELETE, custom_role_user) is False
+        assert check_permission(UserPermission.USER_MANAGE, custom_role_user) is False
+
+    def test_custom_role_with_no_permissions_has_none(self):
+        """CUSTOM role with empty permissions list should have no access."""
+        user = User(
+            username="empty_custom",
+            role="CUSTOM",
+            permissions=[],
+            allowed_locations=[],
+        )
+        for perm in UserPermission:
+            assert check_permission(perm, user) is False
+
+    def test_operator_not_admin_does_not_get_all_permissions(self):
+        """OPERATOR role should NOT have all permissions like ADMIN."""
+        user = User(
+            username="operator",
+            role="OPERATOR",
+            permissions=[],
+            allowed_locations=[],
+        )
+        # OPERATOR with no explicit permissions should fail most checks
+        assert check_permission(UserPermission.USER_MANAGE, user) is False
+        assert check_permission(UserPermission.CI_DELETE, user) is False
+        assert check_permission(UserPermission.ROLE_MANAGE, user) is False
+
+    def test_viewer_with_some_permissions_still_restricted(self):
+        """VIEWER with some permissions should still be restricted from admin actions."""
+        user = User(
+            username="privileged_viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW, UserPermission.CI_VIEW],
+            allowed_locations=[],
+        )
+        assert check_permission(UserPermission.EVENT_VIEW, user) is True
+        assert check_permission(UserPermission.CI_VIEW, user) is True
+        assert check_permission(UserPermission.CI_EDIT, user) is False
+        assert check_permission(UserPermission.USER_MANAGE, user) is False
+
+    def test_admin_with_empty_permissions_still_has_full_access(self):
+        """ADMIN role should have full access even with empty permissions list."""
+        admin = User(
+            username="pure_admin",
+            role="ADMIN",
+            permissions=[],
+            allowed_locations=[],
+        )
+        for perm in UserPermission:
+            assert check_permission(perm, admin) is True
+
+    def test_admin_string_comparison_works(self):
+        """Role comparison should work with string 'ADMIN' (not just enum)."""
+        user = User(
+            username="string_admin",
+            role="ADMIN",  # String, not UserRole.ADMIN
+            permissions=[],
+            allowed_locations=[],
+        )
+        assert check_permission(UserPermission.USER_MANAGE, user) is True
+        assert check_permission(UserPermission.CI_DELETE, user) is True
+
+    def test_all_permissions_covered_by_admin(self):
+        """Verify ADMIN has access to ALL defined permissions."""
+        admin = User(
+            username="full_admin",
+            role="ADMIN",
+            permissions=[],
+            allowed_locations=[],
+        )
+        permission_count = len(list(UserPermission))
+        assert permission_count > 0, "No permissions defined — test is meaningless"
+
+        granted = sum(1 for perm in UserPermission if check_permission(perm, admin))
+        assert granted == permission_count
+
+    def test_permission_enum_values_are_unique(self):
+        """All permission enum values should be unique strings."""
+        values = [perm.value for perm in UserPermission]
+        assert len(values) == len(set(values)), "Duplicate permission values found"
+
+    def test_role_enum_values_are_unique(self):
+        """All role enum values should be unique strings."""
+        values = [role.value for role in UserRole]
+        assert len(values) == len(set(values)), "Duplicate role values found"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Token validation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestTokenEdgeCases:
+    """Tests for JWT token edge cases and validation."""
+
+    def test_expired_token_raises_jwt_error(self, expired_token):
+        """Expired tokens should raise JWTError when decoded."""
+        with pytest.raises(JWTError):
+            jwt.decode(expired_token, SECRET_KEY, algorithms=[ALGORITHM])
+
+    def test_token_without_sub_decodes_but_has_no_sub(self, test_secret_key: str):
+        """Token missing 'sub' claim should decode but have no subject."""
+        to_encode = {
+            "role": "OPERATOR",
+            "exp": datetime.utcnow() + timedelta(minutes=15),
+        }
+        token = jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+        payload = jwt.decode(token, test_secret_key, algorithms=[ALGORITHM])
+        assert "sub" not in payload or payload.get("sub") is None
+
+    def test_token_with_extra_claims_preserves_them(self, test_secret_key: str):
+        """Extra claims in token should be preserved."""
+        to_encode = {
+            "sub": "test_user",
+            "role": "OPERATOR",
+            "custom_claim": "custom_value",
+            "exp": datetime.utcnow() + timedelta(minutes=15),
+        }
+        token = jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+        payload = jwt.decode(token, test_secret_key, algorithms=[ALGORITHM])
+        assert payload["custom_claim"] == "custom_value"
+        assert payload["role"] == "OPERATOR"
+
+    def test_token_with_wrong_secret_raises_error(self, test_secret_key: str):
+        """Token signed with wrong secret should fail validation."""
+        token = create_access_token(data={"sub": "testuser"})
+        with pytest.raises(JWTError):
+            jwt.decode(token, "wrong-secret-key", algorithms=[ALGORITHM])
+
+    def test_token_with_wrong_algorithm_raises_error(self, test_secret_key: str):
+        """Token decoded with wrong algorithm should fail."""
+        token = create_access_token(data={"sub": "testuser"})
+        with pytest.raises(JWTError):
+            jwt.decode(token, SECRET_KEY, algorithms=["RS256"])
+
+    def test_empty_token_string_raises_error(self):
+        """Empty string should raise JWTError."""
+        with pytest.raises(JWTError):
+            jwt.decode("", SECRET_KEY, algorithms=[ALGORITHM])
+
+    def test_garbage_token_string_raises_error(self):
+        """Random string should raise JWTError."""
+        with pytest.raises(JWTError):
+            jwt.decode("not.a.valid.jwt.token", SECRET_KEY, algorithms=[ALGORITHM])
+
+    def test_token_expiry_boundary_just_valid(self, test_secret_key: str):
+        """Token expiring in 1 second should still be valid."""
+        to_encode = {
+            "sub": "boundary_user",
+            "exp": datetime.utcnow() + timedelta(seconds=1),
+        }
+        token = jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+        payload = jwt.decode(token, test_secret_key, algorithms=[ALGORITHM])
+        assert payload["sub"] == "boundary_user"
+
+    def test_token_expiry_boundary_just_expired(self, test_secret_key: str):
+        """Token expired 1 second ago should be invalid."""
+        to_encode = {
+            "sub": "just_expired",
+            "exp": datetime.utcnow() - timedelta(seconds=1),
+        }
+        token = jwt.encode(to_encode, test_secret_key, algorithm=ALGORITHM)
+        with pytest.raises(JWTError):
+            jwt.decode(token, test_secret_key, algorithms=[ALGORITHM])
+
+
+# ---------------------------------------------------------------------------
+# Tests: Auth-related model validation
+# ---------------------------------------------------------------------------
+
+
+class TestUserUpdateModel:
+    """Tests for UserUpdate Pydantic model validation."""
+
+    def test_empty_update_is_valid(self):
+        """UserUpdate should allow empty updates (all fields optional)."""
+        update = UserUpdate()
+        assert update.password is None
+        assert update.role is None
+        assert update.permissions is None
+
+    def test_partial_update(self):
+        """UserUpdate should allow partial updates."""
+        update = UserUpdate(role="OPERATOR")
+        assert update.role == "OPERATOR"
+        assert update.password is None
+
+    def test_full_update(self):
+        """UserUpdate should allow full updates."""
+        update = UserUpdate(
+            password="newpass123",
+            role="ADMIN",
+            permissions=[UserPermission.EVENT_VIEW],
+            allowed_locations=["HQ-Madrid"],
+            allowed_ci_types=["router", "switch"],
+        )
+        assert update.password == "newpass123"
+        assert update.role == "ADMIN"
+        assert len(update.permissions) == 1
+
+    def test_permissions_update_with_empty_list(self):
+        """UserUpdate should accept empty permissions list."""
+        update = UserUpdate(permissions=[])
+        assert update.permissions == []
+
+    def test_allowed_locations_update(self):
+        """UserUpdate should handle allowed_locations."""
+        update = UserUpdate(allowed_locations=["Location-A", "Location-B"])
+        assert len(update.allowed_locations) == 2
+
+
+class TestUserResetRequest:
+    """Tests for UserResetRequest model validation."""
+
+    def test_valid_reset_request(self):
+        """UserResetRequest should accept valid password."""
+        req = UserResetRequest(new_password="NewSecureP@ss123")
+        assert req.new_password == "NewSecureP@ss123"
+
+    def test_missing_new_password_raises_error(self):
+        """UserResetRequest should require new_password."""
+        with pytest.raises(ValidationError):
+            UserResetRequest()
+
+    def test_empty_string_password_is_valid_model(self):
+        """Empty string is technically valid for the model (validation happens elsewhere)."""
+        req = UserResetRequest(new_password="")
+        assert req.new_password == ""
+
+
+class TestTokenDataModel:
+    """Tests for TokenData model validation."""
+
+    def test_valid_token_data(self):
+        """TokenData should accept valid username."""
+        data = TokenData(username="testuser")
+        assert data.username == "testuser"
+
+    def test_none_username_is_valid(self):
+        """TokenData should allow None username (used during validation)."""
+        data = TokenData(username=None)
+        assert data.username is None
+
+    def test_default_username_is_none(self):
+        """TokenData should default to None."""
+        data = TokenData()
+        assert data.username is None
+
+
+class TestUserRoleEnum:
+    """Tests for UserRole enum values."""
+
+    def test_admin_role_value(self):
+        assert UserRole.ADMIN.value == "ADMIN"
+
+    def test_operator_role_value(self):
+        assert UserRole.OPERATOR.value == "OPERATOR"
+
+    def test_viewer_role_value(self):
+        assert UserRole.VIEWER.value == "VIEWER"
+
+    def test_custom_role_value(self):
+        assert UserRole.CUSTOM.value == "CUSTOM"
+
+    def test_all_roles_are_string_compatible(self):
+        """All role enum values should be comparable to strings."""
+        for role in UserRole:
+            assert isinstance(role.value, str)
+            assert role.value == role  # str enum comparison
+
+
+# ---------------------------------------------------------------------------
+# Tests: Password change flow validation
+# ---------------------------------------------------------------------------
+
+
+class TestPasswordChangeFlow:
+    """Tests for password change request validation and edge cases."""
+
+    def test_valid_password_change_request(self):
+        """PasswordChangeRequest should accept valid old and new passwords."""
+        req = PasswordChangeRequest(
+            old_password="OldP@ss123", new_password="NewP@ss456"
+        )
+        assert req.old_password == "OldP@ss123"
+        assert req.new_password == "NewP@ss456"
+
+    def test_same_old_and_new_password_is_valid_model(self):
+        """Model allows same old/new password (business logic should reject)."""
+        req = PasswordChangeRequest(
+            old_password="SamePass123", new_password="SamePass123"
+        )
+        assert req.old_password == req.new_password
+
+    def test_empty_old_password_is_valid_model(self):
+        """Model allows empty strings (validation happens in endpoint)."""
+        req = PasswordChangeRequest(old_password="", new_password="NewP@ss123")
+        assert req.old_password == ""
+
+    def test_empty_new_password_is_valid_model(self):
+        """Model allows empty strings (validation happens in endpoint)."""
+        req = PasswordChangeRequest(old_password="OldP@ss123", new_password="")
+        assert req.new_password == ""
+
+    def test_missing_both_passwords_raises_error(self):
+        """PasswordChangeRequest requires both fields."""
+        with pytest.raises(ValidationError):
+            PasswordChangeRequest()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Permission boundary and security edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionSecurity:
+    """Security-focused permission tests."""
+
+    def test_case_sensitive_role_check(self):
+        """Role check should be case-sensitive — 'admin' != 'ADMIN'."""
+        user = User(
+            username="lowercase_admin",
+            role="admin",  # lowercase
+            permissions=[],
+            allowed_locations=[],
+        )
+        # This should NOT grant admin privileges
+        assert check_permission(UserPermission.USER_MANAGE, user) is False
+
+    def test_none_permissions_rejected_by_pydantic(self):
+        """Pydantic User model rejects None for permissions — must be a list."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            User(
+                username="null_perms",
+                role="VIEWER",
+                permissions=None,
+                allowed_locations=[],
+            )
+
+    def test_none_permissions_raw_dict_bypass_crashes(self):
+        """If permissions is None via raw dict (bypassing Pydantic), check_permission crashes."""
+        # Simulate what could happen if data comes directly from DB without Pydantic validation
+        raw_user = type(
+            "RawUser",
+            (),
+            {
+                "username": "null_perms",
+                "role": "VIEWER",
+                "permissions": None,
+            },
+        )()
+        with pytest.raises(TypeError):
+            check_permission(UserPermission.EVENT_VIEW, raw_user)
+
+    def test_permission_check_with_mixed_role_types(self):
+        """Role should work whether it's UserRole enum or string."""
+        enum_admin = User(
+            username="enum_admin",
+            role=UserRole.ADMIN,
+            permissions=[],
+            allowed_locations=[],
+        )
+        string_admin = User(
+            username="string_admin",
+            role="ADMIN",
+            permissions=[],
+            allowed_locations=[],
+        )
+
+        assert check_permission(UserPermission.CI_DELETE, enum_admin) is True
+        assert check_permission(UserPermission.CI_DELETE, string_admin) is True
+
+    def test_operator_with_all_permissions_except_one(self):
+        """Operator with most permissions should still be restricted."""
+        all_perms = list(UserPermission)
+        all_perms.remove(UserPermission.USER_MANAGE)
+
+        user = User(
+            username="almost_admin",
+            role="OPERATOR",
+            permissions=all_perms,
+            allowed_locations=[],
+        )
+
+        # Should have all explicitly granted permissions
+        for perm in all_perms:
+            assert check_permission(perm, user) is True
+
+        # Should NOT have the one they don't have
+        assert check_permission(UserPermission.USER_MANAGE, user) is False
+
+    def test_permission_enum_completeness(self):
+        """All permission types should be covered by at least one test."""
+        # This ensures we don't miss any new permissions added later
+        tested_permissions = {
+            UserPermission.EVENT_VIEW,
+            UserPermission.EVENT_ACK,
+            UserPermission.EVENT_CLOSE,
+            UserPermission.CI_VIEW,
+            UserPermission.CI_EDIT,
+            UserPermission.CI_DELETE,
+            UserPermission.RUN_DIAGNOSTICS,
+            UserPermission.USER_MANAGE,
+            UserPermission.ROLE_MANAGE,
+            UserPermission.METRICS_VIEW,
+        }
+
+        defined_permissions = set(UserPermission)
+        missing = defined_permissions - tested_permissions
+        assert not missing, f"Permissions not covered by tests: {missing}"

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,87 @@
+"""Unit tests for services/auth_service.py — pure logic functions (no DB)."""
+
+from datetime import timedelta
+from jose import jwt, JWTError
+from services.auth_service import (
+    create_access_token,
+    check_permission,
+    SECRET_KEY,
+    ALGORITHM,
+)
+from models.user import UserPermission, User
+
+
+class TestCreateAccessToken:
+    """Tests for JWT token creation."""
+
+    def test_token_contains_subject(self):
+        token = create_access_token(data={"sub": "testuser"})
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        assert payload["sub"] == "testuser"
+
+    def test_token_contains_expiration(self):
+        token = create_access_token(data={"sub": "testuser"})
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        assert "exp" in payload
+
+    def test_token_with_custom_expiry(self):
+        delta = timedelta(minutes=30)
+        token = create_access_token(data={"sub": "testuser"}, expires_delta=delta)
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        assert "exp" in payload
+
+    def test_token_contains_extra_data(self):
+        token = create_access_token(data={"sub": "admin", "role": "ADMIN"})
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        assert payload["role"] == "ADMIN"
+
+    def test_token_invalid_after_tampering(self):
+        token = create_access_token(data={"sub": "testuser"})
+        tampered = token[:-5] + "XXXXX"
+        try:
+            jwt.decode(tampered, SECRET_KEY, algorithms=[ALGORITHM])
+            assert False, "Should have raised an exception"
+        except JWTError:
+            pass  # Expected
+
+
+class TestCheckPermission:
+    """Tests for the role-based permission checker."""
+
+    def _make_user(self, role: str, permissions: list[UserPermission] | None = None):
+        return User(
+            username="testuser",
+            role=role,
+            permissions=permissions or [],
+            allowed_locations=[],
+        )
+
+    def test_admin_has_all_permissions(self):
+        admin = self._make_user("ADMIN")
+        for perm in UserPermission:
+            assert check_permission(perm, admin) is True
+
+    def test_user_with_explicit_permission(self):
+        user = self._make_user("OPERATOR", [UserPermission.EVENT_VIEW])
+        assert check_permission(UserPermission.EVENT_VIEW, user) is True
+
+    def test_user_without_permission(self):
+        user = self._make_user("VIEWER", [UserPermission.EVENT_VIEW])
+        assert check_permission(UserPermission.CI_DELETE, user) is False
+
+    def test_user_with_no_permissions(self):
+        user = self._make_user("VIEWER", [])
+        assert check_permission(UserPermission.EVENT_ACK, user) is False
+
+    def test_user_with_multiple_permissions(self):
+        user = self._make_user(
+            "OPERATOR",
+            [
+                UserPermission.EVENT_VIEW,
+                UserPermission.EVENT_ACK,
+                UserPermission.CI_VIEW,
+            ],
+        )
+        assert check_permission(UserPermission.EVENT_ACK, user) is True
+        assert check_permission(UserPermission.CI_VIEW, user) is True
+        assert check_permission(UserPermission.CI_DELETE, user) is False

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -1,0 +1,95 @@
+"""Smoke tests for event_service — verify the import path and basic structure.
+
+These are intentionally minimal to confirm the test infrastructure works.
+Full event lifecycle tests should go in test_event_lifecycle.py.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+from models.core import MetricDef
+
+
+class TestEventServiceImports:
+    """Verify that event_service can be imported and its functions exist."""
+
+    def test_event_service_imports(self):
+        """The module should import without errors."""
+        from services import event_service
+
+        assert hasattr(event_service, "get_events")
+        assert hasattr(event_service, "get_related_events")
+        assert hasattr(event_service, "ack_event")
+        assert hasattr(event_service, "close_event")
+        assert hasattr(event_service, "add_event_comment")
+        assert hasattr(event_service, "prune_recovered_events")
+        assert hasattr(event_service, "run_event_diagnostic")
+
+
+class TestEventServiceSmoke:
+    """Minimal smoke tests with mocked DB to verify the mocking infrastructure."""
+
+    def test_get_events_returns_empty_with_mock(self, mock_neo4j_session):
+        """get_events should return empty list when no events exist."""
+        mock_neo4j_session.set_response("event", [])
+
+        from services.event_service import get_events
+
+        result = get_events()
+
+        assert result == []
+
+    def test_get_events_filters_by_status(self, mock_neo4j_session):
+        """get_events should pass status filter to the query."""
+        from services.event_service import get_events
+
+        get_events(status="OPEN")
+
+        assert len(mock_neo4j_session.queries) >= 1
+        query = mock_neo4j_session.queries[0]["query"].lower()
+        assert "status" in query
+
+    def test_ack_event_sets_ack_status(self, mock_neo4j_session):
+        """ack_event should set status to ACK."""
+        from services.event_service import ack_event
+
+        ack_event("evt-001", "testuser")
+
+        assert len(mock_neo4j_session.queries) >= 1
+        query = mock_neo4j_session.queries[0]["query"].upper()
+        assert "ACK" in query
+        assert "evt-001" in mock_neo4j_session.queries[0]["params"]["eid"]
+
+    def test_close_event_sets_closed_status(self, mock_neo4j_session):
+        """close_event should set status to CLOSED."""
+        from services.event_service import close_event
+
+        close_event("evt-001", "testuser")
+
+        assert len(mock_neo4j_session.queries) >= 1
+        query = mock_neo4j_session.queries[0]["query"].upper()
+        assert "CLOSED" in query
+
+    def test_add_event_comment_appends_comment(self, mock_neo4j_session):
+        """add_event_comment should append to comments array."""
+        from services.event_service import add_event_comment
+
+        add_event_comment("evt-001", "testuser", "Investigating...")
+
+        assert len(mock_neo4j_session.queries) >= 1
+        query = mock_neo4j_session.queries[0]["query"].lower()
+        assert "comments" in query
+        assert "testuser" in mock_neo4j_session.queries[0]["params"]["user"]
+        assert "Investigating..." in mock_neo4j_session.queries[0]["params"]["msg"]
+
+    def test_prune_recovered_events_cleans_up(self, mock_neo4j_session):
+        """prune_recovered_events should close RECOVERED events without ack."""
+        from services.event_service import prune_recovered_events
+
+        mock_neo4j_session.set_response("recovered", [{"closed_count": 3}])
+
+        result = prune_recovered_events("system")
+
+        assert result["count"] == 3
+        assert "Cleaned up" in result["message"]

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -1,0 +1,195 @@
+# backend/tests/test_helpers.py
+"""
+Lightweight test utilities for NEX-GEN backend testing.
+
+These helpers reduce boilerplate for:
+- Building mock Neo4j records with common patterns
+- Creating test CI nodes and metrics
+- Simulating event lifecycle scenarios
+"""
+
+from typing import List, Dict, Any, Optional
+from datetime import datetime, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Neo4j Mock Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_neo4j_node_record(
+    node_id: str,
+    name: str,
+    node_type: str = "router",
+    status: str = "OK",
+    brand: str = "",
+    model: str = "",
+    ip: str = "",
+    layer: str = "",
+    extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Build a dict that simulates a Neo4j node property map.
+
+    Usage with MockNeo4jSession:
+        session.set_response("match (n:ci)", [
+            {"node": make_neo4j_node_record("ci-1", "Router-01", brand="Cisco")}
+        ])
+    """
+    record = {
+        "id": node_id,
+        "name": name,
+        "layer": node_type,
+        "status": status,
+        "ip": ip,
+        "brand": brand,
+        "model": model,
+    }
+    if layer:
+        record["layer"] = layer
+    if extra:
+        record.update(extra)
+    return record
+
+
+def make_metric_record(
+    metric_id: str,
+    protocol: str = "SNMP",
+    oid: str = "",
+    warning: Optional[float] = None,
+    critical: Optional[float] = None,
+    applicable_to: Optional[Dict[str, List[str]]] = None,
+) -> Dict[str, Any]:
+    """
+    Build a dict simulating a MetricDef node in Neo4j.
+    """
+    import json
+
+    record = {
+        "id": metric_id,
+        "protocol": protocol,
+        "oid": oid,
+        "dataType": "INTEGER",
+    }
+    if warning is not None:
+        record["warning"] = warning
+    if critical is not None:
+        record["critical"] = critical
+    if applicable_to:
+        record["applicable_to"] = json.dumps(applicable_to)
+    return record
+
+
+def make_event_record(
+    event_id: str,
+    ci_id: str,
+    metric_id: str,
+    severity: str = "CRITICAL",
+    status: str = "OPEN",
+    value: float = 0.0,
+    created_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a dict simulating an Event node in Neo4j.
+    """
+    return {
+        "e": {
+            "id": event_id,
+            "ci_id": ci_id,
+            "metric_id": metric_id,
+            "severity": severity,
+            "status": status,
+            "value": value,
+            "created_at": created_at or datetime.utcnow(),
+            "ack": False,
+        },
+        "ci_name": f"CI-{ci_id}",
+        "metric_name": metric_id,
+        "metric_protocol": "SNMP",
+    }
+
+
+# ---------------------------------------------------------------------------
+# CI & Metric Factory Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_ci_payload(
+    ci_id: str,
+    name: str,
+    brand: str = "",
+    model: str = "",
+    layer: str = "router",
+    ip: str = "",
+    **kwargs,
+) -> Dict[str, Any]:
+    """
+    Build a complete CI dict suitable for service-layer tests.
+    """
+    payload = {
+        "id": ci_id,
+        "name": name,
+        "brand": brand,
+        "model": model,
+        "layer": layer,
+        "ip": ip,
+        "status": "OK",
+        "owner": None,
+        "locationName": None,
+        "pollingInterval": 60,
+        "snmp": None,
+        "metrics": [],
+        "metadata": {},
+    }
+    payload.update(kwargs)
+    return payload
+
+
+def make_metric_criteria(
+    brands: Optional[List[str]] = None,
+    models: Optional[List[str]] = None,
+    layers: Optional[List[str]] = None,
+    names: Optional[List[str]] = None,
+    excluded_names: Optional[List[str]] = None,
+) -> Dict[str, List[str]]:
+    """
+    Build the applicable_to criteria dict for a MetricDef.
+    """
+    return {
+        "brands": brands or [],
+        "models": models or [],
+        "layers": layers or [],
+        "names": names or [],
+        "excluded_names": excluded_names or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query Capture Helper
+# ---------------------------------------------------------------------------
+
+
+def find_query(mock_session, keyword: str) -> Optional[Dict[str, Any]]:
+    """
+    Find the first captured query containing the given keyword.
+
+    Usage:
+        q = find_query(mock_session, "has_metric")
+        assert q is not None
+        assert q["params"]["nid"] == "ci-001"
+    """
+    for entry in mock_session.queries:
+        if keyword.lower() in entry["query"].lower():
+            return entry
+    return None
+
+
+def find_all_queries(mock_session, keyword: str) -> List[Dict[str, Any]]:
+    """
+    Find all captured queries containing the given keyword.
+    """
+    return [
+        entry
+        for entry in mock_session.queries
+        if keyword.lower() in entry["query"].lower()
+    ]

--- a/backend/tests/test_metric_service_smoke.py
+++ b/backend/tests/test_metric_service_smoke.py
@@ -1,0 +1,100 @@
+"""Smoke tests for metric_service — verify the import path and basic structure.
+
+These are intentionally minimal to confirm the test infrastructure works.
+Full metric reconciliation tests should go in test_metric_reconciliation.py.
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from models.core import MetricDef
+
+
+class TestMetricServiceImports:
+    """Verify that metric_service can be imported and its functions exist."""
+
+    def test_metric_service_imports(self):
+        """The module should import without errors."""
+        from services import metric_service
+
+        assert hasattr(metric_service, "get_metrics")
+        assert hasattr(metric_service, "create_metric")
+        assert hasattr(metric_service, "delete_metric")
+        assert hasattr(metric_service, "get_metric_usage")
+        assert hasattr(metric_service, "promote_metric_node")
+        assert hasattr(metric_service, "get_applicable_metrics")
+        assert hasattr(metric_service, "reconcile_node_metrics")
+
+    def test_metricdef_model_valid(self, sample_metric_def):
+        """MetricDef Pydantic model should accept a standard payload."""
+        metric = MetricDef(**sample_metric_def)
+        assert metric.id == "cpu-load"
+        assert metric.protocol == "SNMP"
+        assert metric.warning == 80.0
+        assert metric.critical == 95.0
+        assert metric.applicable_to["brands"] == ["cisco"]
+
+
+class TestMetricServiceSmoke:
+    """Minimal smoke tests with mocked DB to verify the mocking infrastructure."""
+
+    def test_get_metrics_returns_empty_with_mock(self, mock_neo4j_session):
+        """get_metrics should return empty list when no metrics exist."""
+        mock_neo4j_session.set_response("metricdef", [])
+
+        from services.metric_service import get_metrics
+
+        result = get_metrics()
+
+        assert result == []
+
+    def test_get_metrics_returns_data_with_mock(self, mock_neo4j_session):
+        """get_metrics should parse Neo4j records correctly."""
+        mock_neo4j_session.set_response(
+            "metricdef",
+            [
+                {
+                    "m": {
+                        "id": "cpu-load",
+                        "protocol": "SNMP",
+                        "warning": 80.0,
+                        "critical": 95.0,
+                        "oid": "1.2.3",
+                        "dataType": "INTEGER",
+                        "unit": "%",
+                        "description": "CPU",
+                        "criticality": 2,
+                        "applicable_to": '{"brands": ["cisco"]}',
+                    }
+                }
+            ],
+        )
+
+        from services.metric_service import get_metrics
+
+        result = get_metrics()
+
+        assert len(result) == 1
+        assert result[0]["id"] == "cpu-load"
+        assert result[0]["protocol"] == "SNMP"
+
+    def test_create_metric_calls_merge(self, mock_neo4j_session):
+        """create_metric should execute a MERGE query."""
+        from services.metric_service import create_metric
+        from models.core import MetricDef
+
+        metric = MetricDef(id="test-metric", protocol="SNMP")
+        create_metric(metric)
+
+        # Verify a query was executed
+        assert len(mock_neo4j_session.queries) >= 1
+        assert "merge" in mock_neo4j_session.queries[0]["query"].lower()
+
+    def test_delete_metric_calls_detach_delete(self, mock_neo4j_session):
+        """delete_metric should execute a DETACH DELETE query."""
+        from services.metric_service import delete_metric
+
+        delete_metric("test-metric")
+
+        assert len(mock_neo4j_session.queries) >= 1
+        assert "detach delete" in mock_neo4j_session.queries[0]["query"].lower()

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,149 @@
+"""Unit tests for Pydantic models — pure validation logic, no external deps."""
+
+import pytest
+from pydantic import ValidationError
+from models.user import (
+    UserCreate,
+    UserUpdate,
+    User,
+    UserInDB,
+    Token,
+    TokenData,
+    UserRole,
+    UserPermission,
+    PasswordChangeRequest,
+)
+from models.core import Node, Link, MetricDef, Category, OwnerGroup
+
+
+class TestUserCreateModel:
+    """Tests for UserCreate Pydantic model validation."""
+
+    def test_valid_user_create(self):
+        user = UserCreate(
+            username="testuser",
+            password="SecureP@ss123",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+        assert user.username == "testuser"
+        assert user.role == "OPERATOR"
+
+    def test_default_role_is_viewer(self):
+        user = UserCreate(username="newuser", password="pass123")
+        assert user.role == "VIEWER"
+
+    def test_default_permissions_empty(self):
+        user = UserCreate(username="newuser", password="pass123")
+        assert user.permissions == []
+
+    def test_missing_password_raises_error(self):
+        with pytest.raises(ValidationError):
+            UserCreate(username="newuser")
+
+    def test_missing_username_raises_error(self):
+        with pytest.raises(ValidationError):
+            UserCreate(password="pass123")
+
+
+class TestUserModel:
+    """Tests for User Pydantic model."""
+
+    def test_default_disabled_is_false(self):
+        user = User(username="test", role="VIEWER")
+        assert user.disabled is False
+
+    def test_default_force_password_change_is_false(self):
+        user = User(username="test", role="VIEWER")
+        assert user.force_password_change is False
+
+
+class TestTokenModel:
+    """Tests for Token Pydantic model."""
+
+    def test_valid_token(self):
+        token = Token(access_token="abc123", token_type="bearer")
+        assert token.access_token == "abc123"
+        assert token.token_type == "bearer"
+
+    def test_missing_fields_raises_error(self):
+        with pytest.raises(ValidationError):
+            Token(access_token="abc123")
+
+
+class TestPasswordChangeRequest:
+    """Tests for PasswordChangeRequest model."""
+
+    def test_valid_request(self):
+        req = PasswordChangeRequest(old_password="old123", new_password="new456")
+        assert req.old_password == "old123"
+        assert req.new_password == "new456"
+
+    def test_missing_old_password_raises_error(self):
+        with pytest.raises(ValidationError):
+            PasswordChangeRequest(new_password="new456")
+
+
+class TestNodeModel:
+    """Tests for Node (CI) Pydantic model."""
+
+    def test_minimal_node(self):
+        node = Node(id="ci-001", label="Router-01", type="router")
+        assert node.status == "OK"
+        assert node.pollingInterval == 60
+        assert node.metadata == {}
+        assert node.metrics == []
+
+    def test_node_with_optional_fields(self):
+        node = Node(
+            id="ci-002",
+            label="Switch-01",
+            type="switch",
+            ip="192.168.1.1",
+            brand="Cisco",
+            model="Catalyst 9300",
+        )
+        assert node.ip == "192.168.1.1"
+        assert node.brand == "Cisco"
+
+    def test_missing_required_fields_raises_error(self):
+        with pytest.raises(ValidationError):
+            Node(label="Missing ID")
+
+
+class TestLinkModel:
+    """Tests for Link Pydantic model."""
+
+    def test_minimal_link(self):
+        link = Link(source="ci-1", target="ci-2", relationship="DEPENDS_ON")
+        assert link.relationship == "DEPENDS_ON"
+        assert link.id is None
+
+    def test_missing_required_fields_raises_error(self):
+        with pytest.raises(ValidationError):
+            Link(source="ci-1")
+
+
+class TestMetricDefModel:
+    """Tests for MetricDef Pydantic model."""
+
+    def test_default_protocol_is_snmp(self):
+        metric = MetricDef(id="cpu-load")
+        assert metric.protocol == "SNMP"
+
+    def test_default_data_type_is_integer(self):
+        metric = MetricDef(id="mem-usage")
+        assert metric.dataType == "INTEGER"
+
+    def test_full_metric(self):
+        metric = MetricDef(
+            id="cpu-load",
+            protocol="SNMP",
+            oid="1.3.6.1.2.1.25.3.3.1.2",
+            warning=80.0,
+            critical=95.0,
+            unit="%",
+            description="CPU Load percentage",
+        )
+        assert metric.warning == 80.0
+        assert metric.critical == 95.0

--- a/backend/tests/test_node_service.py
+++ b/backend/tests/test_node_service.py
@@ -1,329 +1,1667 @@
+"""Service-level tests for node_service.py — mocks/stubs, no real DB.
+
+Focus areas:
+- get_nodes(): data scoping, metric parsing, SNMP deserialization, location handling
+- create_update_node(): permission enforcement, ping metric creation, reconciliation triggers
+- delete_node(): permission enforcement
+- get_node_usage(): passthrough behavior
+- bulk_upload_nodes(): Excel parsing, validation, status normalization, error aggregation
+- get_node_template(): streaming response generation
+
+Strategy:
+- Patch topology_repo at the module level where it is imported (services.node_service.topology_repo)
+- Patch check_permission from auth_service
+- Patch reconcile_node_metrics from metric_service (lazy import inside create_update_node)
+- Use conftest fixtures for User objects
 """
-test_node_service.py
-
-TDD tests for Issue #16 fixes in backend/services/node_service.py.
-
-Scope:
-  - Bug 2: get_nodes must include 'pollingInterval' in the returned node_data dict
-  - Bug 1: get_nodes must include 'owner' at top level in node_data dict
-  - create_update_node must pass owner and pollingInterval correctly to upsert_node
-
-All Neo4j / topology_repo calls are mocked via unittest.mock so no live DB is needed.
-
-NOTE: We use patch.object() throughout to avoid string-path resolution ambiguity
-that arises from the backend/ sub-directory not being the pytest rootdir.
-"""
-
-import sys
-import os
-
-# ── Make backend packages importable without installing them ──────────────────
-_backend_dir = os.path.join(os.path.dirname(__file__), "..")
-if _backend_dir not in sys.path:
-    sys.path.insert(0, _backend_dir)
-
-# Pre-import modules so patch.object() can reference them reliably
-import repositories.topology_repo as topology_repo_mod
-import services.node_service as node_service_mod
-import services.auth_service as auth_service_mod
 
 import pytest
-from unittest.mock import patch, MagicMock
+import json
+import io
+import asyncio
+from unittest.mock import patch, MagicMock, call
+from datetime import datetime
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse
+
+from models.user import User, UserRole, UserPermission
 from models.core import Node
 
 
-# ─────────────────────────────────────────────────────────────────────────────
+_UNSET = object()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
 
 
-def _make_raw_node(overrides: dict | None = None) -> dict:
-    """
-    Return a dict that looks like a Neo4j node record as returned by
-    topology_repo.get_nodes (the 'node' key inside each record).
-    """
-    base = {
-        "id": "CI-TEST01",
-        "name": "Test Router",
-        "status": "ACTIVE",
-        "ip": "10.0.0.1",
-        "layer": "INFRASTRUCTURE",
-        "owner": "NetOps",
-        "brand": "Cisco",
-        "model": "ASR-1001X",
-        "serialNumber": "SN-TEST1234",
-        "firmwareVersion": "17.6.4",
-        "pollingInterval": 120,
-        "snmp": None,
+def _make_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+    allowed_locations: list[str] | None = None,
+    disabled: bool = False,
+) -> User:
+    return User(
+        username=username,
+        role=role,
+        permissions=permissions or [],
+        allowed_locations=allowed_locations or [],
+        disabled=disabled,
+    )
+
+
+def _make_node_record(
+    node_id: str = "ci-001",
+    name: str = "Router-01",
+    status: str = "OK",
+    ip: str = "192.168.1.1",
+    brand: str = "Cisco",
+    model: str = "ASR-1000",
+    layer: str = "router",
+    location_name: str = "Data Center A",
+    snmp: str | dict | None | object = _UNSET,
+    extra_props: dict | None = None,
+) -> dict:
+    """Build a raw node dict as returned from Neo4j."""
+    props = {
+        "id": node_id,
+        "name": name,
+        "status": status,
+        "ip": ip,
+        "brand": brand,
+        "model": model,
+        "layer": layer,
+        "location_name": location_name,
+        "snmp": (
+            json.dumps({"version": "v2c", "readCommunity": "public"})
+            if snmp is _UNSET
+            else snmp
+        ),
         "location": None,
-        "location_name": "Madrid DC",
+        "pollingInterval": 60,
     }
-    if overrides:
-        base.update(overrides)
-    return base
+    if extra_props:
+        props.update(extra_props)
+    return props
 
 
-def _make_raw_record(node_overrides: dict | None = None) -> dict:
-    """
-    Return a full record dict as returned by topology_repo.get_nodes.
-    Simulates: {"node": <Neo4j-node-dict>, "category": "...", "metrics": [...]}
-    """
-    node = _make_raw_node(node_overrides)
+def _make_full_record(
+    node_props: dict | None = None,
+    category: str = "router",
+    metrics: list[dict] | None = None,
+) -> dict:
     return {
-        "node": node,
-        "category": "NETWORK",
-        "metrics": [],
+        "node": node_props or _make_node_record(),
+        "category": category,
+        "metrics": metrics or [],
     }
 
 
-def _make_admin_user() -> MagicMock:
-    user = MagicMock()
-    user.role = "ADMIN"
-    user.allowed_locations = []
-    return user
+def _run(coro):
+    return asyncio.run(coro)
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Tests: get_nodes — pollingInterval (Bug 2)
-# ─────────────────────────────────────────────────────────────────────────────
+async def _collect_body(response: StreamingResponse) -> bytes:
+    content = b""
+    async for chunk in response.body_iterator:
+        content += chunk
+    return content
 
 
-class TestGetNodesPollingInterval:
-    """Bug 2 — pollingInterval must be included in node_data returned by get_nodes."""
-
-    def test_get_nodes_includes_polling_interval_in_result(self):
-        """
-        GIVEN a CI stored in Neo4j with pollingInterval=120
-        WHEN get_nodes is called
-        THEN the returned dict includes pollingInterval=120
-        """
-        raw_records = [_make_raw_record({"pollingInterval": 120})]
-
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
-
-        assert len(result) == 1
-        assert result[0]["pollingInterval"] == 120
-
-    def test_get_nodes_polling_interval_defaults_to_60_when_absent(self):
-        """
-        GIVEN a CI stored in Neo4j with no pollingInterval property (None / missing)
-        WHEN get_nodes is called
-        THEN the returned dict has pollingInterval=60 (default)
-        """
-        raw_records = [_make_raw_record({"pollingInterval": None})]
-
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
-
-        assert result[0]["pollingInterval"] == 60
-
-    def test_get_nodes_polling_interval_preserved_at_custom_value(self):
-        """
-        GIVEN a CI with pollingInterval=300 (5 minutes)
-        WHEN get_nodes is called
-        THEN the returned dict has pollingInterval=300 (not overwritten to default)
-        """
-        raw_records = [_make_raw_record({"pollingInterval": 300})]
-
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
-
-        assert result[0]["pollingInterval"] == 300
+def _read_streaming_body(response: StreamingResponse) -> bytes:
+    return asyncio.run(_collect_body(response))
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Tests: get_nodes — owner (Bug 1)
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Tests: get_nodes()
+# ---------------------------------------------------------------------------
 
 
-class TestGetNodesOwner:
-    """Bug 1 — owner must be exposed at top level in node_data (not buried in metadata)."""
+class TestGetNodes:
+    """Tests for the get_nodes service function."""
 
-    def test_get_nodes_includes_owner_at_top_level(self):
-        """
-        GIVEN a CI with owner='NetOps' in Neo4j
-        WHEN get_nodes is called
-        THEN the returned dict has owner='NetOps' as a top-level key
-        """
-        raw_records = [_make_raw_record({"owner": "NetOps"})]
+    def test_admin_gets_all_nodes_no_location_filter(self):
+        """Admin user should get all nodes with is_admin=True."""
+        admin = _make_user(username="admin", role="ADMIN")
 
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
+        node_record = _make_full_record(
+            node_props=_make_node_record(node_id="ci-001", name="Router-01"),
+        )
 
-        assert result[0]["owner"] == "NetOps"
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
 
-    def test_get_nodes_owner_is_none_when_not_set(self):
-        """
-        GIVEN a CI with no owner in Neo4j
-        WHEN get_nodes is called
-        THEN the returned dict has owner=None at top level
-        """
-        raw_records = [_make_raw_record({"owner": None})]
+            from services.node_service import get_nodes
 
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
+            result = get_nodes(admin)
 
-        assert result[0]["owner"] is None
+            assert len(result) == 1
+            assert result[0]["label"] == "Router-01"
+            mock_repo.get_nodes.assert_called_once()
+            call_args = mock_repo.get_nodes.call_args
+            assert call_args[0][0] == []  # allowed_locations
+            assert call_args[0][1] is True  # is_admin
 
-    def test_get_nodes_owner_is_a_top_level_key_not_only_in_metadata(self):
-        """
-        GIVEN a CI with owner='SecOps'
-        WHEN get_nodes is called
-        THEN the 'owner' key is present at node_data root (not only inside metadata)
-        """
-        raw_records = [_make_raw_record({"owner": "SecOps"})]
+    def test_operator_scoped_by_location(self):
+        """Operator should be scoped to allowed_locations."""
+        operator = _make_user(
+            username="op",
+            role="OPERATOR",
+            allowed_locations=["HQ-Madrid"],
+        )
 
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
+        node_record = _make_full_record(
+            node_props=_make_node_record(node_id="ci-002", name="Switch-01"),
+        )
 
-        node_data = result[0]
-        assert "owner" in node_data, "owner must be a top-level key in node_data"
-        assert node_data["owner"] == "SecOps"
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(operator)
+
+            assert len(result) == 1
+            mock_repo.get_nodes.assert_called_once_with(["HQ-Madrid"], False)
+
+    def test_operator_no_locations_returns_empty(self):
+        """Operator with no allowed_locations should get empty list."""
+        operator = _make_user(
+            username="op",
+            role="OPERATOR",
+            allowed_locations=[],
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = []
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(operator)
+
+            assert result == []
+            mock_repo.get_nodes.assert_called_once_with([], False)
+
+    def test_node_metrics_parsed_correctly(self):
+        """Metrics from Neo4j records should be parsed into the response."""
+        admin = _make_user(username="admin", role="ADMIN")
+        ts = datetime(2026, 4, 1, 12, 0, 0)
+
+        metrics = [
+            {
+                "name": "cpu-load",
+                "protocol": "SNMP",
+                "status": "OK",
+                "value": 45.2,
+                "last_updated": ts,
+            },
+            {
+                "name": None,
+                "protocol": "ICMP",
+                "status": "UNKNOWN",
+            },  # null name → filtered
+        ]
+        node_record = _make_full_record(
+            node_props=_make_node_record(node_id="ci-001"),
+            metrics=metrics,
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert len(result[0]["metrics"]) == 1
+            assert result[0]["metrics"][0]["name"] == "cpu-load"
+            assert result[0]["metrics"][0]["value"] == 45.2
+            assert result[0]["metrics"][0]["last_updated"] == ts.isoformat()
+
+    def test_snmp_string_parsed_to_dict(self):
+        """SNMP stored as JSON string should be deserialized."""
+        admin = _make_user(username="admin", role="ADMIN")
+        snmp_json = json.dumps({"version": "v3", "readCommunity": "secure"})
+        node_record = _make_full_record(
+            node_props=_make_node_record(snmp=snmp_json),
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert isinstance(result[0]["snmp"], dict)
+            assert result[0]["snmp"]["version"] == "v3"
+
+    def test_snmp_none_stays_none(self):
+        """SNMP that is None should remain None."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(snmp=None),
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["snmp"] is None
+
+    def test_snmp_invalid_json_becomes_none(self):
+        """SNMP that is an invalid JSON string should become None."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(snmp="not-valid-json{{{"),
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["snmp"] is None
+
+    def test_location_object_serialized(self):
+        """Location with latitude/longitude attributes should be serialized."""
+        admin = _make_user(username="admin", role="ADMIN")
+
+        class FakeLocation:
+            def __init__(self):
+                self.latitude = 19.4326
+                self.longitude = -99.1332
+
+        node_props = _make_node_record()
+        node_props["location"] = FakeLocation()
+        node_record = _make_full_record(node_props=node_props)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["location"] == {"lat": 19.4326, "long": -99.1332}
+
+    def test_location_none_returns_none(self):
+        """Node without location should have None location in output."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(),
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["location"] is None
+
+    def test_metadata_excludes_standard_fields(self):
+        """Metadata dict should exclude standard fields (id, name, status, etc.)."""
+        admin = _make_user(username="admin", role="ADMIN")
+        extra = {"custom_field": "value1", "another": 42}
+        node_props = _make_node_record()
+        node_props.update(extra)
+        node_record = _make_full_record(node_props=node_props)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            metadata = result[0]["metadata"]
+            assert metadata["custom_field"] == "value1"
+            assert metadata["another"] == 42
+            # Standard fields should NOT be in metadata
+            assert "id" not in metadata
+            assert "name" not in metadata
+            assert "status" not in metadata
+
+    def test_type_defaults_to_layer_when_no_category(self):
+        """When category is None, type should fall back to node layer."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(layer="firewall"),
+            category=None,
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["type"] == "firewall"
+
+    def test_type_uses_category_when_present(self):
+        """When category exists, it should be used as type."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(layer="router"),
+            category="core-router",
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["type"] == "core-router"
+
+    def test_empty_nodes_list_returns_empty(self):
+        """When repo returns no nodes, result should be empty list."""
+        admin = _make_user(username="admin", role="ADMIN")
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = []
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result == []
+
+    def test_datetime_fields_serialized_to_iso(self):
+        """Datetime fields in metadata should be serialized to ISO format."""
+        admin = _make_user(username="admin", role="ADMIN")
+        ts = datetime(2026, 3, 15, 10, 30, 0)
+        node_props = _make_node_record()
+        node_props["created_at"] = ts
+        node_record = _make_full_record(node_props=node_props)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [node_record]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["metadata"]["created_at"] == ts.isoformat()
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Tests: get_nodes — serialNumber and firmwareVersion (Bugs 3 & 4 — backend side)
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class TestGetNodesHardwareFields:
-    """Bugs 3 & 4 — serialNumber and firmwareVersion already in node_data (pre-existing);
-    this confirms they remain correctly populated after the Bug 1+2 fixes."""
-
-    def test_get_nodes_includes_serial_number(self):
-        """
-        GIVEN a CI with serialNumber='SN-ABCD1234'
-        WHEN get_nodes is called
-        THEN the returned dict has serialNumber='SN-ABCD1234'
-        """
-        raw_records = [_make_raw_record({"serialNumber": "SN-ABCD1234"})]
-
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
-
-        assert result[0]["serialNumber"] == "SN-ABCD1234"
-
-    def test_get_nodes_includes_firmware_version(self):
-        """
-        GIVEN a CI with firmwareVersion='17.6.4'
-        WHEN get_nodes is called
-        THEN the returned dict has firmwareVersion='17.6.4'
-        """
-        raw_records = [_make_raw_record({"firmwareVersion": "17.6.4"})]
-
-        with patch.object(topology_repo_mod, "get_nodes", return_value=raw_records):
-            result = node_service_mod.get_nodes(_make_admin_user())
-
-        assert result[0]["firmwareVersion"] == "17.6.4"
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Tests: create_update_node — owner and pollingInterval passed to upsert_node
-# ─────────────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Tests: create_update_node()
+# ---------------------------------------------------------------------------
 
 
 class TestCreateUpdateNode:
-    """Verify create_update_node correctly passes owner and pollingInterval to upsert_node."""
+    """Tests for the create_update_node service function."""
 
-    def _make_node(self, **kwargs) -> Node:
-        defaults = dict(
-            id="CI-TEST01",
-            label="Test Router",
-            type="INFRASTRUCTURE",
-            status="ACTIVE",
-            ip="10.0.0.1",
-            owner="NetOps",
-            pollingInterval=120,
-            serialNumber="SN-ABCD1234",
-            firmwareVersion="17.6.4",
+    def test_denied_without_ci_edit_permission(self):
+        """User without CI_EDIT should get 403."""
+        viewer = _make_user(username="viewer", role="VIEWER", permissions=[])
+        node = Node(id="ci-001", label="Router-01", type="router")
+
+        with patch("services.node_service.check_permission", return_value=False):
+            from services.node_service import create_update_node
+
+            with pytest.raises(HTTPException) as exc_info:
+                create_update_node(node, viewer)
+
+            assert exc_info.value.status_code == 403
+            assert "CI_EDIT" in exc_info.value.detail
+
+    def test_admin_allowed_ci_edit(self):
+        """Admin should pass permission check (check_permission returns True)."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node = Node(id="ci-001", label="Router-01", type="router", ip="10.0.0.1")
+
+        with (
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+            patch("services.metric_service.reconcile_node_metrics") as mock_reconcile,
+        ):
+            from services.node_service import create_update_node
+
+            result = create_update_node(node, admin)
+
+            assert result["message"] == "Node created/updated"
+            assert result["id"] == "ci-001"
+            mock_repo.upsert_node.assert_called_once_with(node)
+
+    def test_operator_with_ci_edit_allowed(self):
+        """Operator with CI_EDIT permission should succeed."""
+        operator = _make_user(
+            username="op",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],
         )
-        defaults.update(kwargs)
-        return Node(**defaults)
-
-    def _make_user(self) -> MagicMock:
-        user = MagicMock()
-        user.role = "ADMIN"
-        return user
-
-    def test_create_update_node_calls_upsert_with_correct_owner(self):
-        """
-        GIVEN a Node with owner='NetOps'
-        WHEN create_update_node is called
-        THEN topology_repo.upsert_node receives the node with owner='NetOps'
-        """
-        node = self._make_node(owner="NetOps")
+        node = Node(id="ci-002", label="Switch-01", type="switch")
 
         with (
-            patch.object(topology_repo_mod, "upsert_node") as mock_upsert,
-            patch.object(topology_repo_mod, "create_default_ping_metric"),
-            patch.object(auth_service_mod, "check_permission", return_value=True),
-            patch.dict(
-                "sys.modules",
-                {
-                    "services.metric_service": MagicMock(
-                        reconcile_node_metrics=MagicMock()
-                    )
-                },
-            ),
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+            patch("services.metric_service.reconcile_node_metrics") as mock_reconcile,
         ):
-            node_service_mod.create_update_node(node, self._make_user())
+            from services.node_service import create_update_node
 
-        mock_upsert.assert_called_once()
-        upserted_node = mock_upsert.call_args[0][0]
-        assert upserted_node.owner == "NetOps"
+            result = create_update_node(node, operator)
 
-    def test_create_update_node_calls_upsert_with_correct_polling_interval(self):
-        """
-        GIVEN a Node with pollingInterval=120
-        WHEN create_update_node is called
-        THEN topology_repo.upsert_node receives the node with pollingInterval=120
-        """
-        node = self._make_node(pollingInterval=120)
+            assert result["message"] == "Node created/updated"
+            mock_repo.upsert_node.assert_called_once()
+
+    def test_creates_ping_metric_when_ip_present(self):
+        """When node has an IP, a default PING metric should be created."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node = Node(id="ci-001", label="Router-01", type="router", ip="192.168.1.1")
 
         with (
-            patch.object(topology_repo_mod, "upsert_node") as mock_upsert,
-            patch.object(topology_repo_mod, "create_default_ping_metric"),
-            patch.object(auth_service_mod, "check_permission", return_value=True),
-            patch.dict(
-                "sys.modules",
-                {
-                    "services.metric_service": MagicMock(
-                        reconcile_node_metrics=MagicMock()
-                    )
-                },
-            ),
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+            patch("services.metric_service.reconcile_node_metrics"),
         ):
-            node_service_mod.create_update_node(node, self._make_user())
+            from services.node_service import create_update_node
 
-        mock_upsert.assert_called_once()
-        upserted_node = mock_upsert.call_args[0][0]
-        assert upserted_node.pollingInterval == 120
+            create_update_node(node, admin)
 
-    def test_create_update_node_calls_upsert_with_serial_and_firmware(self):
-        """
-        GIVEN a Node with serialNumber and firmwareVersion set
-        WHEN create_update_node is called
-        THEN topology_repo.upsert_node receives the node with both fields intact
-        """
-        node = self._make_node(serialNumber="SN-ABCD1234", firmwareVersion="17.6.4")
+            mock_repo.create_default_ping_metric.assert_called_once_with(
+                "ci-001", "Router-01"
+            )
+
+    def test_no_ping_metric_when_ip_absent(self):
+        """When node has no IP, no PING metric should be created."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node = Node(id="ci-002", label="Server-01", type="server", ip=None)
 
         with (
-            patch.object(topology_repo_mod, "upsert_node") as mock_upsert,
-            patch.object(topology_repo_mod, "create_default_ping_metric"),
-            patch.object(auth_service_mod, "check_permission", return_value=True),
-            patch.dict(
-                "sys.modules",
-                {
-                    "services.metric_service": MagicMock(
-                        reconcile_node_metrics=MagicMock()
-                    )
-                },
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+            patch("services.metric_service.reconcile_node_metrics"),
+        ):
+            from services.node_service import create_update_node
+
+            create_update_node(node, admin)
+
+            mock_repo.create_default_ping_metric.assert_not_called()
+
+    def test_reconciliation_called_on_create_update(self):
+        """Metric reconciliation should be triggered after upsert."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node = Node(
+            id="ci-001",
+            label="Router-01",
+            type="router",
+            brand="Cisco",
+            model="ASR-1000",
+        )
+
+        with (
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo"),
+            patch("services.metric_service.reconcile_node_metrics") as mock_reconcile,
+        ):
+            from services.node_service import create_update_node
+
+            create_update_node(node, admin)
+
+            mock_reconcile.assert_called_once()
+            # Should receive the node as a dict
+            call_arg = mock_reconcile.call_args[0][0]
+            assert isinstance(call_arg, dict)
+            assert call_arg["id"] == "ci-001"
+
+    def test_reconciliation_error_logged_but_does_not_fail(self):
+        """If reconciliation fails, the operation should still succeed."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node = Node(id="ci-001", label="Router-01", type="router")
+
+        with (
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo"),
+            patch(
+                "services.metric_service.reconcile_node_metrics",
+                side_effect=Exception("DB timeout"),
             ),
         ):
-            node_service_mod.create_update_node(node, self._make_user())
+            from services.node_service import create_update_node
 
-        mock_upsert.assert_called_once()
-        upserted_node = mock_upsert.call_args[0][0]
-        assert upserted_node.serialNumber == "SN-ABCD1234"
-        assert upserted_node.firmwareVersion == "17.6.4"
+            result = create_update_node(node, admin)
+
+            # Should still return success
+            assert result["message"] == "Node created/updated"
+            assert result["id"] == "ci-001"
+
+    def test_full_flow_order_upsert_then_ping_then_reconcile(self):
+        """Verify the correct order: upsert → ping metric → reconcile."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node = Node(id="ci-001", label="Router-01", type="router", ip="10.0.0.1")
+
+        call_order = []
+
+        def track_upsert(*args, **kwargs):
+            call_order.append("upsert")
+
+        def track_ping(*args, **kwargs):
+            call_order.append("ping")
+
+        def track_reconcile(*args, **kwargs):
+            call_order.append("reconcile")
+
+        with (
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+            patch("services.metric_service.reconcile_node_metrics") as mock_reconcile,
+        ):
+            mock_repo.upsert_node.side_effect = track_upsert
+            mock_repo.create_default_ping_metric.side_effect = track_ping
+            mock_reconcile.side_effect = track_reconcile
+
+            from services.node_service import create_update_node
+
+            create_update_node(node, admin)
+
+            assert call_order == ["upsert", "ping", "reconcile"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: delete_node()
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteNode:
+    """Tests for the delete_node service function."""
+
+    def test_denied_without_ci_delete_permission(self):
+        """User without CI_DELETE should get 403."""
+        operator = _make_user(
+            username="op",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],  # no CI_DELETE
+        )
+
+        with patch("services.node_service.check_permission", return_value=False):
+            from services.node_service import delete_node
+
+            with pytest.raises(HTTPException) as exc_info:
+                delete_node("ci-001", operator)
+
+            assert exc_info.value.status_code == 403
+            assert "CI_DELETE" in exc_info.value.detail
+
+    def test_admin_can_delete(self):
+        """Admin should be able to delete a node."""
+        admin = _make_user(username="admin", role="ADMIN")
+
+        with (
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+        ):
+            from services.node_service import delete_node
+
+            result = delete_node("ci-001", admin)
+
+            assert result["message"] == "Node deleted"
+            assert result["id"] == "ci-001"
+            mock_repo.delete_node.assert_called_once_with("ci-001")
+
+    def test_operator_with_ci_delete_can_delete(self):
+        """Operator with CI_DELETE permission should succeed."""
+        operator = _make_user(
+            username="op",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_DELETE],
+        )
+
+        with (
+            patch("services.node_service.check_permission", return_value=True),
+            patch("services.node_service.topology_repo") as mock_repo,
+        ):
+            from services.node_service import delete_node
+
+            result = delete_node("ci-002", operator)
+
+            assert result["message"] == "Node deleted"
+            mock_repo.delete_node.assert_called_once_with("ci-002")
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_node_usage()
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodeUsage:
+    """Tests for the get_node_usage service function."""
+
+    def test_returns_count_from_repo(self):
+        """Should return the relationship count from the repo."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_node_usage.return_value = 5
+
+            from services.node_service import get_node_usage
+
+            result = get_node_usage("ci-001")
+
+            assert result == {"count": 5}
+            mock_repo.get_node_usage.assert_called_once_with("ci-001")
+
+    def test_returns_zero_when_no_relationships(self):
+        """Should return 0 when node has no relationships."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_node_usage.return_value = 0
+
+            from services.node_service import get_node_usage
+
+            result = get_node_usage("ci-999")
+
+            assert result == {"count": 0}
+
+
+# ---------------------------------------------------------------------------
+# Tests: bulk_upload_nodes()
+# ---------------------------------------------------------------------------
+
+
+class TestBulkUploadNodes:
+    """Tests for the bulk_upload_nodes service function."""
+
+    def _make_fake_excel_bytes(self) -> bytes:
+        """Create minimal valid xlsx bytes using openpyxl."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Test Router",
+                "router",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN123",
+                "17.3.1",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                19.4326,
+                -99.1332,
+                "High",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+        return buf.getvalue()
+
+    def test_successful_bulk_upload(self):
+        """Valid Excel file should process all rows."""
+        excel_bytes = self._make_fake_excel_bytes()
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router", "switch"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            result = _run(bulk_upload_nodes(excel_bytes, "import.xlsx"))
+
+            assert mock_repo.bulk_insert_node.call_count == 1
+            # Check the response
+            content = result
+            if isinstance(content, JSONResponse):
+                data = json.loads(content.body)
+            else:
+                data = content
+            assert "Successfully processed 1" in data["message"]
+
+    def test_validation_error_invalid_owner(self):
+        """Row with unknown owner should be skipped and reported."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Bad Router",
+                "router",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN123",
+                "17.3.1",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "UnknownOwner",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            result = _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            assert mock_repo.bulk_insert_node.call_count == 0
+            assert isinstance(result, JSONResponse)
+            data = json.loads(result.body)
+            assert (
+                data["errors"][0]
+                == "Row 2 (ID: CI-001): Owner 'UnknownOwner' not found."
+            )
+
+    def test_validation_error_invalid_layer(self):
+        """Row with unknown NetworkLayer should be skipped and reported."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Bad Router",
+                "unknown-layer",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN123",
+                "17.3.1",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            result = _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            assert mock_repo.bulk_insert_node.call_count == 0
+            assert isinstance(result, JSONResponse)
+            data = json.loads(result.body)
+            assert "NetworkLayer 'unknown-layer' not found" in data["errors"][0]
+
+    def test_status_normalization_healthy_to_active(self):
+        """Status 'HEALTHY' and 'OK' should be normalized to 'ACTIVE'."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Router A",
+                "router",
+                "HEALTHY",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        ws.append(
+            [
+                "CI-002",
+                "Router B",
+                "router",
+                "OK",
+                "Cisco",
+                "ASR-1000",
+                "SN2",
+                "1.0",
+                "10.0.0.2",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            # Both calls should have status='ACTIVE'
+            calls = mock_repo.bulk_insert_node.call_args_list
+            assert calls[0][0][3] == "ACTIVE"  # HEALTHY → ACTIVE
+            assert calls[1][0][3] == "ACTIVE"  # OK → ACTIVE
+
+    def test_status_normalization_warning_to_exception(self):
+        """Status 'WARNING' and 'CRITICAL' should be normalized to 'EXCEPTION'."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Router A",
+                "router",
+                "WARNING",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        ws.append(
+            [
+                "CI-002",
+                "Router B",
+                "router",
+                "CRITICAL",
+                "Cisco",
+                "ASR-1000",
+                "SN2",
+                "1.0",
+                "10.0.0.2",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            calls = mock_repo.bulk_insert_node.call_args_list
+            assert calls[0][0][3] == "EXCEPTION"  # WARNING → EXCEPTION
+            assert calls[1][0][3] == "EXCEPTION"  # CRITICAL → EXCEPTION
+
+    def test_status_normalization_maintenance(self):
+        """Status 'MAINTENANCE' should remain as 'MAINTENANCE'."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Router A",
+                "router",
+                "MAINTENANCE",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            assert mock_repo.bulk_insert_node.call_args[0][3] == "MAINTENANCE"
+
+    def test_status_normalization_unknown_defaults_to_active(self):
+        """Unknown status should default to 'ACTIVE'."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "Router A",
+                "router",
+                "SOME_WEIRD_STATUS",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            assert mock_repo.bulk_insert_node.call_args[0][3] == "ACTIVE"
+
+    def test_auto_generated_id_when_empty(self):
+        """When ID is empty, an auto-generated CI-XXXXXXXX ID should be used."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "",
+                "Auto-ID Router",
+                "router",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            # The first positional arg is the generated ID
+            generated_id = mock_repo.bulk_insert_node.call_args[0][0]
+            assert generated_id.startswith("CI-")
+            assert len(generated_id) == 11  # CI- + 8 hex chars
+
+    def test_sample_row_skipped(self):
+        """Header sample row ('Sample Router') should be skipped."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        # This is the sample row from the template
+        ws.append(
+            [
+                "(Leave Empty for Auto-ID)",
+                "Sample Router",
+                "INFRASTRUCTURE",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN12345678",
+                "17.3.1",
+                "192.168.1.100",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "Data Center A",
+                19.4326,
+                -99.1332,
+                "High",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            mock_repo.bulk_insert_node.assert_not_called()
+
+    def test_rows_with_empty_label_skipped(self):
+        """Rows without a Label should be skipped."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        ws.append(
+            [
+                "CI-001",
+                "",
+                "router",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            mock_repo.bulk_insert_node.assert_not_called()
+
+    def test_mixed_valid_and_invalid_rows_returns_207(self):
+        """Mix of valid and invalid rows should return 207 with errors."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        # Valid row
+        ws.append(
+            [
+                "CI-001",
+                "Good Router",
+                "router",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN1",
+                "1.0",
+                "10.0.0.1",
+                "v2c",
+                "public",
+                "private",
+                "NetOps",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        # Invalid row (bad owner)
+        ws.append(
+            [
+                "CI-002",
+                "Bad Router",
+                "router",
+                "ACTIVE",
+                "Cisco",
+                "ASR-1000",
+                "SN2",
+                "1.0",
+                "10.0.0.2",
+                "v2c",
+                "public",
+                "private",
+                "BadOwner",
+                "DC-A",
+                0.0,
+                0.0,
+                "Low",
+            ]
+        )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            result = _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            assert isinstance(result, JSONResponse)
+            assert result.status_code == 207
+            data = json.loads(result.body)
+            assert "Processed 1 CIs" in data["message"]
+            assert len(data["errors"]) == 1
+
+    def test_invalid_excel_raises_400(self):
+        """Non-Excel content should raise HTTPException 400."""
+        with pytest.raises(HTTPException) as exc_info:
+            from services.node_service import bulk_upload_nodes
+
+            _run(bulk_upload_nodes(b"not-an-excel-file", "import.xlsx"))
+
+        assert exc_info.value.status_code == 400
+        assert "Error reading Excel file" in exc_info.value.detail
+
+    def test_multiple_valid_rows_processed(self):
+        """Multiple valid rows should all be inserted."""
+        import openpyxl
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.append(
+            [
+                "ID",
+                "Label",
+                "NetworkLayer",
+                "OperationalStatus",
+                "Brand",
+                "Model",
+                "SerialNumber",
+                "Firmware",
+                "IP",
+                "SNMP_Version",
+                "SNMP_Read",
+                "SNMP_Write",
+                "Owner",
+                "Location",
+                "Latitude",
+                "Longitude",
+                "Criticality",
+            ]
+        )
+        for i in range(1, 4):
+            ws.append(
+                [
+                    f"CI-{i:03d}",
+                    f"Router-{i}",
+                    "router",
+                    "ACTIVE",
+                    "Cisco",
+                    "ASR-1000",
+                    f"SN{i}",
+                    "1.0",
+                    f"10.0.0.{i}",
+                    "v2c",
+                    "public",
+                    "private",
+                    "NetOps",
+                    "DC-A",
+                    0.0,
+                    0.0,
+                    "Low",
+                ]
+            )
+        buf = io.BytesIO()
+        wb.save(buf)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_valid_owners_and_layers.return_value = (
+                {"NetOps"},
+                {"router"},
+            )
+            mock_repo.bulk_insert_node = MagicMock()
+
+            from services.node_service import bulk_upload_nodes
+
+            result = _run(bulk_upload_nodes(buf.getvalue(), "import.xlsx"))
+
+            assert mock_repo.bulk_insert_node.call_count == 3
+            content = result
+            if isinstance(content, JSONResponse):
+                data = json.loads(content.body)
+            else:
+                data = content
+            assert "Successfully processed 3" in data["message"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_node_template()
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodeTemplate:
+    """Tests for the get_node_template service function."""
+
+    def test_returns_streaming_response(self):
+        """Should return a StreamingResponse with Excel content."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_template_data.return_value = (
+                ["NetOps", "SecOps"],
+                ["router", "switch"],
+            )
+
+            from services.node_service import get_node_template
+
+            result = get_node_template()
+
+            assert isinstance(result, StreamingResponse)
+
+    def test_template_contains_expected_sheets(self):
+        """Template should contain Data Entry, Owners, and Layers sheets."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_template_data.return_value = (["NetOps"], ["router"])
+
+            from services.node_service import get_node_template
+
+            result = get_node_template()
+
+            # Read the streaming content
+            content = _read_streaming_body(result)
+
+            import openpyxl
+
+            wb = openpyxl.load_workbook(filename=io.BytesIO(content))
+            sheet_names = wb.sheetnames
+            assert "Data Entry Template" in sheet_names
+            assert "Ref - Owners" in sheet_names
+            assert "Ref - Network Layers" in sheet_names
+
+    def test_template_owners_populated_from_repo(self):
+        """Owners reference sheet should contain data from the repo."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_template_data.return_value = (
+                ["NetOps", "SecOps", "CloudOps"],
+                ["router"],
+            )
+
+            from services.node_service import get_node_template
+
+            result = get_node_template()
+
+            content = _read_streaming_body(result)
+
+            import openpyxl
+            import pandas as pd
+
+            owners_df = pd.read_excel(io.BytesIO(content), sheet_name="Ref - Owners")
+            assert list(owners_df["Available Owners"]) == [
+                "NetOps",
+                "SecOps",
+                "CloudOps",
+            ]
+
+    def test_template_layers_populated_from_repo(self):
+        """Layers reference sheet should contain data from the repo."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_template_data.return_value = (
+                ["NetOps"],
+                ["router", "switch", "firewall"],
+            )
+
+            from services.node_service import get_node_template
+
+            result = get_node_template()
+
+            content = _read_streaming_body(result)
+
+            import pandas as pd
+
+            layers_df = pd.read_excel(
+                io.BytesIO(content), sheet_name="Ref - Network Layers"
+            )
+            assert list(layers_df["Available Network Layers"]) == [
+                "router",
+                "switch",
+                "firewall",
+            ]
+
+    def test_template_has_sample_data(self):
+        """Data Entry Template should contain the sample router row."""
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_template_data.return_value = ([], [])
+
+            from services.node_service import get_node_template
+
+            result = get_node_template()
+
+            content = _read_streaming_body(result)
+
+            import pandas as pd
+
+            df = pd.read_excel(io.BytesIO(content), sheet_name="Data Entry Template")
+            assert len(df) == 1
+            assert df.iloc[0]["Label"] == "Sample Router"
+            assert df.iloc[0]["Brand"] == "Cisco"

--- a/backend/tests/test_routers_auth_users_roles.py
+++ b/backend/tests/test_routers_auth_users_roles.py
@@ -1,0 +1,1265 @@
+"""Router-level tests for auth/users/roles endpoints — mocked dependencies.
+
+Focus areas:
+- POST /api/auth/token — login success, wrong password, inactive user, missing user
+- GET /api/auth/users/me — authenticated user retrieval, unauthenticated access
+- POST /api/auth/change-password — success, wrong old password
+- GET /api/users/ — permission enforcement (USER_MANAGE)
+- POST /api/users/ — creation with duplicate check
+- PUT /api/users/{username} — update + permission check
+- DELETE /api/users/{username} — delete + permission check
+- POST /api/users/{username}/reset — admin password reset
+- GET /api/roles/ — permission enforcement (USER_MANAGE or ROLE_MANAGE)
+- POST /api/roles/ — creation + ROLE_MANAGE check
+- PUT /api/roles/{name} — update + is_system protection
+- DELETE /api/roles/{name} — delete + system role protection
+
+Strategy:
+- Use FastAPI TestClient
+- Override DB dependency (get_pg_db) with a mock session
+- Override get_current_active_user to inject fake Pydantic User objects
+- Override Neo4j driver (database.get_db) for roles router
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+# Patch Neo4j driver BEFORE importing anything that touches database.py
+# The driver is created at module import time and tries to connect immediately
+_mock_neo4j_driver = MagicMock()
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    # Import the main app (which imports database.py)
+    from main import app
+    from database import get_db
+
+from models.user import (
+    User,
+    UserInDB,
+    UserCreate,
+    UserUpdate,
+    UserPermission,
+    PasswordChangeRequest,
+    UserResetRequest,
+    Role,
+    RoleCreate,
+)
+from postgres_db import get_pg_db
+from services.auth_service import get_current_active_user
+from repositories import user_repo
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pydantic_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+    disabled: bool = False,
+) -> User:
+    """Create a Pydantic User for injection via dependency override."""
+    return User(
+        username=username,
+        role=role,
+        permissions=permissions or [],
+        allowed_locations=[],
+        disabled=disabled,
+    )
+
+
+def _make_pydantic_user_in_db(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+    disabled: bool = False,
+    hashed_password: str = "$pbkdf2-sha256$fakehash",
+) -> UserInDB:
+    """Create a UserInDB for auth endpoint tests."""
+    return UserInDB(
+        username=username,
+        role=role,
+        permissions=permissions or [],
+        allowed_locations=[],
+        disabled=disabled,
+        password=hashed_password,
+    )
+
+
+def _make_mock_pg_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list | None = None,
+    is_active: bool = True,
+    hashed_password: str = "$pbkdf2-sha256$fakehash",
+):
+    """Create a mock SQLAlchemy User object (simulates DB row)."""
+    mock = MagicMock()
+    mock.username = username
+    mock.role = role
+    mock.permissions = permissions or []
+    mock.is_active = is_active
+    mock.hashed_password = hashed_password
+    mock.allowed_locations = []
+    mock.allowed_ci_types = None
+    mock.phone = None
+    mock.email = None
+    mock.force_password_change = False
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mock DB session
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Provide a mock SQLAlchemy session."""
+    db = MagicMock(spec=Session)
+    return db
+
+
+@pytest.fixture
+def mock_neo4j_driver():
+    """Provide a mock Neo4j driver."""
+    driver = MagicMock()
+    driver.execute_query.return_value = ([], None, None)
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/auth/token
+# ---------------------------------------------------------------------------
+
+
+class TestAuthToken:
+    """Tests for POST /api/auth/token endpoint."""
+
+    def test_login_success(self, mock_db):
+        """Valid credentials should return a token."""
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            role="OPERATOR",
+            is_active=True,
+            hashed_password="$pbkdf2-sha256$29000$abc",
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        # We need to patch verify_password to return True
+        with patch("routers.auth.verify_password", return_value=True):
+            response = client.post(
+                "/api/auth/token",
+                data={"username": "testuser", "password": "correct_password"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_login_wrong_password(self, mock_db):
+        """Wrong password should return 401."""
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            is_active=True,
+            hashed_password="$pbkdf2-sha256$29000$abc",
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_password", return_value=False):
+            response = client.post(
+                "/api/auth/token",
+                data={"username": "testuser", "password": "wrong_password"},
+            )
+
+        assert response.status_code == 401
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_login_user_not_found(self, mock_db):
+        """Non-existent user should return 401."""
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.post(
+            "/api/auth/token",
+            data={"username": "nobody", "password": "any"},
+        )
+
+        assert response.status_code == 401
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_login_inactive_user(self, mock_db):
+        """Inactive (disabled) user should return 400."""
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            is_active=False,
+            hashed_password="$pbkdf2-sha256$29000$abc",
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_password", return_value=True):
+            response = client.post(
+                "/api/auth/token",
+                data={"username": "testuser", "password": "correct_password"},
+            )
+
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/auth/users/me
+# ---------------------------------------------------------------------------
+
+
+class TestAuthUsersMe:
+    """Tests for GET /api/auth/users/me endpoint."""
+
+    def test_get_current_user_success(self):
+        """Authenticated user should receive their own profile."""
+        fake_user = _make_pydantic_user(
+            username="testuser",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/auth/users/me")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["username"] == "testuser"
+        assert data["role"] == "OPERATOR"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_get_current_user_disabled(self):
+        """Disabled user should get 400 from get_current_active_user."""
+        disabled_user = _make_pydantic_user(
+            username="disabled_user",
+            role="VIEWER",
+            disabled=True,
+        )
+
+        async def override_get_current_active_user():
+            from fastapi import HTTPException
+
+            if disabled_user.disabled:
+                raise HTTPException(status_code=400, detail="Inactive user")
+            return disabled_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/auth/users/me")
+
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_get_current_user_unauthenticated(self):
+        """No token should result in 401 from OAuth2PasswordBearer."""
+        # Don't override get_current_active_user — let the real OAuth2 scheme reject
+        response = client.get("/api/auth/users/me")
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/auth/change-password
+# ---------------------------------------------------------------------------
+
+
+class TestAuthChangePassword:
+    """Tests for POST /api/auth/change-password endpoint."""
+
+    def test_change_password_success(self, mock_db):
+        """Valid old password should allow change."""
+        fake_user = _make_pydantic_user(username="testuser", role="OPERATOR")
+        mock_pg_user = _make_mock_pg_user(
+            username="testuser",
+            hashed_password="$pbkdf2-sha256$29000$oldhash",
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_pg_user
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_password", return_value=True):
+            response = client.post(
+                "/api/auth/change-password",
+                json={"old_password": "OldPass123", "new_password": "NewPass456"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_change_password_wrong_old(self, mock_db):
+        """Wrong old password should return 400."""
+        fake_user = _make_pydantic_user(username="testuser", role="OPERATOR")
+        mock_pg_user = _make_mock_pg_user(
+            username="testuser",
+            hashed_password="$pbkdf2-sha256$29000$oldhash",
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_pg_user
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_password", return_value=False):
+            response = client.post(
+                "/api/auth/change-password",
+                json={"old_password": "WrongOld", "new_password": "NewPass456"},
+            )
+
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_change_password_user_not_found(self, mock_db):
+        """If DB user doesn't exist, return 404."""
+        fake_user = _make_pydantic_user(username="ghost_user", role="OPERATOR")
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_password", return_value=True):
+            response = client.post(
+                "/api/auth/change-password",
+                json={"old_password": "OldPass123", "new_password": "NewPass456"},
+            )
+
+        assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Users CRUD — /api/users/
+# ---------------------------------------------------------------------------
+
+
+class TestUsersList:
+    """Tests for GET /api/users/ — list users."""
+
+    def test_list_users_admin_success(self, mock_db):
+        """Admin should be able to list users."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+        mock_pg_user = _make_mock_pg_user(
+            username="testuser",
+            role="OPERATOR",
+            is_active=True,
+        )
+        mock_db.query.return_value.offset.return_value.limit.return_value.all.return_value = [
+            mock_pg_user
+        ]
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.get("/api/users/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["username"] == "testuser"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_list_users_viewer_forbidden(self):
+        """Viewer without USER_MANAGE should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/users/")
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_users_unauthenticated(self):
+        """No auth should return 401."""
+        response = client.get("/api/users/")
+        assert response.status_code == 401
+
+
+class TestUsersCreate:
+    """Tests for POST /api/users/ — create user."""
+
+    def test_create_user_admin_success(self, mock_db):
+        """Admin should be able to create a user."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+        new_pg_user = _make_mock_pg_user(
+            username="newuser",
+            role="OPERATOR",
+            is_active=True,
+            permissions=["EVENT_VIEW"],
+        )
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        # user_repo.create_user has a pre-existing bug: it accesses
+        # user.disabled and user.force_password_change which don't exist
+        # on UserCreate. We must mock the repo call entirely.
+        with patch.object(user_repo, "get_user_by_username", return_value=None):
+            with patch.object(user_repo, "create_user", return_value=new_pg_user):
+                app.dependency_overrides[get_current_active_user] = (
+                    override_get_current_active_user
+                )
+                app.dependency_overrides[get_pg_db] = override_get_db
+
+                response = client.post(
+                    "/api/users/",
+                    json={
+                        "username": "newuser",
+                        "password": "SecureP@ss123",
+                        "role": "OPERATOR",
+                        "permissions": ["EVENT_VIEW"],
+                    },
+                )
+
+                assert response.status_code == 200
+                data = response.json()
+                assert data["username"] == "newuser"
+
+                app.dependency_overrides.pop(get_current_active_user, None)
+                app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_create_user_duplicate_username(self, mock_db):
+        """Creating a user with existing username should return 400."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+        existing_pg_user = _make_mock_pg_user(username="existing_user")
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            existing_pg_user
+        )
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.post(
+            "/api/users/",
+            json={
+                "username": "existing_user",
+                "password": "SecureP@ss123",
+            },
+        )
+
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_create_user_viewer_forbidden(self):
+        """Viewer without USER_MANAGE should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/users/",
+            json={
+                "username": "newuser",
+                "password": "SecureP@ss123",
+            },
+        )
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestUsersUpdate:
+    """Tests for PUT /api/users/{username} — update user."""
+
+    def test_update_user_admin_success(self, mock_db):
+        """Admin should be able to update a user."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+        updated_pg_user = _make_mock_pg_user(
+            username="testuser",
+            role="ADMIN",
+            is_active=True,
+        )
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        # update_user calls get_user_by_username internally
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            updated_pg_user
+        )
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.put(
+            "/api/users/testuser",
+            json={"role": "ADMIN"},
+        )
+
+        assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_update_user_not_found(self, mock_db):
+        """Updating non-existent user should return 404."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.put(
+            "/api/users/nonexistent",
+            json={"role": "ADMIN"},
+        )
+
+        assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_update_user_viewer_forbidden(self):
+        """Viewer should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.put(
+            "/api/users/testuser",
+            json={"role": "ADMIN"},
+        )
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestUsersDelete:
+    """Tests for DELETE /api/users/{username} — delete user."""
+
+    def test_delete_user_admin_success(self, mock_db):
+        """Admin should be able to delete a user."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        # delete_user calls get_user_by_username
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            _make_mock_pg_user(username="testuser")
+        )
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.delete("/api/users/testuser")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_delete_user_not_found(self, mock_db):
+        """Deleting non-existent user should return 404."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.delete("/api/users/nonexistent")
+
+        assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_delete_user_viewer_forbidden(self):
+        """Viewer should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.delete("/api/users/testuser")
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestUsersResetPassword:
+    """Tests for POST /api/users/{username}/reset — admin password reset."""
+
+    def test_reset_password_admin_success(self, mock_db):
+        """Admin should be able to reset a user's password."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+        target_pg_user = _make_mock_pg_user(
+            username="target_user",
+            is_active=True,
+        )
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            target_pg_user
+        )
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.post(
+            "/api/users/target_user/reset",
+            json={"new_password": "ResetP@ss123"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Password reset" in data["message"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_reset_password_no_password(self, mock_db):
+        """Reset without new_password should return 422 (Pydantic validation)."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        def override_get_db():
+            yield mock_db
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        # Sending empty JSON body triggers Pydantic validation error (422)
+        # because UserResetRequest requires new_password.
+        # The endpoint's own check (reset_data is None -> 400) is unreachable
+        # via JSON body since Pydantic rejects it first.
+        response = client.post(
+            "/api/users/target_user/reset",
+            json={},
+        )
+
+        assert response.status_code == 422
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_reset_password_viewer_forbidden(self):
+        """Viewer should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/users/target_user/reset",
+            json={"new_password": "ResetP@ss123"},
+        )
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Roles CRUD — /api/roles/
+# ---------------------------------------------------------------------------
+
+
+class _FakeNeo4jNode:
+    """Mimics a Neo4j node so that dict(node) and node.get() work correctly."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def keys(self):
+        return self._data.keys()
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def items(self):
+        return self._data.items()
+
+
+class TestRolesList:
+    """Tests for GET /api/roles/ — list roles."""
+
+    def test_list_roles_admin_success(self, mock_neo4j_driver):
+        """Admin should be able to list roles."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        # roles.py calls get_db_driver() directly, not via Depends()
+        # so we must patch the function at the router module level
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            # Mock Neo4j results — use FakeNeo4jNode so dict(node) works
+            mock_node = _FakeNeo4jNode(
+                {
+                    "name": "ADMIN",
+                    "description": "System admin",
+                    "permissions": ["EVENT_VIEW", "CI_EDIT"],
+                    "is_system": True,
+                }
+            )
+            mock_record = {"r": mock_node}
+            mock_neo4j_driver.execute_query.return_value = (
+                [mock_record],
+                None,
+                None,
+            )
+
+            response = client.get("/api/roles/")
+
+            assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_roles_viewer_forbidden(self):
+        """Viewer without USER_MANAGE or ROLE_MANAGE should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/roles/")
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_roles_operator_with_user_manage(self, mock_neo4j_driver):
+        """Operator with USER_MANAGE should be able to list roles."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.USER_MANAGE],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            mock_neo4j_driver.execute_query.return_value = ([], None, None)
+            response = client.get("/api/roles/")
+
+        # The key assertion: it should NOT be 403
+        assert response.status_code != 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestRolesCreate:
+    """Tests for POST /api/roles/ — create role."""
+
+    def test_create_role_admin_success(self, mock_neo4j_driver):
+        """Admin with ROLE_MANAGE should create a role."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        # First execute_query: check exists (empty results)
+        # Second execute_query: create (with result)
+        mock_create_node = _FakeNeo4jNode(
+            {
+                "name": "CustomRole",
+                "description": "A custom role",
+                "permissions": ["EVENT_VIEW"],
+                "is_system": False,
+            }
+        )
+        mock_create_record = {"r": mock_create_node}
+
+        call_count = [0]
+
+        def mock_execute(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ([], None, None)
+            return ([mock_create_record], None, None)
+
+        mock_neo4j_driver.execute_query.side_effect = mock_execute
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.post(
+                "/api/roles/",
+                json={
+                    "name": "CustomRole",
+                    "description": "A custom role",
+                    "permissions": ["EVENT_VIEW"],
+                },
+            )
+
+            assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_role_duplicate(self, mock_neo4j_driver):
+        """Creating a role that already exists should return 400."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_existing_node = _FakeNeo4jNode({"name": "ExistingRole"})
+        mock_record = {"r": mock_existing_node}
+        mock_neo4j_driver.execute_query.return_value = ([mock_record], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.post(
+                "/api/roles/",
+                json={
+                    "name": "ExistingRole",
+                    "permissions": ["EVENT_VIEW"],
+                },
+            )
+
+            assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_role_viewer_forbidden(self):
+        """Viewer should get 403 on role creation."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/roles/",
+            json={"name": "NewRole", "permissions": ["EVENT_VIEW"]},
+        )
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestRolesUpdate:
+    """Tests for PUT /api/roles/{name} — update role."""
+
+    def test_update_role_admin_success(self, mock_neo4j_driver):
+        """Admin should be able to update a non-system role."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_node = _FakeNeo4jNode(
+            {
+                "name": "CustomRole",
+                "description": "Updated description",
+                "permissions": ["EVENT_VIEW", "CI_EDIT"],
+                "is_system": False,
+            }
+        )
+        mock_record = {"r": mock_node}
+        mock_neo4j_driver.execute_query.return_value = ([mock_record], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.put(
+                "/api/roles/CustomRole",
+                json={"description": "Updated description"},
+            )
+
+            assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_update_system_role_forbidden(self, mock_neo4j_driver):
+        """Updating a system role should return 400."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_node = _FakeNeo4jNode(
+            {
+                "name": "ADMIN",
+                "is_system": True,
+            }
+        )
+        mock_record = {"r": mock_node}
+        mock_neo4j_driver.execute_query.return_value = ([mock_record], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.put(
+                "/api/roles/ADMIN",
+                json={"description": "Should not work"},
+            )
+
+            assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_update_role_not_found(self, mock_neo4j_driver):
+        """Updating non-existent role should return 404."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_neo4j_driver.execute_query.return_value = ([], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.put(
+                "/api/roles/NonExistent",
+                json={"description": "Should fail"},
+            )
+
+            assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestRolesDelete:
+    """Tests for DELETE /api/roles/{name} — delete role."""
+
+    def test_delete_role_admin_success(self, mock_neo4j_driver):
+        """Admin should be able to delete a non-system, unassigned role."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        call_count = [0]
+
+        def mock_execute(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # Check existence
+                mock_node = _FakeNeo4jNode(
+                    {
+                        "name": "CustomRole",
+                        "is_system": False,
+                    }
+                )
+                return ([{"r": mock_node}], None, None)
+            elif call_count[0] == 2:
+                # Usage check — no users
+                return ([{"count": 0}], None, None)
+            return ([], None, None)
+
+        mock_neo4j_driver.execute_query.side_effect = mock_execute
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.delete("/api/roles/CustomRole")
+
+            assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_delete_system_role_forbidden(self, mock_neo4j_driver):
+        """Deleting a system role should return 400."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_node = _FakeNeo4jNode({"name": "ADMIN", "is_system": True})
+        mock_record = {"r": mock_node}
+        mock_neo4j_driver.execute_query.return_value = ([mock_record], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.delete("/api/roles/ADMIN")
+
+            assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_delete_role_with_assigned_users(self, mock_neo4j_driver):
+        """Deleting a role assigned to users should return 400."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        call_count = [0]
+
+        def mock_execute(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                mock_node = _FakeNeo4jNode(
+                    {
+                        "name": "CustomRole",
+                        "is_system": False,
+                    }
+                )
+                return ([{"r": mock_node}], None, None)
+            elif call_count[0] == 2:
+                return ([{"count": 3}], None, None)
+            return ([], None, None)
+
+        mock_neo4j_driver.execute_query.side_effect = mock_execute
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.delete("/api/roles/CustomRole")
+
+            assert response.status_code == 400
+            assert "assigned to users" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_delete_role_not_found(self, mock_neo4j_driver):
+        """Deleting non-existent role should return 404."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_neo4j_driver.execute_query.return_value = ([], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.delete("/api/roles/NonExistent")
+
+            assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_current_active_user, None)

--- a/backend/tests/test_routers_catalog.py
+++ b/backend/tests/test_routers_catalog.py
@@ -1,0 +1,841 @@
+"""Router-level tests for catalog endpoints - mocked dependencies.
+
+Focus areas:
+- Catalog router has NO authentication. All endpoints are public.
+- Happy path coverage for categories, hardware, and owner groups.
+- Representative error coverage via mocked service exceptions and validation.
+
+Strategy:
+- Patch Neo4j driver BEFORE importing main (avoids real connection at import)
+- Use FastAPI TestClient
+- Mock routers.catalog.catalog_service for router-level isolation
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Patch Neo4j driver BEFORE importing anything that touches database.py
+# ---------------------------------------------------------------------------
+_mock_neo4j_driver = MagicMock()
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from main import app
+
+from models.user import User, UserPermission
+from services.auth_service import get_current_active_user
+
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+
+def _make_pydantic_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+) -> User:
+    return User(
+        username=username,
+        role=role,
+        permissions=permissions or [],
+        allowed_locations=[],
+    )
+
+
+def _override_current_user(user: User) -> None:
+    async def override_get_current_active_user():
+        return user
+
+    app.dependency_overrides[get_current_active_user] = override_get_current_active_user
+
+
+def _request(method: str, url: str, json=None, params=None):
+    return client.request(method.upper(), url, json=json, params=params)
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides():
+    original_overrides = app.dependency_overrides.copy()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+
+class TestCategoriesRouter:
+    """Tests for category catalog endpoints."""
+
+    def test_get_categories_returns_empty(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_categories.return_value = []
+
+            response = client.get("/api/categories")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_categories_returns_data(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_categories.return_value = [
+                {"name": "Router"},
+                {"name": "Switch"},
+            ]
+
+            response = client.get("/api/categories")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["name"] == "Router"
+
+    def test_get_categories_no_auth_required(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_categories.return_value = []
+
+            response = client.get("/api/categories")
+
+        assert response.status_code == 200
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+    @pytest.mark.parametrize(
+        ("method", "url", "json"),
+        [
+            ("post", "/api/categories", {"name": "Router"}),
+            ("put", "/api/categories/Router", {"name": "Edge Router"}),
+            ("delete", "/api/categories/Router", None),
+        ],
+    )
+    def test_category_mutations_require_authentication(self, method, url, json):
+        response = _request(method, url, json=json)
+
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(
+        ("method", "url", "json", "permission"),
+        [
+            ("post", "/api/categories", {"name": "Router"}, UserPermission.CI_EDIT),
+            (
+                "put",
+                "/api/categories/Router",
+                {"name": "Edge Router"},
+                UserPermission.CI_EDIT,
+            ),
+            ("delete", "/api/categories/Router", None, UserPermission.CI_DELETE),
+        ],
+    )
+    def test_category_mutations_require_permissions(
+        self, method, url, json, permission
+    ):
+        _override_current_user(_make_pydantic_user())
+
+        response = _request(method, url, json=json)
+
+        assert response.status_code == 403
+
+        _override_current_user(_make_pydantic_user(permissions=[permission]))
+        with patch("routers.catalog.catalog_service") as mock_service:
+            if method == "post":
+                mock_service.create_category.return_value = {"message": "ok"}
+            elif method == "put":
+                mock_service.update_category.return_value = {"message": "ok"}
+            else:
+                mock_service.delete_category.return_value = {"message": "ok"}
+
+            success_response = _request(method, url, json=json)
+
+        assert success_response.status_code == 200
+
+    def test_create_category_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_category.return_value = {"message": "Category created"}
+
+            response = client.post("/api/categories", json={"name": "Router"})
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Category created"
+        sent_category = mock_service.create_category.call_args.args[0]
+        assert sent_category.name == "Router"
+
+    def test_create_category_conflict(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_category.side_effect = HTTPException(
+                status_code=409,
+                detail="Category already exists",
+            )
+
+            response = client.post("/api/categories", json={"name": "Router"})
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "Category already exists"
+
+    def test_create_category_validation_error(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        response = client.post("/api/categories", json={})
+
+        assert response.status_code == 422
+
+    def test_delete_category_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_DELETE])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.delete_category.return_value = {"message": "Category deleted"}
+
+            response = client.delete("/api/categories/Router")
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Category deleted"
+        mock_service.delete_category.assert_called_once_with("Router")
+
+    def test_update_category_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_category.return_value = {"message": "Category updated"}
+
+            response = client.put(
+                "/api/categories/Router",
+                json={"name": "Edge Router"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Category updated"
+        mock_service.update_category.assert_called_once_with("Router", "Edge Router")
+
+    def test_get_category_usage_success(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_category_usage.return_value = {"count": 4}
+
+            response = client.get("/api/categories/Router/usage")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 4}
+        mock_service.get_category_usage.assert_called_once_with("Router")
+
+
+class TestHardwareRouter:
+    """Tests for hardware catalog endpoints."""
+
+    def test_get_hardware_catalog_returns_empty(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_hardware_catalog.return_value = []
+
+            response = client.get("/api/hardware")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_hardware_catalog_returns_data(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_hardware_catalog.return_value = [
+                {
+                    "brand": "Cisco",
+                    "model": "ASR-1000",
+                    "category": "Router",
+                    "owner": "NetOps",
+                }
+            ]
+
+            response = client.get("/api/hardware")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["brand"] == "Cisco"
+        assert data[0]["model"] == "ASR-1000"
+
+    @pytest.mark.parametrize(
+        ("method", "url", "json", "params"),
+        [
+            (
+                "post",
+                "/api/hardware",
+                {
+                    "brand": "Cisco",
+                    "model": "ASR-1000",
+                    "category": "Router",
+                    "owner": "NetOps",
+                },
+                None,
+            ),
+            ("put", "/api/hardware/Cisco/ASR-1000", {"category": "Router"}, None),
+            ("delete", "/api/hardware/Cisco/ASR-1000", None, None),
+            (
+                "post",
+                "/api/hardware/assign_metric",
+                None,
+                {"brand": "Cisco", "model": "ASR-1000", "metric_id": "cpu-load"},
+            ),
+            (
+                "post",
+                "/api/hardware/unassign_metric",
+                None,
+                {"brand": "Cisco", "model": "ASR-1000", "metric_id": "cpu-load"},
+            ),
+        ],
+    )
+    def test_hardware_mutations_require_authentication(self, method, url, json, params):
+        response = _request(method, url, json=json, params=params)
+
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(
+        ("method", "url", "json", "params", "permission"),
+        [
+            (
+                "post",
+                "/api/hardware",
+                {
+                    "brand": "Cisco",
+                    "model": "ASR-1000",
+                    "category": "Router",
+                    "owner": "NetOps",
+                },
+                None,
+                UserPermission.CI_EDIT,
+            ),
+            (
+                "put",
+                "/api/hardware/Cisco/ASR-1000",
+                {"category": "Router"},
+                None,
+                UserPermission.CI_EDIT,
+            ),
+            (
+                "delete",
+                "/api/hardware/Cisco/ASR-1000",
+                None,
+                None,
+                UserPermission.CI_DELETE,
+            ),
+            (
+                "post",
+                "/api/hardware/assign_metric",
+                None,
+                {"brand": "Cisco", "model": "ASR-1000", "metric_id": "cpu-load"},
+                UserPermission.CI_EDIT,
+            ),
+            (
+                "post",
+                "/api/hardware/unassign_metric",
+                None,
+                {"brand": "Cisco", "model": "ASR-1000", "metric_id": "cpu-load"},
+                UserPermission.CI_EDIT,
+            ),
+        ],
+    )
+    def test_hardware_mutations_require_permissions(
+        self, method, url, json, params, permission
+    ):
+        _override_current_user(_make_pydantic_user())
+
+        response = _request(method, url, json=json, params=params)
+
+        assert response.status_code == 403
+
+        _override_current_user(_make_pydantic_user(permissions=[permission]))
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_hardware_model.return_value = {"message": "ok"}
+            mock_service.update_hardware_model.return_value = {"message": "ok"}
+            mock_service.delete_hardware_model.return_value = {"message": "ok"}
+            mock_service.assign_metric_to_model.return_value = {"message": "ok"}
+            mock_service.unassign_metric_from_model.return_value = {"message": "ok"}
+
+            success_response = _request(method, url, json=json, params=params)
+
+        assert success_response.status_code == 200
+
+    def test_create_hardware_model_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_hardware_model.return_value = {
+                "message": "Hardware Model saved"
+            }
+
+            response = client.post(
+                "/api/hardware",
+                json={
+                    "brand": "Cisco",
+                    "model": "ASR-1000",
+                    "category": "Router",
+                    "owner": "NetOps",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Hardware Model saved"
+        sent_item = mock_service.create_hardware_model.call_args.args[0]
+        assert sent_item.brand == "Cisco"
+        assert sent_item.model == "ASR-1000"
+        assert sent_item.category == "Router"
+        assert sent_item.owner == "NetOps"
+
+    def test_create_hardware_model_validation_error(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        response = client.post("/api/hardware", json={"brand": "Cisco"})
+
+        assert response.status_code == 422
+
+    def test_delete_hardware_model_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_DELETE])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.delete_hardware_model.return_value = {
+                "message": "Hardware Model deleted"
+            }
+
+            response = client.delete("/api/hardware/Cisco/ASR-1000")
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Hardware Model deleted"
+        mock_service.delete_hardware_model.assert_called_once_with("Cisco", "ASR-1000")
+
+    def test_update_hardware_model_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_hardware_model.return_value = {
+                "message": "Hardware Model updated"
+            }
+
+            response = client.put(
+                "/api/hardware/Cisco/ASR-1000",
+                json={
+                    "brand": "Cisco",
+                    "model": "ASR-1000-X",
+                    "category": "Router",
+                    "owner": "CoreOps",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Hardware Model updated"
+        old_brand, old_model, hw_update = (
+            mock_service.update_hardware_model.call_args.args
+        )
+        assert old_brand == "Cisco"
+        assert old_model == "ASR-1000"
+        assert hw_update.brand == "Cisco"
+        assert hw_update.model == "ASR-1000-X"
+        assert hw_update.category == "Router"
+        assert hw_update.owner == "CoreOps"
+
+    def test_update_hardware_model_uses_path_defaults(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_hardware_model.return_value = {
+                "message": "Hardware Model updated"
+            }
+
+            response = client.put(
+                "/api/hardware/Cisco/ASR-1000",
+                json={"category": "Router"},
+            )
+
+        assert response.status_code == 200
+        _, _, hw_update = mock_service.update_hardware_model.call_args.args
+        assert hw_update.brand == "Cisco"
+        assert hw_update.model == "ASR-1000"
+        assert hw_update.category == "Router"
+        assert hw_update.owner is None
+
+    def test_update_hardware_model_not_found(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_hardware_model.side_effect = HTTPException(
+                status_code=404,
+                detail="Hardware model not found",
+            )
+
+            response = client.put(
+                "/api/hardware/Cisco/ASR-404",
+                json={"owner": "NetOps"},
+            )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Hardware model not found"
+
+    def test_get_hardware_usage_success(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_hardware_usage.return_value = {"count": 7}
+
+            response = client.get("/api/hardware/Cisco/ASR-1000/usage")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 7}
+        mock_service.get_hardware_usage.assert_called_once_with("Cisco", "ASR-1000")
+
+    def test_assign_metric_to_model_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.assign_metric_to_model.return_value = {
+                "message": "Metric assigned to model"
+            }
+
+            response = client.post(
+                "/api/hardware/assign_metric",
+                params={"brand": "Cisco", "model": "ASR-1000", "metric_id": "cpu-load"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Metric assigned to model"
+        mock_service.assign_metric_to_model.assert_called_once_with(
+            "Cisco", "ASR-1000", "cpu-load"
+        )
+
+    def test_unassign_metric_from_model_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.unassign_metric_from_model.return_value = {
+                "message": "Metric unassigned from model"
+            }
+
+            response = client.post(
+                "/api/hardware/unassign_metric",
+                params={"brand": "Cisco", "model": "ASR-1000", "metric_id": "cpu-load"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Metric unassigned from model"
+        mock_service.unassign_metric_from_model.assert_called_once_with(
+            "Cisco", "ASR-1000", "cpu-load"
+        )
+
+    def test_assign_metric_requires_query_params(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        response = client.post("/api/hardware/assign_metric", params={"brand": "Cisco"})
+
+        assert response.status_code == 422
+
+
+class TestOwnersRouter:
+    """Tests for owner group catalog endpoints."""
+
+    def test_get_owners_returns_empty(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_owners.return_value = []
+
+            response = client.get("/api/owners")
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_get_owners_returns_data(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_owners.return_value = [
+                {
+                    "name": "NetOps",
+                    "users": [
+                        {
+                            "name": "alice",
+                            "email": "alice@example.com",
+                            "phone": "+541100000000",
+                        }
+                    ],
+                }
+            ]
+
+            response = client.get("/api/owners")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "NetOps"
+        assert data[0]["users"][0]["name"] == "alice"
+
+    @pytest.mark.parametrize(
+        ("method", "url", "json"),
+        [
+            ("post", "/api/owners", {"name": "NetOps", "users": []}),
+            ("put", "/api/owners/NetOps", {"name": "CoreOps"}),
+            ("delete", "/api/owners/NetOps", None),
+            (
+                "post",
+                "/api/owners/NetOps/users",
+                {
+                    "username": "alice",
+                    "role": "VIEWER",
+                    "permissions": [],
+                    "allowed_locations": [],
+                },
+            ),
+            ("delete", "/api/owners/NetOps/users/alice", None),
+        ],
+    )
+    def test_owner_mutations_require_authentication(self, method, url, json):
+        response = _request(method, url, json=json)
+
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize(
+        ("method", "url", "json", "permission"),
+        [
+            (
+                "post",
+                "/api/owners",
+                {"name": "NetOps", "users": []},
+                UserPermission.CI_EDIT,
+            ),
+            ("put", "/api/owners/NetOps", {"name": "CoreOps"}, UserPermission.CI_EDIT),
+            ("delete", "/api/owners/NetOps", None, UserPermission.CI_DELETE),
+            (
+                "post",
+                "/api/owners/NetOps/users",
+                {
+                    "username": "alice",
+                    "role": "VIEWER",
+                    "permissions": [],
+                    "allowed_locations": [],
+                },
+                UserPermission.CI_EDIT,
+            ),
+            (
+                "delete",
+                "/api/owners/NetOps/users/alice",
+                None,
+                UserPermission.CI_DELETE,
+            ),
+        ],
+    )
+    def test_owner_mutations_require_permissions(self, method, url, json, permission):
+        _override_current_user(_make_pydantic_user())
+
+        response = _request(method, url, json=json)
+
+        assert response.status_code == 403
+
+        _override_current_user(_make_pydantic_user(permissions=[permission]))
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_owner_group.return_value = {"message": "ok"}
+            mock_service.update_owner_group.return_value = {"message": "ok"}
+            mock_service.delete_owner_group.return_value = {"message": "ok"}
+            mock_service.link_user_to_group.return_value = {"message": "ok"}
+            mock_service.unlink_user_from_group.return_value = {"message": "ok"}
+
+            success_response = _request(method, url, json=json)
+
+        assert success_response.status_code == 200
+
+    def test_create_owner_group_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_owner_group.return_value = {
+                "message": "Owner Group created/updated"
+            }
+
+            response = client.post(
+                "/api/owners",
+                json={
+                    "name": "NetOps",
+                    "users": [
+                        {
+                            "name": "alice",
+                            "email": "alice@example.com",
+                            "phone": "+541100000000",
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Owner Group created/updated"
+        sent_group = mock_service.create_owner_group.call_args.args[0]
+        assert sent_group.name == "NetOps"
+        assert sent_group.users[0]["name"] == "alice"
+
+    def test_delete_owner_group_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_DELETE])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.delete_owner_group.return_value = {
+                "message": "Owner Group deleted"
+            }
+
+            response = client.delete("/api/owners/NetOps")
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Owner Group deleted"
+        mock_service.delete_owner_group.assert_called_once_with("NetOps")
+
+    def test_update_owner_group_success_with_users(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_owner_group.return_value = {
+                "message": "Owner Group updated"
+            }
+
+            response = client.put(
+                "/api/owners/NetOps",
+                json={
+                    "name": "CoreOps",
+                    "users": [
+                        {
+                            "name": "bob",
+                            "email": "bob@example.com",
+                            "phone": "+541122233344",
+                        }
+                    ],
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Owner Group updated"
+        old_name, owner_update = mock_service.update_owner_group.call_args.args
+        assert old_name == "NetOps"
+        assert owner_update.name == "CoreOps"
+        assert owner_update.users[0]["name"] == "bob"
+
+    def test_update_owner_group_preserves_users_as_none_when_omitted(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_owner_group.return_value = {
+                "message": "Owner Group updated"
+            }
+
+            response = client.put(
+                "/api/owners/NetOps",
+                json={"name": "CoreOps"},
+            )
+
+        assert response.status_code == 200
+        _, owner_update = mock_service.update_owner_group.call_args.args
+        assert owner_update.name == "CoreOps"
+        assert owner_update.users is None
+
+    def test_get_owner_usage_success(self):
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_owner_usage.return_value = {"count": 3, "user_count": 2}
+
+            response = client.get("/api/owners/NetOps/usage")
+
+        assert response.status_code == 200
+        assert response.json() == {"count": 3, "user_count": 2}
+        mock_service.get_owner_usage.assert_called_once_with("NetOps")
+
+    def test_link_user_to_group_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.link_user_to_group.return_value = {
+                "message": "User linked to group"
+            }
+
+            response = client.post(
+                "/api/owners/NetOps/users",
+                json={
+                    "username": "alice",
+                    "role": "VIEWER",
+                    "permissions": [],
+                    "allowed_locations": [],
+                    "email": "alice@example.com",
+                    "phone": "+541100000000",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "User linked to group"
+        mock_service.link_user_to_group.assert_called_once_with(
+            "NetOps",
+            {
+                "username": "alice",
+                "role": "VIEWER",
+                "permissions": [],
+                "allowed_locations": [],
+                "allowed_ci_types": None,
+                "phone": "+541100000000",
+                "email": "alice@example.com",
+                "disabled": False,
+                "force_password_change": False,
+            },
+        )
+
+    def test_link_user_to_group_validation_error(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        response = client.post(
+            "/api/owners/NetOps/users",
+            json={"role": "VIEWER"},
+        )
+
+        assert response.status_code == 422
+
+    def test_link_user_to_group_not_found(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.link_user_to_group.side_effect = HTTPException(
+                status_code=404,
+                detail="Owner group not found",
+            )
+
+            response = client.post(
+                "/api/owners/MissingGroup/users",
+                json={
+                    "username": "alice",
+                    "role": "VIEWER",
+                    "permissions": [],
+                    "allowed_locations": [],
+                },
+            )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Owner group not found"
+
+    def test_unlink_user_from_group_success(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_DELETE])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.unlink_user_from_group.return_value = {
+                "message": "User unlinked from group"
+            }
+
+            response = client.delete("/api/owners/NetOps/users/alice")
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "User unlinked from group"
+        mock_service.unlink_user_from_group.assert_called_once_with("NetOps", "alice")

--- a/backend/tests/test_routers_links.py
+++ b/backend/tests/test_routers_links.py
@@ -1,0 +1,332 @@
+"""Router-level tests for links endpoints — mocked dependencies.
+
+Focus areas:
+- Links: NO auth on any endpoint (documented gap). All endpoints are public.
+- GET /api/links — list all relationship links
+- POST /api/links — create a relationship
+- DELETE /api/links — delete a relationship
+- GET /api/graph/full — fetch complete graph topology
+
+Strategy:
+- Patch Neo4j driver BEFORE importing main (avoids real connection at import)
+- Use FastAPI TestClient
+- Mock topology_repo functions for service-layer isolation
+- Document the auth gap (no endpoint requires authentication)
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Patch Neo4j driver BEFORE importing anything that touches database.py
+# ---------------------------------------------------------------------------
+_mock_neo4j_driver = MagicMock()
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from main import app
+    from database import get_db
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+
+# ===========================================================================
+# LINKS ROUTER TESTS
+# ===========================================================================
+# NOTE: The links router has NO authentication. All endpoints are public.
+# This is a known security gap — these tests document the current behavior.
+# ===========================================================================
+
+
+class TestLinksList:
+    """Tests for GET /api/links — list all relationship links."""
+
+    def test_list_links_returns_empty(self):
+        """Should return empty list when no links exist."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_links.return_value = []
+
+            response = client.get("/api/links")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) == 0
+
+    def test_list_links_returns_data(self):
+        """Should return link definitions when they exist."""
+        sample_links = [
+            {
+                "source": "ci-001",
+                "source_label": "Router-01",
+                "target": "ci-002",
+                "target_label": "Switch-01",
+                "relationship": "CONNECTS_TO",
+            },
+            {
+                "source": "ci-002",
+                "source_label": "Switch-01",
+                "target": "ci-003",
+                "target_label": "Server-01",
+                "relationship": "HOSTED_ON",
+            },
+        ]
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_links.return_value = sample_links
+
+            response = client.get("/api/links")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        assert data[0]["source"] == "ci-001"
+        assert data[0]["relationship"] == "CONNECTS_TO"
+        assert data[1]["relationship"] == "HOSTED_ON"
+
+    def test_list_links_no_auth_required(self):
+        """Links list should NOT require authentication (documented gap)."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_links.return_value = []
+
+            response = client.get("/api/links")
+
+        assert response.status_code == 200
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+
+class TestLinksCreate:
+    """Tests for POST /api/links — create a relationship."""
+
+    def test_create_link_success(self):
+        """Should create a link between two nodes."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.create_link.return_value = None
+
+            response = client.post(
+                "/api/links",
+                json={
+                    "source": "ci-001",
+                    "target": "ci-002",
+                    "relationship": "DEPENDS_ON",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Link created" in data["message"]
+        mock_repo.create_link.assert_called_once_with("ci-001", "ci-002", "DEPENDS_ON")
+
+    def test_create_link_validates_required_fields(self):
+        """Should reject request missing required fields (source, target, relationship)."""
+        response = client.post(
+            "/api/links",
+            json={"source": "ci-001"},
+        )
+
+        assert response.status_code == 422
+
+    def test_create_link_no_auth_required(self):
+        """Create link should NOT require auth (documented gap)."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.create_link.return_value = None
+
+            response = client.post(
+                "/api/links",
+                json={
+                    "source": "ci-001",
+                    "target": "ci-002",
+                    "relationship": "CONNECTS_TO",
+                },
+            )
+
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+
+class TestLinksDelete:
+    """Tests for DELETE /api/links — delete a relationship."""
+
+    def test_delete_link_success(self):
+        """Should delete a link between two nodes."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.delete_link.return_value = None
+
+            response = client.request(
+                "DELETE",
+                "/api/links",
+                json={
+                    "source": "ci-001",
+                    "target": "ci-002",
+                    "relationship": "DEPENDS_ON",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Link deleted" in data["message"]
+        mock_repo.delete_link.assert_called_once_with("ci-001", "ci-002", "DEPENDS_ON")
+
+    def test_delete_link_validates_required_fields(self):
+        """Should reject request missing required fields."""
+        response = client.request(
+            "DELETE",
+            "/api/links",
+            json={"source": "ci-001"},
+        )
+
+        assert response.status_code == 422
+
+    def test_delete_link_no_auth_required(self):
+        """Delete link should NOT require auth (documented gap)."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.delete_link.return_value = None
+
+            response = client.request(
+                "DELETE",
+                "/api/links",
+                json={
+                    "source": "ci-001",
+                    "target": "ci-002",
+                    "relationship": "CONNECTS_TO",
+                },
+            )
+
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+
+class TestGraphFull:
+    """Tests for GET /api/graph/full — fetch complete graph topology."""
+
+    def test_full_graph_returns_empty(self):
+        """Should return empty graph when no data exists."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_full_graph_data.return_value = ([], [])
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "nodes" in data
+        assert "links" in data
+        assert len(data["nodes"]) == 0
+        assert len(data["links"]) == 0
+
+    def test_full_graph_returns_data(self):
+        """Should return formatted nodes and links from graph data."""
+        raw_nodes = [
+            {
+                "id": "ci-001",
+                "name": "Router-01",
+                "status": "OK",
+                "_labels": ["CI"],
+            },
+            {
+                "id": "ci-002",
+                "name": "Switch-01",
+                "status": "WARNING",
+                "_labels": ["CI"],
+            },
+            {
+                "id": "cpu-load",
+                "protocol": "SNMP",
+                "_labels": ["MetricDef"],
+            },
+        ]
+        raw_links = [
+            {
+                "source_node": {"id": "ci-001", "name": "Router-01"},
+                "target_node": {"id": "ci-002", "name": "Switch-01"},
+                "type": "CONNECTS_TO",
+            },
+        ]
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_full_graph_data.return_value = (raw_nodes, raw_links)
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["nodes"]) == 3
+        assert len(data["links"]) == 1
+        assert data["links"][0]["source"] == "ci-001"
+        assert data["links"][0]["target"] == "ci-002"
+        assert data["links"][0]["relationship"] == "CONNECTS_TO"
+
+    def test_full_graph_handles_fallback_ids(self):
+        """Should handle nodes without explicit ID using name/label fallback."""
+        raw_nodes = [
+            {
+                "name": "Router-01",
+                "status": "OK",
+                "_labels": ["CI"],
+            },
+            {
+                "brand": "Cisco",
+                "model": "ASR-1000",
+                "_labels": ["HardwareModel"],
+            },
+        ]
+        raw_links = []
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_full_graph_data.return_value = (raw_nodes, raw_links)
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["nodes"]) == 2
+        # First node: uses name as fallback
+        assert data["nodes"][0]["id"] == "Router-01"
+        assert data["nodes"][0]["type"] == "CI"
+        # Second node: uses "Brand Model" as fallback
+        assert data["nodes"][1]["id"] == "Cisco ASR-1000"
+        assert data["nodes"][1]["type"] == "Hardware"
+
+    def test_full_graph_categorizes_node_types(self):
+        """Should correctly categorize nodes by their Neo4j labels."""
+        raw_nodes = [
+            {"id": "cat-1", "name": "Router", "_labels": ["Category"]},
+            {"id": "owner-1", "name": "NetOps", "_labels": ["OwnerGroup"]},
+            {"id": "user-1", "name": "admin", "_labels": ["User"]},
+            {
+                "id": "hw-1",
+                "brand": "Cisco",
+                "model": "ISR4K",
+                "_labels": ["HardwareModel"],
+            },
+            {"id": "metric-1", "protocol": "SNMP", "_labels": ["MetricDef"]},
+            {"id": "unknown-1", "name": "Something", "_labels": ["CustomLabel"]},
+        ]
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_full_graph_data.return_value = (raw_nodes, [])
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        data = response.json()
+        types = {n["id"]: n["type"] for n in data["nodes"]}
+        assert types["cat-1"] == "Category"
+        assert types["owner-1"] == "Owner"
+        assert types["user-1"] == "User"
+        assert types["hw-1"] == "Hardware"
+        assert types["metric-1"] == "Metric"
+        assert types["unknown-1"] == "Unknown"
+
+    def test_full_graph_no_auth_required(self):
+        """Full graph should NOT require authentication (documented gap)."""
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_full_graph_data.return_value = ([], [])
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        assert response.status_code != 401
+        assert response.status_code != 403

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -1,0 +1,1156 @@
+"""Router-level tests for metrics and events endpoints with mocked dependencies.
+
+Focus areas:
+- Metrics: list/usage/history remain public, while create/delete/promote require
+  authentication plus CI_EDIT. Tests cover CRUD, usage, promotion, validation,
+  and history with mocked Neo4j/Postgres.
+- Events: list/related are public; comment/ack/close/prune/diagnose require
+  authentication. Tests enforce this boundary.
+
+Strategy:
+- Use FastAPI TestClient with the global app import
+- Patch Neo4j driver (database.driver) at module import time
+- Override get_pg_db for PostgreSQL-dependent endpoints (metric history)
+- Override get_current_active_user for auth-protected event endpoints
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+# ---------------------------------------------------------------------------
+# Patch Neo4j driver BEFORE importing anything that touches database.py
+# The driver is created at module import time and tries to connect immediately
+# ---------------------------------------------------------------------------
+_mock_neo4j_driver = MagicMock()
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from main import app
+    from database import get_db
+
+from models.user import User, UserPermission
+from postgres_db import get_pg_db
+from services.auth_service import get_current_active_user
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pydantic_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+    disabled: bool = False,
+) -> User:
+    """Create a Pydantic User for injection via dependency override."""
+    return User(
+        username=username,
+        role=role,
+        permissions=permissions or [],
+        allowed_locations=[],
+        disabled=disabled,
+    )
+
+
+class _FakeNeo4jNode:
+    """Mimics a Neo4j node so that dict(node) and node.get() work correctly."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def keys(self):
+        return self._data.keys()
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def items(self):
+        return self._data.items()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_db():
+    """Provide a mock SQLAlchemy session for PostgreSQL endpoints."""
+    db = MagicMock(spec=Session)
+    return db
+
+
+@pytest.fixture
+def mock_neo4j_driver():
+    """Provide a mock Neo4j driver."""
+    driver = MagicMock()
+    driver.execute_query.return_value = ([], None, None)
+    driver.session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    return driver
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides():
+    """Ensure dependency overrides never leak between tests."""
+    original_overrides = app.dependency_overrides.copy()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+
+# ===========================================================================
+# METRICS ROUTER TESTS
+# ===========================================================================
+# NOTE: The metrics router mixes public read endpoints with protected write
+# endpoints. These tests document the current behavior.
+# ===========================================================================
+
+
+class TestMetricsList:
+    """Tests for GET /api/metrics — list all metric definitions."""
+
+    def test_list_metrics_returns_empty(self, mock_neo4j_driver):
+        """Should return empty list when no metrics exist."""
+        mock_session = MagicMock()
+        mock_session.run.return_value = []
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/metrics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+
+    def test_list_metrics_returns_data(self, mock_neo4j_driver):
+        """Should return metric definitions when they exist."""
+
+        class FakeRecord:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        class FakeResult:
+            def __iter__(self):
+                return iter(
+                    [
+                        FakeRecord(
+                            {
+                                "m": {
+                                    "id": "cpu-load",
+                                    "protocol": "SNMP",
+                                    "warning": 80.0,
+                                    "critical": 95.0,
+                                    "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                                    "dataType": "INTEGER",
+                                    "unit": "%",
+                                    "description": "CPU Load",
+                                    "criticality": 2,
+                                    "applicable_to": '{"brands": ["cisco"]}',
+                                }
+                            }
+                        )
+                    ]
+                )
+
+        mock_session = MagicMock()
+        mock_session.run.return_value = FakeResult()
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/metrics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == "cpu-load"
+        assert data[0]["protocol"] == "SNMP"
+
+    def test_list_metrics_no_auth_required(self):
+        """Metrics list should NOT require authentication (documented gap)."""
+        # No auth headers, no overrides — should still succeed (200, not 401)
+        # Since Neo4j isn't mocked here, it will fail with 500, but NOT 401
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+            with patch("database.driver", MagicMock()):
+                response = client.get("/api/metrics")
+        # 200 or 500 are acceptable — the key is it's NOT 401/403
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+
+class TestMetricsCreate:
+    """Tests for POST /api/metrics — create/update metric definition."""
+
+    def test_create_metric_success(self, mock_neo4j_driver):
+        """Should create a metric definition."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_session = MagicMock()
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with (
+            patch("database.driver", mock_neo4j_driver),
+            patch("routers.metrics.check_permission", return_value=True),
+        ):
+            response = client.post(
+                "/api/metrics",
+                json={
+                    "id": "test-cpu",
+                    "protocol": "SNMP",
+                    "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                    "warning": 80.0,
+                    "critical": 95.0,
+                    "dataType": "INTEGER",
+                    "unit": "%",
+                    "description": "Test CPU metric",
+                    "criticality": 2,
+                    "applicable_to": {
+                        "brands": ["cisco"],
+                        "models": [],
+                        "layers": [],
+                        "names": [],
+                        "excluded_names": [],
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Metric defined" in data["message"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_metric_unauthenticated(self):
+        """Create metric requires authentication."""
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+            with patch("database.driver", MagicMock()):
+                response = client.post(
+                    "/api/metrics",
+                    json={
+                        "id": "no-auth-metric",
+                        "protocol": "SNMP",
+                    },
+                )
+        assert response.status_code == 401
+
+    def test_create_metric_forbidden_without_permission(self):
+        """Authenticated user without CI_EDIT should get 403."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/metrics",
+            json={
+                "id": "forbidden-metric",
+                "protocol": "SNMP",
+            },
+        )
+
+        assert response.status_code == 403
+
+
+class TestMetricsDelete:
+    """Tests for DELETE /api/metrics/{metric_id} — delete metric definition."""
+
+    def test_delete_metric_success(self, mock_neo4j_driver):
+        """Should delete a metric definition."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_session = MagicMock()
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with (
+            patch("database.driver", mock_neo4j_driver),
+            patch("routers.metrics.check_permission", return_value=True),
+        ):
+            response = client.delete("/api/metrics/test-cpu")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Metric deleted" in data["message"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_delete_metric_unauthenticated(self):
+        """Delete metric requires authentication."""
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+            with patch("database.driver", MagicMock()):
+                response = client.delete("/api/metrics/any-metric")
+        assert response.status_code == 401
+
+    def test_delete_metric_forbidden_without_permission(self):
+        """Authenticated user without CI_EDIT should get 403."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.delete("/api/metrics/forbidden-metric")
+
+        assert response.status_code == 403
+
+
+class TestMetricsUsage:
+    """Tests for GET /api/metrics/{metric_id}/usage — analyze CI matching."""
+
+    def test_metric_usage_returns_data(self, mock_neo4j_driver):
+        """Should return usage info with matching CIs."""
+
+        # The service code does dict(record) on each result row.
+        # We need objects that dict() can convert — a dict subclass works.
+        class DictRecord(dict):
+            """A dict that also supports record['key'] and record.get('key')."""
+
+            def __getitem__(self, key):
+                return super().__getitem__(key)
+
+        call_count = [0]
+
+        def mock_run(query, **params):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First query: fetch applicable_to
+                return MagicMock(
+                    single=MagicMock(
+                        return_value=DictRecord(
+                            {"apt": '{"brands": ["cisco"], "excluded_names": []}'}
+                        )
+                    )
+                )
+            # Second query: UNION results — must support dict(record)
+            return [
+                DictRecord(
+                    {
+                        "id": "ci-001",
+                        "name": "Router-01",
+                        "ip": "192.168.1.1",
+                        "model": "ASR-1000",
+                        "brand": "Cisco",
+                    }
+                )
+            ]
+
+        mock_session = MagicMock()
+        mock_session.run.side_effect = mock_run
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/metrics/cpu-load/usage")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "count" in data
+        assert "criteria" in data
+
+
+class TestMetricsPromote:
+    """Tests for POST /api/metrics/promote — promote metric to graph node."""
+
+    def test_promote_metric_success(self, mock_neo4j_driver):
+        """Should promote a metric to a first-class graph node."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_session = MagicMock()
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with (
+            patch("database.driver", mock_neo4j_driver),
+            patch("routers.metrics.check_permission", return_value=True),
+        ):
+            response = client.post(
+                "/api/metrics/promote",
+                json={
+                    "ci_id": "ci-001",
+                    "metric_name": "cpu-load",
+                    "display_name": "CPU Load on Router-01",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Metric promoted" in data["message"]
+        assert "id" in data
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_promote_metric_forbidden_without_permission(self):
+        """Authenticated user without CI_EDIT should get 403."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/metrics/promote",
+            json={
+                "ci_id": "ci-001",
+                "metric_name": "cpu-load",
+                "display_name": "CPU Load on Router-01",
+            },
+        )
+
+        assert response.status_code == 403
+
+
+class TestMetricsValidate:
+    """Tests for POST /api/metrics/validate — OID validation endpoint."""
+
+    def test_validate_oid_snmp_not_available(self):
+        """Should handle SNMP library not being available."""
+        fake_user = _make_pydantic_user(username="operator", role="OPERATOR")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.metrics.validate_snmp_oid") as mock_validate:
+            mock_validate.return_value = {
+                "success": False,
+                "error": "SNMP not available",
+            }
+
+            response = client.post(
+                "/api/metrics/validate",
+                json={
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.1.1.0",
+                },
+            )
+
+            assert response.status_code == 400
+            data = response.json()
+            assert data["success"] is False
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_validate_oid_success(self):
+        """Should return success when OID is reachable."""
+        fake_user = _make_pydantic_user(username="operator", role="OPERATOR")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        # Patch at the router module level where the function is imported
+        with patch("routers.metrics.validate_snmp_oid") as mock_validate:
+            mock_validate.return_value = {
+                "success": True,
+                "value": "Cisco IOS Software",
+                "response_time_ms": 12.5,
+            }
+
+            response = client.post(
+                "/api/metrics/validate",
+                json={
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.1.1.0",
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+class TestMetricsHistory:
+    """Tests for GET /api/metrics/{node_id}/{metric_id}/history — PostgreSQL."""
+
+    def test_history_requires_pg_db(self, mock_db):
+        """History endpoint depends on PostgreSQL via get_pg_db."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        response = client.get("/api/metrics/ci-001/cpu-load/history")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_history_with_hours_param(self, mock_db):
+        """Should pass hours parameter to the repository."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        response = client.get("/api/metrics/ci-001/cpu-load/history?hours=48&limit=500")
+
+        assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+
+# ===========================================================================
+# EVENTS ROUTER TESTS
+# ===========================================================================
+
+
+class TestEventsList:
+    """Tests for GET /api/events — list events (public endpoint)."""
+
+    def test_list_events_no_filter(self, mock_neo4j_driver):
+        """Should return events without any status filter."""
+
+        class FakeEventNode:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+            def keys(self):
+                return self._data.keys()
+
+            def __iter__(self):
+                return iter(self._data)
+
+            def items(self):
+                return self._data.items()
+
+        class FakeRecord:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        from datetime import datetime
+
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(
+            __iter__=MagicMock(
+                return_value=iter(
+                    [
+                        FakeRecord(
+                            {
+                                "e": FakeEventNode(
+                                    {
+                                        "id": "evt-001",
+                                        "status": "OPEN",
+                                        "severity": "CRITICAL",
+                                        "ci_id": "ci-001",
+                                        "value": 97.5,
+                                        "message": "CPU exceeded threshold",
+                                        "created_at": datetime.utcnow(),
+                                    }
+                                ),
+                                "ci_name": "Router-01",
+                                "metric_name": "cpu-load",
+                                "metric_protocol": "SNMP",
+                            }
+                        )
+                    ]
+                )
+            )
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/events")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["ci_name"] == "Router-01"
+
+    def test_list_events_with_status_filter(self, mock_neo4j_driver):
+        """Should pass status filter to the query."""
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(
+            __iter__=MagicMock(return_value=iter([]))
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/events?status=OPEN")
+
+        assert response.status_code == 200
+        # Verify the status param was passed to the query
+        call_args = mock_session.run.call_args
+        assert call_args is not None
+        assert call_args[1]["status"] == "OPEN"
+
+    def test_list_events_active_filter(self, mock_neo4j_driver):
+        """ACTIVE status should include OPEN, ACK, RECOVERED."""
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(
+            __iter__=MagicMock(return_value=iter([]))
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/events?status=ACTIVE")
+
+        assert response.status_code == 200
+        call_args = mock_session.run.call_args
+        assert call_args[1]["status"] == "ACTIVE"
+
+    def test_list_events_no_auth_required(self):
+        """Events list should NOT require authentication (by design)."""
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+            with patch("database.driver", MagicMock()):
+                response = client.get("/api/events")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+
+class TestEventsRelated:
+    """Tests for GET /api/events/related/{ci_id} — events for a CI."""
+
+    def test_related_events_returns_data(self, mock_neo4j_driver):
+        """Should return active events for a specific CI."""
+
+        class FakeEventNode:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+            def keys(self):
+                return self._data.keys()
+
+            def __iter__(self):
+                return iter(self._data)
+
+        class FakeRecord:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(
+            __iter__=MagicMock(
+                return_value=iter(
+                    [
+                        FakeRecord(
+                            {
+                                "e": FakeEventNode(
+                                    {
+                                        "id": "evt-001",
+                                        "status": "OPEN",
+                                        "severity": "CRITICAL",
+                                        "ci_id": "ci-001",
+                                    }
+                                ),
+                                "metric_name": "cpu-load",
+                            }
+                        )
+                    ]
+                )
+            )
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/events/related/ci-001")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["metric_name"] == "cpu-load"
+
+    def test_related_events_no_auth_required(self):
+        """Related events should NOT require auth (by design)."""
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+            with patch("database.driver", MagicMock()):
+                response = client.get("/api/events/related/ci-001")
+        assert response.status_code != 401
+        assert response.status_code != 403
+
+
+class TestEventsAck:
+    """Tests for POST /api/events/{event_id}/ack — acknowledge event (auth required)."""
+
+    def test_ack_event_success(self, mock_neo4j_driver):
+        """Authenticated user should be able to ack an event."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_ACK],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_session = MagicMock()
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.post("/api/events/evt-001/ack")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Acknowledged" in data["message"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ack_event_unauthenticated(self):
+        """Unauthenticated user should get 401."""
+        response = client.post("/api/events/evt-001/ack")
+        assert response.status_code == 401
+
+    def test_ack_event_forbidden_without_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post("/api/events/evt-001/ack")
+
+        assert response.status_code == 403
+
+
+class TestEventsClose:
+    """Tests for POST /api/events/{event_id}/close — close event (auth required)."""
+
+    def test_close_event_success(self, mock_neo4j_driver):
+        """Authenticated user should be able to close an event."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_CLOSE],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_session = MagicMock()
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.post("/api/events/evt-001/close")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Closed" in data["message"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_close_event_unauthenticated(self):
+        """Unauthenticated user should get 401."""
+        response = client.post("/api/events/evt-001/close")
+        assert response.status_code == 401
+
+    def test_close_event_forbidden_without_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post("/api/events/evt-001/close")
+
+        assert response.status_code == 403
+
+
+class TestEventsComment:
+    """Tests for POST /api/events/{event_id}/comment — add comment (auth required)."""
+
+    def test_add_comment_unauthenticated(self):
+        response = client.post(
+            "/api/events/evt-001/comment",
+            json={"message": "test"},
+        )
+
+        assert response.status_code == 401
+
+    def test_add_comment_with_message_only(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch(
+            "routers.events.event_service.add_event_comment"
+        ) as mock_add_comment:
+            mock_add_comment.return_value = {"message": "Comment added"}
+
+            response = client.post(
+                "/api/events/evt-001/comment",
+                json={"message": "Investigating the issue"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Comment added"
+        mock_add_comment.assert_called_once_with(
+            "evt-001", "operator", "Investigating the issue"
+        )
+
+
+class TestEventsPrune:
+    """Tests for POST /api/events/prune — bulk close recovered events (auth required)."""
+
+    def test_prune_recovered_success(self, mock_neo4j_driver):
+        """Authenticated user should prune recovered events."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_CLOSE],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        class FakeRecord:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(
+            single=MagicMock(return_value=FakeRecord({"closed_count": 5}))
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.post("/api/events/prune")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Cleaned up" in data["message"]
+        assert data["count"] == 5
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_prune_recovered_unauthenticated(self):
+        """Unauthenticated user should get 401."""
+        response = client.post("/api/events/prune")
+        assert response.status_code == 401
+
+    def test_prune_recovered_forbidden_without_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post("/api/events/prune")
+
+        assert response.status_code == 403
+
+
+class TestEventsDiagnose:
+    """Tests for POST /api/events/{event_id}/diagnose — run diagnostic (auth required)."""
+
+    def test_diagnose_event_not_found(self, mock_neo4j_driver):
+        """Should return 404 when event doesn't exist."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.RUN_DIAGNOSTICS],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(single=MagicMock(return_value=None))
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.post("/api/events/nonexistent/diagnose")
+
+        assert response.status_code == 404
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_diagnose_event_unauthenticated(self):
+        """Unauthenticated user should get 401."""
+        response = client.post("/api/events/evt-001/diagnose")
+        assert response.status_code == 401
+
+    def test_diagnose_event_forbidden_without_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post("/api/events/evt-001/diagnose")
+
+        assert response.status_code == 403
+
+    def test_diagnose_event_success(self, mock_neo4j_driver):
+        """Should run diagnostic when event and CI exist."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.RUN_DIAGNOSTICS],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        class FakeNode:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+            def keys(self):
+                return self._data.keys()
+
+            def __iter__(self):
+                return iter(self._data)
+
+        class FakeRecord:
+            def __init__(self, data):
+                self._data = data
+
+            def __getitem__(self, key):
+                return self._data[key]
+
+            def get(self, key, default=None):
+                return self._data.get(key, default)
+
+        mock_session = MagicMock()
+        mock_session.run.return_value = MagicMock(
+            single=MagicMock(
+                return_value=FakeRecord(
+                    {
+                        "ci": FakeNode(
+                            {
+                                "id": "ci-001",
+                                "label": "Router-01",
+                                "ip": "192.168.1.1",
+                                "type": "router",
+                            }
+                        ),
+                        "m": FakeNode(
+                            {
+                                "id": "cpu-load",
+                                "protocol": "SNMP",
+                                "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                            }
+                        ),
+                    }
+                )
+            )
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with (
+            patch("database.driver", mock_neo4j_driver),
+            patch(
+                "services.event_service.run_diagnostic",
+                return_value="Ping OK, SNMP reachable",
+            ),
+        ):
+            response = client.post("/api/events/evt-001/diagnose")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "Diagnostic run" in data["message"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)

--- a/backend/tests/test_routers_nodes.py
+++ b/backend/tests/test_routers_nodes.py
@@ -1,0 +1,658 @@
+"""Router-level tests for the nodes endpoints — mocked dependencies.
+
+Focus areas:
+- GET /api/nodes — auth enforcement, admin vs scoped listing
+- POST /api/nodes — CI_EDIT permission, success, validation
+- DELETE /api/nodes/{id} — CI_DELETE permission, success
+- GET /api/nodes/{id}/usage — public endpoint, success
+- GET /api/nodes/{id}/metrics — public endpoint, success
+- POST /api/nodes/upload — file validation (non-.xlsx rejection)
+- GET /api/nodes/template — public endpoint, returns streaming response
+
+Strategy:
+- Patch Neo4j driver BEFORE importing main (avoids real connection at import)
+- Use FastAPI TestClient
+- Override get_current_active_user for protected endpoints
+- Mock topology_repo functions for service-layer isolation
+"""
+
+import pytest
+import json
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from io import BytesIO
+
+# ---------------------------------------------------------------------------
+# Patch Neo4j driver BEFORE importing anything that touches database.py
+# ---------------------------------------------------------------------------
+_mock_neo4j_driver = MagicMock()
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from main import app
+    from database import get_db
+
+from models.user import User, UserPermission
+from services.auth_service import get_current_active_user
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pydantic_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+    disabled: bool = False,
+    allowed_locations: list[str] | None = None,
+) -> User:
+    """Create a Pydantic User for injection via dependency override."""
+    return User(
+        username=username,
+        role=role,
+        permissions=permissions or [],
+        allowed_locations=allowed_locations or [],
+        disabled=disabled,
+    )
+
+
+def _make_neo4j_node_record(
+    node_id: str = "ci-001",
+    name: str = "Router-01",
+    status: str = "OK",
+    ip: str = "192.168.1.1",
+    brand: str = "Cisco",
+    model: str = "ASR-1000",
+    layer: str = "router",
+    location_name: str = "Data Center A",
+    snmp: str | None = None,
+) -> dict:
+    """Build a dict simulating a Neo4j CI node record."""
+    snmp_val = snmp or json.dumps({"version": "v2c", "readCommunity": "public"})
+    return {
+        "id": node_id,
+        "name": name,
+        "status": status,
+        "ip": ip,
+        "brand": brand,
+        "model": model,
+        "layer": layer,
+        "location_name": location_name,
+        "snmp": snmp_val,
+        "location": None,
+        "pollingInterval": 60,
+    }
+
+
+def _make_full_record(
+    node_props: dict | None = None,
+    category: str = "router",
+    metrics: list[dict] | None = None,
+) -> dict:
+    """Wrap node props into the shape returned by topology_repo.get_nodes."""
+    return {
+        "node": node_props or _make_neo4j_node_record(),
+        "category": category,
+        "metrics": metrics or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_neo4j_driver():
+    """Provide a mock Neo4j driver with controllable session/query responses."""
+    driver = MagicMock()
+    mock_session = MagicMock()
+    driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_session.run.return_value = []
+    return driver
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/nodes — list all CIs
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodes:
+    """Tests for GET /api/nodes endpoint."""
+
+    def test_list_nodes_unauthenticated(self):
+        """No auth token should return 401."""
+        response = client.get("/api/nodes")
+        assert response.status_code == 401
+
+    def test_list_nodes_disabled_user(self):
+        """Disabled user should get 400."""
+        disabled_user = _make_pydantic_user(
+            username="disabled_user",
+            role="VIEWER",
+            disabled=True,
+        )
+
+        async def override_get_current_active_user():
+            from fastapi import HTTPException
+
+            if disabled_user.disabled:
+                raise HTTPException(status_code=400, detail="Inactive user")
+            return disabled_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/nodes")
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_nodes_admin_success(self, mock_neo4j_driver):
+        """Admin should list all nodes without location scoping."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        node_record = _make_neo4j_node_record(
+            node_id="ci-001",
+            name="Router-01",
+            brand="Cisco",
+            model="ASR-1000",
+        )
+        full_record = _make_full_record(node_props=node_record, category="router")
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert isinstance(data, list)
+            assert len(data) == 1
+            assert data[0]["label"] == "Router-01"
+            assert data[0]["brand"] == "Cisco"
+
+            # Admin should get is_admin=True, no location filter
+            mock_repo.get_nodes.assert_called_once()
+            call_args = mock_repo.get_nodes.call_args
+            assert call_args[0][1] is True  # is_admin=True
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_nodes_operator_scoped_by_location(self, mock_neo4j_driver):
+        """Non-admin should have results scoped to allowed_locations."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            allowed_locations=["HQ-Madrid"],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        node_record = _make_neo4j_node_record(
+            node_id="ci-002",
+            name="Switch-01",
+            location_name="HQ-Madrid",
+        )
+        full_record = _make_full_record(node_props=node_record, category="switch")
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 1
+            assert data[0]["label"] == "Switch-01"
+
+            # Non-admin: should pass allowed_locations and is_admin=False
+            mock_repo.get_nodes.assert_called_once()
+            call_args = mock_repo.get_nodes.call_args
+            assert call_args[0][0] == ["HQ-Madrid"]
+            assert call_args[0][1] is False
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_nodes_operator_no_locations_returns_empty(self):
+        """Operator with no allowed_locations should get empty list."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            allowed_locations=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        # topology_repo.get_nodes returns [] early when not admin and no locations
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = []
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data == []
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_nodes_with_metrics(self):
+        """Nodes with associated metrics should include metric data."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        node_record = _make_neo4j_node_record(node_id="ci-003", name="Server-01")
+        metrics = [
+            {
+                "name": "cpu-load",
+                "protocol": "SNMP",
+                "status": "OK",
+                "value": 45.2,
+                "last_updated": None,
+            }
+        ]
+        full_record = _make_full_record(node_props=node_record, metrics=metrics)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data[0]["metrics"]) == 1
+            assert data[0]["metrics"][0]["name"] == "cpu-load"
+            assert data[0]["metrics"][0]["value"] == 45.2
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_list_nodes_snmp_string_parsed(self):
+        """SNMP stored as JSON string should be parsed to dict."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        snmp_json = json.dumps({"version": "v3", "readCommunity": "secure"})
+        node_record = _make_neo4j_node_record(snmp=snmp_json)
+        full_record = _make_full_record(node_props=node_record)
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert isinstance(data[0]["snmp"], dict)
+            assert data[0]["snmp"]["version"] == "v3"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/nodes — create/update CI
+# ---------------------------------------------------------------------------
+
+
+class TestCreateNode:
+    """Tests for POST /api/nodes endpoint."""
+
+    def test_create_node_unauthenticated(self):
+        """No auth token should return 401."""
+        response = client.post(
+            "/api/nodes",
+            json={
+                "id": "ci-new",
+                "label": "New Router",
+                "type": "router",
+            },
+        )
+        assert response.status_code == 401
+
+    def test_create_node_no_ci_edit_permission(self):
+        """User without CI_EDIT should get 403."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/nodes",
+            json={
+                "id": "ci-new",
+                "label": "New Router",
+                "type": "router",
+            },
+        )
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_node_admin_success(self):
+        """Admin should be able to create a node."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.nodes.node_service") as mock_service:
+            mock_service.create_update_node.return_value = {
+                "message": "Node created/updated",
+                "id": "ci-new",
+            }
+
+            response = client.post(
+                "/api/nodes",
+                json={
+                    "id": "ci-new",
+                    "label": "New Router",
+                    "type": "router",
+                    "status": "OK",
+                    "ip": "10.0.0.1",
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["message"] == "Node created/updated"
+            assert data["id"] == "ci-new"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_node_operator_with_ci_edit(self):
+        """Operator with CI_EDIT permission should create a node."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.nodes.node_service") as mock_service:
+            mock_service.create_update_node.return_value = {
+                "message": "Node created/updated",
+                "id": "ci-002",
+            }
+
+            response = client.post(
+                "/api/nodes",
+                json={
+                    "id": "ci-002",
+                    "label": "Switch-01",
+                    "type": "switch",
+                },
+            )
+
+            assert response.status_code == 200
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_node_invalid_payload(self):
+        """Missing required fields should return 422."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        # Missing required 'label' and 'type'
+        response = client.post(
+            "/api/nodes",
+            json={"id": "ci-bad"},
+        )
+
+        assert response.status_code == 422
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: DELETE /api/nodes/{id} — delete CI
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteNode:
+    """Tests for DELETE /api/nodes/{node_id} endpoint."""
+
+    def test_delete_node_unauthenticated(self):
+        """No auth token should return 401."""
+        response = client.delete("/api/nodes/ci-001")
+        assert response.status_code == 401
+
+    def test_delete_node_no_ci_delete_permission(self):
+        """User without CI_DELETE should get 403."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.CI_EDIT],  # has CI_EDIT but not CI_DELETE
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.delete("/api/nodes/ci-001")
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_delete_node_admin_success(self):
+        """Admin should be able to delete a node."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.nodes.node_service") as mock_service:
+            mock_service.delete_node.return_value = {
+                "message": "Node deleted",
+                "id": "ci-001",
+            }
+
+            response = client.delete("/api/nodes/ci-001")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["message"] == "Node deleted"
+            assert data["id"] == "ci-001"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/nodes/{id}/usage — public endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodeUsage:
+    """Tests for GET /api/nodes/{node_id}/usage endpoint."""
+
+    def test_get_node_usage_success(self):
+        """Should return usage count without auth."""
+        with patch("routers.nodes.node_service") as mock_service:
+            mock_service.get_node_usage.return_value = {"count": 5}
+
+            response = client.get("/api/nodes/ci-001/usage")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["count"] == 5
+
+    def test_get_node_usage_no_auth_required(self):
+        """Endpoint should be accessible without authentication."""
+        with patch("routers.nodes.node_service") as mock_service:
+            mock_service.get_node_usage.return_value = {"count": 0}
+
+            response = client.get("/api/nodes/ci-999/usage")
+
+            # Should NOT be 401 — this is a public endpoint
+            assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/nodes/{id}/metrics — public endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodeMetrics:
+    """Tests for GET /api/nodes/{node_id}/metrics endpoint."""
+
+    def test_get_node_metrics_success(self):
+        """Should return applicable metrics without auth."""
+        with patch("routers.nodes.metric_service") as mock_service:
+            mock_service.get_applicable_metrics.return_value = [
+                {"id": "cpu-load", "protocol": "SNMP"},
+                {"id": "PING-Router-01", "protocol": "ICMP"},
+            ]
+
+            response = client.get("/api/nodes/ci-001/metrics")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert isinstance(data, list)
+            assert len(data) == 2
+
+    def test_get_node_metrics_no_auth_required(self):
+        """Endpoint should be accessible without authentication."""
+        with patch("routers.nodes.metric_service") as mock_service:
+            mock_service.get_applicable_metrics.return_value = []
+
+            response = client.get("/api/nodes/ci-001/metrics")
+
+            assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/nodes/upload — bulk upload
+# ---------------------------------------------------------------------------
+
+
+class TestUploadNodes:
+    """Tests for POST /api/nodes/upload endpoint."""
+
+    def test_upload_invalid_file_format(self):
+        """Non-.xlsx file should return 400."""
+        from fastapi import UploadFile
+
+        # TestClient sends files via the `files` parameter
+        response = client.post(
+            "/api/nodes/upload",
+            files={"file": ("data.csv", b"fake,csv,content", "text/csv")},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid file format" in response.json()["detail"]
+
+    def test_upload_xlsx_accepted(self):
+        """An .xlsx file should be accepted (service mocked)."""
+        # Create a minimal fake xlsx-like bytes (service will be mocked)
+        fake_xlsx = b"PK\x03\x04fake-xlsx-content"
+
+        async def mock_bulk_upload(*args, **kwargs):
+            return {"message": "Successfully processed 0 CIs"}
+
+        with patch.object(
+            __import__("services").node_service,
+            "bulk_upload_nodes",
+            new=mock_bulk_upload,
+        ):
+            response = client.post(
+                "/api/nodes/upload",
+                files={
+                    "file": (
+                        "import.xlsx",
+                        fake_xlsx,
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    )
+                },
+            )
+
+            # Should NOT be 400 — file format is valid
+            assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/nodes/template — public endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodeTemplate:
+    """Tests for GET /api/nodes/template endpoint."""
+
+    def test_get_template_no_auth_required(self):
+        """Template endpoint should be accessible without authentication."""
+        with patch("routers.nodes.node_service") as mock_service:
+            # Return a mock StreamingResponse-compatible object
+            mock_stream = MagicMock()
+            mock_stream.status_code = 200
+            mock_service.get_node_template.return_value = mock_stream
+
+            response = client.get("/api/nodes/template")
+
+            # Should NOT be 401
+            assert response.status_code != 401

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,45 @@
+"""Unit tests for utils/security.py — pure password hashing functions."""
+
+from utils.security import verify_password, get_password_hash
+
+
+class TestVerifyPassword:
+    """Tests for the verify_password function."""
+
+    def test_correct_password_returns_true(self, plain_password, hashed_password):
+        assert verify_password(plain_password, hashed_password) is True
+
+    def test_incorrect_password_returns_false(self, hashed_password):
+        assert verify_password("WrongP@ss!", hashed_password) is False
+
+    def test_empty_password_returns_false(self, hashed_password):
+        assert verify_password("", hashed_password) is False
+
+    def test_case_sensitive(self, hashed_password):
+        # Passwords are case-sensitive
+        assert verify_password("testp@ss123!", hashed_password) is False
+
+
+class TestGetPasswordHash:
+    """Tests for the get_password_hash function."""
+
+    def test_hash_is_not_plain_text(self, plain_password):
+        hashed = get_password_hash(plain_password)
+        assert hashed != plain_password
+
+    def test_hash_is_non_empty_string(self, plain_password):
+        hashed = get_password_hash(plain_password)
+        assert isinstance(hashed, str)
+        assert len(hashed) > 0
+
+    def test_same_password_produces_different_hashes(self, plain_password):
+        """PBKDF2/SHA256 uses salt — same input should produce different hashes."""
+        hash1 = get_password_hash(plain_password)
+        hash2 = get_password_hash(plain_password)
+        assert hash1 != hash2
+
+    def test_both_hashes_verify_same_password(self, plain_password):
+        hash1 = get_password_hash(plain_password)
+        hash2 = get_password_hash(plain_password)
+        assert verify_password(plain_password, hash1) is True
+        assert verify_password(plain_password, hash2) is True

--- a/backend/tests/test_user_repo_create.py
+++ b/backend/tests/test_user_repo_create.py
@@ -1,0 +1,158 @@
+"""Tests for user_repo.create_user — verifies the fix for accessing
+non-existent fields (disabled, force_password_change) on UserCreate.
+
+Bug: user_repo.create_user accessed user.disabled and
+user.force_password_change which don't exist on UserCreate (they only
+exist on the User response model). This caused AttributeError at runtime
+whenever a new user was created via POST /api/users/.
+
+Fix: Hardcode is_active=True and force_password_change=False in
+create_user, since UserCreate has no fields for these concepts.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from pydantic import ValidationError
+
+# Patch Neo4j before importing main
+_mock_neo4j_driver = MagicMock()
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from models.user import UserCreate, UserPermission
+    from repositories import user_repo
+
+
+class TestUserCreateModelFields:
+    """Verify UserCreate does NOT have disabled or force_password_change."""
+
+    def test_user_create_has_no_disabled_field(self):
+        """UserCreate should not expose a disabled field."""
+        uc = UserCreate(username="test", password="pass123")
+        assert not hasattr(uc, "disabled") or "disabled" not in uc.model_fields
+
+    def test_user_create_has_no_force_password_change_field(self):
+        """UserCreate should not expose a force_password_change field."""
+        uc = UserCreate(username="test", password="pass123")
+        assert (
+            not hasattr(uc, "force_password_change")
+            or "force_password_change" not in uc.model_fields
+        )
+
+    def test_user_response_model_has_disabled(self):
+        """The User response model SHOULD have disabled (for API responses)."""
+        from models.user import User
+
+        u = User(username="test", role="VIEWER")
+        assert hasattr(u, "disabled")
+        assert u.disabled is False
+
+    def test_user_response_model_has_force_password_change(self):
+        """The User response model SHOULD have force_password_change."""
+        from models.user import User
+
+        u = User(username="test", role="VIEWER")
+        assert hasattr(u, "force_password_change")
+        assert u.force_password_change is False
+
+
+class TestUserRepoCreateUser:
+    """Test user_repo.create_user does NOT access non-existent fields."""
+
+    def _make_mock_db(self):
+        """Create a mock DB session that captures the User() constructor call."""
+        db = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+        return db
+
+    def test_create_user_does_not_access_disabled(self):
+        """create_user must NOT access user.disabled on UserCreate.
+
+        If the bug exists, this raises AttributeError.
+        """
+        db = self._make_mock_db()
+        user_in = UserCreate(
+            username="newuser",
+            password="SecureP@ss123",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        # This will raise AttributeError if create_user accesses user.disabled
+        result = user_repo.create_user(db, user_in)
+
+        # Verify the DB User was created with is_active=True (default)
+        call_kwargs = db.add.call_args[0][0]
+        assert call_kwargs.is_active is True
+
+    def test_create_user_does_not_access_force_password_change(self):
+        """create_user must NOT access user.force_password_change on UserCreate.
+
+        If the bug exists, this raises AttributeError.
+        """
+        db = self._make_mock_db()
+        user_in = UserCreate(
+            username="newuser",
+            password="SecureP@ss123",
+            role="VIEWER",
+        )
+
+        # This will raise AttributeError if create_user accesses user.force_password_change
+        result = user_repo.create_user(db, user_in)
+
+        # Verify the DB User was created with force_password_change=False (default)
+        call_kwargs = db.add.call_args[0][0]
+        assert call_kwargs.force_password_change is False
+
+    def test_create_user_sets_correct_defaults(self):
+        """New users should be active and not forced to change password."""
+        db = self._make_mock_db()
+        user_in = UserCreate(
+            username="newuser",
+            password="SecureP@ss123",
+            role="OPERATOR",
+        )
+
+        user_repo.create_user(db, user_in)
+
+        db_user = db.add.call_args[0][0]
+        assert db_user.username == "newuser"
+        assert db_user.role == "OPERATOR"
+        assert db_user.is_active is True
+        assert db_user.force_password_change is False
+        assert db_user.hashed_password is not None
+        assert db_user.hashed_password != "SecureP@ss123"  # Should be hashed
+
+    def test_create_user_preserves_all_user_create_fields(self):
+        """All fields from UserCreate should be correctly mapped."""
+        db = self._make_mock_db()
+        user_in = UserCreate(
+            username="fulluser",
+            password="SecureP@ss123",
+            role="ADMIN",
+            permissions=[UserPermission.USER_MANAGE, UserPermission.CI_EDIT],
+            allowed_locations=["NYC", "LDN"],
+            allowed_ci_types=["router", "switch"],
+            phone="+1234567890",
+            email="user@example.com",
+        )
+
+        user_repo.create_user(db, user_in)
+
+        db_user = db.add.call_args[0][0]
+        assert db_user.username == "fulluser"
+        assert db_user.role == "ADMIN"
+        assert db_user.permissions == ["USER_MANAGE", "CI_EDIT"]
+        assert db_user.allowed_locations == ["NYC", "LDN"]
+        assert db_user.allowed_ci_types == ["router", "switch"]
+        assert db_user.phone == "+1234567890"
+        assert db_user.email == "user@example.com"
+
+    def test_create_user_commits_and_refreshes(self):
+        """create_user should commit and refresh the new user."""
+        db = self._make_mock_db()
+        user_in = UserCreate(username="test", password="pass123")
+
+        user_repo.create_user(db, user_in)
+
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,33 @@ services:
       - ./docker/neo4j/logs:/logs
       - ./docker/neo4j/entrypoint.sh:/entrypoint.sh
     entrypoint: [ "/bin/bash", "/entrypoint.sh" ]
+    healthcheck:
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "nexgen_password", "RETURN 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  # PostgreSQL / TimescaleDB
+  postgres:
+    image: timescale/timescaledb:2.15.0-pg16
+    container_name: nexgen_postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=nexgen_admin
+      - POSTGRES_PASSWORD=nexgen_password
+      - POSTGRES_DB=nexgen_auth
+    volumes:
+      - ./docker/postgres/data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U nexgen_admin -d nexgen_auth"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    restart: unless-stopped
 
   # Python Backend API
   backend:
@@ -23,7 +50,10 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - neo4j
+      neo4j:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
     environment:
       - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
@@ -35,6 +65,13 @@ services:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-super-secret-key-change-me-in-production}
     volumes:
       - ./backend:/app
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
 
   # Frontend (Vite Service)
   frontend:
@@ -45,12 +82,14 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     volumes:
       - ./frontend:/app
       - /app/node_modules
     environment:
       - VITE_API_TARGET=${VITE_API_TARGET:-http://backend:8000}
+    restart: unless-stopped
 
   # Engines / Workers
   snmp-engine:
@@ -59,8 +98,12 @@ services:
       dockerfile: engines/Dockerfile
     container_name: nexgen_snmp_worker
     depends_on:
-      - backend
-      - neo4j
+      neo4j:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
     environment:
       - NEO4J_URI=${NEO4J_URI:-bolt://neo4j:7687}
       - NEO4J_USER=${NEO4J_USER:-neo4j}
@@ -69,15 +112,4 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-nexgen_password}
       - POSTGRES_DB=${POSTGRES_DB:-nexgen_auth}
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
-
-  postgres:
-    image: timescale/timescaledb:latest-pg16
-    container_name: nexgen_postgres
-    ports:
-      - "5432:5432"
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER:-nexgen_admin}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-nexgen_password}
-      - POSTGRES_DB=${POSTGRES_DB:-nexgen_auth}
-    volumes:
-      - ./docker/postgres/data:/var/lib/postgresql/data
+    restart: unless-stopped

--- a/frontend/components/GlobalInventory.test.tsx
+++ b/frontend/components/GlobalInventory.test.tsx
@@ -1,0 +1,415 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import GlobalInventory from './GlobalInventory';
+import type { GraphNode } from '../types';
+
+type MockResponse = {
+  ok: boolean;
+  statusText: string;
+  json: () => Promise<unknown>;
+};
+
+const buildResponse = (data: unknown, ok = true, statusText = 'OK'): MockResponse => ({
+  ok,
+  statusText,
+  json: vi.fn().mockResolvedValue(data),
+});
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const makeNode = (overrides: Partial<GraphNode> = {}): GraphNode => ({
+  id: overrides.id ?? 'node-1',
+  label: overrides.label ?? 'Router-01',
+  type: overrides.type ?? 'INFRASTRUCTURE',
+  status: overrides.status ?? 'ACTIVE',
+  metadata: overrides.metadata ?? {},
+  ip: overrides.ip ?? '10.0.0.1',
+  category: overrides.category ?? 'Network',
+  metrics: overrides.metrics ?? [
+    {
+      name: 'CPU Load',
+      protocol: 'SNMP',
+      oid: '1.3.6.1.4.1.9',
+      value: '42',
+      status: 'OK',
+      last_updated: '2026-04-04T10:00:00.000Z',
+    },
+  ],
+  ...overrides,
+});
+
+const queueFetchResponses = (...responses: MockResponse[]) => {
+  const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+  responses.forEach((response) => {
+    fetchMock.mockResolvedValueOnce(response);
+  });
+};
+
+describe('GlobalInventory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders the initial inventory shell before requests resolve', () => {
+    const nodesRequest = createDeferred<MockResponse>();
+    const categoriesRequest = createDeferred<MockResponse>();
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+
+    fetchMock
+      .mockReturnValueOnce(nodesRequest.promise)
+      .mockReturnValueOnce(categoriesRequest.promise);
+
+    render(<GlobalInventory />);
+
+    expect(screen.getByText('Global Inventory')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('SEARCH CI...')).toBeInTheDocument();
+    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetches nodes and categories with the auth header', async () => {
+    queueFetchResponses(buildResponse([]), buildResponse([{ name: 'Network' }]));
+
+    render(<GlobalInventory />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+      expect(global.fetch).toHaveBeenCalledWith('/api/categories', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+    });
+  });
+
+  it('loads and renders nodes correctly', async () => {
+    const router = makeNode();
+    const server = makeNode({
+      id: 'node-2',
+      label: 'Server-01',
+      ip: '10.0.0.2',
+      category: 'Compute',
+      type: 'APPLICATION',
+    });
+
+    queueFetchResponses(
+      buildResponse([router, server]),
+      buildResponse([{ name: 'Network' }, { name: 'Compute' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    expect(await screen.findByText('Router-01')).toBeInTheDocument();
+    expect(screen.getByText('Server-01')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+    expect(screen.getByText('10.0.0.2')).toBeInTheDocument();
+  });
+
+  it('logs an error and keeps the inventory empty when /api/nodes fails', async () => {
+    queueFetchResponses(
+      buildResponse(null, false, 'Internal Server Error'),
+      buildResponse([{ name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(
+        'Failed to fetch inventory:',
+        expect.any(Error),
+      );
+    });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
+  });
+
+  it('filters nodes by category', async () => {
+    queueFetchResponses(
+      buildResponse([
+        makeNode({ id: 'node-1', label: 'Router-01', category: 'Network' }),
+        makeNode({ id: 'node-2', label: 'DB-01', category: 'Database', ip: '10.0.0.20' }),
+      ]),
+      buildResponse([{ name: 'Network' }, { name: 'Database' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await screen.findByText('Router-01');
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Database' } });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.getByText('DB-01')).toBeInTheDocument();
+  });
+
+  it('filters nodes by type when category does not exist', async () => {
+    queueFetchResponses(
+      buildResponse([
+        makeNode({ id: 'node-1', label: 'Router-01', type: 'INFRASTRUCTURE', category: 'Network' }),
+        makeNode({ id: 'node-2', label: 'ERP-App', type: 'APPLICATION', category: 'Business', ip: '10.0.0.30' }),
+      ]),
+      buildResponse([{ name: 'APPLICATION' }, { name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await screen.findByText('ERP-App');
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'APPLICATION' } });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.getByText('ERP-App')).toBeInTheDocument();
+  });
+
+  it('filters nodes by search text using the label', async () => {
+    queueFetchResponses(
+      buildResponse([
+        makeNode({ id: 'node-1', label: 'Router-01' }),
+        makeNode({ id: 'node-2', label: 'Database-01', category: 'Database', ip: '10.0.0.11' }),
+      ]),
+      buildResponse([{ name: 'Network' }, { name: 'Database' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await screen.findByText('Router-01');
+
+    fireEvent.change(screen.getByPlaceholderText('SEARCH CI...'), {
+      target: { value: 'database' },
+    });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.getByText('Database-01')).toBeInTheDocument();
+  });
+
+  it('filters nodes by search text using the ip address', async () => {
+    queueFetchResponses(
+      buildResponse([
+        makeNode({ id: 'node-1', label: 'Router-01', ip: '10.0.0.1' }),
+        makeNode({ id: 'node-2', label: 'Switch-01', ip: '192.168.50.10' }),
+      ]),
+      buildResponse([{ name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await screen.findByText('Switch-01');
+
+    fireEvent.change(screen.getByPlaceholderText('SEARCH CI...'), {
+      target: { value: '192.168.50' },
+    });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.getByText('Switch-01')).toBeInTheDocument();
+  });
+
+  it('polls every 5 seconds and refetches both endpoints', async () => {
+    vi.useFakeTimers();
+    queueFetchResponses(
+      buildResponse([makeNode({ id: 'node-1', label: 'Router-01' })]),
+      buildResponse([{ name: 'Network' }]),
+      buildResponse([makeNode({ id: 'node-1', label: 'Router-01' })]),
+      buildResponse([{ name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Router-01')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('clicking a node opens its detail panel', async () => {
+    const node = makeNode({
+      label: 'Router-01',
+      metrics: [
+        {
+          name: 'CPU Load',
+          protocol: 'SNMP',
+          oid: '1.3.6.1.4.1.9',
+          value: '64',
+          status: 'CRITICAL',
+          last_updated: '2026-04-04T10:00:00.000Z',
+        },
+      ],
+    });
+
+    queueFetchResponses(buildResponse([node]), buildResponse([{ name: 'Network' }]));
+
+    render(<GlobalInventory />);
+
+    const card = await screen.findByText('Router-01');
+    fireEvent.click(card);
+
+    expect(screen.getByText('ID: node-1')).toBeInTheDocument();
+    expect(screen.getByText('CPU Load')).toBeInTheDocument();
+    expect(screen.getByText('64')).toBeInTheDocument();
+  });
+
+  it('keeps the selected item synchronized with polling updates', async () => {
+    vi.useFakeTimers();
+    const initialNode = makeNode({
+      id: 'node-1',
+      label: 'Router-01',
+      metrics: [
+        {
+          name: 'CPU Load',
+          protocol: 'SNMP',
+          oid: '1.3.6.1.4.1.9',
+          value: '42',
+          status: 'OK',
+          last_updated: '2026-04-04T10:00:00.000Z',
+        },
+      ],
+    });
+    const updatedNode = makeNode({
+      id: 'node-1',
+      label: 'Router-01',
+      metrics: [
+        {
+          name: 'CPU Load',
+          protocol: 'SNMP',
+          oid: '1.3.6.1.4.1.9',
+          value: '95',
+          status: 'CRITICAL',
+          last_updated: '2026-04-04T10:05:00.000Z',
+        },
+      ],
+    });
+
+    queueFetchResponses(
+      buildResponse([initialNode]),
+      buildResponse([{ name: 'Network' }]),
+      buildResponse([updatedNode]),
+      buildResponse([{ name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByText('Router-01'));
+    expect(screen.getByText('42')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('95')).toBeInTheDocument();
+  });
+
+  it('clears the selected item when polling no longer returns that CI', async () => {
+    vi.useFakeTimers();
+
+    queueFetchResponses(
+      buildResponse([makeNode({ id: 'node-1', label: 'Router-01' })]),
+      buildResponse([{ name: 'Network' }]),
+      buildResponse([makeNode({ id: 'node-2', label: 'Switch-01', ip: '10.0.0.2' })]),
+      buildResponse([{ name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByText('Router-01'));
+    expect(screen.getByText('ID: node-1')).toBeInTheDocument();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('ID: node-1')).not.toBeInTheDocument();
+    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
+    expect(screen.getByText('Switch-01')).toBeInTheDocument();
+  });
+
+  it('shows the empty metrics state for a selected node without metrics', async () => {
+    queueFetchResponses(
+      buildResponse([makeNode({ id: 'node-1', label: 'Router-01', metrics: [] })]),
+      buildResponse([{ name: 'Network' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    fireEvent.click(await screen.findByText('Router-01'));
+
+    expect(screen.getByText('No Metrics Configured')).toBeInTheDocument();
+  });
+
+  it('renders an empty inventory list when the API returns no nodes', async () => {
+    queueFetchResponses(buildResponse([]), buildResponse([{ name: 'Network' }]));
+
+    render(<GlobalInventory />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
+  });
+
+  it('shows no list items when filters produce no results', async () => {
+    queueFetchResponses(
+      buildResponse([
+        makeNode({ id: 'node-1', label: 'Router-01', category: 'Network' }),
+        makeNode({ id: 'node-2', label: 'Server-01', category: 'Compute', ip: '10.0.0.50' }),
+      ]),
+      buildResponse([{ name: 'Network' }, { name: 'Compute' }]),
+    );
+
+    render(<GlobalInventory />);
+
+    await screen.findByText('Router-01');
+
+    fireEvent.change(screen.getByPlaceholderText('SEARCH CI...'), {
+      target: { value: 'does-not-exist' },
+    });
+
+    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
+    expect(screen.queryByText('Server-01')).not.toBeInTheDocument();
+    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/GlobalInventory.tsx
+++ b/frontend/components/GlobalInventory.tsx
@@ -1,5 +1,5 @@
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { GraphNode } from '../types';
 import { getStatusClasses } from '../utils/status';
 
@@ -17,6 +17,11 @@ const GlobalInventory: React.FC = () => {
     const [selectedCategory, setSelectedCategory] = useState<string>('ALL');
     const [selectedItem, setSelectedItem] = useState<GraphNode | null>(null);
     const [searchTerm, setSearchTerm] = useState('');
+    const selectedItemRef = useRef<GraphNode | null>(null);
+
+    useEffect(() => {
+        selectedItemRef.current = selectedItem;
+    }, [selectedItem]);
 
     const fetchData = () => {
         const token = localStorage.getItem('token');
@@ -31,10 +36,15 @@ const GlobalInventory: React.FC = () => {
             .then(data => {
                 if (Array.isArray(data)) {
                     setInventory(data);
-                    if (selectedItem) {
+                    const currentSelectedItem = selectedItemRef.current;
+                    if (currentSelectedItem) {
                         // Real-time update of selected item
-                        const updated = data.find((i: GraphNode) => i.id === selectedItem.id);
-                        if (updated) setSelectedItem(updated);
+                        const updated = data.find((i: GraphNode) => i.id === currentSelectedItem.id);
+                        if (updated) {
+                            setSelectedItem(updated);
+                        } else {
+                            setSelectedItem(null);
+                        }
                     }
                 } else {
                     console.error("Expected array for inventory but got:", data);

--- a/frontend/components/LoginPage.test.tsx
+++ b/frontend/components/LoginPage.test.tsx
@@ -1,0 +1,345 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import LoginPage from './LoginPage';
+import { AuthProvider } from '../context/AuthContext';
+
+// ─── Module mocks (must be hoisted) ────────────────────────────────
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  apiRequest: vi.fn(),
+  apiGet: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+vi.mock('../services/api', () => ({
+  api: {
+    request: mocks.apiRequest,
+    get: mocks.apiGet,
+  },
+}));
+
+// ─── Render helper ─────────────────────────────────────────────────
+
+const renderLoginPage = () => {
+  return render(
+    <MemoryRouter>
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.navigate.mockClear();
+    mocks.apiRequest.mockClear();
+    mocks.apiGet.mockClear();
+  });
+
+  // ─── 1. Form Rendering ───────────────────────────────────────────
+
+  describe('form rendering', () => {
+    it('renders the login form with username and password inputs', () => {
+      renderLoginPage();
+
+      // NOTE: Labels in LoginPage are not associated with inputs via htmlFor,
+      // so we query by placeholder text instead.
+      expect(screen.getByPlaceholderText('admin')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/•••/)).toBeInTheDocument();
+    });
+
+    it('renders the submit button with AUTHENTICATE text', () => {
+      renderLoginPage();
+
+      expect(screen.getByRole('button', { name: /authenticate/i })).toBeInTheDocument();
+    });
+
+    it('renders the NEX-GEN branding', () => {
+      renderLoginPage();
+
+      expect(screen.getByText('NEX-GEN')).toBeInTheDocument();
+      expect(screen.getByText(/secure access gateway/i)).toBeInTheDocument();
+    });
+
+    it('inputs are initially empty', () => {
+      renderLoginPage();
+
+      const usernameInput = screen.getByPlaceholderText('admin') as HTMLInputElement;
+      const passwordInput = screen.getByPlaceholderText(/•••/) as HTMLInputElement;
+
+      expect(usernameInput.value).toBe('');
+      expect(passwordInput.value).toBe('');
+    });
+
+    it('password input has type password', () => {
+      renderLoginPage();
+
+      const passwordInput = screen.getByPlaceholderText(/•••/);
+      expect(passwordInput).toHaveAttribute('type', 'password');
+    });
+  });
+
+  // ─── 2. Input Changes ────────────────────────────────────────────
+
+  describe('input changes', () => {
+    it('updates username when typing', async () => {
+      const user = userEvent.setup();
+      renderLoginPage();
+
+      const usernameInput = screen.getByPlaceholderText('admin');
+      await user.type(usernameInput, 'admin');
+
+      expect(usernameInput).toHaveValue('admin');
+    });
+
+    it('updates password when typing', async () => {
+      const user = userEvent.setup();
+      renderLoginPage();
+
+      const passwordInput = screen.getByPlaceholderText(/•••/);
+      await user.type(passwordInput, 'secret123');
+
+      expect(passwordInput).toHaveValue('secret123');
+    });
+  });
+
+  // ─── 3. Submission Behavior ──────────────────────────────────────
+
+  describe('submission behavior', () => {
+    it('calls api.request with correct endpoint and form data on submit', async () => {
+      const user = userEvent.setup();
+      mocks.apiRequest.mockResolvedValue({ access_token: 'test-token' });
+      mocks.apiGet.mockResolvedValue({ username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] });
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'secret');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(mocks.apiRequest).toHaveBeenCalledWith('/auth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: expect.any(URLSearchParams),
+        });
+      });
+
+      // Verify the body contains the right credentials
+      const callArgs = mocks.apiRequest.mock.calls[0][1];
+      const body = callArgs.body as URLSearchParams;
+      expect(body.get('username')).toBe('admin');
+      expect(body.get('password')).toBe('secret');
+    });
+
+    it('fetches user details after successful token exchange', async () => {
+      const user = userEvent.setup();
+      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
+      mocks.apiRequest.mockResolvedValue({ access_token: 'test-token' });
+      mocks.apiGet.mockResolvedValue(mockUser);
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'secret');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(mocks.apiGet).toHaveBeenCalledWith('/auth/users/me');
+      });
+    });
+  });
+
+  // ─── 4. Success Handling ─────────────────────────────────────────
+
+  describe('success handling', () => {
+    it('stores token in localStorage on successful login', async () => {
+      const user = userEvent.setup();
+      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
+      mocks.apiRequest.mockResolvedValue({ access_token: 'success-token' });
+      mocks.apiGet.mockResolvedValue(mockUser);
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(localStorage.getItem('token')).toBe('success-token');
+      });
+    });
+
+    it('navigates to home page ("/") on successful login', async () => {
+      const user = userEvent.setup();
+      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
+      mocks.apiRequest.mockResolvedValue({ access_token: 'tok' });
+      mocks.apiGet.mockResolvedValue(mockUser);
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(mocks.navigate).toHaveBeenCalledWith('/');
+      });
+    });
+
+    it('clears any previous error message on new submission', async () => {
+      const user = userEvent.setup();
+      // First submission fails to show an error
+      mocks.apiRequest.mockRejectedValueOnce(new Error('Invalid credentials'));
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
+      });
+
+      // Second submission succeeds — error should disappear
+      mocks.apiRequest.mockResolvedValue({ access_token: 'tok' });
+      mocks.apiGet.mockResolvedValue({ username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] });
+
+      await user.type(screen.getByPlaceholderText(/•••/), 'correct');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Invalid credentials')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  // ─── 5. Error Handling ───────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('displays error message when api.request fails', async () => {
+      const user = userEvent.setup();
+      mocks.apiRequest.mockRejectedValue(new Error('Invalid credentials'));
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
+      });
+    });
+
+    it('displays generic "Login failed" message when error has no message', async () => {
+      const user = userEvent.setup();
+      mocks.apiRequest.mockRejectedValue({});
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Login failed')).toBeInTheDocument();
+      });
+    });
+
+    it('removes token from localStorage on login failure', async () => {
+      const user = userEvent.setup();
+      localStorage.setItem('token', 'stale-token');
+      mocks.apiRequest.mockRejectedValue(new Error('Auth error'));
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(localStorage.getItem('token')).toBeNull();
+      });
+    });
+
+    it('does NOT navigate on failure', async () => {
+      const user = userEvent.setup();
+      mocks.apiRequest.mockRejectedValue(new Error('Bad creds'));
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Bad creds')).toBeInTheDocument();
+      });
+
+      expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call /auth/users/me when token request fails', async () => {
+      const user = userEvent.setup();
+      mocks.apiRequest.mockRejectedValue(new Error('Network error'));
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
+
+      expect(mocks.apiGet).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── 6. Navigation Interactions ──────────────────────────────────
+
+  describe('navigation interactions', () => {
+    it('does not navigate on initial render', () => {
+      renderLoginPage();
+
+      expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+
+    it('navigates only after both api calls succeed', async () => {
+      const user = userEvent.setup();
+
+      // Token succeeds but user fetch fails
+      mocks.apiRequest.mockResolvedValue({ access_token: 'tok' });
+      mocks.apiGet.mockRejectedValue(new Error('User fetch failed'));
+
+      renderLoginPage();
+
+      await user.type(screen.getByPlaceholderText('admin'), 'admin');
+      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
+      await user.click(screen.getByRole('button', { name: /authenticate/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('User fetch failed')).toBeInTheDocument();
+      });
+
+      // Should NOT have navigated because the user fetch failed
+      expect(mocks.navigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/components/MetricsManager.test.tsx
+++ b/frontend/components/MetricsManager.test.tsx
@@ -1,0 +1,518 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MetricsManager from './MetricsManager';
+import type { MetricDef } from '../types';
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiDelete: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  api: {
+    get: mocks.apiGet,
+    post: mocks.apiPost,
+    delete: mocks.apiDelete,
+  },
+}));
+
+const metricA: MetricDef = {
+  id: 'cpu.load',
+  protocol: 'SNMP',
+  oid: '.1.3.6.1.4.1.9.2.1.57.0',
+  warning: 70,
+  critical: 90,
+  dataType: 'INTEGER',
+  description: 'CPU load metric',
+  criticality: 2,
+  applicable_to: {
+    brands: ['Cisco'],
+    models: ['ASR1001'],
+    layers: ['INFRASTRUCTURE'],
+    names: ['router-01'],
+    excluded_names: ['router-02'],
+  },
+};
+
+const metricB: MetricDef = {
+  id: 'mem.usage',
+  protocol: 'SNMP',
+  oid: '.1.3.6.1.4.1.2021.4.6.0',
+  warning: 80,
+  critical: 95,
+  dataType: 'FLOAT',
+  description: 'Memory usage metric',
+  criticality: 3,
+  applicable_to: {
+    brands: ['Dell'],
+    models: ['R740'],
+  },
+};
+
+const hardwareModels = [
+  { brand: 'Cisco', model: 'ASR1001' },
+  { brand: 'Dell', model: 'R740' },
+  { brand: 'Dell', model: 'R750' },
+];
+
+const usageData = {
+  count: 2,
+  cis: [
+    { id: 'ci-1', name: 'router-01', ip: '10.0.0.1', brand: 'Cisco', model: 'ASR1001' },
+    { id: 'ci-2', name: 'router-02', ip: '10.0.0.2', brand: 'Cisco', model: 'ASR1001' },
+  ],
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const setupApiGet = (options?: {
+  metrics?: MetricDef[];
+  hardware?: Array<{ brand: string; model: string }>;
+  usage?: Record<string, any>;
+}) => {
+  const metrics = options?.metrics ?? [metricA, metricB];
+  const hardware = options?.hardware ?? hardwareModels;
+  const usage = options?.usage ?? {
+    'cpu.load': usageData,
+    'mem.usage': { count: 0, cis: [] },
+  };
+
+  mocks.apiGet.mockImplementation(async (endpoint: string) => {
+    if (endpoint === '/metrics') return metrics;
+    if (endpoint === '/hardware') return hardware;
+    if (endpoint === '/metrics/cpu.load/usage') return usage['cpu.load'];
+    if (endpoint === '/metrics/mem.usage/usage') return usage['mem.usage'];
+    throw new Error(`Unhandled GET ${endpoint}`);
+  });
+};
+
+const renderMetricsManager = () => render(<MetricsManager />);
+
+const getInputByLabel = (label: string | RegExp) => {
+  const labelNode = screen.getByText(label);
+  return labelNode.parentElement?.querySelector('input, select') as HTMLInputElement | HTMLSelectElement;
+};
+
+const clickSaveMetric = () => {
+  fireEvent.click(screen.getByText('SAVE METRIC'));
+};
+
+const clickDeleteMetric = () => {
+  const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+  fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+};
+
+const openCreateForm = async () => {
+  renderMetricsManager();
+  await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/metrics'));
+  fireEvent.click(screen.getByRole('button', { name: /add/i }));
+};
+
+const openEditForm = async () => {
+  renderMetricsManager();
+  await screen.findByText('cpu.load');
+  fireEvent.click(screen.getByText('cpu.load'));
+  await screen.findByRole('button', { name: /save metric/i });
+};
+
+describe('MetricsManager', () => {
+  beforeEach(() => {
+    mocks.apiGet.mockReset();
+    mocks.apiPost.mockReset();
+    mocks.apiDelete.mockReset();
+    setupApiGet();
+    mocks.apiPost.mockResolvedValue({ ok: true });
+    mocks.apiDelete.mockResolvedValue({ ok: true });
+    vi.stubGlobal('alert', vi.fn());
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe('initial loading', () => {
+    it('does not render metrics before the initial request resolves and then shows the metric list', async () => {
+      const metricsDeferred = createDeferred<MetricDef[]>();
+      mocks.apiGet.mockImplementation((endpoint: string) => {
+        if (endpoint === '/metrics') return metricsDeferred.promise;
+        if (endpoint === '/hardware') return Promise.resolve(hardwareModels);
+        if (endpoint === '/metrics/cpu.load/usage') return Promise.resolve(usageData);
+        if (endpoint === '/metrics/mem.usage/usage') return Promise.resolve({ count: 0, cis: [] });
+        return Promise.reject(new Error(`Unhandled GET ${endpoint}`));
+      });
+
+      renderMetricsManager();
+
+      expect(screen.queryByText('cpu.load')).not.toBeInTheDocument();
+      expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument();
+
+      metricsDeferred.resolve([metricA, metricB]);
+
+      expect(await screen.findByText('cpu.load')).toBeInTheDocument();
+      expect(screen.getByText('mem.usage')).toBeInTheDocument();
+    });
+
+    it('logs an error and keeps the editor empty when the initial metrics load fails', async () => {
+      mocks.apiGet.mockImplementation(async (endpoint: string) => {
+        if (endpoint === '/metrics') throw new Error('metrics failed');
+        if (endpoint === '/hardware') return hardwareModels;
+        throw new Error(`Unhandled GET ${endpoint}`);
+      });
+
+      renderMetricsManager();
+
+      await waitFor(() => {
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument();
+      expect(screen.queryByText('cpu.load')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('create flow', () => {
+    it('opens the create form with default values', async () => {
+      await openCreateForm();
+
+      expect(screen.getByText('New Metric')).toBeInTheDocument();
+      expect((getInputByLabel(/protocol/i) as HTMLSelectElement).value).toBe('SNMP');
+      expect((getInputByLabel(/data type/i) as HTMLSelectElement).value).toBe('INTEGER');
+      expect(screen.getByText(/no models selected/i)).toBeInTheDocument();
+    });
+
+    it('creates a new metric on the happy path', async () => {
+      await openCreateForm();
+
+      fireEvent.change(getInputByLabel(/metric id/i), { target: { value: 'temp.sensor' } });
+      fireEvent.change(getInputByLabel(/description/i), { target: { value: 'Temperature sensor metric' } });
+      fireEvent.change(screen.getByPlaceholderText(/examples: \.1\.3\.6\.1/i), { target: { value: '.1.3.6.1.4.1.9.9.13.1' } });
+      fireEvent.change(screen.getByPlaceholderText(/target brands/i), { target: { value: 'Cisco, Dell' } });
+      fireEvent.change(screen.getByPlaceholderText(/target layers/i), { target: { value: 'INFRASTRUCTURE, EDGE' } });
+      fireEvent.change(screen.getByPlaceholderText(/target specific host names or ids/i), { target: { value: 'router-01, switch-02' } });
+
+      const numberInputs = screen.getAllByRole('spinbutton');
+      fireEvent.change(numberInputs[0], { target: { value: '65' } });
+      fireEvent.change(numberInputs[1], { target: { value: '85' } });
+
+      fireEvent.change(getInputByLabel(/quick add model/i), { target: { value: 'ASR1001' } });
+
+      clickSaveMetric();
+
+      await waitFor(() => {
+        expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', {
+          id: 'temp.sensor',
+          protocol: 'SNMP',
+          dataType: 'INTEGER',
+          criticality: 1,
+          description: 'Temperature sensor metric',
+          oid: '.1.3.6.1.4.1.9.9.13.1',
+          warning: 65,
+          critical: 85,
+          applicable_to: {
+            brands: ['Cisco', 'Dell'],
+            models: ['ASR1001'],
+            layers: ['INFRASTRUCTURE', 'EDGE'],
+            names: ['router-01', 'switch-02'],
+            excluded_names: [],
+          },
+        });
+      });
+
+      expect(window.alert).toHaveBeenCalledWith('Metric Saved');
+      await waitFor(() => {
+        expect(mocks.apiGet).toHaveBeenCalledTimes(3);
+      });
+      expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument();
+    });
+
+    it('sends null thresholds when warning and critical are left blank', async () => {
+      await openCreateForm();
+
+      fireEvent.change(getInputByLabel(/metric id/i), { target: { value: 'disk.health' } });
+      fireEvent.change(screen.getByPlaceholderText(/examples: \.1\.3\.6\.1/i), { target: { value: '.1.3.6.1.4.1.2021.9.1.9.1' } });
+
+      clickSaveMetric();
+
+      await waitFor(() => {
+        expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', expect.objectContaining({
+          id: 'disk.health',
+          warning: null,
+          critical: null,
+        }));
+      });
+    });
+
+    it('shows an alert when saving fails', async () => {
+      mocks.apiPost.mockRejectedValueOnce(new Error('save failed'));
+      await openCreateForm();
+
+      fireEvent.change(getInputByLabel(/metric id/i), { target: { value: 'packet.loss' } });
+      clickSaveMetric();
+
+      await waitFor(() => {
+        expect(window.alert).toHaveBeenCalledWith('Error saving metric');
+      });
+      expect(screen.getByText('New Metric')).toBeInTheDocument();
+    });
+  });
+
+  describe('edit flow', () => {
+    it('loads a metric into the editor and renders its applicability criteria', async () => {
+      await openEditForm();
+
+      expect(screen.getByText('Edit Metric')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('cpu.load')).toBeDisabled();
+      expect(screen.getByDisplayValue('CPU load metric')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Cisco')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('INFRASTRUCTURE')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('router-01')).toBeInTheDocument();
+      expect(screen.getAllByText(/cisco asr1001/i).length).toBeGreaterThan(0);
+    });
+
+    it('edits an existing metric and saves the updated payload', async () => {
+      await openEditForm();
+
+      fireEvent.change(screen.getByDisplayValue('CPU load metric'), { target: { value: 'Updated CPU metric' } });
+      fireEvent.change(screen.getByPlaceholderText(/target brands/i), { target: { value: 'Cisco, Juniper' } });
+
+      clickSaveMetric();
+
+      await waitFor(() => {
+        expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', expect.objectContaining({
+          id: 'cpu.load',
+          description: 'Updated CPU metric',
+          applicable_to: expect.objectContaining({
+            brands: ['Cisco', 'Juniper'],
+            models: ['ASR1001'],
+          }),
+        }));
+      });
+
+      expect(window.alert).toHaveBeenCalledWith('Metric Saved');
+    });
+
+    it('closes the editor when cancel is clicked', async () => {
+      await openEditForm();
+
+      fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+      expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('usage preview', () => {
+    it('shows usage loading first and then renders the associated CIs table', async () => {
+      const usageDeferred = createDeferred<typeof usageData>();
+      mocks.apiGet.mockImplementation((endpoint: string) => {
+        if (endpoint === '/metrics') return Promise.resolve([metricA, metricB]);
+        if (endpoint === '/hardware') return Promise.resolve(hardwareModels);
+        if (endpoint === '/metrics/cpu.load/usage') return usageDeferred.promise;
+        if (endpoint === '/metrics/mem.usage/usage') return Promise.resolve({ count: 0, cis: [] });
+        return Promise.reject(new Error(`Unhandled GET ${endpoint}`));
+      });
+
+      renderMetricsManager();
+      fireEvent.click(await screen.findByText('cpu.load'));
+
+      expect(await screen.findByText(/loading coverage/i)).toBeInTheDocument();
+
+      usageDeferred.resolve(usageData);
+
+      expect(await screen.findByText('router-01')).toBeInTheDocument();
+      expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
+      expect(screen.getByText('router-02')).toBeInTheDocument();
+    });
+
+    it('shows the empty usage state when no CIs match the metric', async () => {
+      setupApiGet({ usage: { 'cpu.load': { count: 0, cis: [] }, 'mem.usage': { count: 0, cis: [] } } });
+
+      await openEditForm();
+
+      expect(await screen.findByText(/no cis currently match these criteria/i)).toBeInTheDocument();
+    });
+
+    it('auto-detects the data type from the validation endpoint', async () => {
+      mocks.apiPost.mockResolvedValueOnce({ success: true, value: '42', detectedType: 'FLOAT' });
+      await openCreateForm();
+
+      fireEvent.change(screen.getByPlaceholderText(/examples: \.1\.3\.6\.1/i), { target: { value: '.1.3.6.1.2.1.1.5.0' } });
+      fireEvent.change(screen.getByPlaceholderText(/test ip/i), { target: { value: '192.168.0.10' } });
+      fireEvent.change(screen.getByPlaceholderText(/community/i), { target: { value: 'private' } });
+      fireEvent.click(screen.getByRole('button', { name: /auto-detect type/i }));
+
+      await waitFor(() => {
+        expect(mocks.apiPost).toHaveBeenCalledWith('/metrics/validate', {
+          ip: '192.168.0.10',
+          community: 'private',
+          oid: '.1.3.6.1.2.1.1.5.0',
+        });
+      });
+
+      expect(await screen.findByText(/value: 42 \(detected: float\)/i)).toBeInTheDocument();
+      expect((getInputByLabel(/data type/i) as HTMLSelectElement).value).toBe('FLOAT');
+    });
+
+    it('requires both IP and OID before running validation', async () => {
+      await openCreateForm();
+
+      fireEvent.click(screen.getByRole('button', { name: /auto-detect type/i }));
+
+      expect(window.alert).toHaveBeenCalledWith('IP and OID required');
+      expect(mocks.apiPost).not.toHaveBeenCalled();
+    });
+
+    it('shows an alert when validation fails', async () => {
+      mocks.apiPost.mockRejectedValueOnce(new Error('validation failed'));
+      await openCreateForm();
+
+      fireEvent.change(screen.getByPlaceholderText(/examples: \.1\.3\.6\.1/i), { target: { value: '.1.3.6.1.2.1.1.5.0' } });
+      fireEvent.change(screen.getByPlaceholderText(/test ip/i), { target: { value: '192.168.0.10' } });
+      fireEvent.click(screen.getByRole('button', { name: /auto-detect type/i }));
+
+      await waitFor(() => {
+        expect(window.alert).toHaveBeenCalledWith('Test Failed');
+      });
+    });
+  });
+
+  describe('delete and association removal', () => {
+    it('deletes a metric when the user confirms the action', async () => {
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(true);
+      mocks.apiGet.mockClear();
+
+      clickDeleteMetric();
+
+      await waitFor(() => {
+        expect(mocks.apiGet).toHaveBeenCalledWith('/metrics/cpu.load/usage');
+      });
+      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("This action cannot be undone."));
+
+      await waitFor(() => {
+        expect(mocks.apiDelete).toHaveBeenCalledWith('/metrics/cpu.load');
+      });
+    });
+
+    it('does not delete a metric when the user cancels the confirmation', async () => {
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(false);
+      mocks.apiGet.mockClear();
+
+      clickDeleteMetric();
+
+      await waitFor(() => {
+        expect(mocks.apiGet).toHaveBeenCalledWith('/metrics/cpu.load/usage');
+      });
+      expect(mocks.apiDelete).not.toHaveBeenCalled();
+    });
+
+    it('shows an alert when checking metric usage for delete fails', async () => {
+      await openEditForm();
+      mocks.apiGet.mockImplementation(async (endpoint: string) => {
+        if (endpoint === '/metrics') return [metricA, metricB];
+        if (endpoint === '/hardware') return hardwareModels;
+        if (endpoint === '/metrics/cpu.load/usage') throw new Error('usage failed');
+        if (endpoint === '/metrics/mem.usage/usage') return { count: 0, cis: [] };
+        throw new Error(`Unhandled GET ${endpoint}`);
+      });
+
+      clickDeleteMetric();
+
+      await waitFor(() => {
+        expect(window.alert).toHaveBeenCalledWith('Error checking metric usage');
+      });
+    });
+
+    it('does not remove an associated CI when confirm returns false', async () => {
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(false);
+      mocks.apiPost.mockClear();
+
+      const deleteButtons = await screen.findAllByTitle('Remove specific association');
+      fireEvent.click(deleteButtons[0]);
+
+      expect(mocks.apiPost).not.toHaveBeenCalled();
+    });
+
+    it('removes an associated CI and persists excluded names when confirm returns true', async () => {
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(true);
+
+      const deleteButtons = await screen.findAllByTitle('Remove specific association');
+      fireEvent.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', expect.objectContaining({
+          id: 'cpu.load',
+          applicable_to: {
+            brands: ['Cisco'],
+            models: ['ASR1001'],
+            layers: ['INFRASTRUCTURE'],
+            names: [],
+            excluded_names: ['router-02', 'router-01', 'ci-1'],
+          },
+        }));
+      });
+
+      expect(window.alert).not.toHaveBeenCalledWith('Metric Saved');
+      expect(screen.getByText('Edit Metric')).toBeInTheDocument();
+    });
+
+    it('keeps draft applicability edits when excluding an associated CI', async () => {
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(true);
+      mocks.apiPost.mockClear();
+
+      fireEvent.change(screen.getByDisplayValue('CPU load metric'), {
+        target: { value: 'Unsaved draft description' },
+      });
+      fireEvent.change(screen.getByPlaceholderText(/target brands/i), {
+        target: { value: 'Cisco, Juniper' },
+      });
+      fireEvent.change(screen.getByPlaceholderText(/target layers/i), {
+        target: { value: 'INFRASTRUCTURE, EDGE' },
+      });
+      fireEvent.change(screen.getByPlaceholderText(/target specific host names or ids/i), {
+        target: { value: 'router-01, draft-node' },
+      });
+      fireEvent.change(getInputByLabel(/quick add model/i), { target: { value: 'R750' } });
+
+      const deleteButtons = await screen.findAllByTitle('Remove specific association');
+      fireEvent.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', expect.objectContaining({
+          id: 'cpu.load',
+          description: 'Unsaved draft description',
+          applicable_to: {
+            brands: ['Cisco', 'Juniper'],
+            models: ['ASR1001', 'R750'],
+            layers: ['INFRASTRUCTURE', 'EDGE'],
+            names: ['draft-node'],
+            excluded_names: ['router-02', 'router-01', 'ci-1'],
+          },
+        }));
+      });
+
+      expect(screen.getByText('Edit Metric')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Unsaved draft description')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Cisco, Juniper')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('INFRASTRUCTURE, EDGE')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('draft-node')).toBeInTheDocument();
+      expect(window.alert).not.toHaveBeenCalledWith('Metric Saved');
+    });
+  });
+});

--- a/frontend/components/MetricsManager.tsx
+++ b/frontend/components/MetricsManager.tsx
@@ -103,7 +103,7 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
 
     const handleCreate = () => {
         setSelectedMetric(null);
-        setFormData({ protocol: 'SNMP', dataType: 'INTEGER', operator: '>=', applicable_to: {} });
+        setFormData({ protocol: 'SNMP', dataType: 'INTEGER', operator: '>=', criticality: 1, applicable_to: {} });
         setCriteria({ brands: '', models: '', layers: '', names: '', excluded_names: '' });
         setIsEditing(true);
         setTestResult(null);
@@ -111,7 +111,9 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
 
     const handleSave = async (overrideCriteria?: any) => {
         // Prepare applicable_to
-        const crit = overrideCriteria || criteria;
+        const crit = overrideCriteria && typeof overrideCriteria === 'object' && 'brands' in overrideCriteria
+            ? overrideCriteria
+            : criteria;
 
         const appTo = {
             brands: (crit.brands || '').split(',').map((s: string) => s.trim()).filter((s: string) => s),
@@ -134,6 +136,71 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
             setIsEditing(false);
             setFormData({});
             setCriteria({ brands: '', models: '', layers: '', names: '', excluded_names: '' });
+            fetchMetrics();
+        } catch (e) {
+            alert('Error saving metric');
+        }
+    };
+
+    const buildCriteriaStrings = (applicableTo?: MetricDef['applicable_to']) => ({
+        brands: (applicableTo?.brands || []).join(', '),
+        models: (applicableTo?.models || []).join(', '),
+        layers: (applicableTo?.layers || []).join(', '),
+        names: (applicableTo?.names || []).join(', '),
+        excluded_names: (applicableTo?.excluded_names || []).join(', ')
+    });
+
+    const buildMetricPayload = (applicableTo: MetricDef['applicable_to']) => ({
+        ...formData,
+        warning: formData.warning === undefined || formData.warning === null || String(formData.warning) === '' ? null : Number(formData.warning),
+        critical: formData.critical === undefined || formData.critical === null || String(formData.critical) === '' ? null : Number(formData.critical),
+        applicable_to: applicableTo,
+    });
+
+    const handleExcludeAssociatedCI = async (ci: any) => {
+        if (!selectedMetric) return;
+
+        const currentNames = criteria.names.split(',').map(s => s.trim()).filter(s => s);
+        const newNames = currentNames.filter(n => n !== ci.name && n !== ci.id);
+
+        const currentExcluded = criteria.excluded_names.split(',').map(s => s.trim()).filter(s => s);
+        const newExcluded = [...currentExcluded];
+        if (!newExcluded.includes(ci.name)) newExcluded.push(ci.name);
+        if (!newExcluded.includes(ci.id)) newExcluded.push(ci.id);
+
+        const updatedApplicableTo = {
+            brands: criteria.brands.split(',').map(s => s.trim()).filter(s => s),
+            models: criteria.models.split(',').map(s => s.trim()).filter(s => s),
+            layers: criteria.layers.split(',').map(s => s.trim()).filter(s => s),
+            names: newNames,
+            excluded_names: newExcluded,
+        };
+
+        const payload = buildMetricPayload(updatedApplicableTo);
+
+        try {
+            await api.post('/metrics', payload);
+
+            const updatedMetric = {
+                ...selectedMetric,
+                ...payload,
+                applicable_to: updatedApplicableTo,
+            };
+
+            const nextCriteria = {
+                ...criteria,
+                names: newNames.join(', '),
+                excluded_names: newExcluded.join(', '),
+            };
+
+            setFormData(payload);
+            setSelectedMetric(updatedMetric);
+            setCriteria(nextCriteria);
+            setUsageData((prev: any) => prev ? {
+                ...prev,
+                count: Math.max((prev.count || 1) - 1, 0),
+                cis: Array.isArray(prev.cis) ? prev.cis.filter((item: any) => item.id !== ci.id) : [],
+            } : prev);
             fetchMetrics();
         } catch (e) {
             alert('Error saving metric');
@@ -476,31 +543,7 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 if (confirm(`Are you sure you want to remove '${ci.name}' from this metric's applicability list?`)) {
-                                                                    // Logic: 
-                                                                    // 1. Remove from NAMES (if present)
-                                                                    const currentNames = (criteria.names || '').split(',').map(s => s.trim());
-                                                                    const newNames = currentNames.filter(n => n !== ci.name && n !== ci.id).join(', ');
-
-                                                                    // 2. Add to EXCLUDED_NAMES
-                                                                    const currentExcluded = (criteria.excluded_names || '').split(',').map(s => s.trim());
-                                                                    const newExcluded = [...currentExcluded];
-                                                                    if (!newExcluded.includes(ci.name)) newExcluded.push(ci.name);
-                                                                    // Optionally exclude by ID too for robustness
-                                                                    if (!newExcluded.includes(ci.id)) newExcluded.push(ci.id);
-
-                                                                    const newExcludedStr = newExcluded.filter(s => s).join(', ');
-
-                                                                    // Update State
-                                                                    const newCriteria = {
-                                                                        ...criteria,
-                                                                        names: newNames,
-                                                                        excluded_names: newExcludedStr
-                                                                    };
-                                                                    setCriteria(newCriteria);
-
-                                                                    // 3. PERSIST IMMEDIATELY
-                                                                    // Pass overridden criteria because state update might be async
-                                                                    handleSave(newCriteria);
+                                                                    handleExcludeAssociatedCI(ci);
                                                                 }
                                                             }}
                                                             className="text-neutral-600 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"

--- a/frontend/components/ProtectedRoute.test.tsx
+++ b/frontend/components/ProtectedRoute.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { AuthProvider, useAuth } from '../context/AuthContext';
+
+// Mock react-router-dom's useNavigate for the api.ts import chain
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+// Mock the api module - use vi.hoisted to avoid hoisting issues
+const mocks = vi.hoisted(() => ({
+  api: { get: vi.fn() },
+}));
+vi.mock('../services/api', () => ({
+  api: mocks.api,
+}));
+
+// --- Replicate the ProtectedRoute logic from App.tsx for isolated testing ---
+const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
+  const { isAuthenticated, token, user } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated && !token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  if (user?.force_password_change && location.pathname !== '/change-password') {
+    return <Navigate to="/change-password" replace />;
+  }
+
+  return children;
+};
+
+// Helper to capture current location
+const LocationSpy = () => {
+  const location = useLocation();
+  return <span data-testid="location">{location.pathname}</span>;
+};
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    mocks.api.get.mockReset();
+    // Default: resolve with null user so hydration doesn't crash
+    mocks.api.get.mockResolvedValue(null);
+  });
+
+  describe('unauthenticated access', () => {
+    it('redirects to /login when no token and no user', async () => {
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <AuthProvider>
+            <Routes>
+              <Route path="/login" element={<span>Login Page</span>} />
+              <Route path="/*" element={
+                <ProtectedRoute>
+                  <span>Protected Content</span>
+                </ProtectedRoute>
+              } />
+            </Routes>
+          </AuthProvider>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Login Page')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
+    });
+
+    it('renders protected content when token exists (even without user yet)', async () => {
+      localStorage.setItem('token', 'some-token');
+
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <AuthProvider>
+            <Routes>
+              <Route path="/login" element={<span>Login Page</span>} />
+              <Route path="/*" element={
+                <ProtectedRoute>
+                  <span>Protected Content</span>
+                </ProtectedRoute>
+              } />
+            </Routes>
+          </AuthProvider>
+        </MemoryRouter>
+      );
+
+      // With a token in localStorage, ProtectedRoute should render children
+      // (the user may still be loading from the hydration effect)
+      expect(screen.getByText('Protected Content')).toBeInTheDocument();
+      expect(screen.queryByText('Login Page')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('force password change', () => {
+    it('redirects to /change-password when force_password_change is true', async () => {
+      // Setup: login with a user that has force_password_change
+      const TestLogin = () => {
+        const { login } = useAuth();
+        React.useEffect(() => {
+          login('token', {
+            username: 'admin',
+            role: 'USER',
+            permissions: [],
+            allowed_locations: [],
+            force_password_change: true,
+          });
+        }, []);
+        return null;
+      };
+
+      render(
+        <MemoryRouter initialEntries={['/dashboard']}>
+          <AuthProvider>
+            <TestLogin />
+            <Routes>
+              <Route path="/change-password" element={<span>Change Password</span>} />
+              <Route path="/dashboard" element={
+                <ProtectedRoute>
+                  <span>Dashboard</span>
+                </ProtectedRoute>
+              } />
+            </Routes>
+          </AuthProvider>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Change Password')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+    });
+
+    it('allows access to /change-password when force_password_change is true', async () => {
+      // Pre-set token so ProtectedRoute doesn't immediately redirect to /login
+      localStorage.setItem('token', 'token');
+
+      const TestLogin = () => {
+        const { login } = useAuth();
+        React.useEffect(() => {
+          login('token', {
+            username: 'admin',
+            role: 'USER',
+            permissions: [],
+            allowed_locations: [],
+            force_password_change: true,
+          });
+        }, []);
+        return null;
+      };
+
+      render(
+        <MemoryRouter initialEntries={['/change-password']}>
+          <AuthProvider>
+            <TestLogin />
+            <Routes>
+              <Route path="/change-password" element={
+                <ProtectedRoute>
+                  <span>Change Password</span>
+                </ProtectedRoute>
+              } />
+              <Route path="/dashboard" element={<span>Dashboard</span>} />
+              <Route path="/login" element={<span>Login Page</span>} />
+            </Routes>
+          </AuthProvider>
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Change Password')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/components/RoleManager.test.tsx
+++ b/frontend/components/RoleManager.test.tsx
@@ -1,0 +1,333 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import RoleManager from './RoleManager';
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock('../services/api', () => ({
+  api: mocks.api,
+}));
+
+type Role = {
+  name: string;
+  description: string;
+  permissions: string[];
+  is_system: boolean;
+};
+
+const customRole: Role = {
+  name: 'Operator',
+  description: 'Handles incidents and diagnostics',
+  permissions: ['EVENT_VIEW', 'EVENT_ACK', 'RUN_DIAGNOSTICS'],
+  is_system: false,
+};
+
+const systemRole: Role = {
+  name: 'ADMIN',
+  description: 'System administrator',
+  permissions: ['ROLE_MANAGE', 'USER_MANAGE'],
+  is_system: true,
+};
+
+const setAuth = (allowedPerms: string[] = ['ROLE_MANAGE']) => {
+  mocks.useAuth.mockReturnValue({
+    token: 'test-token',
+    hasPermission: (perm: string) => allowedPerms.includes(perm),
+  });
+};
+
+describe('RoleManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuth();
+    mocks.api.get.mockResolvedValue([]);
+    mocks.api.post.mockResolvedValue(undefined);
+    mocks.api.put.mockResolvedValue(undefined);
+    mocks.api.delete.mockResolvedValue(undefined);
+    vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    vi.spyOn(window, 'confirm').mockImplementation(() => true);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('renders access denied when the user lacks role management permissions', () => {
+    setAuth([]);
+
+    render(<RoleManager />);
+
+    expect(screen.getByText(/access denied\. required: role_manage/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
+    expect(mocks.api.get).toHaveBeenCalledWith('/roles/');
+  });
+
+  it('allows ADMIN permission even without explicit ROLE_MANAGE permission', async () => {
+    setAuth(['ADMIN']);
+    mocks.api.get.mockResolvedValue([customRole]);
+
+    render(<RoleManager />);
+
+    expect(screen.getByRole('button', { name: /new role/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Operator')).toBeInTheDocument();
+    });
+  });
+
+  it('starts with no role cards while the fetch is still pending and then renders data', async () => {
+    let resolveRoles: (roles: Role[]) => void = () => undefined;
+    const pendingRoles = new Promise<Role[]>((resolve) => {
+      resolveRoles = resolve;
+    });
+    mocks.api.get.mockReturnValue(pendingRoles);
+
+    render(<RoleManager />);
+
+    expect(screen.getByText(/available roles/i)).toBeInTheDocument();
+    expect(screen.queryByText('Operator')).not.toBeInTheDocument();
+
+    resolveRoles([customRole]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Operator')).toBeInTheDocument();
+    });
+  });
+
+  it('renders the fetched role list after loading completes', async () => {
+    mocks.api.get.mockResolvedValue([customRole, systemRole]);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Operator')).toBeInTheDocument();
+      expect(screen.getByText('ADMIN')).toBeInTheDocument();
+      expect(screen.getByText(/handles incidents and diagnostics/i)).toBeInTheDocument();
+      expect(screen.getByText('System')).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the list empty and logs when the initial fetch fails', async () => {
+    const error = new Error('Roles fetch failed');
+    mocks.api.get.mockRejectedValue(error);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith(error);
+    });
+    expect(screen.getByText(/available roles/i)).toBeInTheDocument();
+    expect(screen.queryByText('Operator')).not.toBeInTheDocument();
+  });
+
+  it('renders an empty list when the API returns no roles', async () => {
+    mocks.api.get.mockResolvedValue([]);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(mocks.api.get).toHaveBeenCalledWith('/roles/');
+    });
+    expect(screen.getByText(/available roles/i)).toBeInTheDocument();
+    expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('shows create, edit, and delete actions for a user with permission', async () => {
+    mocks.api.get.mockResolvedValue([customRole]);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /new role/i })).toBeInTheDocument();
+      expect(screen.getByTitle('Edit')).toBeInTheDocument();
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render action buttons for a user without permission', () => {
+    setAuth([]);
+
+    render(<RoleManager />);
+
+    expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('opens the create form with empty editable fields', async () => {
+    render(<RoleManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new role/i }));
+
+    expect(screen.getByRole('heading', { name: /create role/i })).toBeInTheDocument();
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0]).toHaveValue('');
+    expect(inputs[0]).not.toBeDisabled();
+    expect(inputs[1]).toHaveValue('');
+  });
+
+  it('creates a new role and reloads the list', async () => {
+    mocks.api.get.mockResolvedValueOnce([]).mockResolvedValueOnce([customRole]);
+
+    render(<RoleManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new role/i }));
+
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: 'Operator' } });
+    fireEvent.change(inputs[1], { target: { value: 'Handles incidents and diagnostics' } });
+    fireEvent.click(screen.getByLabelText('EVENT_VIEW'));
+    fireEvent.click(screen.getByRole('button', { name: /save role/i }));
+
+    await waitFor(() => {
+      expect(mocks.api.post).toHaveBeenCalledWith('/roles/', {
+        name: 'Operator',
+        description: 'Handles incidents and diagnostics',
+        permissions: ['EVENT_VIEW'],
+        is_system: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Operator')).toBeInTheDocument();
+    });
+  });
+
+  it('edits an existing role and keeps the name immutable', async () => {
+    mocks.api.get.mockResolvedValue([customRole]);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Edit')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle('Edit'));
+
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0]).toHaveValue('Operator');
+    expect(inputs[0]).toBeDisabled();
+    fireEvent.change(inputs[1], { target: { value: 'Updated operator description' } });
+    fireEvent.click(screen.getByLabelText('EVENT_ACK'));
+    fireEvent.click(screen.getByLabelText('RUN_DIAGNOSTICS'));
+    fireEvent.click(screen.getByRole('button', { name: /save role/i }));
+
+    await waitFor(() => {
+      expect(mocks.api.put).toHaveBeenCalledWith('/roles/Operator', {
+        ...customRole,
+        description: 'Updated operator description',
+        permissions: ['EVENT_VIEW'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.api.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('deletes a role after confirmation and reloads the list', async () => {
+    mocks.api.get.mockResolvedValue([customRole]);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle('Delete'));
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith('Delete role Operator?');
+      expect(mocks.api.delete).toHaveBeenCalledWith('/roles/Operator');
+    });
+
+    await waitFor(() => {
+      expect(mocks.api.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('does not delete a role when confirmation is cancelled', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mocks.api.get.mockResolvedValue([customRole]);
+
+    render(<RoleManager />);
+
+    await screen.findByText('Operator');
+
+    fireEvent.click(screen.getByTitle('Delete'));
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete role Operator?');
+    expect(mocks.api.delete).not.toHaveBeenCalled();
+  });
+
+  it('alerts and stays on the form when creating a role fails', async () => {
+    mocks.api.post.mockRejectedValue(new Error('Create failed'));
+
+    render(<RoleManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new role/i }));
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: 'Auditor' } });
+    fireEvent.click(screen.getByRole('button', { name: /save role/i }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith('Error: Create failed');
+    });
+    expect(screen.getByRole('heading', { name: /create role/i })).toBeInTheDocument();
+  });
+
+  it('alerts when updating a role fails', async () => {
+    mocks.api.get.mockResolvedValue([customRole]);
+    mocks.api.put.mockRejectedValue(new Error('Update failed'));
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Edit')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle('Edit'));
+    fireEvent.click(screen.getByRole('button', { name: /save role/i }));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith('Error: Update failed');
+    });
+  });
+
+  it('alerts when deleting a role fails', async () => {
+    mocks.api.get.mockResolvedValue([customRole]);
+    mocks.api.delete.mockRejectedValue(new Error('Delete failed'));
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Delete')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTitle('Delete'));
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith('Delete failed');
+    });
+  });
+
+  it('returns to the role list when cancelling the edit form', async () => {
+    render(<RoleManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new role/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.getByText(/available roles/i)).toBeInTheDocument();
+    expect(mocks.api.post).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/context/AuthContext.test.tsx
+++ b/frontend/context/AuthContext.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { AuthProvider, useAuth } from '../context/AuthContext';
+
+// Mock react-router-dom for the api.ts import chain
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+// Mock the api module - use vi.hoisted to avoid hoisting issues
+const mocks = vi.hoisted(() => ({
+  api: { get: vi.fn() },
+}));
+vi.mock('../services/api', () => ({
+  api: mocks.api,
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthProvider>{children}</AuthProvider>
+);
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    // Default: resolve with null user so hydration doesn't crash
+    mocks.api.get.mockResolvedValue(null);
+  });
+
+  describe('initial state', () => {
+    it('starts unauthenticated with no user or token', () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.user).toBeNull();
+      expect(result.current.token).toBeNull();
+    });
+
+    it('reads token from localStorage on mount', () => {
+      localStorage.setItem('token', 'stored-token');
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      expect(result.current.token).toBe('stored-token');
+    });
+  });
+
+  describe('token hydration', () => {
+    it('fetches user from /auth/users/me when token exists', async () => {
+      localStorage.setItem('token', 'valid-token');
+      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
+      mocks.api.get.mockResolvedValue(mockUser);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      expect(mocks.api.get).toHaveBeenCalledWith('/auth/users/me');
+      await waitFor(() => {
+        expect(result.current.user).toEqual(mockUser);
+      });
+    });
+
+    it('logs out if user fetch fails (invalid token)', async () => {
+      localStorage.setItem('token', 'expired-token');
+      mocks.api.get.mockRejectedValue(new Error('Unauthorized'));
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.user).toBeNull();
+        expect(result.current.token).toBeNull();
+      });
+      expect(localStorage.getItem('token')).toBeNull();
+    });
+  });
+
+  describe('login', () => {
+    it('stores token and user in state and localStorage', () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      const user = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
+
+      act(() => {
+        result.current.login('new-token', user);
+      });
+
+      expect(result.current.token).toBe('new-token');
+      expect(result.current.user).toEqual(user);
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(localStorage.getItem('token')).toBe('new-token');
+    });
+  });
+
+  describe('logout', () => {
+    it('clears token, user, and localStorage', () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      act(() => {
+        result.current.login('token', { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] });
+      });
+      expect(result.current.isAuthenticated).toBe(true);
+
+      act(() => {
+        result.current.logout();
+      });
+
+      expect(result.current.token).toBeNull();
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(localStorage.getItem('token')).toBeNull();
+    });
+  });
+
+  describe('hasPermission', () => {
+    it('returns false when no user', () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      expect(result.current.hasPermission('ADMIN')).toBe(false);
+    });
+
+    it('returns true for ADMIN role regardless of permissions', () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      const adminUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
+
+      act(() => {
+        result.current.login('t', adminUser);
+      });
+
+      expect(result.current.hasPermission('ANYTHING')).toBe(true);
+      expect(result.current.hasPermission('USER_MANAGE')).toBe(true);
+    });
+
+    it('checks permissions array for non-admin users', () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      const viewerUser = {
+        username: 'viewer',
+        role: 'VIEWER',
+        permissions: ['METRICS_VIEW'],
+        allowed_locations: [],
+      };
+
+      act(() => {
+        result.current.login('t', viewerUser);
+      });
+
+      expect(result.current.hasPermission('METRICS_VIEW')).toBe(true);
+      expect(result.current.hasPermission('ADMIN')).toBe(false);
+    });
+  });
+});

--- a/frontend/hooks/useEventCorrelation.test.ts
+++ b/frontend/hooks/useEventCorrelation.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useEventCorrelation } from '../hooks/useEventCorrelation';
+import { Event } from '../types';
+
+describe('useEventCorrelation', () => {
+  const makeEvent = (overrides: Partial<Event>): Event => ({
+    id: 'evt-1',
+    ci_id: 'ci-1',
+    ci_name: 'Test CI',
+    metric_id: 'metric-1',
+    metric_name: 'CPU',
+    status: 'OPEN',
+    severity: 'CRITICAL',
+    message: 'Test event',
+    created_at: '2024-01-01T00:00:00Z',
+    last_seen: '2024-01-01T00:00:00Z',
+    ack: false,
+    ...overrides,
+  });
+
+  it('returns empty array when no events', () => {
+    const { result } = renderHook(() => useEventCorrelation([], []));
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns single event as root when no correlations', () => {
+    const event = makeEvent({ id: 'evt-1' });
+    const { result } = renderHook(() => useEventCorrelation([event], []));
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].isRoot).toBe(true);
+    expect(result.current[0].relatedEvents).toHaveLength(0);
+  });
+
+  it('groups same-host events with dominant as root', () => {
+    const events = [
+      makeEvent({ id: 'evt-1', ci_id: 'ci-1', severity: 'CRITICAL', message: 'CPU High' }),
+      makeEvent({ id: 'evt-2', ci_id: 'ci-1', severity: 'WARNING', message: 'Memory High', created_at: '2024-01-01T00:01:00Z' }),
+    ];
+    const { result } = renderHook(() => useEventCorrelation(events, []));
+    
+    const roots = result.current;
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe('evt-1'); // CRITICAL is dominant
+    expect(roots[0].relatedEvents).toHaveLength(1);
+    expect(roots[0].relatedEvents[0].id).toBe('evt-2');
+    expect(roots[0].relatedEvents[0].isRoot).toBe(false);
+  });
+
+  it('prioritizes Unreachable/Down messages as dominant', () => {
+    const events = [
+      makeEvent({ id: 'evt-1', ci_id: 'ci-1', severity: 'WARNING', message: 'Host Unreachable' }),
+      makeEvent({ id: 'evt-2', ci_id: 'ci-1', severity: 'CRITICAL', message: 'CPU High' }),
+    ];
+    const { result } = renderHook(() => useEventCorrelation(events, []));
+    
+    const roots = result.current;
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe('evt-1'); // Unreachable wins over severity
+  });
+
+  it('correlates topology dependencies (DEPENDS_ON)', () => {
+    const events = [
+      makeEvent({ id: 'evt-provider', ci_id: 'provider', severity: 'CRITICAL', message: 'Provider Down' }),
+      makeEvent({ id: 'evt-consumer', ci_id: 'consumer', severity: 'WARNING', message: 'Consumer Warning' }),
+    ];
+    const links = [
+      { source: 'consumer', target: 'provider', relationship: 'DEPENDS_ON' },
+    ];
+    
+    const { result } = renderHook(() => useEventCorrelation(events, links));
+    
+    const roots = result.current;
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe('evt-provider');
+    expect(roots[0].relatedEvents).toHaveLength(1);
+    expect(roots[0].relatedEvents[0].id).toBe('evt-consumer');
+    expect(roots[0].relatedEvents[0].cause).toBe('UPSTREAM_DEPENDENCY_FAILURE');
+  });
+
+  it('ignores links without DEPENDS_ON or HOSTED_ON', () => {
+    const events = [
+      makeEvent({ id: 'evt-1', ci_id: 'ci-1', severity: 'CRITICAL', message: 'Event 1' }),
+      makeEvent({ id: 'evt-2', ci_id: 'ci-2', severity: 'CRITICAL', message: 'Event 2' }),
+    ];
+    const links = [
+      { source: 'ci-1', target: 'ci-2', relationship: 'MANAGED_BY' },
+    ];
+    
+    const { result } = renderHook(() => useEventCorrelation(events, links));
+    
+    // Both should remain roots since MANAGED_BY doesn't trigger correlation
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('sorts roots by severity (CRITICAL first) then by date', () => {
+    const events = [
+      makeEvent({ id: 'evt-1', ci_id: 'ci-1', severity: 'WARNING', message: 'Warning', created_at: '2024-01-01T00:00:00Z' }),
+      makeEvent({ id: 'evt-2', ci_id: 'ci-2', severity: 'CRITICAL', message: 'Critical', created_at: '2024-01-01T00:01:00Z' }),
+      makeEvent({ id: 'evt-3', ci_id: 'ci-3', severity: 'CRITICAL', message: 'Critical earlier', created_at: '2024-01-01T00:00:00Z' }),
+    ];
+    
+    const { result } = renderHook(() => useEventCorrelation(events, []));
+    
+    const roots = result.current;
+    expect(roots).toHaveLength(3);
+    expect(roots[0].id).toBe('evt-2'); // CRITICAL + newest (date desc)
+    expect(roots[1].id).toBe('evt-3'); // CRITICAL + older
+    expect(roots[2].id).toBe('evt-1'); // WARNING
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@google/genai": "^1.37.0",
@@ -28,10 +31,10 @@
     "@types/react": "^19.2.8",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.0",
-    "@vitest/coverage-v8": "^4.1.0",
-    "jsdom": "^28.1.0",
+    "@vitest/coverage-v8": "^4.1.2",
+    "jsdom": "^29.0.1",
     "typescript": "~5.8.2",
     "vite": "^6.2.0",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.2"
   }
 }

--- a/frontend/services/api.test.ts
+++ b/frontend/services/api.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ApiError, api } from '../services/api';
+
+// Mock react-router-dom's useNavigate since api.ts imports it
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+describe('ApiError', () => {
+  it('creates error with message and status', () => {
+    const err = new ApiError('Not found', 404);
+    expect(err.message).toBe('Not found');
+    expect(err.status).toBe(404);
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe('api client', () => {
+  const originalFetch = global.fetch;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    // Mock window.location.href for 401 redirect tests
+    Object.defineProperty(window, 'location', {
+      value: { href: '' },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('get (successful)', () => {
+    it('calls fetch with correct URL and headers', async () => {
+      const mockData = { id: '1', name: 'test' };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve(mockData),
+      });
+
+      const result = await api.get('/nodes');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('adds Authorization header when token exists', async () => {
+      localStorage.setItem('token', 'fake-token');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      });
+
+      await api.get('/nodes');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer fake-token',
+        },
+      });
+    });
+
+    it('returns null for 404 responses', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 404,
+        ok: false,
+      });
+
+      const result = await api.get('/nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('throws ApiError for non-2xx responses', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ detail: 'DB error' }),
+      });
+
+      await expect(api.get('/nodes')).rejects.toThrow('DB error');
+      await expect(api.get('/nodes')).rejects.toHaveProperty('status', 500);
+    });
+
+    it('throws ApiError with statusText when no detail in body', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      });
+
+      await expect(api.get('/nodes')).rejects.toThrow('Internal Server Error');
+    });
+  });
+
+  describe('post', () => {
+    it('sends POST request with JSON body', async () => {
+      const created = { id: 'new-1' };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve(created),
+      });
+
+      const result = await api.post('/nodes', { name: 'test' });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'test' }),
+      });
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('put', () => {
+    it('sends PUT request with JSON body', async () => {
+      const updated = { id: '1', name: 'updated' };
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve(updated),
+      });
+
+      const result = await api.put('/nodes/1', { name: 'updated' });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes/1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'updated' }),
+      });
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('delete', () => {
+    it('sends DELETE request without body by default', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 204,
+        headers: { get: () => null },
+        text: () => Promise.resolve(''),
+      });
+
+      await api.delete('/nodes/1');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes/1', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: undefined,
+      });
+    });
+
+    it('sends DELETE request with body when provided', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      });
+
+      await api.delete('/nodes/1', { force: true });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes/1', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force: true }),
+      });
+    });
+  });
+
+  describe('401 handling', () => {
+    it('clears token and redirects on 401', async () => {
+      localStorage.setItem('token', 'stale-token');
+      global.fetch = vi.fn().mockResolvedValue({
+        status: 401,
+        ok: false,
+      });
+
+      await expect(api.get('/nodes')).rejects.toThrow('Unauthorized');
+
+      expect(localStorage.getItem('token')).toBeNull();
+      expect(window.location.href).toBe('/login');
+    });
+  });
+
+  describe('endpoint normalization', () => {
+    it('prepends /api and adds leading slash if missing', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      });
+
+      await api.get('nodes'); // no leading slash
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', expect.any(Object));
+    });
+
+    it('does not double-slash when endpoint starts with /', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      });
+
+      await api.get('/nodes');
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', expect.any(Object));
+    });
+  });
+
+  describe('non-JSON responses', () => {
+    it('returns text when content-type is not JSON', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'text/plain' },
+        text: () => Promise.resolve('ok'),
+      });
+
+      const result = await api.get('/health');
+      expect(result).toBe('ok');
+    });
+  });
+});

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/utils/status.test.ts
+++ b/frontend/utils/status.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { getStatusColorHex, getStatusClasses, STATUS_COLORS } from '../utils/status';
+
+describe('getStatusColorHex', () => {
+  it('returns UNKNOWN color for null/undefined status', () => {
+    expect(getStatusColorHex(null)).toBe(STATUS_COLORS.UNKNOWN);
+    expect(getStatusColorHex(undefined)).toBe(STATUS_COLORS.UNKNOWN);
+  });
+
+  it('returns correct color for CRITICAL status', () => {
+    expect(getStatusColorHex('CRITICAL')).toBe(STATUS_COLORS.CRITICAL);
+    expect(getStatusColorHex('critical')).toBe(STATUS_COLORS.CRITICAL);
+  });
+
+  it('returns correct color for WARNING status', () => {
+    expect(getStatusColorHex('WARNING')).toBe(STATUS_COLORS.WARNING);
+    expect(getStatusColorHex('warning')).toBe(STATUS_COLORS.WARNING);
+  });
+
+  it('returns OK color for both OK and ACTIVE status', () => {
+    expect(getStatusColorHex('OK')).toBe(STATUS_COLORS.OK);
+    expect(getStatusColorHex('ACTIVE')).toBe(STATUS_COLORS.OK);
+    expect(getStatusColorHex('ok')).toBe(STATUS_COLORS.OK);
+  });
+
+  it('returns UNKNOWN for unrecognized status', () => {
+    expect(getStatusColorHex('FOOBAR')).toBe(STATUS_COLORS.UNKNOWN);
+  });
+});
+
+describe('getStatusClasses', () => {
+  it('returns neutral classes for null/undefined status', () => {
+    expect(getStatusClasses(null)).toBe('text-neutral-500 bg-neutral-500/10 border-neutral-500/20');
+    expect(getStatusClasses(undefined)).toBe('text-neutral-500 bg-neutral-500/10 border-neutral-500/20');
+  });
+
+  it('returns correct classes for CRITICAL', () => {
+    expect(getStatusClasses('CRITICAL')).toBe('text-red-500 bg-red-500/10 border-red-500/20');
+  });
+
+  it('returns correct classes for WARNING', () => {
+    expect(getStatusClasses('WARNING')).toBe('text-yellow-500 bg-yellow-500/10 border-yellow-500/20');
+  });
+
+  it('returns emerald classes for OK and ACTIVE', () => {
+    expect(getStatusClasses('OK')).toBe('text-emerald-500 bg-emerald-500/10 border-emerald-500/20');
+    expect(getStatusClasses('ACTIVE')).toBe('text-emerald-500 bg-emerald-500/10 border-emerald-500/20');
+  });
+
+  it('returns neutral classes for unrecognized status', () => {
+    expect(getStatusClasses('UNKNOWN_STATUS')).toBe('text-neutral-500 bg-neutral-500/10 border-neutral-500/20');
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
@@ -29,13 +30,20 @@ export default defineConfig(({ mode }) => {
     test: {
       globals: true,
       environment: 'jsdom',
-      setupFiles: ['./test-setup.ts'],
-      include: ['**/__tests__/**/*.{test,spec}.{ts,tsx}'],
+      setupFiles: ['./test/setup.ts'],
+      include: ['**/*.test.{ts,tsx}'],
       coverage: {
+        provider: 'v8',
         reporter: ['text', 'lcov'],
-        include: ['components/**/*.{ts,tsx}'],
+        include: ['**/*.{ts,tsx}'],
+        exclude: [
+          'test/**',
+          'node_modules/**',
+          'dist/**',
+          '**/*.d.ts',
+          '**/*.config.*',
+        ],
       },
     },
   };
 });
-// Trigger Re-build


### PR DESCRIPTION
Closes #19

## Summary

- Add a complete backend test suite (322 tests) and frontend test suite (115 tests) with zero live-DB dependencies
- Fix 2 critical security vulnerabilities discovered during test authoring
- Fix 4 production bugs (1 backend data corruption, 3 frontend UI bugs)

## Security Fixes

### `backend/routers/catalog.py` — CRITICAL: unauthenticated write endpoints
19 mutation endpoints (POST/PUT/DELETE) had zero authentication or authorization guards. Any unauthenticated caller could create, modify, or delete Categories, OwnerGroups, Locations, and ServiceCatalog entries.

**Fix**: Added `get_current_user` dependency and `CI_EDIT`/`CI_DELETE` `check_permission` calls to all write operations.

### `backend/routers/events.py` — CRITICAL: privilege escalation + forged comment author
- `ack`, `close`, `prune`, and `diagnose` endpoints were accessible without any permission checks → any authenticated user could manage incidents.
- `EventComment.user` was taken from the request body, allowing any user to forge comments under another user's name.

**Fix**: Added `EVENT_ACK`, `EVENT_CLOSE`, `RUN_DIAGNOSTICS` permission checks. Comment author now always set from the authenticated token.

## Bug Fixes

### `backend/services/node_service.py` — `isoformat()` typo
`iso_format()` was called instead of `isoformat()` (Python's stdlib datetime method). Python doesn't raise on `hasattr` check so this silently returned `None` for all timestamp fields.

### `backend/repositories/user_repo.py` — unsafe defaults in `create_user`
Missing default values caused `None`-type errors on optional fields during user creation.

### `frontend/components/GlobalInventory.tsx` — stale closure + zombie selection
`setInterval` captured the initial render's state closure. Fixed with `useRef` to always read current state. Also fixed selection not being cleared when component unmounts.

### `frontend/components/MetricsManager.tsx` — exclusion + criticality bugs
- CI exclusion called `handleSave` with a stale snapshot instead of live draft state.
- `criticality` field was not initialized on create, causing the backend to receive `undefined`.
- Refactored exclusion logic into `handleExcludeAssociatedCI` helper.

## Test Suite

### Backend (`python -m pytest backend/tests/ -v`)
| File | Coverage |
|------|----------|
| `test_routers_catalog.py` | All 32 catalog endpoints (auth + 403 + happy path) |
| `test_routers_nodes.py` | Nodes CRUD with scoping |
| `test_routers_links.py` | Topology link operations |
| `test_routers_metrics_events.py` | Metrics + Events with permission matrix |
| `test_routers_auth_users_roles.py` | Full auth flow, user management, roles |
| `test_node_service.py` | Service-layer unit tests |
| `test_user_repo_create.py` | Repository-layer tests |
| `test_auth_extended.py`, `test_auth_service.py`, `test_security.py` | Auth internals |
| `test_models.py`, `test_helpers.py` | Model validation |
| `test_event_service_smoke.py`, `test_metric_service_smoke.py` | Smoke tests |

### Frontend (`npm run test:run` from `frontend/`)
| File | Tests |
|------|-------|
| `MetricsManager.test.tsx` | 20 |
| `GlobalInventory.test.tsx` | 14 |
| `RoleManager.test.tsx` | 16 |
| `LoginPage.test.tsx`, `ProtectedRoute.test.tsx` | Auth flow |
| `AuthContext.test.tsx` | Context state |
| `api.test.ts` | Service layer |
| `useEventCorrelation.test.ts` | Custom hook |
| `status.test.ts` | Utility functions |

## How to Run Tests

```bash
# Backend
python -m pytest backend/tests/ -v --tb=short

# Frontend
cd frontend && npm run test:run -- --reporter=verbose
```