### PR TITLE
feat(frontend): unify polling and cache ownership with TanStack Query

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,8 +1,11 @@
-import React, { useState, useEffect } from 'react';
-import { HashRouter as Router, Routes, Route, Link, useLocation, Navigate, useNavigate } from 'react-router-dom';
+import React, { useState } from 'react';
+import { HashRouter as Router, Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import LoginPage from './components/LoginPage';
-import { GraphNode, GraphLink } from './types';
+import { GraphNode } from './types';
+import { api } from './services/api';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from './services/queryKeys';
 
 // Components
 import GraphCMDB from './components/GraphCMDB';
@@ -38,93 +41,59 @@ const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
 // --- Main Layout (Authenticated) ---
 const MainLayout: React.FC = () => {
   const { user, logout, hasPermission } = useAuth();
-  const [nodes, setNodes] = useState<GraphNode[]>([]);
-  const [links, setLinks] = useState<GraphLink[]>([]);
+  const queryClient = useQueryClient();
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
-
-  useEffect(() => {
-    fetchNodes();
-    fetchLinks();
-  }, []);
-
-  const fetchNodes = () => {
-    fetch('/api/nodes', {
-      headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
-    })
-      .then(res => {
-        if (res.status === 401) logout();
-        if (!res.ok) throw new Error(res.statusText);
-        return res.json();
-      })
-      .then(data => {
-        if (Array.isArray(data)) setNodes(data);
-      })
-      .catch(err => console.error(err));
-  };
-
-  const fetchLinks = () => {
-    fetch('/api/links', {
-      headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
-    })
-      .then(res => {
-        if (!res.ok) throw new Error(res.statusText);
-        return res.json();
-      })
-      .then(data => {
-        if (Array.isArray(data)) setLinks(data);
-      })
-      .catch(err => console.error(err));
-  };
+  const cachedNodes = queryClient.getQueryData<GraphNode[]>(queryKeys.nodes()) ?? [];
 
   const [isEditing, setIsEditing] = useState(false);
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [showAIAgent, setShowAIAgent] = useState(false);
 
   // --- CRUD Functions ---
-  const handleSaveCI = (newNode: GraphNode) => {
-    fetch('/api/nodes', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${localStorage.getItem('token')}`
-      },
-      body: JSON.stringify(newNode)
-    })
-      .then(res => res.json())
-      .then(savedNode => {
-        setNodes(prev => {
-          const exists = prev.find(n => n.id === savedNode.id);
-          if (exists) return prev.map(n => n.id === savedNode.id ? savedNode : n);
-          return [...prev, savedNode];
-        });
-        setIsEditing(false);
-        setSelectedNode(null);
-      })
-      .catch(err => console.error(err));
+  const refreshTopologyResources = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.graphTopology() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
+    ]);
   };
 
-  const handleDeleteCI = (id: string) => {
-    fetch(`/api/nodes/${id}`, {
-      method: 'DELETE',
-      headers: { 'Authorization': `Bearer ${localStorage.getItem('token')}` }
-    })
-      .then(() => {
-        setNodes(prev => prev.filter(n => n.id !== id));
-        setLinks(prev => prev.filter(l => l.source !== id && l.target !== id));
-        setIsEditing(false);
-        setSelectedNode(null);
-      })
-      .catch(err => console.error(err));
+  const handleSaveCI = async (newNode: GraphNode) => {
+    try {
+      await api.post('/nodes', newNode);
+      await refreshTopologyResources();
+      setIsEditing(false);
+      setSelectedNode(null);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
-  const exportToPythonAgent = () => {
-    const data = JSON.stringify({ nodes, links }, null, 2);
-    const blob = new Blob([data], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'cmdb_inventory.json';
-    a.click();
+  const handleDeleteCI = async (id: string) => {
+    try {
+      await api.delete(`/nodes/${id}`);
+      await refreshTopologyResources();
+      setIsEditing(false);
+      setSelectedNode(null);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const exportToPythonAgent = async () => {
+    try {
+      const topology = await api.get<{ nodes: GraphNode[]; links: unknown[] }>('/graph/full');
+      const data = JSON.stringify(topology, null, 2);
+      const blob = new Blob([data], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'cmdb_inventory.json';
+      a.click();
+    } catch (err) {
+      console.error('Failed to export CMDB inventory for Python agent.', err);
+      alert('No se pudo exportar el inventario. Verificá tu conexion o volve a iniciar sesion.');
+    }
   };
 
   return (
@@ -183,7 +152,7 @@ const MainLayout: React.FC = () => {
             <h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">Platform Engine v3.2</h1>
             <div className="hidden md:flex items-center gap-2 bg-neutral-900 border border-white/5 px-3 py-1 rounded-full text-[10px] font-black text-accent-cyan">
               <span className="w-2 h-2 bg-accent-cyan rounded-full animate-pulse"></span>
-              SNMP Polling: ACTIVE ({nodes.length} Nodes)
+              SNMP Polling: ACTIVE ({cachedNodes.length} Nodes)
             </div>
           </div>
 
@@ -206,7 +175,7 @@ const MainLayout: React.FC = () => {
               <Route path="monitoring" element={<MonitoringConsole />} />
               <Route path="admin" element={<AdminPage />} />
               <Route path="users" element={<UserManager />} />
-              <Route path="cmdb" element={<GraphCMDB nodes={nodes} links={links} onNodeClick={(n) => { setSelectedNode(n); setShowDetailModal(true); }} />} />
+              <Route path="cmdb" element={<GraphCMDB onNodeClick={(n) => { setSelectedNode(n); setShowDetailModal(true); }} />} />
               <Route path="network" element={<NetworkVisualizer />} />
               <Route path="analytics" element={<MetricAnalytics />} />
               <Route path="inventory" element={<GlobalInventory />} />

--- a/frontend/components/GlobalInventory.test.tsx
+++ b/frontend/components/GlobalInventory.test.tsx
@@ -1,30 +1,19 @@
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import GlobalInventory from './GlobalInventory';
 import type { GraphNode } from '../types';
 
-type MockResponse = {
-  ok: boolean;
-  statusText: string;
-  json: () => Promise<unknown>;
-};
+const mockUseNodesQuery = vi.fn();
+const mockUseCategoriesQuery = vi.fn();
 
-const buildResponse = (data: unknown, ok = true, statusText = 'OK'): MockResponse => ({
-  ok,
-  statusText,
-  json: vi.fn().mockResolvedValue(data),
-});
+vi.mock('../hooks/queries/useNodesQuery', () => ({
+  useNodesQuery: () => mockUseNodesQuery(),
+}));
 
-const createDeferred = <T,>() => {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-};
+vi.mock('../hooks/queries/useCategoriesQuery', () => ({
+  useCategoriesQuery: () => mockUseCategoriesQuery(),
+}));
 
 const makeNode = (overrides: Partial<GraphNode> = {}): GraphNode => ({
   id: overrides.id ?? 'node-1',
@@ -34,382 +23,61 @@ const makeNode = (overrides: Partial<GraphNode> = {}): GraphNode => ({
   metadata: overrides.metadata ?? {},
   ip: overrides.ip ?? '10.0.0.1',
   category: overrides.category ?? 'Network',
-  metrics: overrides.metrics ?? [
-    {
-      name: 'CPU Load',
-      protocol: 'SNMP',
-      oid: '1.3.6.1.4.1.9',
-      value: '42',
-      status: 'OK',
-      last_updated: '2026-04-04T10:00:00.000Z',
-    },
-  ],
+  metrics: overrides.metrics ?? [],
   ...overrides,
 });
 
-const queueFetchResponses = (...responses: MockResponse[]) => {
-  const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
-  responses.forEach((response) => {
-    fetchMock.mockResolvedValueOnce(response);
-  });
-};
-
 describe('GlobalInventory', () => {
+  let nodes: GraphNode[];
+
   beforeEach(() => {
-    vi.restoreAllMocks();
-    vi.useRealTimers();
-    localStorage.clear();
-    localStorage.setItem('token', 'test-token');
-    global.fetch = vi.fn();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockUseNodesQuery.mockReset();
+    mockUseCategoriesQuery.mockReset();
+    nodes = [];
+    mockUseNodesQuery.mockImplementation(() => ({ data: nodes, isLoading: false }));
+    mockUseCategoriesQuery.mockReturnValue({ data: [{ name: 'Network' }] });
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it('renders the initial inventory shell before requests resolve', () => {
-    const nodesRequest = createDeferred<MockResponse>();
-    const categoriesRequest = createDeferred<MockResponse>();
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
-
-    fetchMock
-      .mockReturnValueOnce(nodesRequest.promise)
-      .mockReturnValueOnce(categoriesRequest.promise);
+  it('renders shared nodes and categories from query hooks', () => {
+    nodes = [makeNode({ id: 'node-1', label: 'Router-01' }), makeNode({ id: 'node-2', label: 'Switch-01', ip: '10.0.0.2' })];
 
     render(<GlobalInventory />);
-
-    expect(screen.getByText('Global Inventory')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('SEARCH CI...')).toBeInTheDocument();
-    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('fetches nodes and categories with the auth header', async () => {
-    queueFetchResponses(buildResponse([]), buildResponse([{ name: 'Network' }]));
-
-    render(<GlobalInventory />);
-
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
-        headers: { Authorization: 'Bearer test-token' },
-      });
-      expect(global.fetch).toHaveBeenCalledWith('/api/categories', {
-        headers: { Authorization: 'Bearer test-token' },
-      });
-    });
-  });
-
-  it('loads and renders nodes correctly', async () => {
-    const router = makeNode();
-    const server = makeNode({
-      id: 'node-2',
-      label: 'Server-01',
-      ip: '10.0.0.2',
-      category: 'Compute',
-      type: 'APPLICATION',
-    });
-
-    queueFetchResponses(
-      buildResponse([router, server]),
-      buildResponse([{ name: 'Network' }, { name: 'Compute' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    expect(await screen.findByText('Router-01')).toBeInTheDocument();
-    expect(screen.getByText('Server-01')).toBeInTheDocument();
-    expect(screen.getByText('10.0.0.1')).toBeInTheDocument();
-    expect(screen.getByText('10.0.0.2')).toBeInTheDocument();
-  });
-
-  it('logs an error and keeps the inventory empty when /api/nodes fails', async () => {
-    queueFetchResponses(
-      buildResponse(null, false, 'Internal Server Error'),
-      buildResponse([{ name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await waitFor(() => {
-      expect(console.error).toHaveBeenCalledWith(
-        'Failed to fetch inventory:',
-        expect.any(Error),
-      );
-    });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
-  });
-
-  it('filters nodes by category', async () => {
-    queueFetchResponses(
-      buildResponse([
-        makeNode({ id: 'node-1', label: 'Router-01', category: 'Network' }),
-        makeNode({ id: 'node-2', label: 'DB-01', category: 'Database', ip: '10.0.0.20' }),
-      ]),
-      buildResponse([{ name: 'Network' }, { name: 'Database' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await screen.findByText('Router-01');
-
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Database' } });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.getByText('DB-01')).toBeInTheDocument();
-  });
-
-  it('filters nodes by type when category does not exist', async () => {
-    queueFetchResponses(
-      buildResponse([
-        makeNode({ id: 'node-1', label: 'Router-01', type: 'INFRASTRUCTURE', category: 'Network' }),
-        makeNode({ id: 'node-2', label: 'ERP-App', type: 'APPLICATION', category: 'Business', ip: '10.0.0.30' }),
-      ]),
-      buildResponse([{ name: 'APPLICATION' }, { name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await screen.findByText('ERP-App');
-
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'APPLICATION' } });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.getByText('ERP-App')).toBeInTheDocument();
-  });
-
-  it('filters nodes by search text using the label', async () => {
-    queueFetchResponses(
-      buildResponse([
-        makeNode({ id: 'node-1', label: 'Router-01' }),
-        makeNode({ id: 'node-2', label: 'Database-01', category: 'Database', ip: '10.0.0.11' }),
-      ]),
-      buildResponse([{ name: 'Network' }, { name: 'Database' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await screen.findByText('Router-01');
-
-    fireEvent.change(screen.getByPlaceholderText('SEARCH CI...'), {
-      target: { value: 'database' },
-    });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.getByText('Database-01')).toBeInTheDocument();
-  });
-
-  it('filters nodes by search text using the ip address', async () => {
-    queueFetchResponses(
-      buildResponse([
-        makeNode({ id: 'node-1', label: 'Router-01', ip: '10.0.0.1' }),
-        makeNode({ id: 'node-2', label: 'Switch-01', ip: '192.168.50.10' }),
-      ]),
-      buildResponse([{ name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await screen.findByText('Switch-01');
-
-    fireEvent.change(screen.getByPlaceholderText('SEARCH CI...'), {
-      target: { value: '192.168.50' },
-    });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.getByText('Switch-01')).toBeInTheDocument();
-  });
-
-  it('polls every 5 seconds and refetches both endpoints', async () => {
-    vi.useFakeTimers();
-    queueFetchResponses(
-      buildResponse([makeNode({ id: 'node-1', label: 'Router-01' })]),
-      buildResponse([{ name: 'Network' }]),
-      buildResponse([makeNode({ id: 'node-1', label: 'Router-01' })]),
-      buildResponse([{ name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
 
     expect(screen.getByText('Router-01')).toBeInTheDocument();
-    expect(global.fetch).toHaveBeenCalledTimes(2);
-
-    await act(async () => {
-      vi.advanceTimersByTime(5000);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(global.fetch).toHaveBeenCalledTimes(4);
+    expect(screen.getByText('Switch-01')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Network' })).toBeInTheDocument();
   });
 
-  it('clicking a node opens its detail panel', async () => {
-    const node = makeNode({
-      label: 'Router-01',
-      metrics: [
-        {
-          name: 'CPU Load',
-          protocol: 'SNMP',
-          oid: '1.3.6.1.4.1.9',
-          value: '64',
-          status: 'CRITICAL',
-          last_updated: '2026-04-04T10:00:00.000Z',
-        },
-      ],
-    });
+  it('preserves the selected ci by identifier across refreshes', () => {
+    const selectedId = 'node-1';
+    nodes = [makeNode({ id: selectedId, metrics: [{ name: 'CPU Load', protocol: 'SNMP', oid: '1', value: '42', status: 'OK', last_updated: '2026-04-04T10:00:00.000Z' }] })];
 
-    queueFetchResponses(buildResponse([node]), buildResponse([{ name: 'Network' }]));
-
-    render(<GlobalInventory />);
-
-    const card = await screen.findByText('Router-01');
-    fireEvent.click(card);
-
-    expect(screen.getByText('ID: node-1')).toBeInTheDocument();
-    expect(screen.getByText('CPU Load')).toBeInTheDocument();
-    expect(screen.getByText('64')).toBeInTheDocument();
-  });
-
-  it('keeps the selected item synchronized with polling updates', async () => {
-    vi.useFakeTimers();
-    const initialNode = makeNode({
-      id: 'node-1',
-      label: 'Router-01',
-      metrics: [
-        {
-          name: 'CPU Load',
-          protocol: 'SNMP',
-          oid: '1.3.6.1.4.1.9',
-          value: '42',
-          status: 'OK',
-          last_updated: '2026-04-04T10:00:00.000Z',
-        },
-      ],
-    });
-    const updatedNode = makeNode({
-      id: 'node-1',
-      label: 'Router-01',
-      metrics: [
-        {
-          name: 'CPU Load',
-          protocol: 'SNMP',
-          oid: '1.3.6.1.4.1.9',
-          value: '95',
-          status: 'CRITICAL',
-          last_updated: '2026-04-04T10:05:00.000Z',
-        },
-      ],
-    });
-
-    queueFetchResponses(
-      buildResponse([initialNode]),
-      buildResponse([{ name: 'Network' }]),
-      buildResponse([updatedNode]),
-      buildResponse([{ name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    const { rerender } = render(<GlobalInventory />);
 
     fireEvent.click(screen.getByText('Router-01'));
     expect(screen.getByText('42')).toBeInTheDocument();
 
-    await act(async () => {
-      vi.advanceTimersByTime(5000);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    nodes = [makeNode({ id: selectedId, metrics: [{ name: 'CPU Load', protocol: 'SNMP', oid: '1', value: '95', status: 'CRITICAL', last_updated: '2026-04-04T10:05:00.000Z' }] })];
 
+    rerender(<GlobalInventory />);
+
+    expect(screen.getByText('ID: node-1')).toBeInTheDocument();
     expect(screen.getByText('95')).toBeInTheDocument();
   });
 
-  it('clears the selected item when polling no longer returns that CI', async () => {
-    vi.useFakeTimers();
+  it('clears the selected ci when the refreshed dataset no longer contains that id', () => {
+    nodes = [makeNode({ id: 'node-1', label: 'Router-01' })];
 
-    queueFetchResponses(
-      buildResponse([makeNode({ id: 'node-1', label: 'Router-01' })]),
-      buildResponse([{ name: 'Network' }]),
-      buildResponse([makeNode({ id: 'node-2', label: 'Switch-01', ip: '10.0.0.2' })]),
-      buildResponse([{ name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    const { rerender } = render(<GlobalInventory />);
 
     fireEvent.click(screen.getByText('Router-01'));
     expect(screen.getByText('ID: node-1')).toBeInTheDocument();
 
-    await act(async () => {
-      vi.advanceTimersByTime(5000);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    nodes = [makeNode({ id: 'node-2', label: 'Switch-01', ip: '10.0.0.2' })];
+
+    rerender(<GlobalInventory />);
 
     expect(screen.queryByText('ID: node-1')).not.toBeInTheDocument();
-    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
-    expect(screen.getByText('Switch-01')).toBeInTheDocument();
-  });
-
-  it('shows the empty metrics state for a selected node without metrics', async () => {
-    queueFetchResponses(
-      buildResponse([makeNode({ id: 'node-1', label: 'Router-01', metrics: [] })]),
-      buildResponse([{ name: 'Network' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    fireEvent.click(await screen.findByText('Router-01'));
-
-    expect(screen.getByText('No Metrics Configured')).toBeInTheDocument();
-  });
-
-  it('renders an empty inventory list when the API returns no nodes', async () => {
-    queueFetchResponses(buildResponse([]), buildResponse([{ name: 'Network' }]));
-
-    render(<GlobalInventory />);
-
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledTimes(2);
-    });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
-  });
-
-  it('shows no list items when filters produce no results', async () => {
-    queueFetchResponses(
-      buildResponse([
-        makeNode({ id: 'node-1', label: 'Router-01', category: 'Network' }),
-        makeNode({ id: 'node-2', label: 'Server-01', category: 'Compute', ip: '10.0.0.50' }),
-      ]),
-      buildResponse([{ name: 'Network' }, { name: 'Compute' }]),
-    );
-
-    render(<GlobalInventory />);
-
-    await screen.findByText('Router-01');
-
-    fireEvent.change(screen.getByPlaceholderText('SEARCH CI...'), {
-      target: { value: 'does-not-exist' },
-    });
-
-    expect(screen.queryByText('Router-01')).not.toBeInTheDocument();
-    expect(screen.queryByText('Server-01')).not.toBeInTheDocument();
     expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
   });
 });

--- a/frontend/components/GlobalInventory.tsx
+++ b/frontend/components/GlobalInventory.tsx
@@ -1,7 +1,9 @@
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { GraphNode } from '../types';
 import { getStatusClasses } from '../utils/status';
+import { useCategoriesQuery } from '../hooks/queries/useCategoriesQuery';
+import { useNodesQuery } from '../hooks/queries/useNodesQuery';
 
 /**
  * GlobalInventory Component
@@ -10,73 +12,18 @@ import { getStatusClasses } from '../utils/status';
  * Supports filtering by category and search by name/IP.
  */
 const GlobalInventory: React.FC = () => {
-    // Unify on GraphNode for consistency
-    const [inventory, setInventory] = useState<GraphNode[]>([]);
-    const [filteredInventory, setFilteredInventory] = useState<GraphNode[]>([]);
-    const [categories, setCategories] = useState<string[]>([]);
+    const { data: inventoryData } = useNodesQuery();
+    const { data: categoryData } = useCategoriesQuery();
     const [selectedCategory, setSelectedCategory] = useState<string>('ALL');
-    const [selectedItem, setSelectedItem] = useState<GraphNode | null>(null);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
     const [searchTerm, setSearchTerm] = useState('');
-    const selectedItemRef = useRef<GraphNode | null>(null);
+    const inventory = inventoryData ?? [];
+    const categories = useMemo(
+        () => (categoryData ?? []).map((category) => category.name),
+        [categoryData],
+    );
 
-    useEffect(() => {
-        selectedItemRef.current = selectedItem;
-    }, [selectedItem]);
-
-    const fetchData = () => {
-        const token = localStorage.getItem('token');
-        const headers = { 'Authorization': `Bearer ${token}` };
-
-        // Fetch Inventory (CIs with Metrics)
-        fetch('/api/nodes', { headers })
-            .then(res => {
-                if (!res.ok) throw new Error(res.statusText);
-                return res.json();
-            })
-            .then(data => {
-                if (Array.isArray(data)) {
-                    setInventory(data);
-                    const currentSelectedItem = selectedItemRef.current;
-                    if (currentSelectedItem) {
-                        // Real-time update of selected item
-                        const updated = data.find((i: GraphNode) => i.id === currentSelectedItem.id);
-                        if (updated) {
-                            setSelectedItem(updated);
-                        } else {
-                            setSelectedItem(null);
-                        }
-                    }
-                } else {
-                    console.error("Expected array for inventory but got:", data);
-                    setInventory([]);
-                }
-            })
-            .catch(err => console.error("Failed to fetch inventory:", err));
-
-        fetch('/api/categories', { headers })
-            .then(res => {
-                if (!res.ok) throw new Error(res.statusText);
-                return res.json();
-            })
-            .then(data => {
-                if (Array.isArray(data)) {
-                    setCategories(data.map((c: any) => c.name));
-                } else {
-                    console.error("Expected array for categories but got:", data);
-                    setCategories([]);
-                }
-            })
-            .catch(err => console.error("Failed to fetch categories:", err));
-    };
-
-    useEffect(() => {
-        fetchData();
-        const interval = setInterval(fetchData, 5000);
-        return () => clearInterval(interval);
-    }, []);
-
-    // Filter Logic
-    useEffect(() => {
+    const filteredInventory = useMemo(() => {
         let res = inventory;
         if (selectedCategory !== 'ALL') {
             res = res.filter(i => i.category === selectedCategory || i.type === selectedCategory);
@@ -88,8 +35,19 @@ const GlobalInventory: React.FC = () => {
                 i.ip?.toLowerCase().includes(lower)
             );
         }
-        setFilteredInventory(res);
-    }, [inventory, selectedCategory, searchTerm]);
+        return res;
+    }, [inventory, searchTerm, selectedCategory]);
+
+    const selectedItem = useMemo(
+        () => inventory.find((item) => item.id === selectedId) ?? null,
+        [inventory, selectedId],
+    );
+
+    useEffect(() => {
+        if (selectedId && !selectedItem) {
+            setSelectedId(null);
+        }
+    }, [selectedId, selectedItem]);
 
     return (
         <div className="h-full flex flex-col p-6 overflow-hidden">
@@ -123,8 +81,8 @@ const GlobalInventory: React.FC = () => {
                     {filteredInventory.map(item => (
                         <div
                             key={item.id}
-                            onClick={() => setSelectedItem(item)}
-                            className={`p-4 rounded-xl border cursor-pointer transition-all group ${selectedItem?.id === item.id
+                            onClick={() => setSelectedId(item.id)}
+                            className={`p-4 rounded-xl border cursor-pointer transition-all group ${selectedId === item.id
                                 ? 'bg-brand-600/10 border-brand-500/50 shadow-[0_0_15px_rgba(59,130,246,0.15)]'
                                 : 'bg-white/5 border-white/5 hover:bg-white/10 hover:border-white/10'
                                 }`}
@@ -133,7 +91,7 @@ const GlobalInventory: React.FC = () => {
                                 <div>
                                     <div className="flex items-center gap-2">
                                         <span className={`w-2 h-2 rounded-full ${item.metrics?.some(m => m.status === 'CRITICAL') ? 'bg-red-500 animate-pulse' : 'bg-emerald-500'}`}></span>
-                                        <h3 className={`text-sm font-black ${selectedItem?.id === item.id ? 'text-brand-400' : 'text-white'}`}>{item.label || item.id}</h3>
+                                        <h3 className={`text-sm font-black ${selectedId === item.id ? 'text-brand-400' : 'text-white'}`}>{item.label || item.id}</h3>
                                     </div>
                                     <div className="flex gap-2 mt-1">
                                         <span className="text-[10px] font-mono text-neutral-500">{item.ip || 'NO IP'}</span>

--- a/frontend/components/GraphCMDB.tsx
+++ b/frontend/components/GraphCMDB.tsx
@@ -1,408 +1,232 @@
-
-import { useEffect, useRef, RefObject } from 'react';
+import { type RefObject, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import * as d3 from 'd3';
-import { GraphNode, GraphLink } from '../types';
+import { GraphLink, GraphNode } from '../types';
 import { STATUS_COLORS } from '../utils/status';
-import { api } from '../services/api';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface TopologyResponse {
-  nodes: GraphNode[];
-  links: GraphLink[];
-}
+import { useGraphTopologyQuery } from '../hooks/queries/useGraphTopologyQuery';
 
 interface GraphCMDBProps {
-  nodes: GraphNode[];
-  links: GraphLink[];
   onNodeClick: (node: GraphNode) => void;
 }
 
-interface AnimatedLinksLayerProps {
-  svgRef: RefObject<SVGSVGElement | null>;
-  /** Stable ref that holds the latest graph data — never causes re-renders */
-  dataRef: RefObject<TopologyResponse | null>;
-  /** Callback ref set by GraphCMDB so AnimatedLinksLayer can register its D3 updater */
-  onD3UpdaterReady: RefObject<((links: GraphLink[]) => void) | null>;
-}
-
-// ---------------------------------------------------------------------------
-// useGraphData — polling hook
-// ---------------------------------------------------------------------------
-
-/**
- * useGraphData
- *
-  * Polls /api/graph/full every `intervalMs` milliseconds.
- * Data is stored exclusively in a Ref — no React state is ever updated,
- * so polling never triggers a component re-render.
- *
- * The `onNewData` callback ref is called with the fresh payload so that
- * D3 visualizations can update their DOM directly.
- *
- * @param onNewData - Stable RefObject pointing to a D3 updater fn (or null)
- * @param intervalMs - Polling interval in milliseconds (default 30 000)
- * @returns dataRef — a Ref always containing the latest topology data
- */
-function useGraphData(
-  onNewData: RefObject<((data: TopologyResponse) => void) | null>,
-  intervalMs = 30_000,
-): RefObject<TopologyResponse | null> {
-  const dataRef = useRef<TopologyResponse | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchTopology = async () => {
-      try {
-        const data = await api.get<TopologyResponse>('/graph/full');
-        if (cancelled || !data) return;
-
-        // Store latest data in ref — no setState, no re-render
-        dataRef.current = data;
-
-        // Notify D3 updater if one is registered
-        onNewData.current?.(data);
-      } catch (err) {
-        // Network / auth errors are handled by api.ts (401 → redirect, etc.)
-        console.error('[useGraphData] fetch error:', err);
-      }
-    };
-
-    // Kick off immediately, then repeat on interval
-    fetchTopology();
-    const intervalId = setInterval(fetchTopology, intervalMs);
-
-    return () => {
-      cancelled = true;
-      clearInterval(intervalId);
-    };
-  }, [onNewData, intervalMs]); // onNewData is a stable ref, intervalMs is a primitive
-
-  return dataRef;
-}
-
-/**
- * AnimatedLinksLayer Component
- *
- * Renders animated D3 link overlays via React Portal into #d3-portal-root.
- * This component is intentionally decoupled from React's render cycle:
- * - useRef provides direct DOM access without triggering re-renders
- * - useEffect with empty dependency array initializes D3 animations once on mount
- *
- * Portal ensures the SVG overlay sits outside the React component tree,
- * preventing React reconciliation from interfering with D3 mutations.
- *
- * Polling integration:
- * - onD3UpdaterReady receives a D3 update function after mount.
- * - When useGraphData fetches new data it calls that function directly,
- *   updating pulse circle counts via DOM mutation — zero React re-renders.
- */
-const AnimatedLinksLayer = ({ svgRef, dataRef, onD3UpdaterReady }: AnimatedLinksLayerProps) => {
+const AnimatedLinksLayer = ({ svgRef, links }: { svgRef: RefObject<SVGSVGElement | null>; links: GraphLink[] }) => {
   const portalSvgRef = useRef<SVGSVGElement>(null);
 
-  // Initialize D3 animations once — intentionally empty dep array
-  // to prevent D3 from being re-initialized on every React render
   useEffect(() => {
     const portalRoot = document.getElementById('d3-portal-root');
-    if (!portalRoot || !portalSvgRef.current || !svgRef.current) return;
+    if (!portalRoot || !portalSvgRef.current || !svgRef.current) {
+      return;
+    }
 
-    // Mirror the host SVG dimensions via direct DOM access (no React state)
-    const hostRect = svgRef.current.getBoundingClientRect();
+    const rect = svgRef.current.getBoundingClientRect();
     const portalSvg = d3.select(portalSvgRef.current)
-      .attr('width', hostRect.width)
-      .attr('height', hostRect.height)
+      .attr('width', rect.width)
+      .attr('height', rect.height)
       .style('position', 'absolute')
-      .style('top', `${hostRect.top + window.scrollY}px`)
-      .style('left', `${hostRect.left + window.scrollX}px`)
+      .style('top', `${rect.top + window.scrollY}px`)
+      .style('left', `${rect.left + window.scrollX}px`)
       .style('pointer-events', 'none')
       .style('overflow', 'visible');
 
-    // D3 pulse animation group — lives entirely outside React tree
     const pulseGroup = portalSvg.append('g').attr('class', 'd3-pulse-layer');
-
-    /**
-     * renderPulseMarkers
-     *
-     * Performs a D3 data-join on CONNECTS_TO links.
-     * Called once on mount (with initial links from dataRef) and then
-     * directly from the polling callback whenever new data arrives —
-     * without ever going through React's render cycle.
-     */
-    const renderPulseMarkers = (links: GraphLink[]) => {
-      const CONNECTS_TO = links.filter((l: any) => l.relationship === 'CONNECTS_TO');
-
-      // D3 key-join so existing circles are reused, new ones are added,
-      // removed ones are cleaned up — all as direct DOM mutations.
-      pulseGroup
-        .selectAll<SVGCircleElement, GraphLink>('circle')
-        .data(CONNECTS_TO, (d: any) => d.id)
-        .join(
-          enter => enter.append('circle')
-            .attr('r', 5)
-            .attr('fill', '#10b981')
-            .attr('opacity', 0.8),
-          update => update, // no attribute change needed on update
-          exit => exit.remove(),
-        );
-    };
-
-    // Seed with whatever data is already in the ref (may be null on very first render)
-    const initialLinks = dataRef.current?.links ?? [];
-    renderPulseMarkers(initialLinks);
-
-    // Register the D3 updater so useGraphData can call it directly on poll
-    onD3UpdaterReady.current = (links: GraphLink[]) => renderPulseMarkers(links);
-
-    // Sync portal SVG position on window resize via direct DOM — no React state
-    const handleResize = () => {
-      if (!svgRef.current || !portalSvgRef.current) return;
-      const rect = svgRef.current.getBoundingClientRect();
-      d3.select(portalSvgRef.current)
-        .attr('width', rect.width)
-        .attr('height', rect.height)
-        .style('top', `${rect.top + window.scrollY}px`)
-        .style('left', `${rect.left + window.scrollX}px`);
-    };
-
-    window.addEventListener('resize', handleResize);
+    pulseGroup
+      .selectAll('circle')
+      .data(links.filter((link: any) => link.relationship === 'CONNECTS_TO'), (link: any) => link.id)
+      .join(
+        (enter) => enter.append('circle').attr('r', 5).attr('fill', '#10b981').attr('opacity', 0.8),
+        (update) => update,
+        (exit) => exit.remove(),
+      );
 
     return () => {
-      window.removeEventListener('resize', handleResize);
-      // Unregister updater and clean up DOM — bypasses React reconciliation intentionally
-      onD3UpdaterReady.current = null;
       portalSvg.selectAll('*').remove();
     };
-  }, []); // Empty array: D3 owns this DOM subtree after mount
+  }, [links, svgRef]);
 
   const portalRoot = document.getElementById('d3-portal-root');
-  if (!portalRoot) return null;
+  if (!portalRoot) {
+    return null;
+  }
 
   return createPortal(
     <svg ref={portalSvgRef} style={{ position: 'absolute', pointerEvents: 'none' }} />,
-    portalRoot
+    portalRoot,
   );
 };
 
-/**
- * GraphCMDB Component
- *
- * Visualizes the topology of Configuration Items (CIs) and their relationships using D3.js.
- * Implements force-directed graph with auto-centering and status-based coloring.
- *
- * Polling architecture:
-  * - useGraphData polls /api/graph/full every 30 s and stores data in a Ref.
- * - d3UpdaterRef is a callback ref bridging useGraphData → AnimatedLinksLayer.
- *   When new data arrives, useGraphData calls d3UpdaterRef.current(data) which
- *   updates the pulse markers directly in the D3 DOM — no React state, no re-renders.
- * - The force-simulation (nodes / links props) can still be driven externally;
- *   the polling data augments it without replacing the prop-driven flow.
- */
-const GraphCMDB = ({ nodes, links, onNodeClick }: GraphCMDBProps) => {
+const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
   const svgRef = useRef<SVGSVGElement>(null);
-
-  // Ref that AnimatedLinksLayer will populate with its D3 updater function
-  const d3UpdaterRef = useRef<((links: GraphLink[]) => void) | null>(null);
-
-  // Adapter: useGraphData calls back with TopologyResponse; we forward only links to D3.
-  // Assigned inline (not in useEffect) so it always captures the latest d3UpdaterRef
-  // without creating a new function reference on every render (React Compiler handles this).
-  const onNewDataRef = useRef<((data: TopologyResponse) => void) | null>(null);
-  onNewDataRef.current = (data: TopologyResponse) => {
-    d3UpdaterRef.current?.(data.links);
-  };
-
-  // Start polling — dataRef holds the latest snapshot without triggering re-renders
-  const dataRef = useGraphData(onNewDataRef);
+  const { data } = useGraphTopologyQuery();
+  const nodes = data?.nodes ?? [];
+  const links = data?.links ?? [];
 
   useEffect(() => {
-    if (!svgRef.current) return;
+    if (!svgRef.current) {
+      return;
+    }
 
-    const width = svgRef.current.clientWidth;
-    const height = svgRef.current.clientHeight;
-
+    const width = svgRef.current.clientWidth || 1200;
+    const height = svgRef.current.clientHeight || 800;
     const svg = d3.select(svgRef.current);
-    svg.selectAll("*").remove();
+    svg.selectAll('*').remove();
 
-    // Define Arrow Markers
-    const defs = svg.append("defs");
-    Object.values(STATUS_COLORS).forEach(color => {
+    const defs = svg.append('defs');
+    Object.values(STATUS_COLORS).forEach((color) => {
       const idColor = color.replace('#', '');
-      defs.append("marker")
-        .attr("id", `arrow-${idColor}`)
-        .attr("viewBox", "0 -5 10 10")
-        .attr("refX", 28) // Position at edge of node (r=24 + padding)
-        .attr("refY", 0)
-        .attr("markerWidth", 6)
-        .attr("markerHeight", 6)
-        .attr("orient", "auto")
-        .append("path")
-        .attr("d", "M0,-5L10,0L0,5")
-        .attr("fill", color);
+      defs.append('marker')
+        .attr('id', `arrow-${idColor}`)
+        .attr('viewBox', '0 -5 10 10')
+        .attr('refX', 28)
+        .attr('refY', 0)
+        .attr('markerWidth', 6)
+        .attr('markerHeight', 6)
+        .attr('orient', 'auto')
+        .append('path')
+        .attr('d', 'M0,-5L10,0L0,5')
+        .attr('fill', color);
     });
 
-    // Filter links to ensure valid source/target
-    const validLinks = links.filter(l => {
-      const sourceId = typeof l.source === 'object' ? (l.source as any).id : l.source;
-      const targetId = typeof l.target === 'object' ? (l.target as any).id : l.target;
-      return nodes.some(n => n.id === sourceId) && nodes.some(n => n.id === targetId);
-    }).map(d => Object.create(d)); // Create shallow copy for D3 mutation
+    const validLinks = links.filter((link) => {
+      const sourceId = typeof link.source === 'object' ? (link.source as any).id : link.source;
+      const targetId = typeof link.target === 'object' ? (link.target as any).id : link.target;
+      return nodes.some((node) => node.id === sourceId) && nodes.some((node) => node.id === targetId);
+    }).map((link) => Object.create(link));
 
-    const validNodes = nodes.map(d => Object.create(d)); // Create shallow copy for D3 mutation
+    const validNodes = nodes.map((node) => Object.create(node));
+    const criticalNodeIds = validNodes
+      .filter((node) => node.status === 'CRITICAL' || node.status === 'WARNING')
+      .map((node) => node.id);
 
-    // --- Calculate Impact Analysis (Affected Derived Tree) ---
-    const criticalNodeIds = validNodes.filter(n => n.status === 'CRITICAL' || n.status === 'WARNING').map(n => n.id);
     const affectedSet = new Set<string>(criticalNodeIds);
     let added = true;
     while (added) {
       added = false;
-      validLinks.forEach(l => {
-        const sId = typeof l.source === 'object' ? (l.source as any).id : l.source;
-        const tId = typeof l.target === 'object' ? (l.target as any).id : l.target;
-
-        // In typical CMDB dependencies, Target failing impacts the Source that depends on it
-        if (affectedSet.has(tId) && !affectedSet.has(sId)) {
-          affectedSet.add(sId);
+      validLinks.forEach((link) => {
+        const sourceId = typeof link.source === 'object' ? (link.source as any).id : link.source;
+        const targetId = typeof link.target === 'object' ? (link.target as any).id : link.target;
+        if (affectedSet.has(targetId) && !affectedSet.has(sourceId)) {
+          affectedSet.add(sourceId);
           added = true;
         }
       });
     }
+
     const hasGlobalIncidents = criticalNodeIds.length > 0;
-
     const simulation = d3.forceSimulation<GraphNode>(validNodes)
-      .force("link", d3.forceLink<GraphNode, GraphLink>(validLinks).id(d => d.id).distance(150))
-      .force("charge", d3.forceManyBody().strength(-500))
-      .force("center", d3.forceCenter(width / 2, height / 2));
+      .force('link', d3.forceLink<GraphNode, GraphLink>(validLinks).id((node) => node.id).distance(150))
+      .force('charge', d3.forceManyBody().strength(-500))
+      .force('center', d3.forceCenter(width / 2, height / 2));
 
-    const link = svg.append("g")
-      .selectAll("line")
+    const linkSelection = svg.append('g')
+      .selectAll('line')
       .data(validLinks)
-      .join("line")
-      .attr("stroke-opacity", (d: any) => {
-        if (!hasGlobalIncidents) return 0.6;
-        const sId = typeof d.source === 'object' ? (d.source as any).id : d.source;
-        const tId = typeof d.target === 'object' ? (d.target as any).id : d.target;
-        return (affectedSet.has(sId) || affectedSet.has(tId)) ? 0.9 : 0.2;
+      .join('line')
+      .attr('stroke-opacity', (link: any) => {
+        if (!hasGlobalIncidents) {
+          return 0.6;
+        }
+        const sourceId = typeof link.source === 'object' ? (link.source as any).id : link.source;
+        const targetId = typeof link.target === 'object' ? (link.target as any).id : link.target;
+        return affectedSet.has(sourceId) || affectedSet.has(targetId) ? 0.9 : 0.2;
       })
-      .attr("stroke-width", 2)
-      .attr("stroke", (d: any) => {
-        // Color link based on TARGET node status for dependency impact visualization
-        const targetStatus = d.target?.status || 'UNKNOWN';
+      .attr('stroke-width', 2)
+      .attr('stroke', (link: any) => {
+        const targetStatus = link.target?.status || 'UNKNOWN';
         if (targetStatus === 'CRITICAL') return STATUS_COLORS.CRITICAL;
         if (targetStatus === 'WARNING') return STATUS_COLORS.WARNING;
         if (targetStatus === 'ACTIVE' || targetStatus === 'OK') return STATUS_COLORS.OK;
         return STATUS_COLORS.UNKNOWN;
       })
-      .attr("marker-end", (d: any) => {
-        const targetStatus = d.target?.status || 'UNKNOWN';
+      .attr('marker-end', (link: any) => {
+        const targetStatus = link.target?.status || 'UNKNOWN';
         let color = STATUS_COLORS.UNKNOWN;
         if (targetStatus === 'CRITICAL') color = STATUS_COLORS.CRITICAL;
         else if (targetStatus === 'WARNING') color = STATUS_COLORS.WARNING;
         else if (targetStatus === 'ACTIVE' || targetStatus === 'OK') color = STATUS_COLORS.OK;
-
         return `url(#arrow-${color.replace('#', '')})`;
       })
-      .attr("stroke-dasharray", (d: any) => {
-        if (d.relationship === 'DEPENDS_ON') return "5, 8";
-        if (d.relationship === 'CONNECTS_TO') return "none"; // Base is solid now
-        if (d.relationship === 'HOSTED_ON') return "2, 2";
-        return "none";
+      .attr('stroke-dasharray', (link: any) => {
+        if (link.relationship === 'DEPENDS_ON') return '5, 8';
+        if (link.relationship === 'HOSTED_ON') return '2, 2';
+        return 'none';
       })
-      .attr("class", (d: any) => {
-        if (d.relationship === 'HOSTED_ON') return "opacity-50";
-        return "";
-      })
-      .attr("opacity", 0.6)
-      .style("pointer-events", "none");
+      .style('pointer-events', 'none');
 
-    // Declarative SVG Animate - DEPENDS_ON Flow
-    link.filter((d: any) => d.relationship === 'DEPENDS_ON')
-      .append("animate")
-      .attr("attributeName", "stroke-dashoffset")
-      .attr("from", "26")
-      .attr("to", "0")
-      .attr("dur", "1s")
-      .attr("repeatCount", "indefinite");
-    const trafficLink = svg.append("g")
-      .selectAll("line")
-      .data(validLinks.filter((d: any) => d.relationship === 'CONNECTS_TO'))
-      .join("line")
-      .attr("stroke-width", 3)
-      .attr("stroke", "#10b981") // Traffic blast
-      .attr("stroke-dasharray", "5, 50")
-      .attr("opacity", 0.7)
-      .style("pointer-events", "none");
+    const trafficLink = svg.append('g')
+      .selectAll('line')
+      .data(validLinks.filter((link: any) => link.relationship === 'CONNECTS_TO'))
+      .join('line')
+      .attr('stroke-width', 3)
+      .attr('stroke', '#10b981')
+      .attr('stroke-dasharray', '5, 50')
+      .attr('opacity', 0.7)
+      .style('pointer-events', 'none');
 
-    // Declarative SVG Animate - CONNECTS_TO Traffic
-    trafficLink.append("animate")
-      .attr("attributeName", "stroke-dashoffset")
-      .attr("from", "0")
-      .attr("to", "110")
-      .attr("dur", "2.5s")
-      .attr("repeatCount", "indefinite");
+    trafficLink.append('animate')
+      .attr('attributeName', 'stroke-dashoffset')
+      .attr('from', '0')
+      .attr('to', '110')
+      .attr('dur', '2.5s')
+      .attr('repeatCount', 'indefinite');
 
-    const node = svg.append("g")
-      .selectAll("g")
+    const nodeSelection = svg.append('g')
+      .selectAll('g')
       .data(validNodes)
-      .join("g")
-      .attr("class", "cursor-pointer group")
-      .attr("opacity", d => {
-        if (!hasGlobalIncidents) return 1;
-        return affectedSet.has(d.id) ? 1 : 0.4; // Expose healthy nodes at 40% instead of 5%
+      .join('g')
+      .attr('class', 'cursor-pointer group')
+      .attr('opacity', (node) => {
+        if (!hasGlobalIncidents) {
+          return 1;
+        }
+        return affectedSet.has(node.id) ? 1 : 0.4;
       })
-      .on("click", (event, d) => onNodeClick(d))
+      .on('click', (_event, node) => onNodeClick(node))
       .call(d3.drag<SVGGElement, GraphNode>()
-        .on("start", dragstarted)
-        .on("drag", dragged)
-        .on("end", dragended) as any);
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended) as any);
 
-    // Node circles with health indicators
-    node.append("circle")
-      .attr("r", d => d.status === 'CRITICAL' ? 32 : d.status === 'WARNING' ? 28 : 24)
-      .attr("fill", "#1a1a1a")
-      .attr("stroke", d => {
-        if (d.status === 'CRITICAL') return STATUS_COLORS.CRITICAL;
-        if (d.status === 'WARNING') return STATUS_COLORS.WARNING;
-        if (affectedSet.has(d.id)) return '#f97316'; // Orange for derived affected tree
-        return '#345bf2'; // Brand Color for safe nodes
+    nodeSelection.append('circle')
+      .attr('r', (node) => node.status === 'CRITICAL' ? 32 : node.status === 'WARNING' ? 28 : 24)
+      .attr('fill', '#1a1a1a')
+      .attr('stroke', (node) => {
+        if (node.status === 'CRITICAL') return STATUS_COLORS.CRITICAL;
+        if (node.status === 'WARNING') return STATUS_COLORS.WARNING;
+        if (affectedSet.has(node.id)) return '#f97316';
+        return '#345bf2';
       })
-      .attr("stroke-width", d => affectedSet.has(d.id) || d.status === 'CRITICAL' ? 4 : 2)
-      .attr("class", d => affectedSet.has(d.id) ? 'animate-pulse' : '');
+      .attr('stroke-width', (node) => affectedSet.has(node.id) || node.status === 'CRITICAL' ? 4 : 2)
+      .attr('class', (node) => affectedSet.has(node.id) ? 'animate-pulse' : '');
 
-    // Node icons (simplified labels for now)
-    node.append("text")
-      .attr("dy", ".35em")
-      .attr("text-anchor", "middle")
-      .attr("fill", "white")
-      .attr("font-size", "10px")
-      .attr("font-weight", "bold")
-      .text(d => d.label.substring(0, 3).toUpperCase());
+    nodeSelection.append('text')
+      .attr('dy', '.35em')
+      .attr('text-anchor', 'middle')
+      .attr('fill', 'white')
+      .attr('font-size', '10px')
+      .attr('font-weight', 'bold')
+      .text((node) => node.label.substring(0, 3).toUpperCase());
 
-    // Labels
-    node.append("text")
-      .attr("dy", "3.5em")
-      .attr("text-anchor", "middle")
-      .attr("fill", "#a3a3a3")
-      .attr("font-size", "11px")
-      .text(d => d.label);
+    nodeSelection.append('text')
+      .attr('dy', '3.5em')
+      .attr('text-anchor', 'middle')
+      .attr('fill', '#a3a3a3')
+      .attr('font-size', '11px')
+      .text((node) => node.label);
 
-    simulation.on("tick", () => {
-      link
-        .attr("x1", (d: any) => d.source.x)
-        .attr("y1", (d: any) => d.source.y)
-        .attr("x2", (d: any) => d.target.x)
-        .attr("y2", (d: any) => d.target.y);
+    simulation.on('tick', () => {
+      linkSelection
+        .attr('x1', (link: any) => link.source.x)
+        .attr('y1', (link: any) => link.source.y)
+        .attr('x2', (link: any) => link.target.x)
+        .attr('y2', (link: any) => link.target.y);
 
       trafficLink
-        .attr("x1", (d: any) => d.source.x)
-        .attr("y1", (d: any) => d.source.y)
-        .attr("x2", (d: any) => d.target.x)
-        .attr("y2", (d: any) => d.target.y);
+        .attr('x1', (link: any) => link.source.x)
+        .attr('y1', (link: any) => link.source.y)
+        .attr('x2', (link: any) => link.target.x)
+        .attr('y2', (link: any) => link.target.y);
 
-      node.attr("transform", (d: any) => `translate(${d.x},${d.y})`);
+      nodeSelection.attr('transform', (node: any) => `translate(${node.x},${node.y})`);
     });
 
     function dragstarted(event: any) {
@@ -423,23 +247,19 @@ const GraphCMDB = ({ nodes, links, onNodeClick }: GraphCMDBProps) => {
     }
 
     return () => simulation.stop();
-  }, [nodes, links, onNodeClick]);
+  }, [links, nodes, onNodeClick]);
 
   return (
-    <div className="w-full h-full relative overflow-hidden bg-surface-950 grid-bg">
-      <svg ref={svgRef} className="w-full h-full" />
-      <AnimatedLinksLayer
-        svgRef={svgRef}
-        dataRef={dataRef}
-        onD3UpdaterReady={d3UpdaterRef}
-      />
-      <div className="absolute bottom-4 left-4 flex flex-col gap-2 p-3 glass rounded-lg text-xs pointer-events-none select-none">
-        <div className="flex items-center gap-2"><div className="w-3 h-3 bg-brand-500 rounded-full"></div> Healthy CI</div>
-        <div className="flex items-center gap-2"><div className="w-3 h-3 bg-orange-500 rounded-full"></div> Performance Warning</div>
-        <div className="flex items-center gap-2"><div className="w-3 h-3 bg-red-500 rounded-full"></div> Critical Impact</div>
-        <div className="h-px bg-white/10 my-1"></div>
-        <div className="flex items-center gap-2"><div className="w-8 h-0.5 bg-emerald-500"></div> Connection OK</div>
-        <div className="flex items-center gap-2"><div className="w-8 h-0.5 bg-red-500"></div> Critical Path</div>
+    <div className='w-full h-full relative overflow-hidden bg-surface-950 grid-bg'>
+      <svg ref={svgRef} className='w-full h-full' />
+      <AnimatedLinksLayer svgRef={svgRef} links={links} />
+      <div className='absolute bottom-4 left-4 flex flex-col gap-2 p-3 glass rounded-lg text-xs pointer-events-none select-none'>
+        <div className='flex items-center gap-2'><div className='w-3 h-3 bg-brand-500 rounded-full'></div> Healthy CI</div>
+        <div className='flex items-center gap-2'><div className='w-3 h-3 bg-orange-500 rounded-full'></div> Performance Warning</div>
+        <div className='flex items-center gap-2'><div className='w-3 h-3 bg-red-500 rounded-full'></div> Critical Impact</div>
+        <div className='h-px bg-white/10 my-1'></div>
+        <div className='flex items-center gap-2'><div className='w-8 h-0.5 bg-emerald-500'></div> Connection OK</div>
+        <div className='flex items-center gap-2'><div className='w-8 h-0.5 bg-red-500'></div> Critical Path</div>
       </div>
     </div>
   );

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { api } from '../services/api';
 import { MapContainer, TileLayer, Polyline, useMap, CircleMarker, Circle, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { GraphNode, Event } from '../types';
@@ -8,6 +7,9 @@ import DependencyMiniMap from './DependencyMiniMap';
 import { useEventCorrelation } from '../hooks/useEventCorrelation';
 import L from 'leaflet';
 import { useAuth } from '../context/AuthContext';
+import { useEventMutations } from '../hooks/queries/useEventMutations';
+import { useMonitoringConsoleData } from '../hooks/queries/useMonitoringConsoleData';
+import { useRelatedEventsQuery } from '../hooks/queries/useRelatedEventsQuery';
 
 /**
  * Configure Leaflet Default Icon
@@ -244,44 +246,9 @@ const MapBounds = ({ nodes }: { nodes: GraphNode[] }) => {
  */
 const MonitoringConsole: React.FC = () => {
     const [viewMode, setViewMode] = useState<'DASHBOARD' | 'MAP'>('DASHBOARD');
-    const [events, setEvents] = useState<Event[]>([]);
-    const [nodes, setNodes] = useState<GraphNode[]>([]);
-    const [links, setLinks] = useState<any[]>([]);
     const [filterCategory, setFilterCategory] = useState<string>('ALL');
-    const [categories, setCategories] = useState<string[]>([]);
-
-    // Auto-refresh interval (10s)
-    useEffect(() => {
-        fetchData();
-        const interval = setInterval(fetchData, 10000);
-        return () => clearInterval(interval);
-    }, []);
-
-    /**
-     * Fetch all necessary data for the monitoring console.
-     * Retrieving Nodes, Links, and Active Events in parallel.
-     */
-    const fetchData = async () => {
-        try {
-            const [dataNodes, dataLinks, dataEvents] = await Promise.all([
-                api.get<GraphNode[]>('/nodes'),
-                api.get<any[]>('/links'),
-                api.get<Event[]>('/events?status=ACTIVE')
-            ]);
-
-            if (Array.isArray(dataNodes)) {
-                setNodes(dataNodes);
-                const cats = Array.from(new Set(dataNodes.map((n: GraphNode) => n.type))).sort();
-                setCategories(cats as string[]);
-            }
-
-            if (Array.isArray(dataLinks)) setLinks(dataLinks);
-            if (Array.isArray(dataEvents)) setEvents(dataEvents);
-
-        } catch (e) {
-            console.error("Failed to fetch monitoring data", e);
-        }
-    };
+    const { nodes, links, events, categories } = useMonitoringConsoleData();
+    const eventMutations = useEventMutations();
 
     // --- Actions ---
 
@@ -289,8 +256,7 @@ const MonitoringConsole: React.FC = () => {
      * Ackowledge an event (Operator is working on it).
      */
     const handleAck = async (id: string) => {
-        await api.post(`/events/${id}/ack`, {});
-        fetchData();
+        await eventMutations.ackEvent(id);
     };
 
     // --- Comment / Modal State ---
@@ -325,22 +291,19 @@ const MonitoringConsole: React.FC = () => {
 
     const submitComment = async () => {
         if (!selectedEventId || !commentText.trim()) return;
-        await api.post(`/events/${selectedEventId}/comment`, {
+        await eventMutations.commentEvent(selectedEventId, {
             message: commentText,
             user: CURRENT_USER
         });
         setCommentText("");
-        fetchData();
     };
 
     // M2: Take ownership
     const handleTakeCase = async (id: string) => {
-        await api.post(`/events/${id}/comment`, {
-            message: `[OWNERSHIP] Caso tomado por ${CURRENT_USER} — Tier ${CURRENT_TIER}`,
-            user: CURRENT_USER
+        await eventMutations.takeEvent(id, {
+            user: CURRENT_USER,
+            tier: CURRENT_TIER,
         });
-        await api.post(`/events/${id}/ack`, {});
-        fetchData();
     };
 
     // M5: Structured close
@@ -348,28 +311,27 @@ const MonitoringConsole: React.FC = () => {
         if (!selectedEventId) return;
         if (closeForcedMode) {
             if (!closeForcedReason.trim()) return;
-            await api.post(`/events/${selectedEventId}/comment`, {
+            await eventMutations.commentEvent(selectedEventId, {
                 message: `[CIERRE FORZADO — ${CURRENT_TIER}] Motivo: ${closeForcedReason}`,
                 user: CURRENT_USER
             });
         } else {
             if (!closeRootCause || closeNote.trim().length < 20) return;
-            await api.post(`/events/${selectedEventId}/comment`, {
+            await eventMutations.commentEvent(selectedEventId, {
                 message: `[CIERRE] Causa raíz: ${closeRootCause}\nNota: ${closeNote}`,
                 user: CURRENT_USER
             });
         }
-        await api.post(`/events/${selectedEventId}/close`, { forced: closeForcedMode });
+        await eventMutations.closeEvent(selectedEventId, { forced: closeForcedMode });
         setCommentModalOpen(false);
         setCloseFlowOpen(false);
-        fetchData();
     };
 
     // --- Data Processing for Visualization ---
 
     const filteredNodes = filterCategory === 'ALL'
         ? nodes
-        : nodes.filter(n => n.type === filterCategory);
+        : nodes.filter(n => (n.category ?? n.type) === filterCategory);
 
     // Enriched Nodes with Event Status
     const nodesWithEvents = filteredNodes.map(node => {
@@ -417,9 +379,8 @@ const MonitoringConsole: React.FC = () => {
                         onClick={async () => {
                             if (cleanableCount === 0) return;
                             if (!window.confirm(`About to close ${cleanableCount} RECOVERED events that have no Acks or Comments. Proceed?`)) return;
-                            const res: any = await api.post('/events/prune', {});
+                            const res: any = await eventMutations.pruneEvents();
                             alert(res.message);
-                            fetchData();
                         }}
                         disabled={cleanableCount === 0}
                         className={`px-3 py-1.5 rounded-lg text-xs font-bold uppercase flex items-center gap-2 transition-all ${cleanableCount > 0 ? 'bg-brand-600 hover:bg-brand-500 text-white animate-pulse' : 'bg-white/5 text-neutral-600 opacity-30 cursor-not-allowed'}`}
@@ -1062,8 +1023,7 @@ const MonitoringConsole: React.FC = () => {
                                             onClick={async () => {
                                                 setIsDiagnosing(true);
                                                 try {
-                                                    await api.post(`/events/${selectedEventId}/diagnose`, {});
-                                                    await fetchData();
+                                                    await eventMutations.diagnoseEvent(selectedEventId, { user: CURRENT_USER });
                                                 } catch (e) { console.error(e); }
                                                 finally { setIsDiagnosing(false); }
                                             }}
@@ -1114,15 +1074,7 @@ const StatCard = ({ label, value, icon, color, bg, animate }: any) => (
  * Useful for spotting correlated issues (e.g. CPU High + Latency High).
  */
 const RelatedAlarmsPanel = ({ ciId, currentEventId }: { ciId?: string, currentEventId?: string | null }) => {
-    const [related, setRelated] = useState<any[]>([]);
-
-    useEffect(() => {
-        if (ciId) {
-            api.get<any[]>(`/events/related/${ciId}`)
-                .then(data => setRelated(data))
-                .catch(err => console.error("Failed to load related events", err));
-        }
-    }, [ciId]);
+    const { data: related = [] } = useRelatedEventsQuery(ciId);
 
     // Filter out current event
     const displayed = related.filter(e => e.id !== currentEventId);

--- a/frontend/components/SystemDashboard.test.tsx
+++ b/frontend/components/SystemDashboard.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import SystemDashboard from './SystemDashboard';
+
+const mockUseSystemStatusQuery = vi.fn();
+
+vi.mock('../hooks/queries/useSystemStatusQuery', () => ({
+  useSystemStatusQuery: () => mockUseSystemStatusQuery(),
+}));
+
+describe('SystemDashboard', () => {
+  it('shows the loading state while the shared status query is pending', () => {
+    mockUseSystemStatusQuery.mockReturnValue({ data: null, isLoading: true });
+
+    render(<SystemDashboard />);
+
+    expect(screen.getByText('Initializing System Telemetry...')).toBeInTheDocument();
+  });
+
+  it('renders telemetry from the shared status query once available', () => {
+    mockUseSystemStatusQuery.mockReturnValue({
+      data: {
+        cpu: 24,
+        ram: 61,
+        disk: 40,
+        neo4j: 'CONNECTED',
+        collector: {
+          status: 'RUNNING',
+          last_run: '2026-04-04T10:00:00.000Z',
+          stats: {
+            cis_monitored: 8,
+            metrics_collected: 120,
+            metrics_failed: 1,
+            cycle_duration: 3,
+            jobs_per_min: 44,
+          },
+        },
+      },
+      isLoading: false,
+    });
+
+    render(<SystemDashboard />);
+
+    expect(screen.getByText('24%')).toBeInTheDocument();
+    expect(screen.getByText('61%')).toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    expect(screen.getByText('CONNECTED')).toBeInTheDocument();
+    expect(screen.getByText('RUNNING')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/SystemDashboard.tsx
+++ b/frontend/components/SystemDashboard.tsx
@@ -1,43 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Tooltip from './Tooltip';
-
-interface SystemStatus {
-    cpu: number;
-    ram: number;
-    disk: number;
-    neo4j: 'CONNECTED' | 'DISCONNECTED' | 'UNKNOWN';
-    collector: {
-        status: string;
-        last_run: string | null;
-        stats: {
-            cis_monitored: number;
-            metrics_collected: number;
-            metrics_failed: number;
-            cycle_duration: number;
-            jobs_per_min: number;
-        }
-    };
-}
+import { useSystemStatusQuery } from '../hooks/queries/useSystemStatusQuery';
 
 const SystemDashboard: React.FC = () => {
-    const [status, setStatus] = useState<SystemStatus | null>(null);
-    const [loading, setLoading] = useState(true);
-
-    useEffect(() => {
-        const fetchStatus = () => {
-            fetch('/api/system/status')
-                .then(res => res.json())
-                .then(data => {
-                    setStatus(data);
-                    setLoading(false);
-                })
-                .catch(err => console.error("Failed to fetch system status:", err));
-        };
-
-        fetchStatus();
-        const interval = setInterval(fetchStatus, 3000); // 3s polling
-        return () => clearInterval(interval);
-    }, []);
+    const { data: status, isLoading: loading } = useSystemStatusQuery();
 
     const getStatusColor = (val: number) => {
         if (val >= 90) return 'text-red-500';

--- a/frontend/components/__tests__/EventDetailModal.acceptance.test.tsx
+++ b/frontend/components/__tests__/EventDetailModal.acceptance.test.tsx
@@ -20,6 +20,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures
@@ -166,7 +167,12 @@ async function renderAndOpenModal(eventOverride?: any, nodeOverride?: any) {
     });
 
     const { default: MonitoringConsole } = await import('../MonitoringConsole');
-    const result = render(<MonitoringConsole />);
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const result = render(
+        <QueryClientProvider client={client}>
+            <MonitoringConsole />
+        </QueryClientProvider>
+    );
 
     // Wait for data to load (event row appears)
     await waitFor(() => {

--- a/frontend/components/__tests__/GraphCMDB.query.test.tsx
+++ b/frontend/components/__tests__/GraphCMDB.query.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import GraphCMDB from '../GraphCMDB';
+
+const mockUseGraphTopologyQuery = vi.fn();
+
+vi.mock('../../hooks/queries/useGraphTopologyQuery', () => ({
+  useGraphTopologyQuery: () => mockUseGraphTopologyQuery(),
+}));
+
+describe('GraphCMDB query ownership', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    mockUseGraphTopologyQuery.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders graph node labels from the shared topology query snapshot', async () => {
+    mockUseGraphTopologyQuery.mockReturnValue({
+      data: {
+        nodes: [{ id: 'node-1', label: 'Router-01', status: 'OK', type: 'INFRASTRUCTURE', metadata: {} }],
+        links: [],
+      },
+      isLoading: false,
+    });
+
+    render(<GraphCMDB onNodeClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Router-01')).toBeInTheDocument();
+    });
+  });
+
+  it('refreshes rendered topology when the shared query snapshot changes', async () => {
+    const snapshots = [
+      {
+        data: {
+          nodes: [{ id: 'node-1', label: 'Router-01', status: 'OK', type: 'INFRASTRUCTURE', metadata: {} }],
+          links: [],
+        },
+        isLoading: false,
+      },
+      {
+        data: {
+          nodes: [{ id: 'node-1', label: 'Router-02', status: 'OK', type: 'INFRASTRUCTURE', metadata: {} }],
+          links: [],
+        },
+        isLoading: false,
+      },
+    ];
+
+    let snapshotIndex = 0;
+    mockUseGraphTopologyQuery.mockImplementation(() => snapshots[snapshotIndex]);
+
+    const view = render(<GraphCMDB onNodeClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Router-01')).toBeInTheDocument();
+    });
+
+    snapshotIndex = 1;
+    view.rerender(<GraphCMDB onNodeClick={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Router-02')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Router-01')).toBeNull();
+  });
+
+  it('keeps the component source free from local topology polling', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const filePath = path.resolve(process.cwd(), 'components/GraphCMDB.tsx');
+    const source = fs.readFileSync(filePath, 'utf-8');
+
+    expect(source).toContain('useGraphTopologyQuery');
+    expect(source).not.toContain('setInterval(');
+    expect(source).not.toContain("api.get<TopologyResponse>('/graph/full')");
+  });
+});

--- a/frontend/components/__tests__/MonitoringConsole.forcedClose.test.tsx
+++ b/frontend/components/__tests__/MonitoringConsole.forcedClose.test.tsx
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be declared before dynamic imports
@@ -111,7 +112,12 @@ async function renderConsoleWithEvent() {
     });
 
     await act(async () => {
-        render(<MonitoringConsole />);
+        const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+        render(
+            <QueryClientProvider client={client}>
+                <MonitoringConsole />
+            </QueryClientProvider>
+        );
     });
 
     return { MonitoringConsole };

--- a/frontend/components/__tests__/MonitoringConsole.smoke.test.tsx
+++ b/frontend/components/__tests__/MonitoringConsole.smoke.test.tsx
@@ -10,8 +10,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const { mockApiGet, mockApiPost } = vi.hoisted(() => ({
+    mockApiGet: vi.fn(),
+    mockApiPost: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -20,8 +26,8 @@ import React from 'react';
 // Mock api service — returns empty arrays to avoid fetch errors in jsdom
 vi.mock('../../services/api', () => ({
     api: {
-        get: vi.fn().mockResolvedValue([]),
-        post: vi.fn().mockResolvedValue({ message: 'ok' }),
+        get: mockApiGet,
+        post: mockApiPost,
     },
 }));
 
@@ -57,7 +63,7 @@ vi.mock('../DependencyMiniMap', () => ({
 }));
 
 vi.mock('../../hooks/useEventCorrelation', () => ({
-    useEventCorrelation: (_events: any[], _links: any[]) => [],
+    useEventCorrelation: (events: any[]) => events,
 }));
 
 // Mock AuthContext — MonitoringConsole now reads user/tier/hasPermission from useAuth
@@ -77,23 +83,125 @@ vi.mock('../../context/AuthContext', () => ({
 // ---------------------------------------------------------------------------
 
 describe('MonitoringConsole smoke tests', () => {
+    const renderWithQueryClient = (ui: React.ReactElement) => {
+        const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+        return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+    };
+
     beforeEach(() => {
         vi.clearAllMocks();
+        mockApiPost.mockResolvedValue({ message: 'ok' });
+        mockApiGet.mockResolvedValue([]);
     });
 
     it('GIVEN the component WHEN rendered with empty data THEN mounts without throwing', async () => {
         // Dynamic import after mocks are registered
         const { default: MonitoringConsole } = await import('../MonitoringConsole');
 
-        expect(() => render(<MonitoringConsole />)).not.toThrow();
+        expect(() => renderWithQueryClient(<MonitoringConsole />)).not.toThrow();
     });
 
     it('GIVEN the component WHEN rendered THEN Event Console header is visible', async () => {
         const { default: MonitoringConsole } = await import('../MonitoringConsole');
 
-        render(<MonitoringConsole />);
+        renderWithQueryClient(<MonitoringConsole />);
 
         expect(screen.getByText('Event Console')).toBeDefined();
+    });
+
+    it('GIVEN an ack action succeeds WHEN shared active events refetch THEN widgets and table converge without refetching nodes or links', async () => {
+        const { default: MonitoringConsole } = await import('../MonitoringConsole');
+
+        let activeEventsCalls = 0;
+        mockApiGet.mockImplementation((url: string) => {
+            if (url === '/nodes') {
+                return Promise.resolve([
+                    {
+                        id: 'ci-1',
+                        label: 'Router-01',
+                        type: 'INFRASTRUCTURE',
+                        status: 'OK',
+                        metadata: {},
+                        category: 'NETWORK',
+                        ip: '10.0.0.1',
+                        location: { lat: 40.4, long: -3.7 },
+                        locationName: 'Madrid HQ',
+                    },
+                ]);
+            }
+            if (url === '/links') return Promise.resolve([]);
+            if (url === '/categories') return Promise.resolve([{ name: 'NETWORK' }]);
+            if (url === '/events?status=ACTIVE') {
+                activeEventsCalls += 1;
+                return Promise.resolve(activeEventsCalls === 1
+                    ? [{
+                        id: 'evt-1',
+                        ci_id: 'ci-1',
+                        ci_name: 'Router-01',
+                        metric_id: 'metric-1',
+                        metric_name: 'CPU',
+                        metric_protocol: 'SNMP',
+                        status: 'OPEN',
+                        severity: 'CRITICAL',
+                        message: 'CPU over threshold',
+                        created_at: '2026-04-04T20:00:00.000Z',
+                        last_seen: '2026-04-04T20:00:00.000Z',
+                        ack: false,
+                        comments: [],
+                    }]
+                    : [{
+                        id: 'evt-1',
+                        ci_id: 'ci-1',
+                        ci_name: 'Router-01',
+                        metric_id: 'metric-1',
+                        metric_name: 'CPU',
+                        metric_protocol: 'SNMP',
+                        status: 'ACK',
+                        severity: 'CRITICAL',
+                        message: 'CPU over threshold',
+                        created_at: '2026-04-04T20:00:00.000Z',
+                        last_seen: '2026-04-04T20:00:00.000Z',
+                        ack: true,
+                        ack_by: 'admin',
+                        comments: [],
+                    }]);
+            }
+            return Promise.resolve([]);
+        });
+
+        renderWithQueryClient(<MonitoringConsole />);
+
+        expect(await screen.findByText('CPU over threshold')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Ack' })).toBeInTheDocument();
+
+        const criticalCard = screen.getByText('Critical Events').closest('div');
+        const acknowledgedCard = screen.getByText('Acknowledged').closest('div');
+        expect(criticalCard?.textContent).toContain('1');
+        expect(acknowledgedCard?.textContent).toContain('0');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Ack' }));
+
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledWith('/events/evt-1/ack', {});
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('ACK')).toBeInTheDocument();
+        });
+
+        expect(screen.queryByRole('button', { name: 'Ack' })).toBeNull();
+        expect(criticalCard?.textContent).toContain('0');
+        expect(acknowledgedCard?.textContent).toContain('1');
+
+        const endpointCalls = mockApiGet.mock.calls.reduce<Record<string, number>>((counts, [url]) => {
+            counts[url] = (counts[url] ?? 0) + 1;
+            return counts;
+        }, {});
+
+        expect(endpointCalls['/nodes']).toBe(1);
+        expect(endpointCalls['/links']).toBe(1);
+        expect(endpointCalls['/categories']).toBe(1);
+        expect(endpointCalls['/events?status=ACTIVE']).toBe(2);
     });
 
     it('GIVEN the module WHEN imported THEN has no reference to leaflet-ant-path', async () => {

--- a/frontend/hooks/queries/resourceQueries.test.tsx
+++ b/frontend/hooks/queries/resourceQueries.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createQueryWrapper, createTestQueryClient } from '../../test/queryTestUtils';
+import { useActiveEventsQuery } from './useActiveEventsQuery';
+import { useCategoriesQuery } from './useCategoriesQuery';
+import { useGraphTopologyQuery } from './useGraphTopologyQuery';
+import { useLinksQuery } from './useLinksQuery';
+import { useNodesQuery } from './useNodesQuery';
+import { useSystemStatusQuery } from './useSystemStatusQuery';
+
+const { mockApiGet } = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+  api: {
+    get: mockApiGet,
+  },
+}));
+
+function HookProbe({ resource }: { resource: 'status' | 'nodes' | 'links' | 'categories' | 'events' | 'topology' }) {
+  const result = (() => {
+    switch (resource) {
+      case 'status':
+        return useSystemStatusQuery();
+      case 'nodes':
+        return useNodesQuery();
+      case 'links':
+        return useLinksQuery();
+      case 'categories':
+        return useCategoriesQuery();
+      case 'events':
+        return useActiveEventsQuery();
+      case 'topology':
+        return useGraphTopologyQuery();
+    }
+  })();
+
+  return <span data-testid="fetch-status">{result.fetchStatus}</span>;
+}
+
+function DeferredNodesConsumer({ label }: { label: string }) {
+  const { data, isLoading, error } = useNodesQuery();
+
+  return (
+    <section data-testid={`${label}-consumer`}>
+      <span>{`${label}-loading:${String(isLoading)}`}</span>
+      <span>{`${label}-nodes:${(data ?? []).map((node) => node.label).join(',') || 'none'}`}</span>
+      <span>{`${label}-error:${error instanceof Error ? error.message : 'none'}`}</span>
+    </section>
+  );
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('resource query hooks', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockApiGet.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ['status', '/system/status', 3000, { cpu: 10 }],
+    ['nodes', '/nodes', 5000, [{ id: 'node-1' }]],
+    ['categories', '/categories', 5000, [{ name: 'Network' }]],
+    ['links', '/links', 10000, [{ id: 'link-1' }]],
+    ['events', '/events?status=ACTIVE', 10000, [{ id: 'evt-1' }]],
+    ['topology', '/graph/full', 30000, { nodes: [], links: [] }],
+  ] as const)('polls %s with its shared cadence', async (resource, endpoint, intervalMs, payload) => {
+    mockApiGet.mockResolvedValue(payload);
+
+    render(<HookProbe resource={resource} />, { wrapper: createQueryWrapper() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockApiGet).toHaveBeenCalledWith(endpoint, expect.objectContaining({ signal: expect.any(AbortSignal) }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(intervalMs);
+      await Promise.resolve();
+    });
+
+    expect(mockApiGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses one nodes cache entry across concurrent consumers while loading and after success', async () => {
+    vi.useRealTimers();
+    const client = createTestQueryClient();
+    const deferred = createDeferred<Array<{ id: string; label: string; type: 'INFRASTRUCTURE'; status: 'OK'; metadata: Record<string, never> }>>();
+    mockApiGet.mockReturnValue(deferred.promise);
+
+    render(
+      <>
+        <DeferredNodesConsumer label="alpha" />
+        <DeferredNodesConsumer label="beta" />
+      </>,
+      { wrapper: createQueryWrapper(client) }
+    );
+
+    expect(screen.getByText('alpha-loading:true')).toBeInTheDocument();
+    expect(screen.getByText('beta-loading:true')).toBeInTheDocument();
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve([{ id: 'node-1', label: 'Router-01', type: 'INFRASTRUCTURE', status: 'OK', metadata: {} }]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('alpha-loading:false')).toBeInTheDocument();
+      expect(screen.getByText('beta-loading:false')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('alpha-nodes:Router-01')).toBeInTheDocument();
+    expect(screen.getByText('beta-nodes:Router-01')).toBeInTheDocument();
+  });
+
+  it('reuses one nodes cache entry across concurrent consumers when the shared request fails', async () => {
+    vi.useRealTimers();
+    const client = createTestQueryClient();
+    const deferred = createDeferred<never>();
+    mockApiGet.mockReturnValue(deferred.promise);
+
+    render(
+      <>
+        <DeferredNodesConsumer label="alpha" />
+        <DeferredNodesConsumer label="beta" />
+      </>,
+      { wrapper: createQueryWrapper(client) }
+    );
+
+    await act(async () => {
+      deferred.reject(new Error('nodes-down'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('alpha-error:nodes-down')).toBeInTheDocument();
+      expect(screen.getByText('beta-error:nodes-down')).toBeInTheDocument();
+    });
+
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('alpha-loading:false')).toBeInTheDocument();
+    expect(screen.getByText('beta-loading:false')).toBeInTheDocument();
+  });
+});

--- a/frontend/hooks/queries/useActiveEventsQuery.ts
+++ b/frontend/hooks/queries/useActiveEventsQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchActiveEvents } from '../../services/queryResources';
+
+export const useActiveEventsQuery = () => useQuery({
+  queryKey: queryKeys.activeEvents(),
+  queryFn: ({ signal }) => fetchActiveEvents({ signal }),
+  refetchInterval: 10000,
+});

--- a/frontend/hooks/queries/useCategoriesQuery.ts
+++ b/frontend/hooks/queries/useCategoriesQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchCategories } from '../../services/queryResources';
+
+export const useCategoriesQuery = () => useQuery({
+  queryKey: queryKeys.categories(),
+  queryFn: ({ signal }) => fetchCategories({ signal }),
+  refetchInterval: 5000,
+  staleTime: 5000,
+});

--- a/frontend/hooks/queries/useEventMutations.test.tsx
+++ b/frontend/hooks/queries/useEventMutations.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { queryKeys } from '../../services/queryKeys';
+import { useEventMutations } from './useEventMutations';
+
+const { mockApiPost } = vi.hoisted(() => ({
+  mockApiPost: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => ({
+  api: {
+    post: mockApiPost,
+  },
+}));
+
+function Probe() {
+  const mutations = useEventMutations();
+
+  return (
+    <div>
+      <button onClick={() => mutations.ackEvent('evt-1')}>ack</button>
+      <button onClick={() => mutations.commentEvent('evt-1', { message: 'note', user: 'admin' })}>comment</button>
+      <button onClick={() => mutations.takeEvent('evt-1', { user: 'admin', tier: 'T1' })}>take</button>
+      <button onClick={() => mutations.closeEvent('evt-1', { forced: true })}>close</button>
+      <button onClick={() => mutations.pruneEvents()}>prune</button>
+      <button onClick={() => mutations.diagnoseEvent('evt-1', { user: 'admin' })}>diagnose</button>
+    </div>
+  );
+}
+
+describe('useEventMutations', () => {
+  let client: QueryClient;
+
+  beforeEach(() => {
+    client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    vi.spyOn(client, 'invalidateQueries');
+    mockApiPost.mockReset();
+    mockApiPost.mockResolvedValue({ ok: true });
+  });
+
+  it.each([
+    ['ack', '/events/evt-1/ack'],
+    ['comment', '/events/evt-1/comment'],
+    ['take', '/events/evt-1/comment'],
+    ['close', '/events/evt-1/close'],
+    ['prune', '/events/prune'],
+    ['diagnose', '/events/evt-1/diagnose'],
+  ] as const)('invalidates active events after %s succeeds', async (buttonName, endpoint) => {
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: buttonName }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(client.invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.activeEvents() });
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith(endpoint, expect.anything());
+  });
+});

--- a/frontend/hooks/queries/useEventMutations.ts
+++ b/frontend/hooks/queries/useEventMutations.ts
@@ -1,0 +1,66 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { api } from '../../services/api';
+import { queryKeys } from '../../services/queryKeys';
+
+interface CommentPayload {
+  message: string;
+  user: string;
+}
+
+interface TakePayload {
+  user: string;
+  tier: string;
+}
+
+interface ClosePayload {
+  forced: boolean;
+}
+
+interface DiagnosePayload {
+  user: string;
+}
+
+export const useEventMutations = () => {
+  const queryClient = useQueryClient();
+
+  const refreshActiveEvents = async () => {
+    await queryClient.invalidateQueries({ queryKey: queryKeys.activeEvents() });
+  };
+
+  return {
+    ackEvent: async (id: string) => {
+      const result = await api.post(`/events/${id}/ack`, {});
+      await refreshActiveEvents();
+      return result;
+    },
+    commentEvent: async (id: string, payload: CommentPayload) => {
+      const result = await api.post(`/events/${id}/comment`, payload);
+      await refreshActiveEvents();
+      return result;
+    },
+    takeEvent: async (id: string, payload: TakePayload) => {
+      await api.post(`/events/${id}/comment`, {
+        message: `[OWNERSHIP] Caso tomado por ${payload.user} - Tier ${payload.tier}`,
+        user: payload.user,
+      });
+      const result = await api.post(`/events/${id}/ack`, {});
+      await refreshActiveEvents();
+      return result;
+    },
+    closeEvent: async (id: string, payload: ClosePayload) => {
+      const result = await api.post(`/events/${id}/close`, payload);
+      await refreshActiveEvents();
+      return result;
+    },
+    pruneEvents: async () => {
+      const result = await api.post('/events/prune', {});
+      await refreshActiveEvents();
+      return result;
+    },
+    diagnoseEvent: async (id: string, _payload: DiagnosePayload) => {
+      const result = await api.post(`/events/${id}/diagnose`, {});
+      await refreshActiveEvents();
+      return result;
+    },
+  };
+};

--- a/frontend/hooks/queries/useGraphTopologyQuery.ts
+++ b/frontend/hooks/queries/useGraphTopologyQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchGraphTopology } from '../../services/queryResources';
+
+export const useGraphTopologyQuery = () => useQuery({
+  queryKey: queryKeys.graphTopology(),
+  queryFn: ({ signal }) => fetchGraphTopology({ signal }),
+  refetchInterval: 30000,
+});

--- a/frontend/hooks/queries/useLinksQuery.ts
+++ b/frontend/hooks/queries/useLinksQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchLinks } from '../../services/queryResources';
+
+export const useLinksQuery = () => useQuery({
+  queryKey: queryKeys.links(),
+  queryFn: ({ signal }) => fetchLinks({ signal }),
+  refetchInterval: 10000,
+});

--- a/frontend/hooks/queries/useMonitoringConsoleData.test.tsx
+++ b/frontend/hooks/queries/useMonitoringConsoleData.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMonitoringConsoleData } from './useMonitoringConsoleData';
+
+const mockUseNodesQuery = vi.fn();
+const mockUseLinksQuery = vi.fn();
+const mockUseActiveEventsQuery = vi.fn();
+const mockUseCategoriesQuery = vi.fn();
+
+vi.mock('./useNodesQuery', () => ({ useNodesQuery: () => mockUseNodesQuery() }));
+vi.mock('./useLinksQuery', () => ({ useLinksQuery: () => mockUseLinksQuery() }));
+vi.mock('./useActiveEventsQuery', () => ({ useActiveEventsQuery: () => mockUseActiveEventsQuery() }));
+vi.mock('./useCategoriesQuery', () => ({ useCategoriesQuery: () => mockUseCategoriesQuery() }));
+
+function Probe() {
+  const data = useMonitoringConsoleData();
+  return <pre data-testid="payload">{JSON.stringify(data)}</pre>;
+}
+
+describe('useMonitoringConsoleData', () => {
+  beforeEach(() => {
+    mockUseNodesQuery.mockReturnValue({ data: [{ id: 'node-1', type: 'INFRASTRUCTURE' }], isLoading: false, error: null });
+    mockUseLinksQuery.mockReturnValue({ data: [{ id: 'link-1' }], isLoading: false, error: null });
+    mockUseActiveEventsQuery.mockReturnValue({ data: [{ id: 'evt-1', ci_id: 'node-1' }], isLoading: false, error: null });
+    mockUseCategoriesQuery.mockReturnValue({ data: [{ name: 'Network' }], isLoading: false, error: null });
+  });
+
+  it('combines shared monitoring resources into one screen-facing contract', () => {
+    render(<Probe />);
+
+    expect(screen.getByTestId('payload')).toHaveTextContent('\"nodes\":[{\"id\":\"node-1\",\"type\":\"INFRASTRUCTURE\"}]');
+    expect(screen.getByTestId('payload')).toHaveTextContent('\"links\":[{\"id\":\"link-1\"}]');
+    expect(screen.getByTestId('payload')).toHaveTextContent('\"events\":[{\"id\":\"evt-1\",\"ci_id\":\"node-1\"}]');
+    expect(screen.getByTestId('payload')).toHaveTextContent('\"categories\":[\"Network\"]');
+  });
+
+  it('surfaces node types when category names are missing', () => {
+    mockUseCategoriesQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    render(<Probe />);
+
+    expect(screen.getByTestId('payload')).toHaveTextContent('\"categories\":[\"INFRASTRUCTURE\"]');
+  });
+});

--- a/frontend/hooks/queries/useMonitoringConsoleData.ts
+++ b/frontend/hooks/queries/useMonitoringConsoleData.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useActiveEventsQuery } from './useActiveEventsQuery';
+import { useCategoriesQuery } from './useCategoriesQuery';
+import { useLinksQuery } from './useLinksQuery';
+import { useNodesQuery } from './useNodesQuery';
+
+export const useMonitoringConsoleData = () => {
+  const nodesQuery = useNodesQuery();
+  const linksQuery = useLinksQuery();
+  const eventsQuery = useActiveEventsQuery();
+  const categoriesQuery = useCategoriesQuery();
+
+  const nodes = nodesQuery.data ?? [];
+  const categoryNames = useMemo(
+    () => (categoriesQuery.data ?? []).map((category) => category.name).filter(Boolean),
+    [categoriesQuery.data],
+  );
+  const fallbackNames = useMemo(
+    () => Array.from(new Set(nodes.map((node) => node.category ?? node.type).filter(Boolean))).sort(),
+    [nodes],
+  );
+
+  const categories = useMemo(() => {
+    const source = categoryNames.length > 0 ? categoryNames : fallbackNames;
+    return Array.from(new Set(source)).sort();
+  }, [categoryNames, fallbackNames]);
+
+  return {
+    nodes,
+    links: linksQuery.data ?? [],
+    events: eventsQuery.data ?? [],
+    categories,
+    isLoading: nodesQuery.isLoading || linksQuery.isLoading || eventsQuery.isLoading || categoriesQuery.isLoading,
+    error: nodesQuery.error ?? linksQuery.error ?? eventsQuery.error ?? categoriesQuery.error ?? null,
+  };
+};

--- a/frontend/hooks/queries/useNodesQuery.ts
+++ b/frontend/hooks/queries/useNodesQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchNodes } from '../../services/queryResources';
+
+export const useNodesQuery = () => useQuery({
+  queryKey: queryKeys.nodes(),
+  queryFn: ({ signal }) => fetchNodes({ signal }),
+  refetchInterval: 5000,
+});

--- a/frontend/hooks/queries/useRelatedEventsQuery.ts
+++ b/frontend/hooks/queries/useRelatedEventsQuery.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchRelatedEvents } from '../../services/queryResources';
+
+export const useRelatedEventsQuery = (ciId?: string) => useQuery({
+  queryKey: ciId ? queryKeys.relatedEvents(ciId) : ['events', 'related', 'unknown'],
+  queryFn: ({ signal }) => fetchRelatedEvents(ciId as string, { signal }),
+  enabled: Boolean(ciId),
+  refetchInterval: 10000,
+});

--- a/frontend/hooks/queries/useSystemStatusQuery.ts
+++ b/frontend/hooks/queries/useSystemStatusQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchSystemStatus } from '../../services/queryResources';
+
+export const useSystemStatusQuery = () => useQuery({
+  queryKey: queryKeys.systemStatus(),
+  queryFn: ({ signal }) => fetchSystemStatus({ signal }),
+  refetchInterval: 3000,
+});

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -1,7 +1,18 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +22,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.37.0",
+        "@tanstack/react-query": "^5.96.2",
         "@types/leaflet": "^1.9.21",
         "d3": "^7.9.0",
         "leaflet": "^1.9.4",
@@ -27,19 +28,12 @@
         "@types/react": "^19.2.8",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.0.0",
-        "@vitest/coverage-v8": "^4.1.0",
-        "jsdom": "^28.1.0",
+        "@vitest/coverage-v8": "^4.1.2",
+        "jsdom": "^29.0.1",
         "typescript": "~5.8.2",
         "vite": "^6.2.0",
-        "vitest": "^4.1.0"
+        "vitest": "^4.1.2"
       }
-    },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -49,9 +43,9 @@
       "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.5.tgz",
+      "integrity": "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -59,16 +53,16 @@
         "@csstools/css-color-parser": "^4.0.2",
         "@csstools/css-parser-algorithms": "^4.0.0",
         "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.6"
+        "lru-cache": "^11.2.7"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -76,23 +70,26 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.6.tgz",
+      "integrity": "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
+        "css-tree": "^3.2.1",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -516,9 +513,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.0.tgz",
-      "integrity": "sha512-H4tuz2nhWgNKLt1inYpoVCfbJbMwX/lQKp3g69rrrIMIYlFD9+zTykOKhNR8uGrAmbS/kT9n6hTFkmDkxLgeTA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
       "dev": true,
       "funding": [
         {
@@ -530,7 +527,15 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0"
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "4.0.0",
@@ -1591,6 +1596,32 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
+      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.96.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
+      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.96.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1900,14 +1931,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
-      "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.2",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1915,14 +1946,14 @@
         "magicast": "^0.5.2",
         "obug": "^2.1.1",
         "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.0",
-        "vitest": "4.1.0"
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1931,31 +1962,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.0",
+        "@vitest/spy": "4.1.2",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1964,7 +1995,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1976,26 +2007,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.2",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2003,14 +2034,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2019,9 +2050,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2029,15 +2060,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
+        "@vitest/pretty-format": "4.1.2",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2365,32 +2396,6 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cssstyle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3289,20 +3294,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -3449,36 +3440,36 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
         "@bramus/specificity": "^2.4.2",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^6.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
         "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.21.0",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
+        "whatwg-url": "^16.0.1",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -3487,6 +3478,16 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4663,9 +4664,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4700,22 +4701,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.25",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.25.tgz",
-      "integrity": "sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.25"
+        "tldts-core": "^7.0.28"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.25",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.25.tgz",
-      "integrity": "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==",
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4760,9 +4761,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.0.tgz",
-      "integrity": "sha512-jxytwMHhsbdpBXxLAcuu0fzlQeXCNnWdDyRHpvWsUl8vd98UwYdl9YTyn8/HcpcJPC3pwUveefsa3zTxyD/ERg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4913,19 +4914,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4936,8 +4937,8 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -4953,13 +4954,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.37.0",
+    "@tanstack/react-query": "^5.96.2",
     "@types/leaflet": "^1.9.21",
     "d3": "^7.9.0",
     "leaflet": "^1.9.4",

--- a/frontend/services/api.test.ts
+++ b/frontend/services/api.test.ts
@@ -78,14 +78,20 @@ describe('api client', () => {
       });
     });
 
-    it('returns null for 404 responses', async () => {
+    it('throws ApiError for 404 responses', async () => {
       global.fetch = vi.fn().mockResolvedValue({
         status: 404,
         ok: false,
+        statusText: 'Not Found',
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ detail: 'Not found' }),
       });
 
-      const result = await api.get('/nonexistent');
-      expect(result).toBeNull();
+      await expect(api.get('/nonexistent')).rejects.toBeInstanceOf(ApiError);
+      await expect(api.get('/nonexistent')).rejects.toMatchObject({
+        status: 404,
+        message: 'Not found',
+      });
     });
 
     it('throws ApiError for non-2xx responses', async () => {
@@ -133,6 +139,29 @@ describe('api client', () => {
       });
       expect(result).toEqual(created);
     });
+
+    it('forwards signal without dropping auth and json headers', async () => {
+      const signal = new AbortController().signal;
+      localStorage.setItem('token', 'fake-token');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ ok: true }),
+      });
+
+      await api.post('/nodes', { name: 'test' }, { signal });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer fake-token',
+        },
+        body: JSON.stringify({ name: 'test' }),
+        signal,
+      });
+    });
   });
 
   describe('put', () => {
@@ -153,6 +182,25 @@ describe('api client', () => {
         body: JSON.stringify({ name: 'updated' }),
       });
       expect(result).toEqual(updated);
+    });
+
+    it('forwards signal for put requests', async () => {
+      const signal = new AbortController().signal;
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ ok: true }),
+      });
+
+      await api.put('/nodes/1', { name: 'updated' }, { signal });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes/1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'updated' }),
+        signal,
+      });
     });
   });
 
@@ -188,6 +236,71 @@ describe('api client', () => {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ force: true }),
+      });
+    });
+
+    it('forwards signal for delete requests', async () => {
+      const signal = new AbortController().signal;
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({}),
+      });
+
+      await api.delete('/nodes/1', { force: true }, { signal });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes/1', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ force: true }),
+        signal,
+      });
+    });
+  });
+
+  describe('request forwarding', () => {
+    it('forwards signal for request and keeps caller headers', async () => {
+      const signal = new AbortController().signal;
+      localStorage.setItem('token', 'fake-token');
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ ok: true }),
+      });
+
+      await api.request('/custom', {
+        method: 'GET',
+        signal,
+        headers: { Accept: 'application/json' },
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/custom', {
+        method: 'GET',
+        signal,
+        headers: {
+          Authorization: 'Bearer fake-token',
+          Accept: 'application/json',
+        },
+      });
+    });
+
+    it('forwards signal for get requests', async () => {
+      const signal = new AbortController().signal;
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ ok: true }),
+      });
+
+      await api.get('/nodes', { signal });
+
+      expect(global.fetch).toHaveBeenCalledWith('/api/nodes', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        signal,
       });
     });
   });

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,5 +1,3 @@
-import { useNavigate } from 'react-router-dom';
-
 const API_BASE = '/api';
 
 /**
@@ -47,11 +45,6 @@ async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T
         headers,
     });
 
-    // Handle 404
-    if (response.status === 404) {
-        return null as any;
-    }
-
     // Handle 401 Unauthorized
     if (response.status === 401) {
         localStorage.removeItem('token');
@@ -75,10 +68,19 @@ async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T
 }
 
 export const api = {
-    get: <T>(endpoint: string) => request<T>(endpoint, { method: 'GET' }),
-    post: <T>(endpoint: string, body: any) => request<T>(endpoint, { method: 'POST', body: JSON.stringify(body) }),
-    put: <T>(endpoint: string, body: any) => request<T>(endpoint, { method: 'PUT', body: JSON.stringify(body) }),
-    delete: <T>(endpoint: string, body?: any) => request<T>(endpoint, {
+    get: <T>(endpoint: string, config: RequestInit = {}) => request<T>(endpoint, { ...config, method: 'GET' }),
+    post: <T>(endpoint: string, body: any, config: RequestInit = {}) => request<T>(endpoint, {
+        ...config,
+        method: 'POST',
+        body: JSON.stringify(body),
+    }),
+    put: <T>(endpoint: string, body: any, config: RequestInit = {}) => request<T>(endpoint, {
+        ...config,
+        method: 'PUT',
+        body: JSON.stringify(body),
+    }),
+    delete: <T>(endpoint: string, body?: any, config: RequestInit = {}) => request<T>(endpoint, {
+        ...config,
         method: 'DELETE',
         body: body ? JSON.stringify(body) : undefined
     }),

--- a/frontend/services/queryKeys.test.ts
+++ b/frontend/services/queryKeys.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { queryKeys } from './queryKeys';
+
+describe('queryKeys', () => {
+  it('returns stable keys for shared polled resources', () => {
+    expect(queryKeys.systemStatus()).toEqual(['system-status']);
+    expect(queryKeys.nodes()).toEqual(['nodes']);
+    expect(queryKeys.links()).toEqual(['links']);
+    expect(queryKeys.categories()).toEqual(['categories']);
+    expect(queryKeys.activeEvents()).toEqual(['events', 'ACTIVE']);
+    expect(queryKeys.graphTopology()).toEqual(['graph-topology']);
+  });
+
+  it('scopes related events by ci id', () => {
+    expect(queryKeys.relatedEvents('ci-1')).toEqual(['events', 'related', 'ci-1']);
+    expect(queryKeys.relatedEvents('ci-2')).toEqual(['events', 'related', 'ci-2']);
+  });
+});

--- a/frontend/services/queryKeys.ts
+++ b/frontend/services/queryKeys.ts
@@ -1,0 +1,9 @@
+export const queryKeys = {
+  systemStatus: () => ['system-status'] as const,
+  nodes: () => ['nodes'] as const,
+  links: () => ['links'] as const,
+  categories: () => ['categories'] as const,
+  activeEvents: () => ['events', 'ACTIVE'] as const,
+  graphTopology: () => ['graph-topology'] as const,
+  relatedEvents: (ciId: string) => ['events', 'related', ciId] as const,
+};

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -1,0 +1,50 @@
+import { api } from './api';
+import type { Event, GraphLink, GraphNode } from '../types';
+
+export interface SystemStatus {
+  cpu: number;
+  ram: number;
+  disk: number;
+  neo4j: 'CONNECTED' | 'DISCONNECTED' | 'UNKNOWN';
+  collector: {
+    status: string;
+    last_run: string | null;
+    stats: {
+      cis_monitored: number;
+      metrics_collected: number;
+      metrics_failed: number;
+      cycle_duration: number;
+      jobs_per_min: number;
+    };
+  };
+}
+
+export interface CategoryRecord {
+  name: string;
+}
+
+export interface GraphTopologyResponse {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+export const fetchSystemStatus = ({ signal }: { signal?: AbortSignal } = {}) =>
+  api.get<SystemStatus>('/system/status', { signal });
+
+export const fetchNodes = ({ signal }: { signal?: AbortSignal } = {}) =>
+  api.get<GraphNode[]>('/nodes', { signal });
+
+export const fetchLinks = ({ signal }: { signal?: AbortSignal } = {}) =>
+  api.get<GraphLink[]>('/links', { signal });
+
+export const fetchCategories = ({ signal }: { signal?: AbortSignal } = {}) =>
+  api.get<CategoryRecord[]>('/categories', { signal });
+
+export const fetchActiveEvents = ({ signal }: { signal?: AbortSignal } = {}) =>
+  api.get<Event[]>('/events?status=ACTIVE', { signal });
+
+export const fetchRelatedEvents = (ciId: string, { signal }: { signal?: AbortSignal } = {}) =>
+  api.get<Event[]>(`/events/related/${ciId}`, { signal });
+
+export const fetchGraphTopology = ({ signal }: { signal?: AbortSignal } = {}) =>
+  api.get<GraphTopologyResponse>('/graph/full', { signal });

--- a/frontend/test/queryTestUtils.tsx
+++ b/frontend/test/queryTestUtils.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export const createTestQueryClient = () => new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      gcTime: 0,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
+
+export const createQueryWrapper = (client = createTestQueryClient()) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -36,6 +36,7 @@ export interface GraphNode {
   thresholds?: MonitoringThresholds;
   metrics?: MetricValue[]; // Live metrics
   ip?: string;
+  locationName?: string;
   owner?: string; // Top-level owner group (matches backend Node.owner)
   category?: string; // Optional helper
   location?: { lat: number; long: number };


### PR DESCRIPTION
Closes #23

## PR Type
- [x] New feature

## Summary
- Replaces fragmented `setInterval` + local state polling across `SystemDashboard`, `GlobalInventory`, `MonitoringConsole`, and `GraphCMDB` with a shared TanStack Query layer.
- Eliminates dual topology source-of-truth between `App.tsx` and `GraphCMDB.tsx`; both now consume a single `/graph/full` query.
- Post-mutation refresh (ack, comment, take, close, prune, diagnose) uses targeted cache invalidation instead of manual `fetchData()` calls.

## Changes

| File | Change |
|------|--------|
| `frontend/index.tsx` | Bootstrap `QueryClient` con defaults explícitos |
| `frontend/services/queryKeys.ts` | Centralized query key factory |
| `frontend/services/queryResources.ts` | Shared fetch functions with AbortSignal |
| `frontend/hooks/queries/*` | Domain hooks with resource-specific cadences (3s/5s/10s/30s) |
| `frontend/App.tsx` | No global topology poll; header reads cache; export on-demand |
| `frontend/components/SystemDashboard.tsx` | Migrated to useSystemStatusQuery |
| `frontend/components/GlobalInventory.tsx` | Migrated; selection stable via selectedId |
| `frontend/components/MonitoringConsole.tsx` | Migrated; RelatedAlarmsPanel to shared query; category filter fixed |
| `frontend/components/GraphCMDB.tsx` | Topology from useGraphTopologyQuery only |
| `frontend/services/api.ts` | 404 throws ApiError instead of null as any |
| `frontend/types.ts` | locationName added to GraphNode |

## Test Plan
- [x] 86 focused frontend tests passing, 0 failing
- [x] sdd-verify: PASS WITH WARNINGS — 8/8 spec scenarios compliant
- [x] Judgment Day: APPROVED after 3 rounds
- [x] No new typecheck errors in the changed area
- [x] Strict TDD evidence in apply-progress artifact

## Contributor Checklist
- [x] Linked an approved issue (Closes #23)
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] No Co-Authored-By trailers