### PR TITLE
feat(events): Phase 2 event detail with business context, ITSM docs and hardened audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,64 @@
-# NEX-GEN Platform (NEX-GEN ITOM)
+# NEX-GEN Platform
 
-## Descripción General
-NEX-GEN es una plataforma avanzada de gestión de operaciones de TI (ITOM) diseñada bajo los más altos estándares de arquitectura. Su núcleo está centrado en una CMDB basada en grafos (Neo4j), que permite no solo un inventario preciso, sino una visualización y gestión relacional profunda de la infraestructura. Integra telemetría en tiempo real, recolección de métricas dinámicas vía SNMP, y diagnósticos asistidos mediante un motor de analítica (AIOps). Su propósito es brindar una visión holística de la salud tecnológica, gestionando incidentes de forma proactiva y ofreciendo correlación visual y lógica de dependencias.
+NEX-GEN es una plataforma ITOM para operar infraestructura desde una CMDB basada en grafos, telemetria en tiempo real y una consola de eventos orientada a contexto operacional.
 
-## Arquitectura
-El sistema operativo se estructura bajo el estándar de microservicios de Antigravity, garantizando escalabilidad, resiliencia y separación de responsabilidades:
+## Que resuelve
 
-- **Backend (API & Lógica de Negocio)**: Desarrollado en Python (FastAPI). Centraliza la lógica de negocio, expone la API RESTful para la interfaz de usuario, interactúa directamente con la base de datos de grafos para la gestión de topología, y coordina los ciclos de vida de eventos/incidentes (alineado con ITIL 4).
-- **Frontend (Interfaz de Usuario)**: Aplicación SPA (Single Page Application) construida estáticamente con React 18, Vite, TypeScript y TailwindCSS. Incorpora representaciones en 2D/3D (D3/Force Graph) y mapas geoespaciales (Leaflet) para un control situacional en tiempo real.
-- **Capa de Datos**:
-  - **Neo4j**: Base de datos de grafos para la topología, CMDB, y relaciones lógicas complejas.
-  - **TimescaleDB (PostgreSQL 16)**: Repositorio optimizado para métricas de series temporales y persistencia de autenticación/roles.
-- **Motores/Workers (AIOps & Sondeo)**:
-  - **SNMP Worker**: Proceso asíncrono para recolección continua de telemetría de red.
-  - **Analytics Worker (AIOps)**: Motor que busca proactivamente estados críticos en la topología, con capacidad heurística para simular diagnósticos o resolución automática de incidentes (Auto-Fix).
+- Modela CIs, relaciones topologicas y definiciones de metricas sobre Neo4j.
+- Recolecta telemetria via SNMP/ICMP y genera eventos con snapshot de contexto de negocio.
+- Expone un backend FastAPI y un frontend React para monitoreo, diagnostico y gestion de incidentes.
+- Mantiene el feed `/api/events` liviano y usa `GET /api/events/{event_id}` para el detalle enriquecido del modal.
 
-## Instalación y Configuración
+## Arquitectura Rapida
 
-El proyecto está completamente contenerizado, facilitando un despliegue ágil "Zero-Config" en entornos de desarrollo.
+| Capa | Stack | Responsabilidad |
+| --- | --- | --- |
+| Backend | Python, FastAPI, Pydantic | API, reglas de negocio, enriquecimiento de eventos, auth |
+| Frontend | React, Vite, TypeScript, Tailwind | Console, inventario, visualizacion de topologia y modal de detalle |
+| Grafo | Neo4j | CIs, relaciones, metricas, BusinessService, ServiceCatalog |
+| Series temporales | TimescaleDB / PostgreSQL | Historico de metricas |
+| Workers | SNMP / ICMP polling | Ingesta, thresholding y apertura/recuperacion de eventos |
 
-**Requisitos Previos:**
-- Docker y Docker Compose instalados.
+## Flujo de detalle de evento
 
-**Pasos de Despliegue Rápidos:**
-1. Clona el repositorio en tu máquina local.
-2. Navega al directorio raíz del proyecto (`zero-co` o tu directorio local).
-3. Crea tu archivo de configuración de entorno basado en la plantilla segura:
-   ```bash
-   cp .env.example .env
-   ```
-   *(Asegúrate de configurar contraseñas seguras en tu nuevo `.env`)*
-4. Construye e inicializa todo el stack de contenedores:
-   ```bash
-   docker-compose up --build -d
-   ```
-5. **Accesos:**
-   - **Frontend Console**: [http://localhost:3000](http://localhost:3000)
-     - *Login inicial por defecto:* Usuario: `admin` | Password: `admin` *(Requerirá cambio de clave inmediato)*
-   - **Backend API Docs**: [http://localhost:8000/docs](http://localhost:8000/docs)
-   - **Neo4j Browser**: [http://localhost:7474](http://localhost:7474) (Auth según variables de tu `.env`)
+1. El worker detecta una brecha y crea/actualiza un `Event`.
+2. Cuando el evento es nuevo, guarda snapshot de `BusinessService`, `ServiceCatalog`, owners, sitio e SLA.
+3. La grilla sigue consultando `/api/events?status=ACTIVE`.
+4. Al abrir el modal, el frontend consulta `/api/events/{event_id}`.
+5. El backend devuelve `event`, `business_context` e `itsm_context`, priorizando snapshot y usando fallback del grafo para eventos historicos.
 
-## Stack Tecnológico
+## Documentacion Canonica
 
-| Componente | Tecnologías |
-| :--- | :--- |
-| **Backend** | Python 3.10+, FastAPI, Uvicorn, SQLAlchemy, Pydantic, PySNMP, Pandas |
-| **Frontend** | React 18, TypeScript, Vite, TailwindCSS, React Leaflet, D3-Force, Recharts, @google/genai |
-| **Base de Datos** | Neo4j 5.15.0, TimescaleDB (PostgreSQL 16) |
-| **Infraestructura** | Docker, Docker Compose |
-| **Protocolos** | HTTP/REST, SNMP (Polling), Bolt (Neo4j) |
+- [`docs/domain/business-model.md`](docs/domain/business-model.md) - vocabulario de dominio, relaciones `CI -> BusinessService -> ServiceCatalog`, snapshot/fallback y bootstrap manual.
+- [`docs/itsm/event-flow.md`](docs/itsm/event-flow.md) - lifecycle del evento, ownership, SLA, escalacion y puntos de integracion Jira/ServiceNow.
+- [`modelo_entidad_relacion.md`](modelo_entidad_relacion.md) - referencia tecnica de entidades, relaciones y payloads relevantes.
+- [`CONTEXT.md`](CONTEXT.md) - contexto funcional y roadmap del sistema.
 
-## Identificación de Entidades (Graph DB Modelo)
-Las principales entidades que alimentan la base de datos Neo4j para mapear el ecosistema ITIL son:
+## API relevante
 
-- **`CI` (Configuration Item)**: Representa activos, dispositivos de red, servidores o aplicaciones.
-- **`MetricDef`**: Definición de métricas de telemetría asignables dinámicamente.
-- **`Event`**: Incidentes, Alertas o Cambios de estado en la infraestructura.
-- **`Category`**: Clasificaciones lógicas de inventario de hardware y software.
-- **`OwnerGroup`**: Agrupaciones lógicas de responsables o usuarios de soporte.
+- `GET /api/events?status=ACTIVE` - resumen para polling del stream.
+- `GET /api/events/{event_id}` - detalle enriquecido para el modal.
+- `POST /api/events/{event_id}/ack` - reconocimiento.
+- `POST /api/events/{event_id}/comment` - auditoria append-only.
+- `POST /api/events/{event_id}/close` - cierre estructurado o forzado.
+- `POST /api/events/{event_id}/diagnose` - diagnostico on-demand.
 
-*Principales Relaciones (Edges):* `DEPENDS_ON`, `HOSTED_ON`, `CONNECTS_TO`, `HAS_METRIC`, `TRIGGERED_BY`.
+## Setup local
 
-## Estado del Proyecto (Roadmap & Features)
+1. Copia variables base: `cp .env.example .env`.
+2. Levanta servicios: `docker-compose up -d`.
+3. Frontend: `http://localhost:3000`.
+4. Backend docs: `http://localhost:8000/docs`.
+5. Neo4j Browser: `http://localhost:7474`.
 
-**Funcionalidades Implementadas:**
-- CMDB relacional y topológica en tiempo real (Visualización en Grafo Integrada).
-- **Análisis Visual de Impacto AIOps (Blast Radius)**: Mapas geoespaciales interactivos al rojo vivo ("Heatmaps") y filtros dinámicos de transparencia D3-Force  (>90% a nodos sanos), iluminando exclusivamente la falla troncal y la propagación de impacto por dependencias.
-- CRUD de Nodos y Operaciones de Enlaces (Links).
-- Reconciliación Automática de Métricas (Asigna sondas basándose en marca/modelo del CI).
-- **Asignación de Métricas de Alta Granularidad**: Soporte para reglas lógicas (`>=`, `==`, `!=`, etc.) en umbrales y asignación explícita (Opt-In/Opt-Out) por CIs individuales.
-- Monitorización activa vía SNMP Worker para la recolección de datos de red e infraestructura.
-- Event Management básico API (Estados: Open, Ack, Closed).
-- Agente AIOps Simulador: Un script que sondea nodos en estado "CRITICAL" e inyecta resoluciones asistidas simuladas.
+## Tests focalizados
 
-**Pendiente de Definición / Roadmap Futuro:**
-- **Alertas Predictivas Nativas**: Integración profunda del SDK de @google/genai para predecir fallos basándose en patrones anómalos de series temporales (descrito en roadmap pero requiere clarificación en el flujo de backend).
-- **Agentes Remotos**: Compatibilidad confirmada en contexto, pero el mecanismo de despliegue y push-telemetry (vs polling) está *Pendiente de Definición*.
-- **Integración ITSM**: Conectores bidireccionales formales para Jira / ServiceNow *Pendientes de Definición* arquitectónica.
+- Desde la raiz del repo:
+  - Backend: `python -m pytest backend/tests/test_event_service_smoke.py backend/tests/test_routers_metrics_events.py backend/tests/test_snmp_service_snapshots.py`
+  - Frontend: `npm --prefix frontend run test:run -- hooks/queries/resourceQueries.test.tsx components/__tests__/EventDetailModal.acceptance.test.tsx`
+
+## Estado actual
+
+- El modal de detalle ya consume contexto real de negocio e ITSM mediante endpoint dedicado.
+- Los eventos nuevos conservan snapshot historico; los viejos siguen funcionando con fallback por relaciones actuales.
+- La integracion externa con Jira/ServiceNow sigue pendiente; el contrato ya deja listo el punto de acople.

--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -1,30 +1,35 @@
+from typing import Any, Dict, List, Literal, Optional, Union
+
 from pydantic import BaseModel
-from typing import List, Optional, Dict, Any, Union
 
 # --- Models ---
 
+
 class Node(BaseModel):
     """Pydantic model representing a Configuration Item (CI) Node."""
+
     id: str
-    label: str 
-    type: str  
-    status: Optional[str] = "OK" 
+    label: str
+    type: str
+    status: Optional[str] = "OK"
     ip: Optional[str] = None
-    location: Optional[dict] = None 
-    metadata: Optional[dict] = {} 
+    location: Optional[dict] = None
+    metadata: Optional[dict] = {}
     # Flattened Fields (Optional)
     owner: Optional[str] = None
     locationName: Optional[str] = None
     pollingInterval: Optional[int] = 60
-    snmp: Optional[Union[dict, str]] = None # Can be dict or JSON string
+    snmp: Optional[Union[dict, str]] = None  # Can be dict or JSON string
     brand: Optional[str] = None
     model: Optional[str] = None
     serialNumber: Optional[str] = None
     firmwareVersion: Optional[str] = None
     metrics: Optional[List[Dict[str, Any]]] = []
 
+
 class Link(BaseModel):
     """Pydantic model representing a Relationship Link between CIs."""
+
     source: str
     target: str
     relationship: str
@@ -32,11 +37,14 @@ class Link(BaseModel):
     source_label: Optional[str] = None
     target_label: Optional[str] = None
 
+
 class Category(BaseModel):
     name: str
 
+
 class MetricDef(BaseModel):
     """Definition of a monitored metric."""
+
     id: str
     protocol: str = "SNMP"
     oid: Optional[str] = None
@@ -46,8 +54,9 @@ class MetricDef(BaseModel):
     unit: Optional[str] = None
     description: Optional[str] = None
     operator: Optional[str] = ">="
-    criticality: Optional[int] = 1 # 1: Info, 2: Warning, 3: Exception
+    criticality: Optional[int] = 1  # 1: Info, 2: Warning, 3: Exception
     applicable_to: Optional[Dict[str, List[str]]] = None
+
 
 class HardwareModel(BaseModel):
     brand: str
@@ -55,6 +64,104 @@ class HardwareModel(BaseModel):
     category: Optional[str] = None
     owner: Optional[str] = None
 
+
 class OwnerGroup(BaseModel):
     name: str
     users: Optional[List[dict]] = []
+
+
+class BusinessService(BaseModel):
+    id: str
+    name: str
+    tier: Optional[str] = None
+    owner_t1: Optional[str] = None
+    owner_t2: Optional[str] = None
+    owner_t3: Optional[str] = None
+    impacted_users_count: Optional[int] = None
+
+
+class ServiceCatalog(BaseModel):
+    id: str
+    category: str
+    service_tier: Optional[str] = None
+    sla_minutes: Optional[int] = None
+
+
+class CIRef(BaseModel):
+    id: str
+    label: Optional[str] = None
+    hostname: Optional[str] = None
+    location_name: Optional[str] = None
+
+
+class EventFeedSummary(BaseModel):
+    id: str
+    ci_id: str
+    metric_id: str
+    status: Literal["OPEN", "ACK", "CLOSED", "RECOVERED"]
+    severity: Literal["CRITICAL", "WARNING", "INFO"]
+    message: str
+    created_at: str
+    last_seen: Optional[str] = None
+    ack: bool = False
+    ack_at: Optional[str] = None
+    closed_at: Optional[str] = None
+    recovered_at: Optional[str] = None
+    ci_name: Optional[str] = None
+    ci_node_id: Optional[str] = None
+    ci_hostname: Optional[str] = None
+    ci_location_name: Optional[str] = None
+    metric_name: Optional[str] = None
+    metric_protocol: Optional[str] = None
+
+
+class EventDetailEvent(EventFeedSummary):
+    ack_by: Optional[str] = None
+    closed_by: Optional[str] = None
+    comments: Optional[List[str]] = None
+    ci_ref: CIRef
+
+
+class BusinessContextService(BaseModel):
+    id: str
+    name: str
+    tier: Optional[str] = None
+    owner_t1: Optional[str] = None
+    owner_t2: Optional[str] = None
+    owner_t3: Optional[str] = None
+
+
+class BusinessContextCatalog(BaseModel):
+    id: str
+    category: str
+    service_tier: Optional[str] = None
+    sla_minutes: Optional[int] = None
+
+
+class BusinessContext(BaseModel):
+    source: Literal["snapshot", "resolved", "mixed", "unavailable"]
+    business_service: Optional[BusinessContextService] = None
+    service_catalog: Optional[BusinessContextCatalog] = None
+    impacted_users: Optional[int] = None
+    sla_remaining_minutes: Optional[int] = None
+    site: Optional[str] = None
+
+
+class ExternalTicketRef(BaseModel):
+    system: Literal["Jira", "ServiceNow"]
+    key: str
+    status: Optional[str] = None
+
+
+class ItsmContext(BaseModel):
+    assignment_state: Literal["unassigned", "assigned"]
+    assigned_to: Optional[str] = None
+    opened_by: Literal["system"] = "system"
+    escalation_tier: Optional[Literal["T1", "T2", "T3"]] = None
+    external_ticket: Optional[ExternalTicketRef] = None
+
+
+class EventDetailResponse(BaseModel):
+    event: EventDetailEvent
+    business_context: BusinessContext
+    itsm_context: ItsmContext

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 import services.event_service as event_service
 from services.auth_service import get_current_active_user, check_permission
+from models.core import EventDetailResponse, EventFeedSummary
 from models.user import User, UserPermission
 
 router = APIRouter(
@@ -16,11 +17,16 @@ class EventComment(BaseModel):
     message: str
 
 
+class AckRequest(BaseModel):
+    comment_message: Optional[str] = None
+
+
 class CloseRequest(BaseModel):
     forced: bool = False
+    comment_message: Optional[str] = None
 
 
-@router.get("", response_model=List[Dict[str, Any]])
+@router.get("", response_model=List[EventFeedSummary])
 async def get_events(status: Optional[str] = None):
     """
     Fetch system events filtered by status.
@@ -30,17 +36,33 @@ async def get_events(status: Optional[str] = None):
     return event_service.get_events(status)
 
 
+@router.get("/{event_id}", response_model=EventDetailResponse)
+async def get_event_detail(
+    event_id: str, current_user: User = Depends(get_current_active_user)
+):
+    """Fetch modal-specific event detail without bloating the summary feed."""
+    if not check_permission(UserPermission.EVENT_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view events")
+    return event_service.get_event_detail(event_id)
+
+
 @router.get("/related/{ci_id}", response_model=List[Dict[str, Any]])
-async def get_related_events(ci_id: str):
+async def get_related_events(
+    ci_id: str, current_user: User = Depends(get_current_active_user)
+):
     """
     Fetch all ACTIVE (OPEN, ACK) events for a specific CI.
     """
+    if not check_permission(UserPermission.EVENT_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view events")
     return event_service.get_related_events(ci_id)
 
 
 @router.post("/{event_id}/ack")
 async def ack_event(
-    event_id: str, current_user: User = Depends(get_current_active_user)
+    event_id: str,
+    ack_req: AckRequest = AckRequest(),
+    current_user: User = Depends(get_current_active_user),
 ):
     """
     Acknowledge an Event.
@@ -49,7 +71,11 @@ async def ack_event(
         raise HTTPException(
             status_code=403, detail="Not authorized to acknowledge events"
         )
-    return event_service.ack_event(event_id, current_user.username)
+    return event_service.ack_event(
+        event_id,
+        current_user.username,
+        comment_message=ack_req.comment_message,
+    )
 
 
 @router.post("/{event_id}/close")
@@ -72,7 +98,10 @@ async def close_event(
             detail="Not authorized to force-close events (EVENT_FORCED_CLOSE required)",
         )
     return event_service.close_event(
-        event_id, current_user.username, forced=close_req.forced
+        event_id,
+        current_user.username,
+        forced=close_req.forced,
+        comment_message=close_req.comment_message,
     )
 
 
@@ -85,6 +114,10 @@ async def add_event_comment(
     """
     Append a user comment to the Event history.
     """
+    if not check_permission(UserPermission.EVENT_ACK, current_user):
+        raise HTTPException(
+            status_code=403, detail="Not authorized to comment on events"
+        )
     return event_service.add_event_comment(
         event_id, current_user.username, comment.message
     )

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -1,127 +1,545 @@
-from typing import List, Dict, Any, Optional
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
 from database import get_db
 from fastapi import HTTPException
 from services.snmp_service import run_diagnostic
 
 
+def _serialize_value(value: Any) -> Any:
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value
+
+
+def _node_to_dict(value: Any) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return {key: _serialize_value(item) for key, item in value.items()}
+    return {key: _serialize_value(value[key]) for key in value.keys()}
+
+
+def _record_value(record: Any, key: str) -> Any:
+    if record is None:
+        return None
+    try:
+        return record[key]
+    except Exception:
+        return record.get(key) if hasattr(record, "get") else None
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        normalized = value.replace("Z", "+00:00")
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def _compute_sla_remaining_minutes(
+    created_at: Any, sla_minutes: Optional[int], now: Optional[datetime] = None
+) -> Optional[int]:
+    if sla_minutes is None:
+        return None
+    created_dt = _parse_datetime(created_at)
+    if created_dt is None:
+        return None
+    reference = now or datetime.now(timezone.utc)
+    age_minutes = int((reference - created_dt).total_seconds() // 60)
+    return int(sla_minutes) - age_minutes
+
+
+def _clean_dict(payload: Dict[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _strip_known_audit_prefixes(message: Optional[str]) -> str:
+    if not message:
+        return ""
+    cleaned = message.strip()
+    while cleaned.startswith("["):
+        closing_idx = cleaned.find("]")
+        if closing_idx == -1:
+            break
+        prefix = cleaned[: closing_idx + 1]
+        if not prefix.startswith(
+            (
+                "[OWNERSHIP]",
+                "[CIERRE",
+                "[FORCED CLOSE]",
+                "[AUDIT]",
+            )
+        ):
+            break
+        cleaned = cleaned[closing_idx + 1 :].lstrip(" -:\u2014")
+    return cleaned
+
+
+def _build_ack_audit_message(user: str) -> str:
+    return f"[AUDIT][OWNERSHIP] Caso tomado por {user}"
+
+
+def _normalize_ack_note(comment_message: Optional[str]) -> Optional[str]:
+    if not comment_message:
+        return None
+    cleaned = comment_message.strip()
+    if cleaned.startswith(("[OWNERSHIP]", "[AUDIT][OWNERSHIP]")):
+        return None
+    normalized = _strip_known_audit_prefixes(cleaned)
+    return normalized or None
+
+
+def _build_close_audit_message(
+    user: str, forced: bool, comment_message: Optional[str]
+) -> str:
+    detail = _strip_known_audit_prefixes(comment_message)
+    if forced:
+        lines = [f"[AUDIT][FORCED_CLOSE] Cierre forzado por {user}"]
+        if detail:
+            lines.append(detail)
+        return "\n".join(lines)
+
+    lines = [f"[AUDIT][CLOSE] Evento cerrado por {user}"]
+    if detail:
+        lines.append(detail)
+    return "\n".join(lines)
+
+
+def _optional_contract(
+    payload: Dict[str, Any], required_keys: set[str]
+) -> Optional[Dict[str, Any]]:
+    cleaned = _clean_dict(payload)
+    if not required_keys.issubset(cleaned):
+        return None
+    return cleaned
+
+
+def _build_external_ticket_ref(event_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    system = event_data.get("external_ticket_system")
+    key = event_data.get("external_ticket_key")
+    if system not in {"Jira", "ServiceNow"} or not key:
+        return None
+    return _clean_dict(
+        {
+            "system": system,
+            "key": key,
+            "status": event_data.get("external_ticket_status"),
+        }
+    )
+
+
+def _raise_event_not_found(event_id: str) -> None:
+    raise HTTPException(status_code=404, detail=f"Event not found: {event_id}")
+
+
+def _build_event_summary(
+    event_data: Dict[str, Any], ci_data: Dict[str, Any], metric_data: Dict[str, Any]
+) -> Dict[str, Any]:
+    summary = {key: _serialize_value(value) for key, value in event_data.items()}
+    summary["ci_node_id"] = ci_data.get("id")
+    summary["ci_name"] = ci_data.get("label")
+    summary["ci_hostname"] = ci_data.get("ip")
+    summary["ci_location_name"] = ci_data.get("locationName")
+    summary["metric_name"] = metric_data.get("name") or metric_data.get("id")
+    summary["metric_protocol"] = metric_data.get("protocol")
+    return summary
+
+
+def _public_event_summary(summary: Dict[str, Any]) -> Dict[str, Any]:
+    allowed_keys = {
+        "id",
+        "ci_id",
+        "metric_id",
+        "status",
+        "severity",
+        "message",
+        "created_at",
+        "last_seen",
+        "ack",
+        "ack_at",
+        "closed_at",
+        "recovered_at",
+        "ci_name",
+        "ci_node_id",
+        "ci_hostname",
+        "ci_location_name",
+        "metric_name",
+        "metric_protocol",
+    }
+    return {
+        key: value
+        for key, value in summary.items()
+        if key in allowed_keys and value is not None
+    }
+
+
+def _extract_structured_close_fields(comment_message: Optional[str]) -> tuple[str, str]:
+    detail = _strip_known_audit_prefixes(comment_message)
+    root_cause = ""
+    note_lines: List[str] = []
+    collecting_note = False
+
+    for raw_line in detail.splitlines():
+        line = raw_line.strip()
+        lowered = line.lower()
+        if lowered.startswith(("causa raíz:", "causa raiz:")):
+            root_cause = line.split(":", 1)[1].strip()
+            collecting_note = False
+            continue
+        if lowered.startswith("nota:"):
+            note_lines = [line.split(":", 1)[1].strip()]
+            collecting_note = True
+            continue
+        if collecting_note:
+            note_lines.append(line)
+
+    note = "\n".join(part for part in note_lines if part).strip()
+    return root_cause, note
+
+
+def _validate_close_request(forced: bool, comment_message: Optional[str]) -> None:
+    detail = _strip_known_audit_prefixes(comment_message)
+    if forced:
+        if not detail:
+            raise HTTPException(
+                status_code=400,
+                detail="Forced close requires a reason in comment_message",
+            )
+        return
+
+    root_cause, note = _extract_structured_close_fields(comment_message)
+    if not root_cause:
+        raise HTTPException(
+            status_code=400,
+            detail="Normal close requires 'Causa raíz' in comment_message",
+        )
+    if len(note) < 20:
+        raise HTTPException(
+            status_code=400,
+            detail="Normal close requires a 'Nota' of at least 20 characters",
+        )
+
+
+def _pick_value(snapshot_value: Any, resolved_value: Any) -> tuple[Any, Optional[str]]:
+    if snapshot_value is not None:
+        return snapshot_value, "snapshot"
+    if resolved_value is not None:
+        return resolved_value, "resolved"
+    return None, None
+
+
+def _build_business_context(
+    event_data: Dict[str, Any],
+    ci_data: Dict[str, Any],
+    business_service: Dict[str, Any],
+    service_catalog: Dict[str, Any],
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    business_service_id, bs_id_source = _pick_value(
+        event_data.get("business_service_id"), business_service.get("id")
+    )
+    business_service_name, bs_name_source = _pick_value(
+        event_data.get("business_service_name"), business_service.get("name")
+    )
+    business_service_tier, business_service_tier_source = _pick_value(
+        event_data.get("business_service_tier"), business_service.get("tier")
+    )
+    owner_t1, owner_t1_source = _pick_value(
+        event_data.get("owner_t1"), business_service.get("owner_t1")
+    )
+    owner_t2, owner_t2_source = _pick_value(
+        event_data.get("owner_t2"), business_service.get("owner_t2")
+    )
+    owner_t3, owner_t3_source = _pick_value(
+        event_data.get("owner_t3"), business_service.get("owner_t3")
+    )
+    impacted_users, impacted_users_source = _pick_value(
+        event_data.get("impacted_users"), business_service.get("impacted_users_count")
+    )
+    site, site_source = _pick_value(event_data.get("site"), ci_data.get("locationName"))
+    service_catalog_id, sc_id_source = _pick_value(
+        event_data.get("service_catalog_id"), service_catalog.get("id")
+    )
+    category, category_source = _pick_value(
+        event_data.get("service_category"), service_catalog.get("category")
+    )
+    catalog_tier, catalog_tier_source = _pick_value(
+        event_data.get("service_tier"), service_catalog.get("service_tier")
+    )
+    sla_minutes, sla_source = _pick_value(
+        event_data.get("sla_minutes"), service_catalog.get("sla_minutes")
+    )
+
+    sources = {
+        source
+        for source in [
+            bs_id_source,
+            bs_name_source,
+            business_service_tier_source,
+            owner_t1_source,
+            owner_t2_source,
+            owner_t3_source,
+            impacted_users_source,
+            site_source,
+            sc_id_source,
+            category_source,
+            catalog_tier_source,
+            sla_source,
+        ]
+        if source is not None
+    }
+
+    if not sources:
+        source_state = "unavailable"
+    elif sources == {"snapshot"}:
+        source_state = "snapshot"
+    elif sources == {"resolved"}:
+        source_state = "resolved"
+    else:
+        source_state = "mixed"
+
+    business_context = {
+        "source": source_state,
+        "business_service": _optional_contract(
+            {
+                "id": business_service_id,
+                "name": business_service_name,
+                "tier": business_service_tier,
+                "owner_t1": owner_t1,
+                "owner_t2": owner_t2,
+                "owner_t3": owner_t3,
+            },
+            {"id", "name"},
+        ),
+        "service_catalog": _optional_contract(
+            {
+                "id": service_catalog_id,
+                "category": category,
+                "service_tier": catalog_tier,
+                "sla_minutes": sla_minutes,
+            },
+            {"id", "category"},
+        ),
+        "impacted_users": impacted_users,
+        "sla_remaining_minutes": _compute_sla_remaining_minutes(
+            event_data.get("created_at"), sla_minutes, now=now
+        ),
+        "site": site,
+    }
+    return business_context
+
+
+def build_event_detail_response(
+    record: Any, now: Optional[datetime] = None
+) -> Dict[str, Any]:
+    event_data = _node_to_dict(_record_value(record, "e"))
+    ci_data = _node_to_dict(_record_value(record, "ci"))
+    metric_data = _node_to_dict(_record_value(record, "m"))
+    business_service = _node_to_dict(_record_value(record, "bs"))
+    service_catalog = _node_to_dict(_record_value(record, "sc"))
+
+    summary = _build_event_summary(event_data, ci_data, metric_data)
+    business_context = _build_business_context(
+        event_data, ci_data, business_service, service_catalog, now=now
+    )
+    business_service_context = business_context.get("business_service") or {}
+    escalation_tier = event_data.get("escalation_tier") or business_service_context.get(
+        "tier"
+    )
+
+    return {
+        "event": {
+            **summary,
+            "ci_ref": {
+                "id": ci_data.get("id") or summary.get("ci_id"),
+                "label": ci_data.get("label"),
+                "hostname": ci_data.get("ip"),
+                "location_name": ci_data.get("locationName"),
+            },
+        },
+        "business_context": business_context,
+        "itsm_context": {
+            "assignment_state": "assigned"
+            if event_data.get("ack") and event_data.get("ack_by")
+            else "unassigned",
+            "assigned_to": event_data.get("ack_by"),
+            "opened_by": "system",
+            "escalation_tier": escalation_tier
+            if escalation_tier in {"T1", "T2", "T3"}
+            else None,
+            "external_ticket": _build_external_ticket_ref(event_data),
+        },
+    }
+
+
 def get_events(status: Optional[str] = None) -> List[Dict[str, Any]]:
-    """
-    Fetch system events filtered by status.
-    """
     driver = get_db()
     with driver.session() as session:
-        query = """
+        result = session.run(
+            """
             MATCH (e:Event)<-[:HAS_EVENT]-(ci:CI)
             MATCH (e)-[:TRIGGERED_BY]->(m:MetricDef)
             WHERE ($status IS NULL OR e.status = $status OR ($status = 'ACTIVE' AND e.status IN ['OPEN', 'ACK', 'RECOVERED']))
-            RETURN e,
-                   ci.id            AS ci_node_id,
-                   ci.label         AS ci_name,
-                   ci.ip            AS ci_hostname,
-                   ci.locationName  AS ci_location_name,
-                   m.id             AS metric_name,
-                   m.protocol       AS metric_protocol
+            RETURN e, ci, m
             ORDER BY e.created_at DESC
             LIMIT 100
-        """
-        result = session.run(query, status=status)
-        events = []
-        for record in result:
-            evt = dict(record["e"])
-            for k, v in evt.items():
-                if hasattr(v, "isoformat"):
-                    evt[k] = v.isoformat()
+        """,
+            status=status,
+        )
+        return [
+            _public_event_summary(
+                _build_event_summary(
+                    _node_to_dict(record["e"]),
+                    _node_to_dict(record["ci"]),
+                    _node_to_dict(record["m"]),
+                )
+            )
+            for record in result
+        ]
 
-            evt["ci_node_id"] = record["ci_node_id"]  # Real Neo4j CI node ID
-            evt["ci_name"] = record["ci_name"]  # Human-readable label
-            evt["ci_hostname"] = record["ci_hostname"]  # IP / hostname of the CI
-            evt["ci_location_name"] = record[
-                "ci_location_name"
-            ]  # Location name (e.g. "Madrid HQ")
-            evt["metric_name"] = record["metric_name"]
-            evt["metric_protocol"] = record["metric_protocol"]
-            events.append(evt)
-        return events
+
+def get_event_detail(event_id: str) -> Dict[str, Any]:
+    driver = get_db()
+    with driver.session() as session:
+        result = session.run(
+            """
+            MATCH (e:Event {id: $event_id})<-[:HAS_EVENT]-(ci:CI)
+            OPTIONAL MATCH (e)-[:TRIGGERED_BY]->(m:MetricDef)
+            OPTIONAL MATCH (ci)-[:BELONGS_TO]->(bs:BusinessService)
+            OPTIONAL MATCH (bs)-[:USES_SLA]->(sc:ServiceCatalog)
+            WITH e, ci, m, bs, head([item IN collect(sc) WHERE item IS NOT NULL]) AS sc
+            RETURN e, ci, m, bs, sc
+        """,
+            event_id=event_id,
+        ).single()
+
+        if not result:
+            raise HTTPException(status_code=404, detail="Event not found")
+
+        return build_event_detail_response(result)
 
 
 def get_related_events(ci_id: str) -> List[Dict[str, Any]]:
-    """
-    Fetch all ACTIVE (OPEN, ACK) events for a specific CI.
-    """
     driver = get_db()
     with driver.session() as session:
         result = session.run(
             """
             MATCH (e:Event)-[:TRIGGERED_BY]->(m:MetricDef)
             WHERE e.ci_id = $ci_id AND e.status IN ['OPEN', 'ACK']
-            RETURN e, m.name as metric_name
+            RETURN e, m
             ORDER BY e.severity DESC, e.created_at DESC
         """,
             ci_id=ci_id,
         )
 
-        events = []
+        related = []
         for record in result:
-            evt = dict(record["e"])
-            # Format datetime objects
-            if hasattr(evt.get("created_at"), "iso_format"):
-                evt["created_at"] = evt["created_at"].iso_format()
-            if hasattr(evt.get("last_seen"), "iso_format"):
-                evt["last_seen"] = evt["last_seen"].iso_format()
+            event_data = _node_to_dict(record["e"])
+            metric_value = _record_value(record, "m")
+            if metric_value is not None:
+                metric_data = _node_to_dict(metric_value)
+                event_data["metric_name"] = metric_data.get("name") or metric_data.get(
+                    "id"
+                )
+            else:
+                event_data["metric_name"] = _record_value(record, "metric_name")
+            related.append(_public_event_summary(event_data))
 
-            evt["metric_name"] = record["metric_name"]
-            events.append(evt)
-
-        return events
+        return related
 
 
-def ack_event(event_id: str, user: str) -> Dict[str, str]:
+def ack_event(
+    event_id: str, user: str, comment_message: Optional[str] = None
+) -> Dict[str, str]:
     driver = get_db()
+    audit_message = _build_ack_audit_message(user)
+    note_message = _normalize_ack_note(comment_message)
     with driver.session() as session:
-        session.run(
-            """
-            MATCH (e:Event {id: $eid})
-            SET e.status = 'ACK', e.ack = true, e.ack_at = datetime(), e.ack_by = $user
-        """,
-            eid=event_id,
-            user=user,
-        )
+        with session.begin_transaction() as tx:
+            result = tx.run(
+                """
+                MATCH (e:Event {id: $eid})
+                SET e.status = 'ACK', e.ack = true, e.ack_at = datetime(), e.ack_by = $user
+                WITH e
+                SET e.comments = coalesce(e.comments, []) + ($audit_message + ' (' + toString(datetime()) + ')')
+                FOREACH (_ IN CASE WHEN $note_message IS NULL OR trim($note_message) = '' THEN [] ELSE [1] END |
+                    SET e.comments = e.comments + ($user + ': ' + $note_message + ' (' + toString(datetime()) + ')')
+                )
+                RETURN e.id AS event_id
+            """,
+                eid=event_id,
+                user=user,
+                audit_message=audit_message,
+                note_message=note_message,
+            ).single()
+            if not result:
+                _raise_event_not_found(event_id)
     return {"message": "Event Acknowledged"}
 
 
-def close_event(event_id: str, user: str, forced: bool = False) -> Dict[str, str]:
+def close_event(
+    event_id: str,
+    user: str,
+    forced: bool = False,
+    comment_message: Optional[str] = None,
+) -> Dict[str, str]:
     driver = get_db()
-    audit_msg = f"[FORCED CLOSE] Closed by {user}" if forced else ""
+    audit_message = _build_close_audit_message(user, forced, comment_message)
     with driver.session() as session:
         with session.begin_transaction() as tx:
-            tx.run(
+            existing = tx.run(
+                """
+                MATCH (e:Event {id: $eid})
+                RETURN e.id AS event_id
+                """,
+                eid=event_id,
+            ).single()
+            if not existing:
+                _raise_event_not_found(event_id)
+
+            _validate_close_request(forced, comment_message)
+            result = tx.run(
                 """
                 MATCH (e:Event {id: $eid})
                 SET e.status = 'CLOSED', e.closed_at = datetime(), e.closed_by = $user
                 WITH e
-                WHERE $forced
-                SET e.comments = coalesce(e.comments, []) + ($msg + ' (' + toString(datetime()) + ')')
+                SET e.comments = coalesce(e.comments, []) + ($audit_message + ' (' + toString(datetime()) + ')')
+                RETURN e.id AS event_id
                 """,
                 eid=event_id,
                 user=user,
-                forced=forced,
-                msg=audit_msg,
-            )
+                audit_message=audit_message,
+            ).single()
+            if not result:
+                _raise_event_not_found(event_id)
     return {"message": "Event Closed"}
 
 
 def add_event_comment(event_id: str, user: str, message: str) -> Dict[str, str]:
     driver = get_db()
     with driver.session() as session:
-        session.run(
+        result = session.run(
             """
             MATCH (e:Event {id: $eid})
             SET e.comments = coalesce(e.comments, []) + ($user + ': ' + $msg + ' (' + toString(datetime()) + ')')
+            RETURN e.id AS event_id
         """,
             eid=event_id,
             user=user,
             msg=message,
-        )
+        ).single()
+        if not result:
+            _raise_event_not_found(event_id)
     return {"message": "Comment added"}
 
 
@@ -131,24 +549,22 @@ def prune_recovered_events(user: str) -> Dict[str, Any]:
         result = session.run(
             """
             MATCH (e:Event)
-            WHERE e.status = 'RECOVERED' 
+            WHERE e.status = 'RECOVERED'
               AND (e.ack IS NULL OR e.ack = false)
               AND (e.comments IS NULL OR size(e.comments) = 0)
             SET e.status = 'CLOSED', e.closed_at = datetime(), e.closed_by = $user
             RETURN count(e) as closed_count
         """,
             user=user,
-        ).single()
+        ).single() or {"closed_count": 0}
+    closed_count = _record_value(result, "closed_count") or 0
     return {
-        "message": f"Cleaned up {result['closed_count']} events",
-        "count": result["closed_count"],
+        "message": f"Cleaned up {closed_count} events",
+        "count": closed_count,
     }
 
 
 def run_event_diagnostic(event_id: str, user: str) -> Dict[str, str]:
-    """
-    Run an on-demand diagnostic (Ping/SNMP) for the CI related to this event.
-    """
     driver = get_db()
     with driver.session() as session:
         result = session.run(
@@ -163,14 +579,11 @@ def run_event_diagnostic(event_id: str, user: str) -> Dict[str, str]:
         if not result:
             raise HTTPException(status_code=404, detail="Event not found")
 
-        ci = dict(result["ci"])
-        metric = dict(result["m"])
-
-        # Call Service (imported from snmp_service)
+        ci = _node_to_dict(result["ci"])
+        metric = _node_to_dict(result["m"])
         diag_msg = run_diagnostic(ci, metric)
-
-        # Save Result
         final_msg = f"DIAGNOSTIC RUN BY {user}:\n{diag_msg}"
+
         session.run(
             """
             MATCH (e:Event {id: $eid})

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -1,372 +1,424 @@
+from __future__ import annotations
+
 import asyncio
-import time
-from datetime import datetime
+import ast
 import json
 import logging
 import subprocess
+import time
+from datetime import datetime
+from typing import Any, Dict
+
 from database import get_db
 
-# Configure Logging
 logger = logging.getLogger(__name__)
 
-# Try to import PySNMP (Optional Dependency)
-# Try to import PySNMP (Optional Dependency)
 try:
-    from pysnmp.hlapi import getCmd, SnmpEngine, CommunityData, UdpTransportTarget, ContextData, ObjectType, ObjectIdentity
+    from pysnmp.hlapi import (
+        CommunityData,
+        ContextData,
+        ObjectIdentity,
+        ObjectType,
+        SnmpEngine,
+        UdpTransportTarget,
+        getCmd,
+    )
+
     SNMP_AVAILABLE = True
 except ImportError:
     SNMP_AVAILABLE = False
     logger.warning("PySNMP not installed. SNMP features will be disabled.")
+
+LAST_COLLECTION_TIME = None
 COLLECTOR_STATUS = "STOPPED"
 GLOBAL_STATS = {
     "cis_monitored": 0,
     "metrics_collected": 0,
     "metrics_failed": 0,
     "cycle_duration": 0.0,
-    "jobs_per_min": 0.0
+    "jobs_per_min": 0.0,
 }
+
 
 def get_collector_status():
     return {
         "last_run": LAST_COLLECTION_TIME,
         "status": COLLECTOR_STATUS,
-        "stats": GLOBAL_STATS
+        "stats": GLOBAL_STATS,
     }
 
+
+def _parse_snmp_config(snmp_raw: Any) -> Dict[str, Any]:
+    if not snmp_raw:
+        return {}
+    if isinstance(snmp_raw, dict):
+        return snmp_raw
+    try:
+        return json.loads(snmp_raw)
+    except Exception:
+        try:
+            return ast.literal_eval(snmp_raw)
+        except Exception:
+            return {}
+
+
+def resolve_event_snapshot(session, ci_id: str) -> Dict[str, Any]:
+    record = session.run(
+        """
+        MATCH (ci:CI {id: $ci_id})
+        OPTIONAL MATCH (ci)-[:BELONGS_TO]->(bs:BusinessService)
+        OPTIONAL MATCH (bs)-[:USES_SLA]->(sc:ServiceCatalog)
+        RETURN ci.locationName AS site,
+               bs.id AS business_service_id,
+               bs.name AS business_service_name,
+               bs.tier AS business_service_tier,
+               bs.owner_t1 AS owner_t1,
+               bs.owner_t2 AS owner_t2,
+               bs.owner_t3 AS owner_t3,
+               bs.impacted_users_count AS impacted_users,
+               sc.id AS service_catalog_id,
+               sc.category AS service_category,
+               sc.service_tier AS service_tier,
+               sc.sla_minutes AS sla_minutes
+        """,
+        ci_id=ci_id,
+    ).single()
+
+    if not record:
+        return {}
+
+    return {
+        "business_service_id": record.get("business_service_id"),
+        "business_service_name": record.get("business_service_name"),
+        "business_service_tier": record.get("business_service_tier"),
+        "owner_t1": record.get("owner_t1"),
+        "owner_t2": record.get("owner_t2"),
+        "owner_t3": record.get("owner_t3"),
+        "impacted_users": record.get("impacted_users"),
+        "site": record.get("site"),
+        "service_catalog_id": record.get("service_catalog_id"),
+        "service_category": record.get("service_category"),
+        "service_tier": record.get("service_tier"),
+        "sla_minutes": record.get("sla_minutes"),
+    }
+
+
 async def snmp_collector_loop():
-    """
-    Background task to poll CIs based on their pollingInterval and applicable metrics.
-    Runs indefinitely in the background.
-    """
     if not SNMP_AVAILABLE:
         logger.warning("SNMP Collector disabled due to missing pysnmp.")
         return
 
     global LAST_COLLECTION_TIME, COLLECTOR_STATUS
-    
+
     driver = get_db()
     COLLECTOR_STATUS = "RUNNING"
-    
+
     while True:
         try:
             logger.info("[Collector] Starting Poll Cycle (Thread Offload)...")
             start_time = time.time()
-            
-            # Offload the entire blocking cycle to a separate thread
             stats = await asyncio.to_thread(run_snmp_cycle_sync, driver)
-
             elapsed = time.time() - start_time
             LAST_COLLECTION_TIME = datetime.now().isoformat()
-            
-            # Update Global Stats
+
             GLOBAL_STATS["cycle_duration"] = round(elapsed, 2)
             GLOBAL_STATS["cis_monitored"] = stats.get("cis", 0)
             GLOBAL_STATS["metrics_collected"] = stats.get("total", 0)
             GLOBAL_STATS["metrics_failed"] = stats.get("errors", 0)
-            
-            # Calculate Throughput (Metrics per minute equivalent)
             if elapsed > 0:
-                GLOBAL_STATS["jobs_per_min"] = round((stats.get("total", 0) / elapsed) * 60, 1)
+                GLOBAL_STATS["jobs_per_min"] = round(
+                    (stats.get("total", 0) / elapsed) * 60, 1
+                )
 
-            logger.info(f"[Collector] Cycle finished in {elapsed:.2f}s. Stats: {GLOBAL_STATS}")
-            
-            # Simple fixed sleep (Demo Mode)
-            await asyncio.sleep(60) 
-            
-        except Exception as e:
-             logger.error(f"[Collector] Critical Loop Error: {e}", exc_info=True)
-             COLLECTOR_STATUS = "ERROR"
-             await asyncio.sleep(10)
+            logger.info(
+                "[Collector] Cycle finished in %.2fs. Stats: %s", elapsed, GLOBAL_STATS
+            )
+            await asyncio.sleep(60)
+        except Exception as exc:
+            logger.error("[Collector] Critical Loop Error: %s", exc, exc_info=True)
+            COLLECTOR_STATUS = "ERROR"
+            await asyncio.sleep(10)
+
 
 def run_snmp_cycle_sync(driver):
-    """
-    Synchronous wrapper for the polling cycle to run in a thread.
-    """
     with driver.session() as session:
-        # 1. Fetch Candidates (Relaxed: Allow CIs without SNMP if they have IP)
-        cis_result = session.run("""
-            MATCH (n:CI) 
+        cis_result = session.run(
+            """
+            MATCH (n:CI)
             WHERE n.ip IS NOT NULL AND n.status <> 'EXCEPTION'
             RETURN n
-        """)
+        """
+        )
         cis = [dict(record["n"]) for record in cis_result]
-        logger.info(f"[Collector] Found {len(cis)} candidate CIs for monitoring.")
-        
-        # 2. Fetch Metric Definitions
+        logger.info("[Collector] Found %s candidate CIs for monitoring.", len(cis))
+
         metrics_result = session.run("MATCH (m:MetricDef) RETURN m")
         metrics = []
         for record in metrics_result:
-            m = dict(record["m"])
+            metric = dict(record["m"])
             criteria = {}
-            if m.get("applicable_to"):
-                try: criteria = json.loads(m.get("applicable_to"))
-                except: pass
-            
-            metrics.append({
-                "id": m.get("id"),
-                "name": m.get("name") or m.get("id"),
-                "oid": m.get("oid"),
-                "protocol": m.get("protocol"),
-                "criticality": m.get("criticality", 1),
-                "warning": m.get("warning"),
-                "critical": m.get("critical"),
-                "operator": m.get("operator", ">="),
-                "applicable_to": criteria
-            })
+            if metric.get("applicable_to"):
+                try:
+                    criteria = json.loads(metric.get("applicable_to"))
+                except Exception:
+                    criteria = {}
 
-    # 3. Process Each Node
-    logger.info(f"[Collector] Processing {len(cis)} Nodes vs {len(metrics)} MetricDefs...")
-    
+            metrics.append(
+                {
+                    "id": metric.get("id"),
+                    "name": metric.get("name") or metric.get("id"),
+                    "oid": metric.get("oid"),
+                    "protocol": metric.get("protocol"),
+                    "criticality": metric.get("criticality", 1),
+                    "warning": metric.get("warning"),
+                    "critical": metric.get("critical"),
+                    "operator": metric.get("operator", ">="),
+                    "applicable_to": criteria,
+                }
+            )
+
     total_metrics = 0
     total_errors = 0
-    
     for ci in cis:
-        # Debug Log for individual CI processing
-        # logger.debug(f"[Collector] Checking CI: {ci.get('name')} ({ci.get('ip')})")
-        t, e = process_ci_metrics(ci, metrics, driver)
-        total_metrics += t
-        total_errors += e
-        
+        executed, errors = process_ci_metrics(ci, metrics, driver)
+        total_metrics += executed
+        total_errors += errors
+
     return {"cis": len(cis), "total": total_metrics, "errors": total_errors}
 
+
 def process_ci_metrics(ci, metrics, driver):
-    """
-    Evaluates which metrics apply to the CI and executes them.
-    Returns (total_executed, total_errors)
-    """
-    # Parse SNMP config
-    snmp_conf = {}
-    snmp_raw = ci.get("snmp")
-    if snmp_raw:
-        try:
-            snmp_conf = json.loads(snmp_raw)
-        except:
-             try:
-                 import ast
-                 snmp_conf = ast.literal_eval(snmp_raw)
-             except: pass
-    
-    # Validation for SNMP only (skip if ICMP/API)
-    # But we can't skip entirely if we have ICMP metrics.
-    # Refactor: Only require SNMP conf if we have SNMP metrics to run.
-    
-    # Determine applicable metrics
+    snmp_conf = _parse_snmp_config(ci.get("snmp"))
     ci_brand = ci.get("brand", "").lower() if ci.get("brand") else ""
     ci_model = ci.get("model", "").lower() if ci.get("model") else ""
     ci_layer = ci.get("layer", "").lower() if ci.get("layer") else ""
-    
+
     target_metrics = []
-    for m in metrics:
-        crit = m.get("applicable_to", {})
+    for metric in metrics:
+        criteria = metric.get("applicable_to", {})
         match = False
-        
-        # 1. Direct Name Match
-        req_names = [n.strip().lower() for n in crit.get("names", [])]
-        if req_names and (ci.get("name", "").lower() in req_names or ci.get("id", "").lower() in req_names):
+        requested_names = [name.strip().lower() for name in criteria.get("names", [])]
+
+        if requested_names and (
+            ci.get("name", "").lower() in requested_names
+            or ci.get("id", "").lower() in requested_names
+        ):
             match = True
         else:
-            # 2. Category Match (OR Logic)
-            req_brands = [b.lower() for b in crit.get("brands", [])]
-            req_models = [mod.lower() for mod in crit.get("models", [])]
-            req_layers = [l.lower() for l in crit.get("layers", [])]
-            
-            if req_brands and ci_brand in req_brands: match = True
-            if req_models and ci_model in req_models: match = True
-            if req_layers and ci_layer in req_layers: match = True
-            
-        # 3. Apply Exclusions
-        exc_names = [n.strip().lower() for n in crit.get("excluded_names", [])]
-        if match and (ci.get("name", "").lower() in exc_names or ci.get("id", "").lower() in exc_names):
-            match = False
-        
-        # Only add if match AND (OID exists OR Protocol is ICMP)
-        if match:
-             if m.get("oid") or m.get("protocol") == 'ICMP':
-                  target_metrics.append(m)
+            requested_brands = [brand.lower() for brand in criteria.get("brands", [])]
+            requested_models = [model.lower() for model in criteria.get("models", [])]
+            requested_layers = [layer.lower() for layer in criteria.get("layers", [])]
 
-    # Execute Polls
+            if requested_brands and ci_brand in requested_brands:
+                match = True
+            if requested_models and ci_model in requested_models:
+                match = True
+            if requested_layers and ci_layer in requested_layers:
+                match = True
+
+        excluded_names = [
+            name.strip().lower() for name in criteria.get("excluded_names", [])
+        ]
+        if match and (
+            ci.get("name", "").lower() in excluded_names
+            or ci.get("id", "").lower() in excluded_names
+        ):
+            match = False
+
+        if match and (metric.get("oid") or metric.get("protocol") == "ICMP"):
+            target_metrics.append(metric)
+
     executed = 0
     errors = 0
-    
-    for tm in target_metrics:
+    for target_metric in target_metrics:
         try:
             executed += 1
-            # Check SNMP prerequisites if needed
-            if tm.get("protocol") == 'SNMP' and (not snmp_conf or not snmp_conf.get("readCommunity")):
-                 # logger.warning(f"[Collector] Skipping SNMP metric {tm.get('name')} for {ci.get('name')} (No Community String)")
-                 continue
-            
-            # logger.debug(f"[Collector] Polling {tm.get('name')} for {ci.get('name')}...")
-            val, status, err_msg = poll_metric(ci, tm, snmp_conf)
-            # logger.debug(f"[Collector] Poll Result: {val}, {status}")
-            
-            # Always store result
-            store_metric_result(ci, tm, val, status, err_msg, driver)
-            
-        except Exception as e:
+            if target_metric.get("protocol") == "SNMP" and (
+                not snmp_conf or not snmp_conf.get("readCommunity")
+            ):
+                continue
+
+            value, status, error_message = poll_metric(ci, target_metric, snmp_conf)
+            store_metric_result(ci, target_metric, value, status, error_message, driver)
+        except Exception as exc:
             errors += 1
-            logger.error(f"[Collector] Error processing metric {tm.get('name')} for {ci.get('name')}: {e}", exc_info=True)
-            
-    return (executed, errors)
+            logger.error(
+                "[Collector] Error processing metric %s for %s: %s",
+                target_metric.get("name"),
+                ci.get("name"),
+                exc,
+                exc_info=True,
+            )
+
+    return executed, errors
+
 
 def poll_metric(ci, metric_def, snmp_conf):
-    """
-    Executes the actual poll (ICMP or SNMP).
-    Returns (value, status, error_message).
-    Status: 'OK', 'TIMEOUT', 'ERROR'
-    """
     proto = str(metric_def.get("protocol", "")).upper().strip()
-    
-    # 1. ICMP PING
-    if proto == 'ICMP':
+
+    if proto == "ICMP":
         import platform
-        # Detect OS for correct Ping Flag
-        param = '-n' if platform.system().lower() == 'windows' else '-c'
-        
-        command = ['ping', param, '1', ci.get("ip")]
-        logger.debug(f"[Collector] Executing ICMP: {' '.join(command)}")
+
+        param = "-n" if platform.system().lower() == "windows" else "-c"
+        command = ["ping", param, "1", ci.get("ip")]
         try:
-            # 0 = Success (UP), 1 = Fail (DOWN)
-            res = subprocess.call(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            if res == 0:
-                return (1, 'OK', None)
-            else:
-                return (0, 'OK', None) # Valid result, value is 0 (Down)
-        except Exception as e:
-            logger.error(f"PING Exception for {ci.get('ip')}: {e}")
-            return (0, 'ERROR', str(e))
-    
-    # 2. SNMP
-    elif metric_def.get("oid") and metric_def.get("oid") != 'ICMP' and SNMP_AVAILABLE:
+            result = subprocess.call(
+                command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+            return (1, "OK", None) if result == 0 else (0, "OK", None)
+        except Exception as exc:
+            logger.error("PING Exception for %s: %s", ci.get("ip"), exc)
+            return 0, "ERROR", str(exc)
+
+    if metric_def.get("oid") and metric_def.get("oid") != "ICMP" and SNMP_AVAILABLE:
         try:
             oid = metric_def["oid"]
-            # logger.debug(f"[Collector] SNMP GET {oid} from {ci.get('ip')}...")
-            
-            errorIndication, errorStatus, errorIndex, varBinds = next(
-                getCmd(SnmpEngine(),
+            error_indication, error_status, error_index, var_binds = next(
+                getCmd(
+                    SnmpEngine(),
                     CommunityData(snmp_conf.get("readCommunity")),
-                    UdpTransportTarget((ci.get("ip"), snmp_conf.get("port", 161)), timeout=1.0, retries=0),
+                    UdpTransportTarget(
+                        (ci.get("ip"), snmp_conf.get("port", 161)),
+                        timeout=1.0,
+                        retries=0,
+                    ),
                     ContextData(),
-                    ObjectType(ObjectIdentity(oid)))
+                    ObjectType(ObjectIdentity(oid)),
+                )
             )
-            
-            if errorIndication:
-                logger.warning(f"[Collector] SNMP Timeout for {ci.get('name')} (OID: {oid}): {errorIndication}")
-                return (None, 'TIMEOUT', str(errorIndication))
-            elif errorStatus:
-                err = f"{errorStatus.prettyPrint()} at {errorIndex and varBinds[int(errorIndex) - 1][0] or '?'}"
-                logger.error(f"[Collector] SNMP Error for {ci.get('name')} (OID: {oid}): {err}")
-                return (None, 'ERROR', err)
-            else:
-                val = str(varBinds[0][1])
-                # logger.debug(f"[Collector] SNMP Success {ci.get('name')} (OID: {oid}): {val}")
-                return (val, 'OK', None)
-                
-        except Exception as snmp_err:
-            logger.error(f"SNMP Error {ci.get('id')}: {snmp_err}")
-            return (None, 'ERROR', str(snmp_err))
-    
-    return (None, 'ERROR', 'Unknown Protocol or OID')
+
+            if error_indication:
+                return None, "TIMEOUT", str(error_indication)
+            if error_status:
+                error = f"{error_status.prettyPrint()} at {error_index and var_binds[int(error_index) - 1][0] or '?'}"
+                return None, "ERROR", error
+            return str(var_binds[0][1]), "OK", None
+        except Exception as exc:
+            logger.error("SNMP Error %s: %s", ci.get("id"), exc)
+            return None, "ERROR", str(exc)
+
+    return None, "ERROR", "Unknown Protocol or OID"
+
 
 def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
-    """
-    Stores the metric result and triggers event logic.
-    """
-    # 1. Resolve Criticality to Severity
-    # 1 -> INFO, 2 -> WARNING, 3 -> CRITICAL (Exception)
-    crit_level = metric_def.get("criticality", 1) # Default Info
-    base_severity = 'INFO'
-    if crit_level == 2: base_severity = 'WARNING'
-    if crit_level == 3: base_severity = 'CRITICAL'
+    crit_level = metric_def.get("criticality", 1)
+    base_severity = "INFO"
+    if crit_level == 2:
+        base_severity = "WARNING"
+    if crit_level == 3:
+        base_severity = "CRITICAL"
 
-    # Default State
-    status = 'OK'
-    severity = 'INFO' # For the event
+    status = "OK"
+    severity = "INFO"
     is_breach = False
     message = f"Metric {metric_def.get('name', metric_def['id'])} is OK. Value: {val}"
-    
-    # 1. Handle Poll Failures (Timeout/Error)
-    if poll_status != 'OK':
-        status = 'CRITICAL'
-        severity = base_severity # Use the metric's criticality level for the alert
+
+    if poll_status != "OK":
+        status = "CRITICAL"
+        severity = base_severity
         is_breach = True
         message = f"Metric Collection Failed: {err_msg or 'Timeout'}"
         val = "N/A"
-    
-    # 2. Handle Threshold Validations (If Poll OK)
     elif val is not None:
         try:
-            # Normalize Value
             num_val = float(val)
-            
-            # Check Critical
-            # EXCLUDE ICMP and Availability Checks (mariadb-GS) from generic '>=' checks.
-            # For these, 1=GOOD (UP) and 0=BAD (DOWN).
-            is_availability_metric = metric_def.get("protocol") == 'ICMP' or metric_def.get("name") == 'mariadb-GS'
-            
+            is_availability_metric = (
+                metric_def.get("protocol") == "ICMP"
+                or metric_def.get("name") == "mariadb-GS"
+            )
+
             if not is_availability_metric:
-                op = metric_def.get("operator", ">=")
-                def check_op(v, t, oper):
-                    if oper == '>=': return v >= t
-                    if oper == '<=': return v <= t
-                    if oper == '==': return v == t
-                    if oper == '!=': return v != t
-                    return v >= t
-                
-                if metric_def.get("critical") is not None and check_op(num_val, float(metric_def["critical"]), op):
-                    status = 'CRITICAL'
-                    severity = 'CRITICAL'
+                operator = metric_def.get("operator", ">=")
+
+                def check_op(left, right, oper):
+                    if oper == ">=":
+                        return left >= right
+                    if oper == "<=":
+                        return left <= right
+                    if oper == "==":
+                        return left == right
+                    if oper == "!=":
+                        return left != right
+                    return left >= right
+
+                if metric_def.get("critical") is not None and check_op(
+                    num_val, float(metric_def["critical"]), operator
+                ):
+                    status = "CRITICAL"
+                    severity = "CRITICAL"
                     is_breach = True
-                    message = f"Critical Threshold Breached: {val} {op} {metric_def['critical']}"
-                
-                # Check Warning (Only if not already Critical)
-                elif metric_def.get("warning") is not None and check_op(num_val, float(metric_def["warning"]), op):
-                    status = 'WARNING'
-                    severity = 'WARNING'
+                    message = f"Critical Threshold Breached: {val} {operator} {metric_def['critical']}"
+                elif metric_def.get("warning") is not None and check_op(
+                    num_val, float(metric_def["warning"]), operator
+                ):
+                    status = "WARNING"
+                    severity = "WARNING"
                     is_breach = True
-                    message = f"Warning Threshold Breached: {val} {op} {metric_def['warning']}"
-                
-            # SPECIAL CASE: ICMP/Availability (1=UP, 0=DOWN)
+                    message = f"Warning Threshold Breached: {val} {operator} {metric_def['warning']}"
+
             if is_availability_metric and float(val) == 0:
-                 status = 'CRITICAL'
-                 severity = base_severity # Use mapped criticality (e.g. Exception/Level 3)
-                 is_breach = True
-                 message = f"Service/Host Down: {metric_def.get('name')}"
-                 
+                status = "CRITICAL"
+                severity = base_severity
+                is_breach = True
+                message = f"Service/Host Down: {metric_def.get('name')}"
         except ValueError:
-            # String Value Comparison logic could go here
             pass
 
     with driver.session() as session:
-        # 1. Store Raw Result (History)
-        session.run("""
+        session.run(
+            """
             MATCH (n:CI {id: $nid})
             MATCH (m:MetricDef {id: $mid})
             MERGE (n)-[r:HAS_METRIC]->(m)
             SET r.last_value = $val, r.last_updated = datetime(), r.status = $status, r.last_message = $msg
-            
+
             CREATE (res:MetricResult {
-                timestamp: datetime(), 
+                timestamp: datetime(),
                 value: $val,
                 status: $status
             })
             CREATE (n)-[:HAS_RESULT]->(res)
             CREATE (res)-[:FOR_METRIC]->(m)
-        """, nid=ci.get("id"), mid=metric_def["id"], val=str(val), status=status, msg=message)
-        
-        # logger.info(f"[Collector] Stored Metric for {ci.get('name')}: {metric_def.get('name')} = {val} ({status})")
+        """,
+            nid=ci.get("id"),
+            mid=metric_def["id"],
+            val=str(val),
+            status=status,
+            msg=message,
+        )
 
-        # 2. Event Management Logic
         if is_breach:
-            # Upsert OPEN Event
-            session.run("""
-                MATCH (n:CI {id: $nid})
-                MATCH (m:MetricDef {id: $mid})
-                
-                OPTIONAL MATCH (existing:Event)
+            existing = session.run(
+                """
+                MATCH (existing:Event)
                 WHERE existing.ci_id = $nid AND existing.metric_id = $mid AND existing.status IN ['OPEN', 'ACK']
-                
-                FOREACH (ignoreMe IN CASE WHEN existing IS NULL THEN [1] ELSE [] END | 
+                RETURN existing
+                LIMIT 1
+            """,
+                nid=ci.get("id"),
+                mid=metric_def["id"],
+            ).single()
+
+            if existing:
+                session.run(
+                    """
+                    MATCH (existing:Event)
+                    WHERE existing.ci_id = $nid AND existing.metric_id = $mid AND existing.status IN ['OPEN', 'ACK']
+                    SET existing.last_seen = datetime(),
+                        existing.message = $msg,
+                        existing.severity = $sev
+                """,
+                    nid=ci.get("id"),
+                    mid=metric_def["id"],
+                    msg=message,
+                    sev=severity,
+                )
+            else:
+                snapshot = resolve_event_snapshot(session, ci.get("id"))
+                session.run(
+                    """
+                    MATCH (n:CI {id: $nid})
+                    MATCH (m:MetricDef {id: $mid})
                     CREATE (e:Event {
                         id: randomUUID(),
                         ci_id: $nid,
@@ -376,95 +428,101 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         message: $msg,
                         created_at: datetime(),
                         last_seen: datetime(),
-                        ack: false
+                        ack: false,
+                        business_service_id: $business_service_id,
+                        business_service_name: $business_service_name,
+                        business_service_tier: $business_service_tier,
+                        owner_t1: $owner_t1,
+                        owner_t2: $owner_t2,
+                        owner_t3: $owner_t3,
+                        impacted_users: $impacted_users,
+                        site: $site,
+                        service_catalog_id: $service_catalog_id,
+                        service_category: $service_category,
+                        service_tier: $service_tier,
+                        sla_minutes: $sla_minutes
                     })
                     MERGE (n)-[:HAS_EVENT]->(e)
                     MERGE (e)-[:TRIGGERED_BY]->(m)
+                """,
+                    nid=ci.get("id"),
+                    mid=metric_def["id"],
+                    sev=severity,
+                    msg=message,
+                    **snapshot,
                 )
-                
-                FOREACH (ignoreMe IN CASE WHEN existing IS NOT NULL THEN [1] ELSE [] END | 
-                    SET existing.last_seen = datetime(),
-                        existing.message = $msg,
-                        existing.severity = $sev
-                )
-            """, nid=ci.get("id"), mid=metric_def["id"], val=str(val), sev=severity, msg=message)
-        
         else:
-            # Recovery Logic
-            session.run("""
+            session.run(
+                """
                 MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
                 WHERE e.status IN ['OPEN', 'ACK']
                 SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
-            """, nid=ci.get("id"), mid=metric_def["id"], msg=message)
+            """,
+                nid=ci.get("id"),
+                mid=metric_def["id"],
+                msg=message,
+            )
+
 
 def run_diagnostic(ci, metric):
-    """
-    Runs an on-demand diagnostic based on protocol.
-    Returns the diagnostic message.
-    """
     protocol = metric.get("protocol")
-    diag_msg = ""
-    
-    if protocol == 'ICMP':
+    if protocol == "ICMP":
         try:
-            # Run ping count 3
-            process = subprocess.Popen(['ping', '-c', '3', ci.get("ip")], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            ping_flag = "-n" if subprocess.os.name == "nt" else "-c"
+            process = subprocess.Popen(
+                ["ping", ping_flag, "3", ci.get("ip")],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
             stdout, stderr = process.communicate()
-            
             if process.returncode == 0:
-                 diag_msg = f"[SUCCESS] PING CHECK PASSED\nOutput:\n{stdout.decode()}"
-            else:
-                 diag_msg = f"[FAILED] PING CHECK FAILED\nError:\n{stderr.decode() or stdout.decode()}"
-        except Exception as e:
-            diag_msg = f"[ERROR] Diagnostic Error: {str(e)}"
-            
-    elif protocol == 'SNMP':
-         diag_msg = f"[INFO] SNMP Diagnostic initiated for OID {metric.get('oid')}. \n(Verify connectivity manually to {ci.get('ip')})"
-    else:
-         diag_msg = f"[INFO] No automated diagnostic available for protocol {protocol}"
+                return f"[SUCCESS] PING CHECK PASSED\nOutput:\n{stdout.decode()}"
+            return f"[FAILED] PING CHECK FAILED\nError:\n{stderr.decode() or stdout.decode()}"
+        except Exception as exc:
+            return f"[ERROR] Diagnostic Error: {str(exc)}"
 
-    return diag_msg
+    if protocol == "SNMP":
+        return f"[INFO] SNMP Diagnostic initiated for OID {metric.get('oid')}. \n(Verify connectivity manually to {ci.get('ip')})"
+
+    return f"[INFO] No automated diagnostic available for protocol {protocol}"
+
 
 def validate_snmp_oid(ip, community, oid, port=161):
-    """
-    Validates an SNMP OID against a target IP.
-    Returns dict with success status and value/type.
-    """
     if not SNMP_AVAILABLE:
         return {"success": False, "error": "PySNMP not installed"}
 
     try:
-        errorIndication, errorStatus, errorIndex, varBinds = next(
-            getCmd(SnmpEngine(),
+        error_indication, error_status, error_index, var_binds = next(
+            getCmd(
+                SnmpEngine(),
                 CommunityData(community),
                 UdpTransportTarget((ip, port), timeout=2.0, retries=1),
                 ContextData(),
-                ObjectType(ObjectIdentity(oid)))
+                ObjectType(ObjectIdentity(oid)),
+            )
         )
 
-        if errorIndication:
-            return {"success": False, "error": str(errorIndication)}
-        elif errorStatus:
-             return {"success": False, "error": f"{errorStatus.prettyPrint()} at {errorIndex and varBinds[int(errorIndex) - 1][0] or '?'}"}
-        else:
-            # Success - Analyze type
-            vb = varBinds[0]
-            val = vb[1]
-            val_type = type(val).__name__
-            pretty_val = str(val)
-            
-            # Simple heuristic mapping
-            dtype = "STRING"
-            if "Integer" in val_type or "Gauge" in val_type or "Counter" in val_type:
-                dtype = "INTEGER"
-            elif "Float" in val_type:
-                dtype = "FLOAT"
-            
+        if error_indication:
+            return {"success": False, "error": str(error_indication)}
+        if error_status:
             return {
-                "success": True, 
-                "value": pretty_val, 
-                "detectedType": dtype, 
-                "rawType": val_type
+                "success": False,
+                "error": f"{error_status.prettyPrint()} at {error_index and var_binds[int(error_index) - 1][0] or '?'}",
             }
-    except Exception as e:
-        return {"success": False, "error": str(e)}
+
+        value = var_binds[0][1]
+        value_type = type(value).__name__
+        detected_type = "STRING"
+        if "Integer" in value_type or "Gauge" in value_type or "Counter" in value_type:
+            detected_type = "INTEGER"
+        elif "Float" in value_type:
+            detected_type = "FLOAT"
+
+        return {
+            "success": True,
+            "value": str(value),
+            "detectedType": detected_type,
+            "rawType": value_type,
+        }
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -1,14 +1,22 @@
-"""Smoke tests for event_service — verify the import path and basic structure.
+"""Focused service tests for event detail shaping and event snapshots."""
 
-These are intentionally minimal to confirm the test infrastructure works.
-Full event lifecycle tests should go in test_event_lifecycle.py.
-"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib
+import sys
+import types
 
 import pytest
-from unittest.mock import patch, MagicMock
-from datetime import datetime
+from fastapi import HTTPException
 
-from models.core import MetricDef
+
+def _load_event_service_module():
+    sys.modules.pop("services.event_service", None)
+    stub = types.ModuleType("services.snmp_service")
+    setattr(stub, "run_diagnostic", lambda ci, metric: "diagnostic-ok")
+    sys.modules["services.snmp_service"] = stub
+    return importlib.import_module("services.event_service")
 
 
 class TestEventServiceImports:
@@ -16,9 +24,10 @@ class TestEventServiceImports:
 
     def test_event_service_imports(self):
         """The module should import without errors."""
-        from services import event_service
+        event_service = _load_event_service_module()
 
         assert hasattr(event_service, "get_events")
+        assert hasattr(event_service, "get_event_detail")
         assert hasattr(event_service, "get_related_events")
         assert hasattr(event_service, "ack_event")
         assert hasattr(event_service, "close_event")
@@ -34,7 +43,7 @@ class TestEventServiceSmoke:
         """get_events should return empty list when no events exist."""
         mock_neo4j_session.set_response("event", [])
 
-        from services.event_service import get_events
+        get_events = _load_event_service_module().get_events
 
         result = get_events()
 
@@ -42,7 +51,7 @@ class TestEventServiceSmoke:
 
     def test_get_events_filters_by_status(self, mock_neo4j_session):
         """get_events should pass status filter to the query."""
-        from services.event_service import get_events
+        get_events = _load_event_service_module().get_events
 
         get_events(status="OPEN")
 
@@ -50,9 +59,48 @@ class TestEventServiceSmoke:
         query = mock_neo4j_session.queries[0]["query"].lower()
         assert "status" in query
 
+    def test_get_events_strips_audit_heavy_fields_from_public_summary(
+        self, mock_neo4j_session
+    ):
+        get_events = _load_event_service_module().get_events
+        now = datetime.now(timezone.utc)
+        mock_neo4j_session.set_response(
+            "return e, ci, m",
+            [
+                {
+                    "e": {
+                        "id": "evt-001",
+                        "ci_id": "ci-001",
+                        "metric_id": "cpu",
+                        "status": "ACK",
+                        "severity": "CRITICAL",
+                        "message": "CPU high",
+                        "created_at": now,
+                        "last_seen": now,
+                        "ack": True,
+                        "ack_by": "operator-1",
+                        "closed_by": "operator-2",
+                        "comments": ["internal audit"],
+                    },
+                    "ci": {"id": "ci-001", "label": "Router-01", "ip": "10.0.0.1"},
+                    "m": {"id": "cpu", "name": "CPU", "protocol": "SNMP"},
+                }
+            ],
+        )
+
+        result = get_events()
+
+        assert len(result) == 1
+        assert "comments" not in result[0]
+        assert "ack_by" not in result[0]
+        assert "closed_by" not in result[0]
+
     def test_ack_event_sets_ack_status(self, mock_neo4j_session):
         """ack_event should set status to ACK."""
-        from services.event_service import ack_event
+        ack_event = _load_event_service_module().ack_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
 
         ack_event("evt-001", "testuser")
 
@@ -63,17 +111,30 @@ class TestEventServiceSmoke:
 
     def test_close_event_sets_closed_status(self, mock_neo4j_session):
         """close_event should set status to CLOSED."""
-        from services.event_service import close_event
+        close_event = _load_event_service_module().close_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
+        mock_neo4j_session.set_response(
+            "set e.status = 'closed'", [{"event_id": "evt-001"}]
+        )
 
-        close_event("evt-001", "testuser")
+        close_event(
+            "evt-001",
+            "testuser",
+            comment_message="Causa raíz: Falla de hardware\nNota: Se reemplazó el módulo principal averiado",
+        )
 
-        assert len(mock_neo4j_session.queries) >= 1
-        query = mock_neo4j_session.queries[0]["query"].upper()
+        assert len(mock_neo4j_session.queries) >= 2
+        query = mock_neo4j_session.queries[1]["query"].upper()
         assert "CLOSED" in query
 
     def test_add_event_comment_appends_comment(self, mock_neo4j_session):
         """add_event_comment should append to comments array."""
-        from services.event_service import add_event_comment
+        add_event_comment = _load_event_service_module().add_event_comment
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
 
         add_event_comment("evt-001", "testuser", "Investigating...")
 
@@ -85,7 +146,7 @@ class TestEventServiceSmoke:
 
     def test_prune_recovered_events_cleans_up(self, mock_neo4j_session):
         """prune_recovered_events should close RECOVERED events without ack."""
-        from services.event_service import prune_recovered_events
+        prune_recovered_events = _load_event_service_module().prune_recovered_events
 
         mock_neo4j_session.set_response("recovered", [{"closed_count": 3}])
 
@@ -93,3 +154,424 @@ class TestEventServiceSmoke:
 
         assert result["count"] == 3
         assert "Cleaned up" in result["message"]
+
+    def test_build_event_detail_prefers_snapshot_values_and_sla_math(self):
+        event_service = _load_event_service_module()
+        now = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        created_at = now - timedelta(minutes=35)
+
+        detail = event_service.build_event_detail_response(
+            {
+                "e": {
+                    "id": "evt-001",
+                    "ci_id": "ci-001",
+                    "metric_id": "cpu-load",
+                    "status": "OPEN",
+                    "severity": "CRITICAL",
+                    "message": "CPU over threshold",
+                    "created_at": created_at,
+                    "last_seen": created_at,
+                    "ack": False,
+                    "business_service_id": "svc-snapshot",
+                    "business_service_name": "Corp-WAN Snapshot",
+                    "owner_t1": "Mesa N1",
+                    "owner_t2": "NetOps",
+                    "owner_t3": "Arquitectura",
+                    "impacted_users": 350,
+                    "site": "Madrid HQ",
+                    "service_catalog_id": "sla-snapshot",
+                    "service_category": "NETWORK",
+                    "service_tier": "Gold",
+                    "sla_minutes": 60,
+                },
+                "ci": {
+                    "id": "ci-001",
+                    "label": "Router-01",
+                    "ip": "10.0.0.1",
+                    "locationName": "Madrid HQ",
+                },
+                "m": {"id": "cpu-load", "protocol": "SNMP"},
+                "bs": {
+                    "id": "svc-live",
+                    "name": "Corp-WAN Live",
+                    "owner_t1": "Live T1",
+                    "owner_t2": "Live T2",
+                    "owner_t3": "Live T3",
+                    "impacted_users_count": 900,
+                },
+                "sc": {
+                    "id": "sla-live",
+                    "category": "NETWORK",
+                    "service_tier": "Silver",
+                    "sla_minutes": 120,
+                },
+            },
+            now=now,
+        )
+
+        assert detail["event"]["ci_ref"]["id"] == "ci-001"
+        assert detail["business_context"]["source"] == "snapshot"
+        assert (
+            detail["business_context"]["business_service"]["name"]
+            == "Corp-WAN Snapshot"
+        )
+        assert "tier" not in detail["business_context"]["business_service"]
+        assert detail["business_context"]["service_catalog"]["id"] == "sla-snapshot"
+        assert detail["business_context"]["service_catalog"]["service_tier"] == "Gold"
+        assert detail["business_context"]["impacted_users"] == 350
+        assert detail["business_context"]["sla_remaining_minutes"] == 25
+        assert detail["itsm_context"]["assignment_state"] == "unassigned"
+
+    def test_build_event_detail_falls_back_to_resolved_context_when_snapshot_missing(
+        self,
+    ):
+        event_service = _load_event_service_module()
+        now = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        created_at = now - timedelta(minutes=5)
+
+        detail = event_service.build_event_detail_response(
+            {
+                "e": {
+                    "id": "evt-002",
+                    "ci_id": "ci-002",
+                    "metric_id": "ping",
+                    "status": "ACK",
+                    "severity": "WARNING",
+                    "message": "Ping jitter",
+                    "created_at": created_at,
+                    "last_seen": created_at,
+                    "ack": True,
+                    "ack_by": "operator-1",
+                },
+                "ci": {
+                    "id": "ci-002",
+                    "label": "Router-02",
+                    "ip": "10.0.0.2",
+                    "locationName": "Cordoba",
+                },
+                "m": {"id": "ping", "protocol": "ICMP"},
+                "bs": {
+                    "id": "svc-live",
+                    "name": "Payments",
+                    "owner_t1": "Mesa N1",
+                    "owner_t2": "Network Core",
+                    "owner_t3": "Platform SRE",
+                    "tier": "T2",
+                    "impacted_users_count": 1200,
+                },
+                "sc": {
+                    "id": "sla-live",
+                    "category": "NETWORK",
+                    "service_tier": "Platinum",
+                    "sla_minutes": 30,
+                },
+            },
+            now=now,
+        )
+
+        assert detail["business_context"]["source"] == "resolved"
+        assert detail["business_context"]["business_service"]["name"] == "Payments"
+        assert detail["business_context"]["business_service"]["tier"] == "T2"
+        assert (
+            detail["business_context"]["service_catalog"]["service_tier"] == "Platinum"
+        )
+        assert detail["business_context"]["service_catalog"]["sla_minutes"] == 30
+        assert detail["business_context"]["sla_remaining_minutes"] == 25
+        assert detail["itsm_context"]["assignment_state"] == "assigned"
+        assert detail["itsm_context"]["assigned_to"] == "operator-1"
+
+    def test_build_event_detail_marks_mixed_source_for_partial_snapshot(self):
+        event_service = _load_event_service_module()
+        now = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        created_at = now - timedelta(minutes=10)
+
+        detail = event_service.build_event_detail_response(
+            {
+                "e": {
+                    "id": "evt-003",
+                    "ci_id": "ci-003",
+                    "metric_id": "latency",
+                    "status": "OPEN",
+                    "severity": "CRITICAL",
+                    "message": "Latency spike",
+                    "created_at": created_at,
+                    "last_seen": created_at,
+                    "ack": False,
+                    "business_service_name": "Inventory",
+                },
+                "ci": {
+                    "id": "ci-003",
+                    "label": "App-01",
+                    "ip": "10.0.0.3",
+                    "locationName": None,
+                },
+                "m": {"id": "latency", "protocol": "HTTP"},
+                "bs": {
+                    "id": "svc-live",
+                    "name": "Inventory",
+                    "owner_t1": "Service Desk",
+                    "owner_t2": "AppOps",
+                    "owner_t3": "SRE",
+                    "impacted_users_count": 75,
+                },
+                "sc": {
+                    "id": "sla-live",
+                    "category": "APPLICATION",
+                    "service_tier": "Gold",
+                    "sla_minutes": 45,
+                },
+            },
+            now=now,
+        )
+
+        assert detail["business_context"]["source"] == "mixed"
+        assert detail["business_context"]["business_service"]["name"] == "Inventory"
+        assert detail["business_context"]["impacted_users"] == 75
+        assert detail["business_context"]["sla_remaining_minutes"] == 35
+
+    def test_build_event_detail_returns_degraded_payload_when_context_missing_or_invalid(
+        self,
+    ):
+        event_service = _load_event_service_module()
+
+        detail = event_service.build_event_detail_response(
+            {
+                "e": {
+                    "id": "evt-004",
+                    "ci_id": "ci-004",
+                    "metric_id": "availability",
+                    "status": "OPEN",
+                    "severity": "WARNING",
+                    "message": "Legacy event without snapshot",
+                    "created_at": "not-a-datetime",
+                    "last_seen": "not-a-datetime",
+                    "ack": False,
+                },
+                "ci": {"id": "ci-004", "label": "Legacy-CI", "ip": None},
+                "m": {"id": "availability", "protocol": "ICMP"},
+                "bs": None,
+                "sc": None,
+            }
+        )
+
+        assert detail["event"]["ci_ref"]["id"] == "ci-004"
+        assert detail["business_context"]["source"] == "unavailable"
+        assert detail["business_context"]["business_service"] is None
+        assert detail["business_context"]["service_catalog"] is None
+        assert detail["business_context"]["sla_remaining_minutes"] is None
+        assert detail["itsm_context"]["escalation_tier"] is None
+
+    def test_build_event_detail_omits_partial_external_ticket_contract(self):
+        event_service = _load_event_service_module()
+
+        detail = event_service.build_event_detail_response(
+            {
+                "e": {
+                    "id": "evt-005",
+                    "ci_id": "ci-005",
+                    "metric_id": "availability",
+                    "status": "OPEN",
+                    "severity": "WARNING",
+                    "message": "Ticket sync degraded",
+                    "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+                    "last_seen": datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+                    "ack": False,
+                    "external_ticket_status": "Open",
+                },
+                "ci": {"id": "ci-005", "label": "Router-05", "ip": "10.0.0.5"},
+                "m": {"id": "availability", "protocol": "ICMP"},
+                "bs": None,
+                "sc": None,
+            }
+        )
+
+        assert detail["itsm_context"]["external_ticket"] is None
+
+    def test_ack_event_raises_404_when_event_is_missing(self, mock_neo4j_session):
+        ack_event = _load_event_service_module().ack_event
+
+        with pytest.raises(HTTPException) as exc_info:
+            ack_event("missing-event", "testuser")
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Event not found: missing-event"
+
+    def test_close_event_raises_404_when_event_is_missing(self, mock_neo4j_session):
+        close_event = _load_event_service_module().close_event
+
+        with pytest.raises(HTTPException) as exc_info:
+            close_event(
+                "missing-event",
+                "testuser",
+                comment_message="Causa raíz: Falla de hardware\nNota: Se reemplazó el módulo principal averiado",
+            )
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Event not found: missing-event"
+
+    def test_close_event_rejects_normal_close_without_root_cause_and_note(
+        self, mock_neo4j_session
+    ):
+        close_event = _load_event_service_module().close_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            close_event(
+                "evt-001", "testuser", forced=False, comment_message="Nota: corto"
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "Causa raíz" in exc_info.value.detail
+
+    def test_close_event_rejects_normal_close_with_short_note(self, mock_neo4j_session):
+        close_event = _load_event_service_module().close_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            close_event(
+                "evt-001",
+                "testuser",
+                forced=False,
+                comment_message="Causa raíz: Error de configuración\nNota: breve",
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "at least 20 characters" in exc_info.value.detail
+
+    def test_close_event_rejects_forced_close_without_reason(self, mock_neo4j_session):
+        close_event = _load_event_service_module().close_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            close_event("evt-001", "testuser", forced=True, comment_message="   ")
+
+        assert exc_info.value.status_code == 400
+        assert "Forced close requires a reason" in exc_info.value.detail
+
+    def test_add_event_comment_raises_404_when_event_is_missing(
+        self, mock_neo4j_session
+    ):
+        add_event_comment = _load_event_service_module().add_event_comment
+
+        with pytest.raises(HTTPException) as exc_info:
+            add_event_comment("missing-event", "testuser", "Investigating...")
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Event not found: missing-event"
+
+    def test_ack_event_writes_ownership_comment_atomically(self, mock_neo4j_session):
+        ack_event = _load_event_service_module().ack_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
+
+        ack_event(
+            "evt-001",
+            "testuser",
+            comment_message="[OWNERSHIP] Caso tomado por testuser - Tier T2",
+        )
+
+        params = mock_neo4j_session.queries[0]["params"]
+        assert params["audit_message"] == "[AUDIT][OWNERSHIP] Caso tomado por testuser"
+        assert params["note_message"] is None
+
+    def test_close_event_writes_closure_comment_atomically(self, mock_neo4j_session):
+        close_event = _load_event_service_module().close_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-001"}]
+        )
+        mock_neo4j_session.set_response(
+            "set e.status = 'closed'", [{"event_id": "evt-001"}]
+        )
+
+        close_event(
+            "evt-001",
+            "testuser",
+            forced=False,
+            comment_message="[CIERRE] Causa raíz: Falla de hardware\nNota: Se reemplazó el módulo principal",
+        )
+
+        params = mock_neo4j_session.queries[1]["params"]
+        assert params["audit_message"] == (
+            "[AUDIT][CLOSE] Evento cerrado por testuser\n"
+            "Causa raíz: Falla de hardware\n"
+            "Nota: Se reemplazó el módulo principal"
+        )
+
+    def test_close_event_forced_writes_single_canonical_audit_entry(
+        self, mock_neo4j_session
+    ):
+        close_event = _load_event_service_module().close_event
+        mock_neo4j_session.set_response(
+            "return e.id as event_id", [{"event_id": "evt-002"}]
+        )
+        mock_neo4j_session.set_response(
+            "set e.status = 'closed'", [{"event_id": "evt-002"}]
+        )
+
+        close_event(
+            "evt-002",
+            "testuser",
+            forced=True,
+            comment_message="[CIERRE FORZADO - T2] Motivo: Ventana de mantenimiento",
+        )
+
+        params = mock_neo4j_session.queries[1]["params"]
+        assert params["audit_message"] == (
+            "[AUDIT][FORCED_CLOSE] Cierre forzado por testuser\n"
+            "Motivo: Ventana de mantenimiento"
+        )
+        assert "forced" not in params
+
+    def test_get_event_detail_query_collapses_multiple_sla_matches(
+        self, mock_neo4j_session
+    ):
+        mock_neo4j_session.set_response(
+            "return e, ci, m, bs, sc",
+            [
+                {
+                    "e": {
+                        "id": "evt-010",
+                        "ci_id": "ci-010",
+                        "status": "OPEN",
+                        "severity": "WARNING",
+                        "message": "Latency spike",
+                        "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+                        "ack": False,
+                    },
+                    "ci": {"id": "ci-010", "label": "Router-10", "ip": "10.0.0.10"},
+                    "m": {"id": "latency", "protocol": "SNMP"},
+                    "bs": {"id": "svc-010", "name": "WAN"},
+                    "sc": {"id": "sla-010", "category": "NETWORK", "sla_minutes": 60},
+                }
+            ],
+        )
+
+        get_event_detail = _load_event_service_module().get_event_detail
+
+        detail = get_event_detail("evt-010")
+
+        assert detail["business_context"]["service_catalog"]["id"] == "sla-010"
+        query = mock_neo4j_session.queries[0]["query"]
+        assert (
+            "head([item in collect(sc) where item is not null]) as sc" in query.lower()
+        )
+
+    def test_get_event_detail_raises_404_when_event_is_missing(
+        self, mock_neo4j_session
+    ):
+        mock_neo4j_session.set_response("match (e:event {id: $event_id})", [])
+
+        get_event_detail = _load_event_service_module().get_event_detail
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_event_detail("missing-event")
+
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Event not found"

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -15,8 +15,11 @@ Strategy:
 """
 
 import pytest
+import sys
+import types
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 # ---------------------------------------------------------------------------
@@ -24,6 +27,22 @@ from sqlalchemy.orm import Session
 # The driver is created at module import time and tries to connect immediately
 # ---------------------------------------------------------------------------
 _mock_neo4j_driver = MagicMock()
+_snmp_service_stub = types.ModuleType("services.snmp_service")
+setattr(_snmp_service_stub, "snmp_collector_loop", lambda: None)
+setattr(
+    _snmp_service_stub,
+    "get_collector_status",
+    lambda: {
+        "last_run": None,
+        "status": "STOPPED",
+        "stats": {},
+    },
+)
+setattr(
+    _snmp_service_stub, "validate_snmp_oid", lambda *args, **kwargs: {"success": False}
+)
+setattr(_snmp_service_stub, "run_diagnostic", lambda *args, **kwargs: "diagnostic-ok")
+sys.modules["services.snmp_service"] = _snmp_service_stub
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
     from database import get_db
@@ -647,14 +666,29 @@ class TestEventsList:
                                         "status": "OPEN",
                                         "severity": "CRITICAL",
                                         "ci_id": "ci-001",
+                                        "metric_id": "cpu-load",
                                         "value": 97.5,
                                         "message": "CPU exceeded threshold",
                                         "created_at": datetime.utcnow(),
+                                        "last_seen": datetime.utcnow(),
+                                        "ack": False,
                                     }
                                 ),
-                                "ci_name": "Router-01",
-                                "metric_name": "cpu-load",
-                                "metric_protocol": "SNMP",
+                                "ci": _FakeNeo4jNode(
+                                    {
+                                        "id": "ci-001",
+                                        "label": "Router-01",
+                                        "ip": "10.0.0.1",
+                                        "locationName": "Madrid HQ",
+                                    }
+                                ),
+                                "m": _FakeNeo4jNode(
+                                    {
+                                        "id": "cpu-load",
+                                        "name": "cpu-load",
+                                        "protocol": "SNMP",
+                                    }
+                                ),
                             }
                         )
                     ]
@@ -717,12 +751,254 @@ class TestEventsList:
         assert response.status_code != 401
         assert response.status_code != 403
 
+    def test_list_events_remains_summary_only(self):
+        """Summary polling must not expose modal-only business context payloads."""
+        payload = [
+            {
+                "id": "evt-lean",
+                "ci_id": "ci-001",
+                "ci_name": "Router-01",
+                "ci_node_id": "ci-001",
+                "metric_id": "cpu-load",
+                "metric_name": "cpu-load",
+                "metric_protocol": "SNMP",
+                "status": "OPEN",
+                "severity": "CRITICAL",
+                "message": "CPU exceeded threshold",
+                "created_at": "2026-04-05T11:00:00+00:00",
+                "last_seen": "2026-04-05T11:00:00+00:00",
+                "ack": False,
+                "ack_by": "operator-1",
+                "closed_by": "operator-2",
+                "comments": [
+                    "[AUDIT][CLOSE] Evento cerrado por operator-2\nNota: detalle interno"
+                ],
+            }
+        ]
+
+        with patch("routers.events.event_service.get_events", return_value=payload):
+            response = client.get("/api/events")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "business_context" not in data[0]
+        assert "itsm_context" not in data[0]
+        assert "comments" not in data[0]
+        assert "ack_by" not in data[0]
+        assert "closed_by" not in data[0]
+
+
+class TestEventsDetail:
+    """Tests for GET /api/events/{event_id} — modal detail payload."""
+
+    def test_get_event_detail_success(self):
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        payload = {
+            "event": {
+                "id": "evt-001",
+                "ci_id": "ci-001",
+                "ci_name": "Router-01",
+                "metric_id": "cpu-load",
+                "metric_name": "cpu-load",
+                "metric_protocol": "SNMP",
+                "status": "OPEN",
+                "severity": "CRITICAL",
+                "message": "CPU exceeded threshold",
+                "created_at": "2026-04-05T11:25:00+00:00",
+                "last_seen": "2026-04-05T11:25:00+00:00",
+                "ack": False,
+                "ci_ref": {
+                    "id": "ci-001",
+                    "label": "Router-01",
+                    "hostname": "10.0.0.1",
+                    "location_name": "Madrid HQ",
+                },
+            },
+            "business_context": {
+                "source": "snapshot",
+                "business_service": {
+                    "id": "svc-001",
+                    "name": "Corp-WAN",
+                    "owner_t1": "Mesa N1",
+                    "owner_t2": "NetOps",
+                    "owner_t3": "Arquitectura",
+                },
+                "service_catalog": {
+                    "id": "sla-001",
+                    "category": "NETWORK",
+                    "service_tier": "Gold",
+                    "sla_minutes": 60,
+                },
+                "impacted_users": 350,
+                "sla_remaining_minutes": 25,
+                "site": "Madrid HQ",
+            },
+            "itsm_context": {
+                "assignment_state": "unassigned",
+                "assigned_to": None,
+                "opened_by": "system",
+                "escalation_tier": "T2",
+                "external_ticket": None,
+            },
+        }
+
+        with patch(
+            "routers.events.event_service.get_event_detail", return_value=payload
+        ):
+            response = client.get("/api/events/evt-001")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["event"]["ci_ref"]["id"] == "ci-001"
+        assert data["business_context"]["source"] == "snapshot"
+        assert data["business_context"]["sla_remaining_minutes"] == 25
+        assert data["itsm_context"]["opened_by"] == "system"
+
+    def test_get_event_detail_requires_authentication(self):
+        response = client.get("/api/events/evt-001")
+
+        assert response.status_code == 401
+
+    def test_get_event_detail_forbidden_without_event_view_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_ACK],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/events/evt-001")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to view events"
+
+    def test_get_event_detail_real_contract_handles_partial_snapshot(
+        self, mock_neo4j_driver
+    ):
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        class FakeRecord(dict):
+            def __getitem__(self, key):
+                return super().__getitem__(key)
+
+            def get(self, key, default=None):
+                return super().get(key, default)
+
+        mock_session = MagicMock()
+        mock_session.run.return_value.single.return_value = FakeRecord(
+            {
+                "e": _FakeNeo4jNode(
+                    {
+                        "id": "evt-legacy",
+                        "ci_id": "ci-legacy",
+                        "metric_id": "ping",
+                        "status": "OPEN",
+                        "severity": "WARNING",
+                        "message": "Legacy event without full snapshot",
+                        "created_at": "not-a-datetime",
+                        "last_seen": "not-a-datetime",
+                        "ack": False,
+                        "business_service_name": "Legacy Payments",
+                    }
+                ),
+                "ci": _FakeNeo4jNode(
+                    {
+                        "id": "ci-legacy",
+                        "label": "Router-99",
+                        "ip": "10.0.0.99",
+                        "locationName": None,
+                    }
+                ),
+                "m": _FakeNeo4jNode({"id": "ping", "protocol": "ICMP"}),
+                "bs": None,
+                "sc": _FakeNeo4jNode({"id": "sla-legacy", "category": "NETWORK"}),
+            }
+        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
+            return_value=mock_session
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.get("/api/events/evt-legacy")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["business_context"]["source"] == "mixed"
+        assert data["business_context"]["business_service"] is None
+        assert data["business_context"]["service_catalog"]["id"] == "sla-legacy"
+        assert data["business_context"]["service_catalog"].get("service_tier") is None
+        assert data["business_context"]["sla_remaining_minutes"] is None
+
+    def test_get_event_detail_404(self):
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch(
+            "routers.events.event_service.get_event_detail",
+            side_effect=HTTPException(status_code=404, detail="Event not found"),
+        ):
+            response = client.get("/api/events/missing")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Event not found"
+
 
 class TestEventsRelated:
     """Tests for GET /api/events/related/{ci_id} — events for a CI."""
 
     def test_related_events_returns_data(self, mock_neo4j_driver):
         """Should return active events for a specific CI."""
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
 
         class FakeEventNode:
             def __init__(self, data):
@@ -783,20 +1059,38 @@ class TestEventsRelated:
         data = response.json()
         assert len(data) == 1
         assert data[0]["metric_name"] == "cpu-load"
+        app.dependency_overrides.pop(get_current_active_user, None)
 
-    def test_related_events_no_auth_required(self):
-        """Related events should NOT require auth (by design)."""
-        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
-            with patch("database.driver", MagicMock()):
-                response = client.get("/api/events/related/ci-001")
-        assert response.status_code != 401
-        assert response.status_code != 403
+    def test_related_events_requires_authentication(self):
+        response = client.get("/api/events/related/ci-001")
+
+        assert response.status_code == 401
+
+    def test_related_events_forbidden_without_event_view_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_ACK],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/events/related/ci-001")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to view events"
+        app.dependency_overrides.pop(get_current_active_user, None)
 
 
 class TestEventsAck:
     """Tests for POST /api/events/{event_id}/ack — acknowledge event (auth required)."""
 
-    def test_ack_event_success(self, mock_neo4j_driver):
+    def test_ack_event_success(self):
         """Authenticated user should be able to ack an event."""
         fake_user = _make_pydantic_user(
             username="operator",
@@ -811,17 +1105,48 @@ class TestEventsAck:
             override_get_current_active_user
         )
 
-        mock_session = MagicMock()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
-
-        with patch("database.driver", mock_neo4j_driver):
+        with patch("routers.events.event_service.ack_event") as mock_ack_event:
+            mock_ack_event.return_value = {"message": "Event Acknowledged"}
             response = client.post("/api/events/evt-001/ack")
 
         assert response.status_code == 200
         data = response.json()
         assert "Acknowledged" in data["message"]
+        mock_ack_event.assert_called_once_with(
+            "evt-001", "operator", comment_message=None
+        )
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ack_event_accepts_atomic_ownership_comment(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_ACK],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.events.event_service.ack_event") as mock_ack_event:
+            mock_ack_event.return_value = {"message": "Event Acknowledged"}
+            response = client.post(
+                "/api/events/evt-001/ack",
+                json={
+                    "comment_message": "[OWNERSHIP] Caso tomado por operator - Tier T2"
+                },
+            )
+
+        assert response.status_code == 200
+        mock_ack_event.assert_called_once_with(
+            "evt-001",
+            "operator",
+            comment_message="[OWNERSHIP] Caso tomado por operator - Tier T2",
+        )
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -852,7 +1177,7 @@ class TestEventsAck:
 class TestEventsClose:
     """Tests for POST /api/events/{event_id}/close — close event (auth required)."""
 
-    def test_close_event_success(self, mock_neo4j_driver):
+    def test_close_event_success(self):
         """Authenticated user should be able to close an event."""
         fake_user = _make_pydantic_user(
             username="operator",
@@ -867,17 +1192,50 @@ class TestEventsClose:
             override_get_current_active_user
         )
 
-        mock_session = MagicMock()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
-
-        with patch("database.driver", mock_neo4j_driver):
+        with patch("routers.events.event_service.close_event") as mock_close_event:
+            mock_close_event.return_value = {"message": "Event Closed"}
             response = client.post("/api/events/evt-001/close")
 
         assert response.status_code == 200
         data = response.json()
         assert "Closed" in data["message"]
+        mock_close_event.assert_called_once_with(
+            "evt-001", "operator", forced=False, comment_message=None
+        )
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_close_event_accepts_atomic_closure_comment(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_CLOSE],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("routers.events.event_service.close_event") as mock_close_event:
+            mock_close_event.return_value = {"message": "Event Closed"}
+            response = client.post(
+                "/api/events/evt-001/close",
+                json={
+                    "forced": False,
+                    "comment_message": "[CIERRE] Causa raíz: Error de configuración\nNota: Se corrigió la configuración BGP",
+                },
+            )
+
+        assert response.status_code == 200
+        mock_close_event.assert_called_once_with(
+            "evt-001",
+            "operator",
+            forced=False,
+            comment_message="[CIERRE] Causa raíz: Error de configuración\nNota: Se corrigió la configuración BGP",
+        )
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -904,9 +1262,59 @@ class TestEventsClose:
 
         assert response.status_code == 403
 
+    def test_close_event_requires_structured_root_cause_and_note(
+        self, mock_neo4j_driver
+    ):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_CLOSE],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.post(
+                "/api/events/evt-001/close",
+                json={"forced": False, "comment_message": "Nota: corto"},
+            )
+
+        assert response.status_code == 400
+        assert "Causa raíz" in response.json()["detail"]
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_forced_close_requires_reason(self, mock_neo4j_driver):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_CLOSE, UserPermission.EVENT_FORCED_CLOSE],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        with patch("database.driver", mock_neo4j_driver):
+            response = client.post(
+                "/api/events/evt-001/close",
+                json={"forced": True, "comment_message": "   "},
+            )
+
+        assert response.status_code == 400
+        assert "Forced close requires a reason" in response.json()["detail"]
+        app.dependency_overrides.pop(get_current_active_user, None)
+
 
 class TestEventsComment:
-    """Tests for POST /api/events/{event_id}/comment — add comment (auth required)."""
+    """Tests for POST /api/events/{event_id}/comment — add comment (auth + permission)."""
 
     def test_add_comment_unauthenticated(self):
         response = client.post(
@@ -920,7 +1328,7 @@ class TestEventsComment:
         fake_user = _make_pydantic_user(
             username="operator",
             role="OPERATOR",
-            permissions=[UserPermission.EVENT_VIEW],
+            permissions=[UserPermission.EVENT_ACK],
         )
 
         async def override_get_current_active_user():
@@ -945,6 +1353,29 @@ class TestEventsComment:
         mock_add_comment.assert_called_once_with(
             "evt-001", "operator", "Investigating the issue"
         )
+
+    def test_add_comment_forbidden_without_event_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.post(
+            "/api/events/evt-001/comment",
+            json={"message": "Investigating the issue"},
+        )
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
 
 
 class TestEventsPrune:
@@ -1186,7 +1617,10 @@ class TestEventsForcedCloseAuthorization:
         with patch("database.driver", mock_neo4j_driver):
             response = client.post(
                 "/api/events/evt-001/close",
-                json={"forced": False},
+                json={
+                    "forced": False,
+                    "comment_message": "Causa raíz: Falla de hardware\nNota: Se reemplazó el módulo principal averiado",
+                },
             )
 
         assert response.status_code == 200
@@ -1239,7 +1673,10 @@ class TestEventsForcedCloseAuthorization:
         with patch("database.driver", mock_neo4j_driver):
             response = client.post(
                 "/api/events/evt-001/close",
-                json={"forced": True},
+                json={
+                    "forced": True,
+                    "comment_message": "Motivo: Ventana de mantenimiento aprobada",
+                },
             )
 
         assert response.status_code == 200

--- a/backend/tests/test_snmp_service_snapshots.py
+++ b/backend/tests/test_snmp_service_snapshots.py
@@ -1,0 +1,90 @@
+import importlib
+import sys
+
+
+def _load_snmp_service_module():
+    sys.modules.pop("services.snmp_service", None)
+    return importlib.import_module("services.snmp_service")
+
+
+def test_resolve_event_snapshot_flattens_business_context(mock_neo4j_session):
+    snmp_service = _load_snmp_service_module()
+    mock_neo4j_session.set_response(
+        "MATCH (ci:CI",
+        [
+            {
+                "site": "Madrid HQ",
+                "business_service_id": "svc-001",
+                "business_service_name": "Corp-WAN",
+                "business_service_tier": "T2",
+                "owner_t1": "Mesa N1",
+                "owner_t2": "NetOps",
+                "owner_t3": "Arquitectura",
+                "impacted_users": 350,
+                "service_catalog_id": "sla-001",
+                "service_category": "NETWORK",
+                "service_tier": "Gold",
+                "sla_minutes": 60,
+            }
+        ],
+    )
+
+    snapshot = snmp_service.resolve_event_snapshot(mock_neo4j_session, "ci-001")
+
+    assert snapshot["business_service_name"] == "Corp-WAN"
+    assert snapshot["business_service_tier"] == "T2"
+    assert snapshot["service_catalog_id"] == "sla-001"
+    assert snapshot["service_tier"] == "Gold"
+    assert snapshot["sla_minutes"] == 60
+
+
+def test_store_metric_result_writes_snapshot_fields_on_new_event(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response(
+        "MATCH (existing:Event)",
+        [],
+    )
+    session.set_response(
+        "MATCH (ci:CI",
+        [
+            {
+                "site": "Cordoba",
+                "business_service_id": "svc-002",
+                "business_service_name": "Payments",
+                "business_service_tier": "T1",
+                "owner_t1": "Service Desk",
+                "owner_t2": "AppOps",
+                "owner_t3": "SRE",
+                "impacted_users": 1200,
+                "service_catalog_id": "sla-002",
+                "service_category": "APPLICATION",
+                "service_tier": "Platinum",
+                "sla_minutes": 30,
+            }
+        ],
+    )
+
+    snmp_service.store_metric_result(
+        {"id": "ci-002", "ip": "10.0.0.2", "name": "Payments-API"},
+        {
+            "id": "latency",
+            "name": "latency",
+            "protocol": "HTTP",
+            "criticality": 3,
+            "critical": 500,
+            "operator": ">=",
+        },
+        900,
+        "OK",
+        None,
+        mock_neo4j_driver,
+    )
+
+    create_event_query = session.queries[-1]
+    assert "CREATE (e:Event" in create_event_query["query"]
+    assert create_event_query["params"]["business_service_name"] == "Payments"
+    assert create_event_query["params"]["business_service_tier"] == "T1"
+    assert create_event_query["params"]["service_catalog_id"] == "sla-002"
+    assert create_event_query["params"]["service_tier"] == "Platinum"
+    assert create_event_query["params"]["sla_minutes"] == 30

--- a/docs/domain/business-model.md
+++ b/docs/domain/business-model.md
@@ -1,0 +1,120 @@
+# Business Domain Model
+
+## Proposito
+
+Este documento define el lenguaje comun para el contexto de negocio que se muestra en el modal de detalle de eventos.
+
+## Entidades clave
+
+### CI
+
+- Representa un Configuration Item tecnico: router, switch, servidor, aplicacion o servicio operativo.
+- Es la entidad que produce telemetria, recibe metricas y dispara eventos.
+
+### BusinessService
+
+- Representa el servicio de negocio al que pertenece un CI.
+- Campos usados por el detalle del evento:
+  - `id`
+  - `name`
+  - `tier` opcional
+  - `owner_t1`
+  - `owner_t2`
+  - `owner_t3`
+  - `impacted_users_count`
+
+### ServiceCatalog
+
+- Define el objetivo de SLA para una categoria de servicio.
+- Campos usados hoy:
+  - `id`
+  - `category`
+  - `service_tier` opcional
+  - `sla_minutes`
+
+## Relaciones canonicas
+
+```mermaid
+graph LR
+  CI[CI] -->|BELONGS_TO| BS[BusinessService]
+  BS -->|USES_SLA| SC[ServiceCatalog]
+  CI -->|HAS_EVENT| EVT[Event]
+  EVT -->|TRIGGERED_BY| METRIC[MetricDef]
+```
+
+- `CI -[:BELONGS_TO]-> BusinessService`
+- `BusinessService -[:USES_SLA]-> ServiceCatalog`
+- `CI -[:HAS_EVENT]-> Event`
+- `Event -[:TRIGGERED_BY]-> MetricDef`
+
+## Snapshot de evento
+
+Cuando se crea un evento nuevo, el worker guarda en el nodo `Event` una foto del contexto que importa para operaciones:
+
+- `business_service_id`
+- `business_service_name`
+- `business_service_tier`
+- `owner_t1`
+- `owner_t2`
+- `owner_t3`
+- `impacted_users`
+- `site`
+- `service_catalog_id`
+- `service_category`
+- `service_tier`
+- `sla_minutes`
+
+Esto evita drift historico cuando un CI cambia de servicio, owners o SLA despues del incidente.
+
+## Semantica snapshot vs fallback
+
+- `snapshot`: todos los datos mostrados vienen del `Event`.
+- `resolved`: el `Event` no tenia snapshot y el backend resolvio todo desde el grafo actual.
+- `mixed`: parte viene del snapshot y parte se completo desde relaciones actuales.
+- `unavailable`: ni snapshot ni relaciones actuales pudieron resolver contexto suficiente.
+
+La UI no debe inventar datos faltantes desde metadata arbitraria del CI. Solo se conserva `node.metadata` como ultimo fallback de rollout para no romper el modal mientras se completa la migracion.
+
+## Owners y escalacion
+
+- `owner_t1`, `owner_t2`, `owner_t3` describen responsables esperados por tier.
+- No implican asignacion activa por si solos.
+- La asignacion activa del incidente sigue viniendo del propio `Event` (`ack`, `ack_by`) y del `itsm_context` devuelto por la API.
+
+## Usuarios impactados
+
+- `impacted_users_count` es una aproximacion operacional, no una medicion en tiempo real.
+- Se usa para priorizacion y lectura rapida del impacto.
+- Si no existe dato confiable, el contrato devuelve `null` y la UI muestra `No configurado`.
+
+## Decisiones de modelado
+
+- `ServiceCatalog` se modela por categoria con `service_tier` opcional.
+- El detalle del evento expone `ci_ref.id` como identificador canonico del CI.
+- `ci_node_id` sigue existiendo solo en el resumen para compatibilidad con consumidores viejos.
+
+## Bootstrap manual minimo
+
+Mientras no exista CRUD dedicado, se puede sembrar el contexto con Cypher:
+
+```cypher
+MERGE (ci:CI {id: 'ci-001'})
+MERGE (bs:BusinessService {id: 'svc-corp-wan'})
+SET bs.name = 'Corp-WAN',
+    bs.tier = 'T2',
+    bs.owner_t1 = 'Mesa N1',
+    bs.owner_t2 = 'NetOps',
+    bs.owner_t3 = 'Arquitectura',
+    bs.impacted_users_count = 350
+MERGE (sc:ServiceCatalog {id: 'sla-corp-wan'})
+SET sc.category = 'NETWORK',
+    sc.service_tier = 'Gold',
+    sc.sla_minutes = 60
+MERGE (ci)-[:BELONGS_TO]->(bs)
+MERGE (bs)-[:USES_SLA]->(sc)
+```
+
+## Lectura recomendada
+
+- Arranca por `README.md` para el mapa general.
+- Usa `docs/itsm/event-flow.md` para entender como este modelo impacta el lifecycle del evento.

--- a/docs/itsm/event-flow.md
+++ b/docs/itsm/event-flow.md
@@ -1,0 +1,103 @@
+# ITSM Event Flow
+
+## Proposito
+
+Este documento explica como NEX-GEN lleva un evento tecnico hacia un contexto operativo listo para incident management y futuras integraciones ITSM.
+
+## Flujo end-to-end
+
+```text
+Metric breach
+  -> worker normaliza severidad y mensaje
+  -> crea o actualiza Event
+  -> si el Event es nuevo, captura snapshot de negocio y SLA
+  -> /api/events mantiene el resumen del stream
+  -> /api/events/{event_id} resuelve detalle del modal
+  -> operador reconoce, comenta, diagnostica y cierra
+  -> futuro: adjunta / sincroniza ticket externo
+```
+
+## Estados del evento
+
+- `OPEN`: evento nuevo, sin ownership activo.
+- `ACK`: alguien tomo el caso o lo reconocio.
+- `RECOVERED`: la condicion tecnica desaparecio, pero el evento puede seguir abierto para auditoria.
+- `CLOSED`: incidente cerrado manualmente o por limpieza controlada.
+
+## Ownership y asignacion
+
+- `ack = true` + `ack_by` representan asignacion activa basica.
+- El `itsm_context.assignment_state` traduce eso a `assigned` o `unassigned`.
+- Los comentarios siguen siendo append-only y funcionan como timeline operacional.
+- `Tomar caso` en frontend agrega comentario de ownership y luego hace `ack`.
+
+## SLA: como se interpreta
+
+### Fuente del SLA
+
+1. Se intenta leer `sla_minutes` guardado en el snapshot del `Event`.
+2. Si no existe snapshot, se intenta resolver desde `BusinessService -> ServiceCatalog`.
+3. Si no hay fuente confiable, la API devuelve `sla_remaining_minutes = null`.
+
+### Calculo
+
+- `sla_remaining_minutes = sla_minutes - minutos_desde_created_at`
+- Puede dar negativo; eso significa SLA vencido.
+- La UI muestra alerta visual cuando el remanente es bajo o vencido.
+
+### Estados de procedencia
+
+- `snapshot`: todo sale del evento historico.
+- `resolved`: todo sale del grafo actual.
+- `mixed`: el backend mezclo snapshot con fallback para completar huecos.
+- `unavailable`: no hay suficiente data para afirmar servicio, sitio o SLA.
+
+## No-data states
+
+Cuando falta contexto, el contrato devuelve `null` de forma explicita. Eso es IMPORTANTE:
+
+- evita precision falsa
+- evita inferencias desde metadata vieja del CI
+- deja claro que el problema es de datos, no de rendering
+
+La UI solo conserva `node.metadata` como fallback transitorio de rollout. No es la fuente canonica del dominio.
+
+## Diagnostico y timeline
+
+- `POST /api/events/{event_id}/diagnose` ejecuta diagnostico on-demand y persiste el resultado como comentario.
+- `POST /api/events/{event_id}/comment` agrega notas operativas o cierres estructurados.
+- El timeline del modal mezcla disparador inicial, ownership, notas, diagnosticos y cierres sin edicion destructiva.
+
+## Cierre y auditoria
+
+- El cierre normal exige causa raiz y nota descriptiva.
+- El cierre forzado deja marca explicita en el timeline.
+- `RECOVERED` sin ack ni comentarios puede limpiarse en lote con `/api/events/prune`.
+
+## Puntos de integracion futura
+
+El contrato ya deja el espacio para acoplar ITSM externo sin inflar el stream principal:
+
+- `itsm_context.external_ticket.system`
+- `itsm_context.external_ticket.key`
+- `itsm_context.external_ticket.status`
+
+Integraciones futuras esperadas:
+
+- Jira: creacion de incident / bug con link al evento.
+- ServiceNow: incidente o alert record con sincronizacion de estado.
+
+## Reglas operativas para reviewers
+
+Una entrega de esta capability NO esta completa si falta alguno de estos artefactos:
+
+- `README.md`
+- `docs/domain/business-model.md`
+- `docs/itsm/event-flow.md`
+- `modelo_entidad_relacion.md`
+
+## Referencias cruzadas
+
+- `README.md`
+- `docs/domain/business-model.md`
+- `modelo_entidad_relacion.md`

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -8,6 +8,7 @@ import { useEventCorrelation } from '../hooks/useEventCorrelation';
 import L from 'leaflet';
 import { useAuth } from '../context/AuthContext';
 import { useEventMutations } from '../hooks/queries/useEventMutations';
+import { useEventDetailQuery } from '../hooks/queries/useEventDetailQuery';
 import { useMonitoringConsoleData } from '../hooks/queries/useMonitoringConsoleData';
 import { useRelatedEventsQuery } from '../hooks/queries/useRelatedEventsQuery';
 
@@ -265,6 +266,7 @@ const MonitoringConsole: React.FC = () => {
     const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
     const [commentText, setCommentText] = useState("");
     const [isDiagnosing, setIsDiagnosing] = useState(false);
+    const selectedEvent = selectedEventId ? events.find(e => e.id === selectedEventId) ?? null : null;
 
     // M5: Close flow state
     const [closeFlowOpen, setCloseFlowOpen] = useState(false);
@@ -277,6 +279,26 @@ const MonitoringConsole: React.FC = () => {
     const { user, hasPermission } = useAuth();
     const CURRENT_USER = user?.username ?? 'unknown';
     const CURRENT_TIER = user?.tier ?? 'T1';
+    const canViewEventDetail = hasPermission('EVENT_VIEW');
+    const canAckEvent = hasPermission('EVENT_ACK');
+    const canCloseEvent = hasPermission('EVENT_CLOSE');
+    const canForceCloseEvent = canCloseEvent && hasPermission('EVENT_FORCED_CLOSE');
+    const canRunDiagnostics = hasPermission('RUN_DIAGNOSTICS');
+    const canOpenEventModal = canViewEventDetail || canAckEvent || canCloseEvent || canRunDiagnostics;
+    const eventDetailQuery = useEventDetailQuery(selectedEventId, commentModalOpen && canViewEventDetail);
+    const eventDetail = eventDetailQuery.data;
+
+    const resetModalState = () => {
+        setCommentModalOpen(false);
+        setSelectedEventId(null);
+        setCommentText("");
+        setCloseFlowOpen(false);
+        setCloseRootCause('');
+        setCloseNote('');
+        setCloseForcedMode(false);
+        setCloseForcedReason('');
+        setIsDiagnosing(false);
+    };
 
     const handleOpenComment = (id: string) => {
         setSelectedEventId(id);
@@ -309,22 +331,19 @@ const MonitoringConsole: React.FC = () => {
     // M5: Structured close
     const handleStructuredClose = async () => {
         if (!selectedEventId) return;
+        const closeComment = closeForcedMode
+            ? `Motivo: ${closeForcedReason}`
+            : `Causa raíz: ${closeRootCause}\nNota: ${closeNote}`;
         if (closeForcedMode) {
             if (!closeForcedReason.trim()) return;
-            await eventMutations.commentEvent(selectedEventId, {
-                message: `[CIERRE FORZADO — ${CURRENT_TIER}] Motivo: ${closeForcedReason}`,
-                user: CURRENT_USER
-            });
         } else {
             if (!closeRootCause || closeNote.trim().length < 20) return;
-            await eventMutations.commentEvent(selectedEventId, {
-                message: `[CIERRE] Causa raíz: ${closeRootCause}\nNota: ${closeNote}`,
-                user: CURRENT_USER
-            });
         }
-        await eventMutations.closeEvent(selectedEventId, { forced: closeForcedMode });
-        setCommentModalOpen(false);
-        setCloseFlowOpen(false);
+        await eventMutations.closeEvent(selectedEventId, {
+            forced: closeForcedMode,
+            comment_message: closeComment,
+        });
+        resetModalState();
     };
 
     // --- Data Processing for Visualization ---
@@ -357,6 +376,23 @@ const MonitoringConsole: React.FC = () => {
     const groupedEvents = useEventCorrelation(events, links);
 
     const activeEventsDisplay = groupedEvents;
+
+    const extractAuditActor = (body: string): string | null => {
+        const patterns = [
+            /Caso tomado por\s+([^\n]+)/i,
+            /Evento cerrado por\s+([^\n]+)/i,
+            /Cierre forzado por\s+([^\n]+)/i,
+        ];
+
+        for (const pattern of patterns) {
+            const match = body.match(pattern);
+            if (match?.[1]) {
+                return match[1].split(/\s(?:\u2014|-)\s+Tier/i)[0].trim();
+            }
+        }
+
+        return null;
+    };
 
     return (
         <div className="h-full flex flex-col bg-surface-950 overflow-hidden relative">
@@ -479,10 +515,12 @@ const MonitoringConsole: React.FC = () => {
                                                     </td>
                                                     <td className="p-3 text-right">
                                                         <div className="flex justify-end gap-2 transition-opacity">
+                                                            {canOpenEventModal && (
                                                             <button onClick={() => handleOpenComment(evt.id)} className="px-3 py-1 bg-neutral-700 hover:bg-neutral-600 text-brand-400 border border-brand-500/30 rounded text-xs font-bold uppercase flex items-center gap-1">
                                                                 <span className="material-symbols-outlined text-[10px]">visibility</span> Details
                                                             </button>
-                                                            {evt.status === 'OPEN' && (
+                                                            )}
+                                                            {evt.status === 'OPEN' && canAckEvent && (
                                                                 <button onClick={() => handleAck(evt.id)} className="px-3 py-1 bg-blue-600 hover:bg-blue-500 text-white rounded text-xs font-bold uppercase">Ack</button>
                                                             )}
                                                         </div>
@@ -622,37 +660,73 @@ const MonitoringConsole: React.FC = () => {
             </div>
 
             {commentModalOpen && selectedEventId && (() => {
-                const evt = events.find(e => e.id === selectedEventId);
+                const evt = selectedEvent;
                 if (!evt) return null;
 
                 const node = nodesWithEvents.find(n => n.id === evt.ci_id);
-                const isAssigned = evt.ack && evt.ack_by;
-                const assignedTo = evt.ack_by || null;
-
-                // SLA calculation (mock — field not in model yet)
-                const slaMinutes: number | null = (node?.metadata?.sla_minutes as number) ?? null;
-                const ageMs = Date.now() - new Date(evt.created_at).getTime();
+                const detailEvent = eventDetail?.event;
+                const businessContext = eventDetail?.business_context;
+                const itsmContext = eventDetail?.itsm_context;
+                const displayEvent = detailEvent ?? evt;
+                 const isBusinessContextReady = canViewEventDetail && eventDetailQuery.isSuccess && Boolean(eventDetail);
+                 const businessContextStatus = isBusinessContextReady
+                     ? businessContext?.source ?? 'unavailable'
+                     : canViewEventDetail && eventDetailQuery.isError
+                         ? 'degraded'
+                         : canViewEventDetail && eventDetailQuery.isLoading
+                            ? 'loading'
+                            : 'summary-only';
+                const isAssigned = itsmContext?.assignment_state === 'assigned' || (displayEvent.ack && displayEvent.ack_by);
+                const assignedTo = itsmContext?.assigned_to || displayEvent.ack_by || null;
+                const businessServiceName = isBusinessContextReady ? businessContext?.business_service?.name ?? null : null;
+                const impactedUsers = isBusinessContextReady ? businessContext?.impacted_users ?? null : null;
+                const site = isBusinessContextReady
+                    ? businessContext?.site ?? detailEvent?.ci_ref?.location_name ?? displayEvent.ci_location_name ?? node?.locationName ?? null
+                    : detailEvent?.ci_ref?.location_name ?? displayEvent.ci_location_name ?? node?.locationName ?? null;
+                const category = businessContext?.service_catalog?.category ?? node?.category ?? node?.type ?? null;
+                const ageMs = Date.now() - new Date(displayEvent.created_at).getTime();
                 const ageMinutes = Math.floor(ageMs / 60000);
-                const slaRemaining = slaMinutes !== null ? slaMinutes - ageMinutes : null;
+                const slaRemaining = isBusinessContextReady ? businessContext?.sla_remaining_minutes ?? null : null;
                 const slaCritical = slaRemaining !== null && slaRemaining <= 30;
+                 const eventTier = itsmContext?.escalation_tier ?? null;
+                 const detailFetchBlocked = !canViewEventDetail;
 
                 // M3: Parse timeline entries from comments[]
-                const parseTimelineEntry = (raw: string) => {
-                    const diagMatch = raw.match(/^DIAGNOSTIC RUN BY (.+?):\n([\s\S]*)$/);
-                    if (diagMatch) return { type: 'diagnostic' as const, user: diagMatch[1], body: diagMatch[2], raw };
-                    const ownerMatch = raw.match(/^\[OWNERSHIP\] (.+)$/m);
-                    if (ownerMatch) return { type: 'ownership' as const, user: '', body: ownerMatch[1], raw };
-                    const closeMatch = raw.match(/^\[CIERRE/);
-                    if (closeMatch) return { type: 'close' as const, user: '', body: raw, raw };
+                 const parseTimelineEntry = (raw: string) => {
+                     const diagMatch = raw.match(/^DIAGNOSTIC RUN BY (.+?):\n([\s\S]*)$/);
+                     if (diagMatch) return { type: 'diagnostic' as const, user: diagMatch[1], body: diagMatch[2], raw };
+                    const forcedAuditMatch = raw.match(/^\[AUDIT\]\[FORCED_CLOSE\]\s+([\s\S]+?)(?:\s\((.+)\))?$/);
+                    if (forcedAuditMatch) return { type: 'force_close' as const, user: extractAuditActor(forcedAuditMatch[1]) || '', body: forcedAuditMatch[1], ts: forcedAuditMatch[2], raw };
+                    const closeAuditMatch = raw.match(/^\[AUDIT\]\[CLOSE\]\s+([\s\S]+?)(?:\s\((.+)\))?$/);
+                    if (closeAuditMatch) return { type: 'close' as const, user: extractAuditActor(closeAuditMatch[1]) || '', body: closeAuditMatch[1], ts: closeAuditMatch[2], raw };
+                    const ownershipAuditMatch = raw.match(/^\[AUDIT\]\[OWNERSHIP\]\s+([\s\S]+?)(?:\s\((.+)\))?$/);
+                    if (ownershipAuditMatch) return { type: 'ownership' as const, user: extractAuditActor(ownershipAuditMatch[1]) || '', body: ownershipAuditMatch[1], ts: ownershipAuditMatch[2], raw };
                     const forceMatch = raw.match(/^\[CIERRE FORZADO/);
                     if (forceMatch) return { type: 'force_close' as const, user: '', body: raw, raw };
+                    const closeMatch = raw.match(/^\[CIERRE/);
+                    if (closeMatch) return { type: 'close' as const, user: '', body: raw, raw };
                     // Standard format: "user: message (datetime)"
                     const stdMatch = raw.match(/^(.+?):\s([\s\S]+?)\s\((.+)\)$/);
-                    if (stdMatch) return { type: 'note' as const, user: stdMatch[1], body: stdMatch[2], ts: stdMatch[3], raw };
+                    if (stdMatch) {
+                        const [, user, body, ts] = stdMatch;
+                        const structuredOwnershipMatch = body.match(/^\[AUDIT\]\[OWNERSHIP\]\s+([\s\S]+)$/m);
+                        if (structuredOwnershipMatch) return { type: 'ownership' as const, user, body: structuredOwnershipMatch[1], ts, raw };
+                        const structuredForceCloseMatch = body.match(/^\[AUDIT\]\[FORCED_CLOSE\]\s+([\s\S]+)$/m);
+                        if (structuredForceCloseMatch) return { type: 'force_close' as const, user, body: structuredForceCloseMatch[1], ts, raw };
+                        const structuredCloseMatch = body.match(/^\[AUDIT\]\[CLOSE\]\s+([\s\S]+)$/m);
+                        if (structuredCloseMatch) return { type: 'close' as const, user, body: structuredCloseMatch[1], ts, raw };
+                        const ownershipBodyMatch = body.match(/^\[OWNERSHIP\] (.+)$/m);
+                        if (ownershipBodyMatch) return { type: 'ownership' as const, user, body: ownershipBodyMatch[1], ts, raw };
+                        if (/^\[CIERRE FORZADO/.test(body)) return { type: 'force_close' as const, user, body, ts, raw };
+                        if (/^\[CIERRE/.test(body)) return { type: 'close' as const, user, body, ts, raw };
+                        return { type: 'note' as const, user, body, ts, raw };
+                    }
+                    const ownerMatch = raw.match(/^\[OWNERSHIP\] (.+)$/m);
+                    if (ownerMatch) return { type: 'ownership' as const, user: '', body: ownerMatch[1], raw };
                     return { type: 'note' as const, user: 'Sistema', body: raw, raw };
                 };
 
-                const timelineEntries = (evt.comments || []).map(parseTimelineEntry);
+                const timelineEntries = (displayEvent.comments || []).map(parseTimelineEntry);
 
                 const entryIcon = (type: string) => {
                     if (type === 'diagnostic') return { icon: 'build', color: 'border-brand-500 text-brand-400' };
@@ -676,39 +750,39 @@ const MonitoringConsole: React.FC = () => {
                             <div className="px-6 pt-5 pb-3 flex justify-between items-start gap-4">
                                 <div className="flex-1 min-w-0">
                                     <div className="flex items-center gap-3 flex-wrap">
-                                        <span className={`px-3 py-1 rounded text-xs font-black uppercase tracking-wider flex-shrink-0 ${evt.severity === 'CRITICAL' ? 'bg-red-500 text-white' : evt.severity === 'WARNING' ? 'bg-yellow-400 text-black' : 'bg-blue-500 text-white'}`}>
-                                            {evt.severity}
+                                        <span className={`px-3 py-1 rounded text-xs font-black uppercase tracking-wider flex-shrink-0 ${displayEvent.severity === 'CRITICAL' ? 'bg-red-500 text-white' : displayEvent.severity === 'WARNING' ? 'bg-yellow-400 text-black' : 'bg-blue-500 text-white'}`}>
+                                            {displayEvent.severity}
                                         </span>
-                                        <h3 className="text-xl font-black text-white uppercase tracking-tight truncate">{evt.message}</h3>
+                                        <h3 className="text-xl font-black text-white uppercase tracking-tight truncate">{displayEvent.message}</h3>
                                     </div>
                                      <div className="mt-2 text-neutral-400 text-xs flex flex-wrap gap-x-4 gap-y-1">
                                         <span>
                                             <strong className="text-neutral-300">CI ID:</strong>{' '}
-                                            {evt.ci_node_id
-                                                ? <span className="font-mono text-brand-400">{evt.ci_node_id}</span>
+                                            {(detailEvent?.ci_ref?.id || displayEvent.ci_node_id)
+                                                ? <span className="font-mono text-brand-400">{detailEvent?.ci_ref?.id || displayEvent.ci_node_id}</span>
                                                 : <span className="text-neutral-600 italic">—</span>}
                                         </span>
                                         <span>
                                             <strong className="text-neutral-300">Host:</strong>{' '}
-                                            {evt.ci_name
-                                                ? <span className="text-white">{evt.ci_name}</span>
+                                            {(detailEvent?.ci_ref?.label || displayEvent.ci_name)
+                                                ? <span className="text-white">{detailEvent?.ci_ref?.label || displayEvent.ci_name}</span>
                                                 : <span className="text-neutral-600 italic">—</span>}
-                                            {evt.ci_hostname && (
-                                                <span className="text-neutral-500 ml-1">({evt.ci_hostname})</span>
+                                            {(detailEvent?.ci_ref?.hostname || displayEvent.ci_hostname) && (
+                                                <span className="text-neutral-500 ml-1">({detailEvent?.ci_ref?.hostname || displayEvent.ci_hostname})</span>
                                             )}
                                         </span>
-                                        {evt.ci_location_name && (
+                                        {site && (
                                             <span>
                                                 <strong className="text-neutral-300">Ubicación:</strong>{' '}
-                                                <span className="text-white">{evt.ci_location_name}</span>
+                                                <span className="text-white">{site}</span>
                                             </span>
                                         )}
-                                        <span><strong className="text-neutral-300">Métrica:</strong> {evt.metric_name || '—'}</span>
-                                        <span><strong className="text-neutral-300">Protocolo:</strong> {evt.metric_protocol || 'N/A'}</span>
-                                        <span><strong className="text-neutral-300">Inicio:</strong> {new Date(evt.created_at).toLocaleString()}</span>
+                                        <span><strong className="text-neutral-300">Métrica:</strong> {displayEvent.metric_name || '—'}</span>
+                                        <span><strong className="text-neutral-300">Protocolo:</strong> {displayEvent.metric_protocol || 'N/A'}</span>
+                                        <span><strong className="text-neutral-300">Inicio:</strong> {new Date(displayEvent.created_at).toLocaleString()}</span>
                                     </div>
                                 </div>
-                                <button onClick={() => setCommentModalOpen(false)} className="text-neutral-500 hover:text-white transition-colors flex-shrink-0 mt-1">
+                                <button onClick={resetModalState} className="text-neutral-500 hover:text-white transition-colors flex-shrink-0 mt-1">
                                     <span className="material-symbols-outlined">close</span>
                                 </button>
                             </div>
@@ -717,27 +791,19 @@ const MonitoringConsole: React.FC = () => {
                             <div className="px-6 pb-3 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
                                 <div className="bg-white/5 rounded-lg px-3 py-2 text-xs">
                                     <div className="text-neutral-500 uppercase font-bold tracking-wider mb-0.5">Servicio de negocio</div>
-                                    <div className="text-white font-semibold truncate">{(node?.metadata?.business_service as string) || <span className="text-neutral-600 italic">No configurado</span>}</div>
+                                    <div className="text-white font-semibold truncate">{businessServiceName || <span className="text-neutral-600 italic">No configurado</span>}</div>
                                 </div>
                                 <div className="bg-white/5 rounded-lg px-3 py-2 text-xs">
                                     <div className="text-neutral-500 uppercase font-bold tracking-wider mb-0.5">Usuarios impactados</div>
-                                    <div className="text-white font-semibold">{(node?.metadata?.impacted_users as string) || <span className="text-neutral-600 italic">No configurado</span>}</div>
+                                    <div className="text-white font-semibold">{impactedUsers ?? <span className="text-neutral-600 italic">No configurado</span>}</div>
                                 </div>
                                  <div className="bg-white/5 rounded-lg px-3 py-2 text-xs">
                                     <div className="text-neutral-500 uppercase font-bold tracking-wider mb-0.5">Sede</div>
-                                     <div className="text-white font-semibold">
-                                        {evt.ci_location_name
-                                            ? evt.ci_location_name
-                                            : node?.locationName
-                                                ? node.locationName
-                                                : (node?.metadata?.site as string)
-                                                    ? (node?.metadata?.site as string)
-                                                    : <span className="text-neutral-600 italic">No configurado</span>}
-                                    </div>
+                                     <div className="text-white font-semibold">{site || <span className="text-neutral-600 italic">No configurado</span>}</div>
                                 </div>
                                 <div className="bg-white/5 rounded-lg px-3 py-2 text-xs">
                                     <div className="text-neutral-500 uppercase font-bold tracking-wider mb-0.5">Categoría CI</div>
-                                    <div className="text-white font-semibold">{node?.category || node?.type || <span className="text-neutral-600 italic">No configurado</span>}</div>
+                                    <div className="text-white font-semibold">{category || <span className="text-neutral-600 italic">No configurado</span>}</div>
                                 </div>
                                 <div className={`rounded-lg px-3 py-2 text-xs ${slaCritical ? 'bg-red-500/20 border border-red-500/40' : 'bg-white/5'}`}>
                                     <div className={`uppercase font-bold tracking-wider mb-0.5 ${slaCritical ? 'text-red-400' : 'text-neutral-500'}`}>SLA Restante</div>
@@ -751,6 +817,9 @@ const MonitoringConsole: React.FC = () => {
                                     </div>
                                 </div>
                             </div>
+                            <div className="px-6 pb-3 text-[10px] uppercase tracking-widest text-neutral-500">
+                                Contexto de negocio: {businessContextStatus === 'loading' ? 'cargando' : businessContextStatus === 'degraded' ? 'degradado' : businessContextStatus === 'summary-only' ? 'resumen local' : businessContextStatus}
+                            </div>
 
                             {/* ── M2: Ownership Bar ── */}
                             <div className={`px-6 py-2 border-t border-white/5 flex flex-wrap items-center gap-4 text-xs ${!isAssigned ? 'bg-red-950/30' : 'bg-black/20'}`}>
@@ -762,31 +831,33 @@ const MonitoringConsole: React.FC = () => {
                                     ) : (
                                         <span className="flex items-center gap-2">
                                             <span className="text-red-400 font-bold animate-pulse">Sin asignar</span>
+                                            {canAckEvent && (
                                             <button
-                                                onClick={() => handleTakeCase(evt.id)}
+                                                onClick={() => handleTakeCase(displayEvent.id)}
                                                 className="px-2 py-0.5 bg-emerald-600 hover:bg-emerald-500 text-white rounded font-bold uppercase tracking-wide transition-colors"
                                             >Tomar caso</button>
+                                            )}
                                         </span>
                                     )}
                                 </div>
                                 <div className="w-px h-4 bg-white/10" />
                                 {/* Tier */}
                                 <div className="flex items-center gap-1.5">
-                                    <span className="text-neutral-500 uppercase font-bold">Tier:</span>
-                                    <span className="px-2 py-0.5 bg-brand-600/30 border border-brand-500/40 rounded text-brand-300 font-black">{CURRENT_TIER}</span>
+                                    <span className="text-neutral-500 uppercase font-bold">Tier del evento:</span>
+                                    <span className="px-2 py-0.5 bg-brand-600/30 border border-brand-500/40 rounded text-brand-300 font-black">{eventTier ?? 'No definido'}</span>
                                 </div>
                                 <div className="w-px h-4 bg-white/10" />
                                 {/* Estado */}
                                 <div className="flex items-center gap-1.5">
                                     <span className="text-neutral-500 uppercase font-bold">Estado:</span>
                                     <span className={`px-2 py-0.5 rounded font-black uppercase text-[10px] ${
-                                        evt.status === 'OPEN' ? 'bg-red-500/20 text-red-400 border border-red-500/30' :
-                                        evt.status === 'ACK'  ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30' :
+                                        displayEvent.status === 'OPEN' ? 'bg-red-500/20 text-red-400 border border-red-500/30' :
+                                        displayEvent.status === 'ACK'  ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30' :
                                         'bg-neutral-500/20 text-neutral-400 border border-neutral-500/30'
                                     }`}>{
-                                        evt.status === 'OPEN' ? 'Nuevo' :
-                                        evt.status === 'ACK'  ? 'En atención' :
-                                        evt.status === 'CLOSED' ? 'Cerrado' : evt.status
+                                        displayEvent.status === 'OPEN' ? 'Nuevo' :
+                                        displayEvent.status === 'ACK'  ? 'En atención' :
+                                        displayEvent.status === 'CLOSED' ? 'Cerrado' : displayEvent.status
                                     }</span>
                                 </div>
                                 <div className="w-px h-4 bg-white/10" />
@@ -806,7 +877,22 @@ const MonitoringConsole: React.FC = () => {
 
                         {/* ── Body: 3 columns ── */}
                         <div className="flex-1 flex overflow-hidden min-h-0">
-
+                            <>
+                            {(canViewEventDetail && eventDetailQuery.isLoading && !eventDetail) && (
+                                <div className="mx-5 mt-5 rounded-lg border border-brand-500/20 bg-brand-950/20 px-4 py-3 text-xs text-brand-100">
+                                    Cargando contexto extendido del evento...
+                                </div>
+                            )}
+                            {(canViewEventDetail && eventDetailQuery.isError && !eventDetail) && (
+                                <div className="mx-5 mt-5 rounded-lg border border-red-500/20 bg-red-950/20 px-4 py-3 text-xs text-red-200">
+                                    No se pudo cargar el detalle protegido. Seguís trabajando con el resumen del stream.
+                                </div>
+                            )}
+                            {detailFetchBlocked && (
+                                <div className="mx-5 mt-5 rounded-lg border border-white/10 bg-white/5 px-4 py-3 text-xs text-neutral-300">
+                                    Sin permiso `EVENT_VIEW`: se muestra el resumen local y solo las acciones autorizadas.
+                                </div>
+                            )}
                             {/* Left: M3 Timeline */}
                             <div className="w-[270px] lg:w-[310px] xl:w-[360px] flex-shrink-0 flex flex-col border-r border-white/10 bg-[#0f1117]">
                                 <div className="px-5 pt-5 pb-3 flex-shrink-0 border-b border-white/5">
@@ -822,9 +908,9 @@ const MonitoringConsole: React.FC = () => {
                                         <div className="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-[#0f1117] border-2 border-red-500 flex items-center justify-center">
                                             <div className="w-1.5 h-1.5 bg-red-500 rounded-full" />
                                         </div>
-                                        <div className="text-[10px] text-neutral-600 font-mono mb-1">{new Date(evt.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} · Sistema · Evento disparador</div>
+                                        <div className="text-[10px] text-neutral-600 font-mono mb-1">{new Date(displayEvent.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} · Sistema · Evento disparador</div>
                                         <div className="bg-red-950/30 border border-red-500/20 p-2.5 rounded-lg text-xs text-red-200 leading-relaxed">
-                                            <span className="font-black text-red-400">DISPARADOR:</span> {evt.message}
+                                            <span className="font-black text-red-400">DISPARADOR:</span> {displayEvent.message}
                                         </div>
                                     </div>
 
@@ -837,7 +923,7 @@ const MonitoringConsole: React.FC = () => {
                                                     <span className={`material-symbols-outlined text-[8px] ${color.split(' ')[1]}`}>{icon}</span>
                                                 </div>
                                                 <div className={`text-[10px] font-mono mb-1 ${color.includes('emerald') ? 'text-emerald-600' : color.includes('neutral') ? 'text-neutral-600' : 'text-neutral-600'}`}>
-                                                    {entry.ts ? new Date(entry.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '--:--'} · {entry.user || CURRENT_USER} · {
+                                                    {entry.ts ? new Date(entry.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '--:--'} · {entry.user || 'Sistema'} · {
                                                         entry.type === 'diagnostic' ? 'Diagnóstico ejecutado' :
                                                         entry.type === 'ownership' ? 'Ownership asignado' :
                                                         entry.type === 'close' ? 'Evento cerrado' :
@@ -859,6 +945,7 @@ const MonitoringConsole: React.FC = () => {
                                 </div>
 
                                 {/* Add note */}
+                                {canAckEvent && (
                                 <div className="flex-shrink-0 border-t border-white/5 px-5 py-4">
                                     <h4 className="text-[10px] font-black text-neutral-500 uppercase tracking-widest mb-2">Agregar nota</h4>
                                     <textarea
@@ -873,6 +960,7 @@ const MonitoringConsole: React.FC = () => {
                                         className="w-full py-2 bg-brand-700 hover:bg-brand-600 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded text-xs font-bold transition-colors"
                                     >Guardar nota</button>
                                 </div>
+                                )}
                             </div>
 
                             {/* Center: M4 Dependency Impact (dominant) */}
@@ -886,10 +974,10 @@ const MonitoringConsole: React.FC = () => {
                                 </div>
                                 <div className="flex-1 min-h-0 p-4">
                                     <DependencyMiniMap
-                                        ciId={evt.ci_id}
+                                        ciId={displayEvent.ci_id}
                                         nodes={nodesWithEvents}
                                         links={links}
-                                        event={evt}
+                                        event={displayEvent}
                                     />
                                 </div>
                                 <div className="flex-shrink-0 px-5 pb-3 text-[10px] text-neutral-600 text-center italic">
@@ -902,14 +990,14 @@ const MonitoringConsole: React.FC = () => {
 
                                 {/* Related alarms */}
                                 <div className="px-5 pt-5 pb-3 border-b border-white/5">
-                                    <RelatedAlarmsPanel ciId={evt.ci_id} currentEventId={selectedEventId} />
+                                    <RelatedAlarmsPanel ciId={displayEvent.ci_id} currentEventId={selectedEventId} enabled={canViewEventDetail} />
                                 </div>
 
                                 {/* Quick actions */}
                                 <div className="px-5 py-4 border-b border-white/5">
                                     <h4 className="text-[10px] font-black text-neutral-500 uppercase tracking-widest mb-3">Acciones rápidas</h4>
                                     <div className="flex flex-col gap-2">
-                                        {evt.status === 'OPEN' && (
+                                        {displayEvent.status === 'OPEN' && canAckEvent && (
                                             <button
                                                 onClick={() => handleAck(selectedEventId!)}
                                                 className="w-full py-2.5 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-bold text-white flex items-center justify-center gap-2 transition-colors"
@@ -920,7 +1008,7 @@ const MonitoringConsole: React.FC = () => {
                                         )}
 
                                         {/* M5: Close flow */}
-                                        {!closeFlowOpen ? (
+                                        {canCloseEvent && (!closeFlowOpen ? (
                                             <button
                                                 onClick={() => setCloseFlowOpen(true)}
                                                 className="w-full py-2.5 bg-neutral-800 hover:bg-neutral-700 border border-white/10 rounded-lg text-sm font-bold text-neutral-300 flex items-center justify-center gap-2 transition-colors"
@@ -975,13 +1063,15 @@ const MonitoringConsole: React.FC = () => {
                                                         </div>
 
                                                         <button
-                                                            onClick={handleStructuredClose}
+                                                            onClick={() => {
+                                                                void handleStructuredClose().catch(() => undefined);
+                                                            }}
                                                             disabled={!canClose}
                                                             className="w-full py-2 bg-emerald-700 hover:bg-emerald-600 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-lg text-xs font-black uppercase transition-colors"
                                                         >Confirmar Cierre</button>
 
                                                         {/* Forced close — requires EVENT_FORCED_CLOSE permission */}
-                                                        {hasPermission('EVENT_FORCED_CLOSE') && (
+                                                        {canForceCloseEvent && (
                                                             <button
                                                                 onClick={() => setCloseForcedMode(true)}
                                                                 className="w-full py-1.5 text-[10px] text-neutral-600 hover:text-red-400 transition-colors uppercase font-bold"
@@ -1002,7 +1092,9 @@ const MonitoringConsole: React.FC = () => {
                                                         <div className="flex gap-2">
                                                             <button onClick={() => setCloseForcedMode(false)} className="flex-1 py-2 bg-neutral-800 text-neutral-400 rounded-lg text-xs font-bold">Cancelar</button>
                                                             <button
-                                                                onClick={handleStructuredClose}
+                                                                onClick={() => {
+                                                                    void handleStructuredClose().catch(() => undefined);
+                                                                }}
                                                                 disabled={!canClose}
                                                                 className="flex-1 py-2 bg-red-700 hover:bg-red-600 disabled:opacity-40 text-white rounded-lg text-xs font-black transition-colors"
                                                             >Forzar Cierre</button>
@@ -1010,11 +1102,12 @@ const MonitoringConsole: React.FC = () => {
                                                     </>
                                                 )}
                                             </div>
-                                        )}
+                                        ))}
                                     </div>
                                 </div>
 
                                 {/* Diagnostics */}
+                                {canRunDiagnostics && (
                                 <div className="px-5 py-4">
                                     <h4 className="text-[10px] font-black text-brand-400 uppercase tracking-widest mb-3">Herramientas de Diagnóstico</h4>
                                     <div className="bg-black/40 rounded-xl border border-white/5 p-3">
@@ -1038,7 +1131,9 @@ const MonitoringConsole: React.FC = () => {
                                         <p className="text-[10px] text-neutral-600 mt-2 leading-relaxed">El resultado se registrará automáticamente en el timeline.</p>
                                     </div>
                                 </div>
+                                )}
                             </div>
+                            </>
                         </div>
                     </div>
                 </div>
@@ -1073,8 +1168,10 @@ const StatCard = ({ label, value, icon, color, bg, animate }: any) => (
  * Shows other active alarms for the same CI, excluding the currently selected one.
  * Useful for spotting correlated issues (e.g. CPU High + Latency High).
  */
-const RelatedAlarmsPanel = ({ ciId, currentEventId }: { ciId?: string, currentEventId?: string | null }) => {
-    const { data: related = [] } = useRelatedEventsQuery(ciId);
+const RelatedAlarmsPanel = ({ ciId, currentEventId, enabled }: { ciId?: string, currentEventId?: string | null, enabled: boolean }) => {
+    const { data: related = [] } = useRelatedEventsQuery(ciId, enabled);
+
+    if (!enabled) return null;
 
     // Filter out current event
     const displayed = related.filter(e => e.id !== currentEventId);

--- a/frontend/components/__tests__/EventDetailModal.acceptance.test.tsx
+++ b/frontend/components/__tests__/EventDetailModal.acceptance.test.tsx
@@ -45,6 +45,54 @@ const MOCK_NODE = {
     metrics: [],
 };
 
+function buildEventDetail(event: any, node: any, overrides: any = {}) {
+    const metadata = node?.metadata ?? {};
+    const createdAt = new Date(event.created_at).getTime();
+    const ageMinutes = Math.floor((Date.now() - createdAt) / 60000);
+    const defaultSla = typeof metadata.sla_minutes === 'number' ? metadata.sla_minutes : null;
+
+    return {
+        event: {
+            ...event,
+            ci_ref: {
+                id: event.ci_id,
+                label: event.ci_name,
+                hostname: node?.ip ?? null,
+                location_name: event.ci_location_name ?? node?.locationName ?? metadata.site ?? null,
+            },
+        },
+        business_context: {
+            source: metadata.business_service || metadata.impacted_users || metadata.sla_minutes ? 'snapshot' : 'unavailable',
+            business_service: metadata.business_service ? {
+                id: 'svc-001',
+                name: metadata.business_service,
+                owner_t1: 'Mesa N1',
+                owner_t2: 'NetOps',
+                owner_t3: 'Arquitectura',
+            } : null,
+            service_catalog: defaultSla !== null ? {
+                id: 'sla-001',
+                category: node?.category ?? node?.type ?? 'UNKNOWN',
+                service_tier: 'Gold',
+                sla_minutes: defaultSla,
+            } : null,
+            impacted_users: metadata.impacted_users ? Number(metadata.impacted_users) : null,
+            sla_remaining_minutes: defaultSla !== null ? defaultSla - ageMinutes : null,
+            site: event.ci_location_name ?? node?.locationName ?? metadata.site ?? null,
+            ...overrides.business_context,
+        },
+        itsm_context: {
+            assignment_state: event.ack && event.ack_by ? 'assigned' : 'unassigned',
+            assigned_to: event.ack_by ?? null,
+            opened_by: 'system',
+            escalation_tier: 'T2',
+            external_ticket: null,
+            ...overrides.itsm_context,
+        },
+        ...overrides,
+    };
+}
+
 // Event created 5 minutes ago (well within SLA)
 const MOCK_EVENT_WITHIN_SLA: any = {
     id: 'evt-1',
@@ -99,6 +147,7 @@ vi.mock('../../services/api', () => ({
             if (url === '/nodes') return [MOCK_NODE];
             if (url === '/links') return [];
             if (url.startsWith('/events?')) return [MOCK_EVENT_WITHIN_SLA];
+            if (url === `/events/${MOCK_EVENT_WITHIN_SLA.id}`) return buildEventDetail(MOCK_EVENT_WITHIN_SLA, MOCK_NODE);
             if (url.startsWith('/events/related/')) return [];
             return [];
         }),
@@ -153,15 +202,17 @@ vi.mock('../../context/AuthContext', () => ({
 // Helper: render MonitoringConsole and open the event detail modal
 // ---------------------------------------------------------------------------
 
-async function renderAndOpenModal(eventOverride?: any, nodeOverride?: any) {
+async function renderAndOpenModal(eventOverride?: any, nodeOverride?: any, detailOverride?: any) {
     const { api } = await import('../../services/api');
     const mockEvent = eventOverride ?? MOCK_EVENT_WITHIN_SLA;
     const mockNode = nodeOverride ?? MOCK_NODE;
+    const mockDetail = detailOverride ?? buildEventDetail(mockEvent, mockNode);
 
     (api.get as any).mockImplementation(async (url: string) => {
         if (url === '/nodes') return [mockNode];
         if (url === '/links') return [];
         if (url.startsWith('/events?')) return [mockEvent];
+        if (url === `/events/${mockEvent.id}`) return mockDetail;
         if (url.startsWith('/events/related/')) return [];
         return [];
     });
@@ -191,6 +242,18 @@ async function renderAndOpenModal(eventOverride?: any, nodeOverride?: any) {
     return result;
 }
 
+function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+
+    return { promise, resolve, reject };
+}
+
 // ---------------------------------------------------------------------------
 // M1: Business Context Band
 // ---------------------------------------------------------------------------
@@ -200,18 +263,23 @@ describe('M1 — Business Context Band', () => {
 
     it('GIVEN an event with business metadata WHEN modal opens THEN business service is visible without scroll', async () => {
         await renderAndOpenModal();
-        // Business service card should be present
-        expect(screen.getByText('Corp-WAN')).toBeDefined();
+        await waitFor(() => {
+            expect(screen.getByText('Corp-WAN')).toBeDefined();
+        });
     });
 
     it('GIVEN an event with impacted_users metadata WHEN modal opens THEN users count is visible', async () => {
         await renderAndOpenModal();
-        expect(screen.getByText('350')).toBeDefined();
+        await waitFor(() => {
+            expect(screen.getByText('350')).toBeDefined();
+        });
     });
 
     it('GIVEN an event with site metadata WHEN modal opens THEN site is visible', async () => {
         await renderAndOpenModal();
-        expect(screen.getByText('Madrid HQ')).toBeDefined();
+        await waitFor(() => {
+            expect(screen.getAllByText('Madrid HQ').length).toBeGreaterThanOrEqual(1);
+        });
     });
 
     it('GIVEN SLA remaining > 30 min WHEN modal opens THEN SLA label is NOT in red/critical state', async () => {
@@ -237,6 +305,124 @@ describe('M1 — Business Context Band', () => {
         // At least 3 cards should show "No configurado" (service, users, site, sla)
         expect(placeholders.length).toBeGreaterThanOrEqual(3);
     });
+
+    it('GIVEN detail API returns business context WHEN modal opens THEN modal prefers detail payload over node metadata', async () => {
+        const staleNode = {
+            ...MOCK_NODE,
+            metadata: {
+                ...MOCK_NODE.metadata,
+                business_service: 'Legacy Metadata Service',
+            },
+        };
+
+        await renderAndOpenModal(
+            MOCK_EVENT_WITHIN_SLA,
+            staleNode,
+            buildEventDetail(MOCK_EVENT_WITHIN_SLA, staleNode, {
+                business_context: {
+                    source: 'snapshot',
+                    business_service: {
+                        id: 'svc-001',
+                        name: 'Corp-WAN API',
+                        owner_t1: 'Mesa N1',
+                        owner_t2: 'NetOps',
+                        owner_t3: 'Arquitectura',
+                    },
+                },
+            })
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Corp-WAN API')).toBeDefined();
+        });
+        expect(screen.queryByText('Legacy Metadata Service')).toBeNull();
+    });
+
+    it('GIVEN detail query is pending WHEN modal opens THEN loading state is rendered', async () => {
+        const { api } = await import('../../services/api');
+        const deferred = createDeferred<any>();
+        const staleNode = {
+            ...MOCK_NODE,
+            metadata: {
+                ...MOCK_NODE.metadata,
+                business_service: 'Legacy Metadata Service',
+            },
+        };
+
+        (api.get as any).mockImplementation(async (url: string) => {
+            if (url === '/nodes') return [staleNode];
+            if (url === '/links') return [];
+            if (url.startsWith('/events?')) return [MOCK_EVENT_WITHIN_SLA];
+            if (url === `/events/${MOCK_EVENT_WITHIN_SLA.id}`) return deferred.promise;
+            if (url.startsWith('/events/related/')) return [];
+            return [];
+        });
+
+        const { default: MonitoringConsole } = await import('../MonitoringConsole');
+        const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+
+        render(
+            <QueryClientProvider client={client}>
+                <MonitoringConsole />
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(MOCK_EVENT_WITHIN_SLA.message)).toBeDefined();
+        });
+
+        fireEvent.click(screen.getByText('Details'));
+
+        expect(await screen.findByText('Cargando contexto extendido del evento...')).toBeDefined();
+        expect(screen.getByText('Timeline de Investigación')).toBeDefined();
+        expect(screen.queryByText('Legacy Metadata Service')).toBeNull();
+        expect(screen.getByText(/Contexto de negocio: cargando/i)).toBeDefined();
+
+        deferred.resolve(buildEventDetail(MOCK_EVENT_WITHIN_SLA, MOCK_NODE));
+        await waitFor(() => {
+            expect(screen.getByText('Timeline de Investigación')).toBeDefined();
+        });
+    });
+
+    it('GIVEN detail query fails WHEN modal opens THEN error state is rendered', async () => {
+        const { api } = await import('../../services/api');
+        const staleNode = {
+            ...MOCK_NODE,
+            metadata: {
+                ...MOCK_NODE.metadata,
+                business_service: 'Legacy Metadata Service',
+            },
+        };
+
+        (api.get as any).mockImplementation(async (url: string) => {
+            if (url === '/nodes') return [staleNode];
+            if (url === '/links') return [];
+            if (url.startsWith('/events?')) return [MOCK_EVENT_WITHIN_SLA];
+            if (url === `/events/${MOCK_EVENT_WITHIN_SLA.id}`) throw new Error('detail-down');
+            if (url.startsWith('/events/related/')) return [];
+            return [];
+        });
+
+        const { default: MonitoringConsole } = await import('../MonitoringConsole');
+        const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+
+        render(
+            <QueryClientProvider client={client}>
+                <MonitoringConsole />
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(MOCK_EVENT_WITHIN_SLA.message)).toBeDefined();
+        });
+
+        fireEvent.click(screen.getByText('Details'));
+
+        expect(await screen.findByText('No se pudo cargar el detalle protegido. Seguís trabajando con el resumen del stream.')).toBeDefined();
+        expect(screen.getByText('Timeline de Investigación')).toBeDefined();
+        expect(screen.queryByText('Legacy Metadata Service')).toBeNull();
+        expect(screen.getByText(/Contexto de negocio: degradado/i)).toBeDefined();
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -256,7 +442,7 @@ describe('M2 — Ownership Bar', () => {
         expect(screen.getByText('Tomar caso')).toBeDefined();
     });
 
-    it('GIVEN an unassigned event WHEN "Tomar caso" is clicked THEN api.post is called twice (comment + ack)', async () => {
+    it('GIVEN an unassigned event WHEN "Tomar caso" is clicked THEN api.post is called once through the atomic ack flow', async () => {
         const { api } = await import('../../services/api');
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
 
@@ -265,14 +451,13 @@ describe('M2 — Ownership Bar', () => {
 
         await waitFor(() => {
             const calls = (api.post as any).mock.calls;
-            const commentCall = calls.find((c: any[]) => c[0].includes('/comment'));
             const ackCall = calls.find((c: any[]) => c[0].includes('/ack'));
-            expect(commentCall).toBeDefined();
             expect(ackCall).toBeDefined();
+            expect(calls).toHaveLength(1);
         });
     });
 
-    it('GIVEN "Tomar caso" click THEN the comment message contains [OWNERSHIP] tag', async () => {
+    it('GIVEN "Tomar caso" click THEN the ack payload stays empty and leaves audit generation to the backend', async () => {
         const { api } = await import('../../services/api');
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
 
@@ -280,16 +465,18 @@ describe('M2 — Ownership Bar', () => {
 
         await waitFor(() => {
             const calls = (api.post as any).mock.calls;
-            const commentCall = calls.find((c: any[]) => c[0].includes('/comment'));
-            expect(commentCall).toBeDefined();
-            expect(commentCall[1].message).toContain('[OWNERSHIP]');
+            const ackCall = calls.find((c: any[]) => c[0].includes('/ack'));
+            expect(ackCall).toBeDefined();
+            expect(ackCall[1]).toEqual({});
         });
     });
 
-    it('GIVEN modal open THEN Tier badge is always visible', async () => {
+    it('GIVEN modal open THEN event escalation tier is displayed honestly', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        // CURRENT_TIER = 'T2' is hardcoded
-        expect(screen.getByText('T2')).toBeDefined();
+        expect(screen.getByText('Tier del evento:')).toBeDefined();
+        await waitFor(() => {
+            expect(screen.getByText('T2')).toBeDefined();
+        });
     });
 
     it('GIVEN an assigned event WHEN modal opens THEN assigned username is displayed', async () => {
@@ -319,6 +506,26 @@ describe('M3 — Enriched Timeline', () => {
     it('GIVEN event with OWNERSHIP comment WHEN modal opens THEN it renders as ownership entry', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITH_COMMENTS);
         expect(screen.getByText(/Caso tomado por Admin/)).toBeDefined();
+    });
+
+    it('GIVEN event with forced close comment WHEN modal opens THEN it renders as forced-close entry', async () => {
+        await renderAndOpenModal({
+            ...MOCK_EVENT_WITH_COMMENTS,
+            id: 'evt-force',
+            comments: ['[AUDIT][FORCED_CLOSE] Cierre forzado por testop\nMotivo: Ventana de mantenimiento (2024-01-01T10:06:00)'],
+        });
+        expect(screen.getAllByText((_, node) => node?.textContent?.includes('Cierre forzado') ?? false).length).toBeGreaterThan(0);
+    });
+
+    it('GIVEN structured audit entry from another actor WHEN modal opens THEN timeline shows the real actor instead of the viewer', async () => {
+        await renderAndOpenModal({
+            ...MOCK_EVENT_WITH_COMMENTS,
+            id: 'evt-audit-actor',
+            comments: ['[AUDIT][CLOSE] Evento cerrado por alice\nCausa raíz: Error de configuración\nNota: Se corrigió la política de enrutamiento principal (2024-01-01T10:06:00)'],
+        });
+
+        expect(screen.getAllByText((_, node) => node?.textContent?.includes('alice · Evento cerrado') ?? false).length).toBeGreaterThan(0);
+        expect(screen.queryByText((_, node) => node?.textContent?.includes('testop · Evento cerrado') ?? false)).toBeNull();
     });
 
     it('GIVEN a note is typed WHEN Guardar nota is clicked THEN api.post is called with the note', async () => {
@@ -434,23 +641,52 @@ describe('Auth Context Integration', () => {
 
     it('GIVEN authenticated user WHEN modal opens THEN CURRENT_USER displays authenticated username', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        // The comment ownership message should use the authenticated username from AuthContext
-        // Trigger "Tomar caso" and assert the username sent to API
+        // Trigger "Tomar caso" and assert the atomic ack payload uses the authenticated username
         const { api } = await import('../../services/api');
         fireEvent.click(screen.getByText('Tomar caso'));
 
         await waitFor(() => {
             const calls = (api.post as any).mock.calls;
-            const commentCall = calls.find((c: any[]) => c[0].includes('/comment'));
-            expect(commentCall).toBeDefined();
-            // Should use 'testop' (from mock useAuth), NOT hardcoded 'Admin'
-            expect(commentCall[1].message).toContain('testop');
+            const ackCall = calls.find((c: any[]) => c[0].includes('/ack'));
+            expect(ackCall).toBeDefined();
+            expect(ackCall[1]).toEqual({});
         });
+    });
+
+    it('GIVEN user without EVENT_VIEW but with close and diagnostics permissions WHEN modal opens THEN no detail fetch occurs and authorized actions stay available', async () => {
+        const { api } = await import('../../services/api');
+        const { useAuth } = await import('../../context/AuthContext');
+
+        (useAuth as any).mockImplementation(() => ({
+            user: { username: 'closer', role: 'OPERATOR', permissions: ['EVENT_CLOSE', 'RUN_DIAGNOSTICS'], tier: 'T2', allowed_locations: [] },
+            hasPermission: (perm: string) => ['EVENT_CLOSE', 'RUN_DIAGNOSTICS'].includes(perm),
+            isAuthenticated: true,
+            token: 'mock-token',
+            login: vi.fn(),
+            logout: vi.fn(),
+        }));
+
+        await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
+
+        expect((api.get as any).mock.calls.some((c: any[]) => c[0] === `/events/${MOCK_EVENT_WITHIN_SLA.id}`)).toBe(false);
+        expect((api.get as any).mock.calls.some((c: any[]) => c[0] === `/events/related/${MOCK_EVENT_WITHIN_SLA.ci_id}`)).toBe(false);
+        expect(await screen.findByText('Cerrar Evento')).toBeDefined();
+        expect(screen.getByText('Ejecutar diagnóstico')).toBeDefined();
+        expect(screen.getByText(/Sin permiso `EVENT_VIEW`/)).toBeDefined();
+
+        (useAuth as any).mockImplementation(() => ({
+            user: { username: 'testop', role: 'OPERATOR', permissions: ['EVENT_FORCED_CLOSE'], tier: 'T2', allowed_locations: [] },
+            hasPermission: (perm: string) => perm === 'EVENT_FORCED_CLOSE' || ['EVENT_VIEW', 'EVENT_ACK', 'EVENT_CLOSE'].includes(perm),
+            isAuthenticated: true,
+            token: 'mock-token',
+            login: vi.fn(),
+            logout: vi.fn(),
+        }));
     });
 
     it('GIVEN user WITH EVENT_FORCED_CLOSE permission WHEN close form opens THEN forced close button is visible', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => {
             expect(screen.getByText(/Cierre forzado/)).toBeDefined();
@@ -461,8 +697,8 @@ describe('Auth Context Integration', () => {
         // Override the mock with a persistent implementation for this test
         const { useAuth } = await import('../../context/AuthContext');
         const viewerAuth = {
-            user: { username: 'viewer', role: 'VIEWER', permissions: [], tier: 'T1', allowed_locations: [] },
-            hasPermission: (_perm: string) => false,
+            user: { username: 'viewer', role: 'VIEWER', permissions: ['EVENT_CLOSE'], tier: 'T1', allowed_locations: [] },
+            hasPermission: (perm: string) => perm === 'EVENT_CLOSE',
             isAuthenticated: true,
             token: 'mock-token',
             login: vi.fn(),
@@ -471,7 +707,7 @@ describe('Auth Context Integration', () => {
         (useAuth as any).mockImplementation(() => viewerAuth);
 
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => screen.getByText('Confirmar Cierre'));
 
@@ -495,11 +731,17 @@ describe('Auth Context Integration', () => {
 // ---------------------------------------------------------------------------
 
 describe('M5 — Close with mandatory root cause', () => {
+    beforeEach(async () => {
+        const { api } = await import('../../services/api');
+        (api.post as any).mockReset();
+        (api.post as any).mockResolvedValue({ message: 'ok' });
+    });
+
     afterEach(() => vi.clearAllMocks());
 
     it('GIVEN modal open WHEN "Cerrar Evento" clicked THEN close form appears', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
         await waitFor(() => {
             expect(screen.getByText('Cierre de Evento')).toBeDefined();
         });
@@ -507,7 +749,7 @@ describe('M5 — Close with mandatory root cause', () => {
 
     it('GIVEN close form open WHEN neither cause nor note filled THEN Confirmar Cierre is disabled', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => screen.getByText('Confirmar Cierre'));
         const confirmBtn = screen.getByText('Confirmar Cierre');
@@ -516,7 +758,7 @@ describe('M5 — Close with mandatory root cause', () => {
 
     it('GIVEN close form WHEN cause selected but note < 20 chars THEN Confirmar is still disabled', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => screen.getByText('Confirmar Cierre'));
 
@@ -531,7 +773,7 @@ describe('M5 — Close with mandatory root cause', () => {
 
     it('GIVEN close form WHEN cause + note (≥20 chars) filled THEN Confirmar Cierre is enabled', async () => {
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => screen.getByText('Confirmar Cierre'));
 
@@ -546,10 +788,10 @@ describe('M5 — Close with mandatory root cause', () => {
         });
     });
 
-    it('GIVEN close form filled WHEN Confirmar Cierre clicked THEN api.post comment contains root cause', async () => {
+    it('GIVEN close form filled WHEN Confirmar Cierre clicked THEN close payload contains root cause audit data', async () => {
         const { api } = await import('../../services/api');
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => screen.getByText('Confirmar Cierre'));
 
@@ -563,17 +805,71 @@ describe('M5 — Close with mandatory root cause', () => {
 
         await waitFor(() => {
             const calls = (api.post as any).mock.calls;
-            const commentCall = calls.find((c: any[]) => c[0].includes('/comment'));
-            expect(commentCall).toBeDefined();
-            expect(commentCall[1].message).toContain('Error de configuración');
-            expect(commentCall[1].message).toContain('[CIERRE]');
+            const closeCall = calls.find((c: any[]) => c[0].includes('/close'));
+            expect(closeCall).toBeDefined();
+            expect(closeCall[1].comment_message).toContain('Error de configuración');
+            expect(closeCall[1].comment_message).not.toContain('[CIERRE]');
         });
     });
 
-    it('GIVEN T2 user WHEN forced close used THEN comment contains [CIERRE FORZADO — T2]', async () => {
+    it('GIVEN close succeeds WHEN structured close is submitted THEN only the atomic close request is sent', async () => {
         const { api } = await import('../../services/api');
         await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
-        fireEvent.click(screen.getByText('Cerrar Evento'));
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
+
+        await waitFor(() => screen.getByText('Confirmar Cierre'));
+
+        fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'Error de configuración' } });
+        fireEvent.change(
+            screen.getByPlaceholderText('Describe la resolución del incidente...'),
+            { target: { value: 'Se corrigió la configuración de BGP en el router principal' } }
+        );
+
+        fireEvent.click(screen.getByText('Confirmar Cierre'));
+
+        await waitFor(() => {
+            const calls = (api.post as any).mock.calls.filter((c: any[]) => c[0].includes(`/events/${MOCK_EVENT_WITHIN_SLA.id}/`));
+            expect(calls[0][0]).toContain('/close');
+            expect(calls).toHaveLength(1);
+        });
+    });
+
+    it('GIVEN close request fails WHEN structured close is submitted THEN no closure comment is written', async () => {
+        const { api } = await import('../../services/api');
+        const swallowUnhandled = (event: PromiseRejectionEvent) => event.preventDefault();
+        window.addEventListener('unhandledrejection', swallowUnhandled);
+        (api.post as any).mockImplementation(async (url: string, payload: any) => {
+            if (url === `/events/${MOCK_EVENT_WITHIN_SLA.id}/close`) {
+                throw new Error('close-down');
+            }
+            return { message: 'ok', payload };
+        });
+
+        await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
+
+        await waitFor(() => screen.getByText('Confirmar Cierre'));
+
+        fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'Falla de hardware' } });
+        fireEvent.change(
+            screen.getByPlaceholderText('Describe la resolución del incidente...'),
+            { target: { value: 'Se reemplazó el módulo averiado durante la ventana aprobada' } }
+        );
+
+        fireEvent.click(screen.getByText('Confirmar Cierre'));
+
+        await waitFor(() => {
+            expect((api.post as any).mock.calls.some((c: any[]) => c[0] === `/events/${MOCK_EVENT_WITHIN_SLA.id}/close`)).toBe(true);
+        });
+
+        expect((api.post as any).mock.calls.some((c: any[]) => c[0] === `/events/${MOCK_EVENT_WITHIN_SLA.id}/comment`)).toBe(false);
+        window.removeEventListener('unhandledrejection', swallowUnhandled);
+    });
+
+    it('GIVEN T2 user WHEN forced close used THEN close payload sends only the operator reason', async () => {
+        const { api } = await import('../../services/api');
+        await renderAndOpenModal(MOCK_EVENT_WITHIN_SLA);
+        fireEvent.click(await screen.findByText('Cerrar Evento'));
 
         await waitFor(() => screen.getByText('Cierre forzado (T2)'));
         fireEvent.click(screen.getByText('Cierre forzado (T2)'));
@@ -588,9 +884,9 @@ describe('M5 — Close with mandatory root cause', () => {
 
         await waitFor(() => {
             const calls = (api.post as any).mock.calls;
-            const commentCall = calls.find((c: any[]) => c[0].includes('/comment'));
-            expect(commentCall).toBeDefined();
-            expect(commentCall[1].message).toContain('[CIERRE FORZADO — T2]');
+            const closeCall = calls.find((c: any[]) => c[0].includes('/close'));
+            expect(closeCall).toBeDefined();
+            expect(closeCall[1].comment_message).toBe('Motivo: Requiere cierre inmediato por ventana de mantenimiento');
         });
     });
 });

--- a/frontend/components/__tests__/MonitoringConsole.forcedClose.test.tsx
+++ b/frontend/components/__tests__/MonitoringConsole.forcedClose.test.tsx
@@ -96,6 +96,38 @@ const MOCK_EVENT = {
     comments: [],
 };
 
+const MOCK_EVENT_DETAIL = {
+    event: {
+        ...MOCK_EVENT,
+        ci_ref: {
+            id: MOCK_EVENT.ci_id,
+            label: MOCK_EVENT.ci_name,
+            hostname: MOCK_EVENT.ci_hostname,
+            location_name: MOCK_EVENT.ci_location_name,
+        },
+    },
+    business_context: {
+        source: 'snapshot',
+        business_service: null,
+        service_catalog: {
+            id: 'sla-001',
+            category: 'NETWORK',
+            service_tier: 'Gold',
+            sla_minutes: 60,
+        },
+        impacted_users: null,
+        sla_remaining_minutes: 45,
+        site: MOCK_EVENT.ci_location_name,
+    },
+    itsm_context: {
+        assignment_state: 'unassigned',
+        assigned_to: null,
+        opened_by: 'system',
+        escalation_tier: 'T2',
+        external_ticket: null,
+    },
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -107,6 +139,7 @@ async function renderConsoleWithEvent() {
     mockApiGet.mockImplementation((url: string) => {
         if (url === '/nodes') return Promise.resolve([]);
         if (url === '/links') return Promise.resolve([]);
+        if (url === `/events/${MOCK_EVENT.id}`) return Promise.resolve(MOCK_EVENT_DETAIL);
         if (url.includes('/events')) return Promise.resolve([MOCK_EVENT]);
         return Promise.resolve([]);
     });
@@ -171,15 +204,20 @@ describe('MonitoringConsole — forced close API call', () => {
             fireEvent.click(forceSubmitBtn);
         });
 
-        // Wait for the API call
+        // Wait for the atomic close API call
         await waitFor(() => {
             const closeCalls = mockApiPost.mock.calls.filter(([url]) =>
                 url === `/events/${MOCK_EVENT.id}/close`
             );
             expect(closeCalls.length).toBeGreaterThan(0);
             const lastCloseCall = closeCalls[closeCalls.length - 1];
-            expect(lastCloseCall[1]).toEqual({ forced: true });
+            expect(lastCloseCall[1]).toEqual({
+                forced: true,
+                comment_message: 'Motivo: Mantenimiento de emergencia aprobado por CTO',
+            });
         });
+
+        expect(mockApiPost.mock.calls.some(([url]) => url === `/events/${MOCK_EVENT.id}/comment`)).toBe(false);
     });
 
     it('GIVEN standard close mode WHEN handleStructuredClose is called THEN sends { forced: false } to close endpoint', async () => {
@@ -210,15 +248,20 @@ describe('MonitoringConsole — forced close API call', () => {
             fireEvent.click(confirmBtn);
         });
 
-        // Wait for the API call
+        // Wait for the atomic close API call
         await waitFor(() => {
             const closeCalls = mockApiPost.mock.calls.filter(([url]) =>
                 url === `/events/${MOCK_EVENT.id}/close`
             );
             expect(closeCalls.length).toBeGreaterThan(0);
             const lastCloseCall = closeCalls[closeCalls.length - 1];
-            expect(lastCloseCall[1]).toEqual({ forced: false });
+            expect(lastCloseCall[1]).toEqual({
+                forced: false,
+                comment_message: 'Causa raíz: Falla de hardware\nNota: Se reemplazó el módulo de CPU defectuoso',
+            });
         });
+
+        expect(mockApiPost.mock.calls.some(([url]) => url === `/events/${MOCK_EVENT.id}/comment`)).toBe(false);
     });
 
     it('GIVEN event table rows WHEN rendered THEN no close API call is possible without modal interaction', async () => {

--- a/frontend/hooks/queries/resourceQueries.test.tsx
+++ b/frontend/hooks/queries/resourceQueries.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createQueryWrapper, createTestQueryClient } from '../../test/queryTestUtils';
 import { useActiveEventsQuery } from './useActiveEventsQuery';
 import { useCategoriesQuery } from './useCategoriesQuery';
+import { useEventDetailQuery } from './useEventDetailQuery';
 import { useGraphTopologyQuery } from './useGraphTopologyQuery';
 import { useLinksQuery } from './useLinksQuery';
 import { useNodesQuery } from './useNodesQuery';
@@ -19,7 +20,15 @@ vi.mock('../../services/api', () => ({
   },
 }));
 
-function HookProbe({ resource }: { resource: 'status' | 'nodes' | 'links' | 'categories' | 'events' | 'topology' }) {
+function HookProbe({
+  resource,
+  eventId,
+  detailEnabled,
+}: {
+  resource: 'status' | 'nodes' | 'links' | 'categories' | 'events' | 'topology' | 'detail';
+  eventId?: string;
+  detailEnabled?: boolean;
+}) {
   const result = (() => {
     switch (resource) {
       case 'status':
@@ -34,6 +43,8 @@ function HookProbe({ resource }: { resource: 'status' | 'nodes' | 'links' | 'cat
         return useActiveEventsQuery();
       case 'topology':
         return useGraphTopologyQuery();
+      case 'detail':
+        return useEventDetailQuery(eventId, detailEnabled);
     }
   })();
 
@@ -159,5 +170,48 @@ describe('resource query hooks', () => {
     expect(mockApiGet).toHaveBeenCalledTimes(1);
     expect(screen.getByText('alpha-loading:false')).toBeInTheDocument();
     expect(screen.getByText('beta-loading:false')).toBeInTheDocument();
+  });
+
+  it('fetches event detail by id without background polling', async () => {
+    mockApiGet.mockResolvedValue({
+      event: { id: 'evt-1', ci_id: 'ci-1', metric_id: 'cpu-load', status: 'OPEN', severity: 'CRITICAL', message: 'boom', created_at: '2026-04-05T11:00:00Z', last_seen: '2026-04-05T11:00:00Z', ack: false, ci_ref: { id: 'ci-1' } },
+      business_context: { source: 'unavailable', sla_remaining_minutes: null },
+      itsm_context: { assignment_state: 'unassigned', opened_by: 'system' },
+    });
+
+    render(<HookProbe resource="detail" eventId="evt-1" />, { wrapper: createQueryWrapper() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockApiGet).toHaveBeenCalledWith('/events/evt-1', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(60000);
+      await Promise.resolve();
+    });
+
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch event detail until an id exists', async () => {
+    render(<HookProbe resource="detail" />, { wrapper: createQueryWrapper() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch event detail when explicitly disabled', async () => {
+    render(<HookProbe resource="detail" eventId="evt-1" detailEnabled={false} />, { wrapper: createQueryWrapper() });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockApiGet).not.toHaveBeenCalled();
   });
 });

--- a/frontend/hooks/queries/useEventDetailQuery.ts
+++ b/frontend/hooks/queries/useEventDetailQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchEventDetail } from '../../services/queryResources';
+
+export const useEventDetailQuery = (eventId?: string | null, enabled = true) => useQuery({
+  queryKey: eventId ? queryKeys.eventDetail(eventId) : ['events', 'detail', 'unknown'],
+  queryFn: ({ signal }) => fetchEventDetail(eventId as string, { signal }),
+  enabled: Boolean(eventId) && enabled,
+});

--- a/frontend/hooks/queries/useEventMutations.test.tsx
+++ b/frontend/hooks/queries/useEventMutations.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { queryKeys } from '../../services/queryKeys';
 import { useEventMutations } from './useEventMutations';
 
 const { mockApiPost } = vi.hoisted(() => ({
@@ -21,11 +20,11 @@ function Probe() {
   return (
     <div>
       <button onClick={() => mutations.ackEvent('evt-1')}>ack</button>
-      <button onClick={() => mutations.commentEvent('evt-1', { message: 'note', user: 'admin' })}>comment</button>
-      <button onClick={() => mutations.takeEvent('evt-1', { user: 'admin', tier: 'T1' })}>take</button>
-      <button onClick={() => mutations.closeEvent('evt-1', { forced: true })}>close</button>
-      <button onClick={() => mutations.pruneEvents()}>prune</button>
-      <button onClick={() => mutations.diagnoseEvent('evt-1', { user: 'admin' })}>diagnose</button>
+      <button onClick={() => mutations.commentEvent('evt-1', { message: 'note', user: 'admin' }).catch(() => undefined)}>comment</button>
+      <button onClick={() => mutations.takeEvent('evt-1', { user: 'admin', tier: 'T1' }).catch(() => undefined)}>take</button>
+      <button onClick={() => mutations.closeEvent('evt-1', { forced: true }).catch(() => undefined)}>close</button>
+      <button onClick={() => mutations.pruneEvents().catch(() => undefined)}>prune</button>
+      <button onClick={() => mutations.diagnoseEvent('evt-1', { user: 'admin' }).catch(() => undefined)}>diagnose</button>
     </div>
   );
 }
@@ -43,7 +42,7 @@ describe('useEventMutations', () => {
   it.each([
     ['ack', '/events/evt-1/ack'],
     ['comment', '/events/evt-1/comment'],
-    ['take', '/events/evt-1/comment'],
+    ['take', '/events/evt-1/ack'],
     ['close', '/events/evt-1/close'],
     ['prune', '/events/prune'],
     ['diagnose', '/events/evt-1/diagnose'],
@@ -61,9 +60,91 @@ describe('useEventMutations', () => {
     });
 
     await waitFor(() => {
-      expect(client.invalidateQueries).toHaveBeenCalledWith({ queryKey: queryKeys.activeEvents() });
+      expect(client.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['events'] });
     });
 
     expect(mockApiPost).toHaveBeenCalledWith(endpoint, expect.anything());
+  });
+
+  it('routes take-case through the ack endpoint without client-generated ownership text', async () => {
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'take' }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockApiPost.mock.calls[0]).toEqual([
+      '/events/evt-1/ack',
+      {},
+    ]);
+  });
+
+  it('sends close audit data through the close endpoint atomically', async () => {
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockApiPost.mock.calls[0]).toEqual([
+      '/events/evt-1/close',
+      { forced: true },
+    ]);
+  });
+
+  it('does not attempt a separate ownership comment call', async () => {
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'take' }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockApiPost).not.toHaveBeenCalledWith(
+      '/events/evt-1/comment',
+      expect.anything(),
+    );
+  });
+
+  it('does not attempt a separate ownership write when ack fails', async () => {
+    mockApiPost.mockImplementation((url: string) => {
+      if (url === '/events/evt-1/ack') {
+        return Promise.reject(new Error('ack-down'));
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(
+      <QueryClientProvider client={client}>
+        <Probe />
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'take' }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith('/events/evt-1/ack', {});
+    expect(mockApiPost).not.toHaveBeenCalledWith('/events/evt-1/comment', expect.anything());
+    expect(client.invalidateQueries).not.toHaveBeenCalled();
   });
 });

--- a/frontend/hooks/queries/useEventMutations.ts
+++ b/frontend/hooks/queries/useEventMutations.ts
@@ -1,6 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { api } from '../../services/api';
-import { queryKeys } from '../../services/queryKeys';
 
 interface CommentPayload {
   message: string;
@@ -14,6 +13,7 @@ interface TakePayload {
 
 interface ClosePayload {
   forced: boolean;
+  comment_message?: string;
 }
 
 interface DiagnosePayload {
@@ -23,43 +23,39 @@ interface DiagnosePayload {
 export const useEventMutations = () => {
   const queryClient = useQueryClient();
 
-  const refreshActiveEvents = async () => {
-    await queryClient.invalidateQueries({ queryKey: queryKeys.activeEvents() });
+  const refreshEventQueries = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['events'] });
   };
 
   return {
     ackEvent: async (id: string) => {
       const result = await api.post(`/events/${id}/ack`, {});
-      await refreshActiveEvents();
+      await refreshEventQueries();
       return result;
     },
     commentEvent: async (id: string, payload: CommentPayload) => {
       const result = await api.post(`/events/${id}/comment`, payload);
-      await refreshActiveEvents();
+      await refreshEventQueries();
       return result;
     },
-    takeEvent: async (id: string, payload: TakePayload) => {
-      await api.post(`/events/${id}/comment`, {
-        message: `[OWNERSHIP] Caso tomado por ${payload.user} - Tier ${payload.tier}`,
-        user: payload.user,
-      });
+    takeEvent: async (id: string, _payload: TakePayload) => {
       const result = await api.post(`/events/${id}/ack`, {});
-      await refreshActiveEvents();
+      await refreshEventQueries();
       return result;
     },
     closeEvent: async (id: string, payload: ClosePayload) => {
       const result = await api.post(`/events/${id}/close`, payload);
-      await refreshActiveEvents();
+      await refreshEventQueries();
       return result;
     },
     pruneEvents: async () => {
       const result = await api.post('/events/prune', {});
-      await refreshActiveEvents();
+      await refreshEventQueries();
       return result;
     },
     diagnoseEvent: async (id: string, _payload: DiagnosePayload) => {
       const result = await api.post(`/events/${id}/diagnose`, {});
-      await refreshActiveEvents();
+      await refreshEventQueries();
       return result;
     },
   };

--- a/frontend/hooks/queries/useRelatedEventsQuery.ts
+++ b/frontend/hooks/queries/useRelatedEventsQuery.ts
@@ -2,9 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../../services/queryKeys';
 import { fetchRelatedEvents } from '../../services/queryResources';
 
-export const useRelatedEventsQuery = (ciId?: string) => useQuery({
+export const useRelatedEventsQuery = (ciId?: string, enabled = true) => useQuery({
   queryKey: ciId ? queryKeys.relatedEvents(ciId) : ['events', 'related', 'unknown'],
   queryFn: ({ signal }) => fetchRelatedEvents(ciId as string, { signal }),
-  enabled: Boolean(ciId),
+  enabled: Boolean(ciId) && enabled,
   refetchInterval: 10000,
 });

--- a/frontend/services/queryKeys.ts
+++ b/frontend/services/queryKeys.ts
@@ -4,6 +4,7 @@ export const queryKeys = {
   links: () => ['links'] as const,
   categories: () => ['categories'] as const,
   activeEvents: () => ['events', 'ACTIVE'] as const,
+  eventDetail: (eventId: string) => ['events', 'detail', eventId] as const,
   graphTopology: () => ['graph-topology'] as const,
   relatedEvents: (ciId: string) => ['events', 'related', ciId] as const,
 };

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import type { Event, GraphLink, GraphNode } from '../types';
+import type { EventDetail, EventSummary, GraphLink, GraphNode } from '../types';
 
 export interface SystemStatus {
   cpu: number;
@@ -41,10 +41,13 @@ export const fetchCategories = ({ signal }: { signal?: AbortSignal } = {}) =>
   api.get<CategoryRecord[]>('/categories', { signal });
 
 export const fetchActiveEvents = ({ signal }: { signal?: AbortSignal } = {}) =>
-  api.get<Event[]>('/events?status=ACTIVE', { signal });
+  api.get<EventSummary[]>('/events?status=ACTIVE', { signal });
+
+export const fetchEventDetail = (eventId: string, { signal }: { signal?: AbortSignal } = {}) =>
+  api.get<EventDetail>(`/events/${eventId}`, { signal });
 
 export const fetchRelatedEvents = (ciId: string, { signal }: { signal?: AbortSignal } = {}) =>
-  api.get<Event[]>(`/events/related/${ciId}`, { signal });
+  api.get<EventSummary[]>(`/events/related/${ciId}`, { signal });
 
 export const fetchGraphTopology = ({ signal }: { signal?: AbortSignal } = {}) =>
   api.get<GraphTopologyResponse>('/graph/full', { signal });

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -49,7 +49,7 @@ export interface GraphNode {
   // UI Helpers (optional, added during runtime)
   hasCritical?: boolean;
   hasWarning?: boolean;
-  events?: Event[];
+  events?: EventSummary[];
 }
 
 export interface GraphLink {
@@ -59,7 +59,7 @@ export interface GraphLink {
   relationship: 'DEPENDS_ON' | 'RUNS_ON' | 'PART_OF' | 'MANAGED_BY';
 }
 
-export interface Event {
+export interface EventSummary {
   id: string;
   ci_id: string;
   ci_name?: string;
@@ -85,6 +85,64 @@ export interface Event {
   recovered_at?: string;
   comments?: string[];
 }
+
+export interface CIRef {
+  id: string;
+  label?: string | null;
+  hostname?: string | null;
+  location_name?: string | null;
+}
+
+export interface BusinessServiceRef {
+  id: string;
+  name: string;
+  tier?: string | null;
+  owner_t1?: string | null;
+  owner_t2?: string | null;
+  owner_t3?: string | null;
+}
+
+export interface ServiceCatalogRef {
+  id: string;
+  category: string;
+  service_tier?: string | null;
+  sla_minutes?: number | null;
+}
+
+export interface BusinessContext {
+  source: 'snapshot' | 'resolved' | 'mixed' | 'unavailable';
+  business_service?: BusinessServiceRef | null;
+  service_catalog?: ServiceCatalogRef | null;
+  impacted_users?: number | null;
+  sla_remaining_minutes?: number | null;
+  site?: string | null;
+}
+
+export interface ExternalTicketRef {
+  system: 'Jira' | 'ServiceNow';
+  key: string;
+  status?: string | null;
+}
+
+export interface ItsmContext {
+  assignment_state: 'unassigned' | 'assigned';
+  assigned_to?: string | null;
+  opened_by: 'system';
+  escalation_tier?: 'T1' | 'T2' | 'T3' | null;
+  external_ticket?: ExternalTicketRef | null;
+}
+
+export interface EventDetailEvent extends EventSummary {
+  ci_ref: CIRef;
+}
+
+export interface EventDetail {
+  event: EventDetailEvent;
+  business_context: BusinessContext;
+  itsm_context: ItsmContext;
+}
+
+export type Event = EventSummary;
 
 export interface MetricDef {
   id: string;

--- a/modelo_entidad_relacion.md
+++ b/modelo_entidad_relacion.md
@@ -1,156 +1,151 @@
-# 📊 Modelo Entidad-Relación (NEX-GEN ITOM)
+# Modelo Entidad-Relacion (NEX-GEN ITOM)
 
-Este documento detalla el Modelo Entidad-Relación (ER) completo de la plataforma NEX-GEN, agrupado por la base de datos de persistencia en donde reside cada entidad. Todos los campos extraídos del código backend (`backend/models`) están descritos con sus respectivos tipos de datos.
+Documento tecnico de referencia para las entidades persistidas y los contratos que hoy alimentan la consola operativa.
 
----
+## 1. Neo4j / Grafo operacional
 
-## 🟢 1. Base de Datos de Grafos (Neo4j)
+### `Node` / `CI`
 
-Las entidades de Graph DB están modeladas usando Pydantic y representan topología y configuraciones estructurales (CIs, relacionales, métricas lógicas).
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `id` | `str` | Identificador canonico del CI |
+| `label` | `str` | Nombre visible |
+| `type` | `str` | Categoria base |
+| `status` | `str` | Estado general |
+| `ip` | `str?` | Hostname/IP |
+| `locationName` | `str?` | Sitio legible |
+| `metadata` | `dict?` | Fallback transitorio, no fuente canonica del modal |
+| `owner` | `str?` | Grupo responsable legacy |
+| `brand`, `model`, `serialNumber`, `firmwareVersion` | `str?` | Inventario |
 
-### Entidad: `Node` (Configuration Item / CI)
-Representa un activo, componente de red o dispositivo.
+### `MetricDef`
 
-| Campo | Tipo / Formato | Obligatorio | Valor por Defecto / Detalles |
-| :--- | :--- | :---: | :--- |
-| `id` | `str` | Sí | Identificador único del Nodo. |
-| `label` | `str` | Sí | Nombre / Etiqueta visible del Nodo. |
-| `type` | `str` | Sí | Tipo o Categoría base del CI. |
-| `status` | `str` | No | `"OK"` (Estado general de salud). |
-| `ip` | `str` | No | Dirección IP del host. |
-| `location` | `dict` | No | Objeto con coordenadas/detalles espaciales. |
-| `metadata` | `dict` | No | Campos arbitrarios adicionales (tags). |
-| `owner` | `str` | No | Propietario o Response Group responsable. |
-| `locationName` | `str` | No | Nombre legible de la localización física. |
-| `pollingInterval` | `int` | No | `60` (Frecuencia de sondeo en segundos). |
-| `snmp` | `Union[dict, str]` | No | Configuración/Comunidad SNMP asíncrona. |
-| `brand` | `str` | No | Marca o fabricante del CI. |
-| `model` | `str` | No | Modelo del dispositivo físico. |
-| `serialNumber` | `str` | No | Número de serie. |
-| `firmwareVersion` | `str` | No | Versión de firmware/OS. |
-| `metrics` | `List[Dict[str, Any]]`| No | Lista pre-calculada de las métricas que afectan al CI. |
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `id` | `str` | Identificador de metrica |
+| `protocol` | `str` | SNMP, ICMP, HTTP, etc. |
+| `oid` | `str?` | OID o referencia tecnica |
+| `warning`, `critical` | `float?` | Umbrales |
+| `operator` | `str?` | `>=`, `<=`, `==`, `!=` |
+| `criticality` | `int?` | Mapeo base a severidad |
+| `applicable_to` | `dict?` | Reglas de aplicabilidad |
 
-### Entidad: `Link` (Relaciones Topológicas / Edges)
-Rutas conectivas o dependencias de nivel de arquitectura.
+### `BusinessService`
 
-| Campo | Tipo / Formato | Obligatorio | Valor por Defecto / Detalles |
-| :--- | :--- | :---: | :--- |
-| `source` | `str` | Sí | `id` del Nodo origen. |
-| `target` | `str` | Sí | `id` del Nodo de destino. |
-| `relationship` | `str` | Sí | Tipo de conexión (Ej. `DEPENDS_ON`, `CONNECTS_TO`). |
-| `id` | `str` | No | Identificador del Link (opcional). |
-| `source_label` | `str` | No | Etiqueta del Nodo Origen (desnormalizado). |
-| `target_label` | `str` | No | Etiqueta del Nodo Destino. |
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `id` | `str` | Identificador del servicio |
+| `name` | `str` | Nombre de negocio |
+| `tier` | `str?` | Tier operativo opcional |
+| `owner_t1` | `str?` | Responsable esperado T1 |
+| `owner_t2` | `str?` | Responsable esperado T2 |
+| `owner_t3` | `str?` | Responsable esperado T3 |
+| `impacted_users_count` | `int?` | Magnitud estimada de impacto |
 
-### Entidad: `MetricDef` (Definición Lógica de Métrica)
-Define el patrón y alertas base de telemetría a asociar contra los CIs.
+### `ServiceCatalog`
 
-| Campo | Tipo / Formato | Obligatorio | Valor por Defecto / Detalles |
-| :--- | :--- | :---: | :--- |
-| `id` | `str` | Sí | Identificador de definición de Métrica. |
-| `protocol` | `str` | Sí | `"SNMP"` (U otros agentes de sondeo). |
-| `oid` | `str` | No | Identificador SNMP para consulta técnica. |
-| `warning` | `float` | No | Umbral de advertencia para alarmas. |
-| `critical` | `float` | No | Umbral crítico para fallos inminentes. |
-| `dataType` | `str` | No | `"INTEGER"` |
-| `unit` | `str` | No | Unidad de medición (%, Kbps, C°). |
-| `description` | `str` | No | Detalles funcionales de la métrica. |
-| `criticality` | `int` | No | Nivel base (1: Info, 2: Warning, 3: Exception). |
-| `applicable_to` | `Dict[str, List[str]]` | No | Diccionario para auto-reconciliación por marca/modelo o CIs explícitos. |
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `id` | `str` | Identificador del SLA/catálogo |
+| `category` | `str` | Categoria funcional del servicio |
+| `service_tier` | `str?` | Tier opcional para segmentar el SLA |
+| `sla_minutes` | `int?` | Objetivo de tiempo |
 
-### Entidad: `Category`
-Entidad para clasificación semántica base de inventarios.
+### `Event`
 
-| Campo | Tipo / Formato | Obligatorio | Valor por Defecto / Detalles |
-| :--- | :--- | :---: | :--- |
-| `name` | `str` | Sí | Nombre unívoco de una categoría de equipos. |
+| Campo | Tipo | Notas |
+| --- | --- | --- |
+| `id` | `str` | Identificador del evento |
+| `ci_id` | `str` | Referencia canonica al CI |
+| `metric_id` | `str` | Metrica detonante |
+| `status` | `str` | `OPEN`, `ACK`, `RECOVERED`, `CLOSED` |
+| `severity` | `str` | `CRITICAL`, `WARNING`, `INFO` |
+| `message` | `str` | Mensaje operativo |
+| `created_at` | `datetime` | Apertura |
+| `last_seen` | `datetime?` | Ultima observacion |
+| `ack`, `ack_at`, `ack_by` | `bool/datetime/str?` | Ownership actual |
+| `closed_at`, `closed_by`, `recovered_at` | `datetime/str?` | Cierre/recuperacion |
+| `comments` | `list[str]?` | Timeline append-only |
+| `business_service_id` | `str?` | Snapshot |
+| `business_service_name` | `str?` | Snapshot |
+| `business_service_tier` | `str?` | Snapshot |
+| `owner_t1`, `owner_t2`, `owner_t3` | `str?` | Snapshot |
+| `impacted_users` | `int?` | Snapshot |
+| `site` | `str?` | Snapshot |
+| `service_catalog_id` | `str?` | Snapshot |
+| `service_category` | `str?` | Snapshot |
+| `service_tier` | `str?` | Snapshot |
+| `sla_minutes` | `int?` | Snapshot |
 
-### Entidad: `HardwareModel`
-Diccionario canónico de fabricantes y variantes de dispositivos de la infraestructura.
+## 2. Relaciones relevantes
 
-| Campo | Tipo / Formato | Obligatorio | Valor por Defecto / Detalles |
-| :--- | :--- | :---: | :--- |
-| `brand` | `str` | Sí | Nombre del fabricante (Ej. Cisco, HP). |
-| `model` | `str` | Sí | SKU específico. |
-| `category` | `str` | No | Referencia lógica a `Category`. |
-| `owner` | `str` | No | Enlace a la unidad/group de propiedad. |
+| Relacion | Origen | Destino | Proposito |
+| --- | --- | --- | --- |
+| `HAS_METRIC` | `CI` | `MetricDef` | Asignacion de metrica |
+| `HAS_EVENT` | `CI` | `Event` | Eventos abiertos / historicos |
+| `TRIGGERED_BY` | `Event` | `MetricDef` | Metrica que disparo el evento |
+| `BELONGS_TO` | `CI` | `BusinessService` | Mapeo de negocio |
+| `USES_SLA` | `BusinessService` | `ServiceCatalog` | SLA esperado |
+| `DEPENDS_ON`, `HOSTED_ON`, `CONNECTS_TO` | `CI` | `CI` | Topologia |
 
-### Entidad: `OwnerGroup`
-Agrupación de técnicos L1/L2 para escalado de incidentes o inventario de CIs.
+## 3. Contratos API relevantes
 
-| Campo | Tipo / Formato | Obligatorio | Valor por Defecto / Detalles |
-| :--- | :--- | :---: | :--- |
-| `name` | `str` | Sí | Nombre descriptivo del Grupo Soporte. |
-| `users` | `List[dict]` | No | Array de diccionarios referenciando a usuarios internos. |
+### Resumen (`GET /api/events`)
 
----
+- Mantiene payload liviano para polling.
+- Sigue exponiendo `ci_node_id` por compatibilidad legacy.
+- NO incluye `business_context` ni `itsm_context`.
 
-## 📈 2. Base de Datos de Series Temporales (TimescaleDB / PostgreSQL)
+### Detalle (`GET /api/events/{event_id}`)
 
-Almacenamiento optimizado de telemetría e ingesta por workers. 
-
-### Entidad/Tabla: `metric_values`
-Registra el historial síncrono muestreado por los colectores de métricas.
-
-| Columna SQL | Tipo SQL | PK | Índice | Obligatorio | Detalles |
-| :--- | :--- | :---: | :---: | :---: | :--- |
-| `time` | `DateTime(timezone=True)`| **Sí** | - | Sí | Timestamp del Muestreo (Hiper-tabla Timescale). |
-| `node_id` | `String` | **Sí** | Sí (Cy) | Sí | Referencia al `id` del Node (CI Neo4j). |
-| `metric_id` | `String` | **Sí** | - | Sí | Referencia a la entidad de la `MetricDef`. |
-| `value` | `Float` | - | - | Sí | Valor numérico devuelto por el protocolo en T. |
-
-> **Nota de Índices**: Cuenta con un composite index `idx_metric_values_node_time` integrando `(node_id, time)` para máxima eficiencia de renderizado o cálculos AIOps sobre secuencias.
-
----
-
-## 🔒 3. Base de Datos Relacional / IAM (PostgreSQL)
-
-El módulo IAM interactúa con PostgreSQL (mediante SQLAlchemy / Pydantic) para el Control de Acceso Basado en Roles (RBAC).
-
-### Entidad/Tabla: `users`
-Manejo local de cuentas y su control fino de visibilidad sectorial.
-
-| Columna SQL | Tipo SQL | PK / Único | Obligatorio | Detalles |
-| :--- | :--- | :---: | :---: | :--- |
-| `id` | `Integer` | **PK** | Sí | ID numérico indexado por SQLAlchemy. |
-| `username` | `String` | Único / IDx | Sí | Alias del operador o administrador. |
-| `hashed_password` | `String` | - | Sí | Hash asimétrico seguro de credenciales. |
-| `email` | `String` | IDx | No | Correo electrónico de notificaciones. |
-| `phone` | `String` | - | No | Teléfono de guardia/directorio. |
-| `role` | `String` | - | No | Valor default: `"VIEWER"`. |
-| `is_active` | `Boolean` | - | No | Bloqueo o deshabilitación. Default: `True` |
-| `force_password_change` | `Boolean` | - | No | Petición para cambio al primer Login. Default: `False` |
-| `permissions` | `ARRAY(String)` | - | No | Vector explícito de privilegios (`['EVENT_VIEW', 'CI_EDIT']...`) |
-| `allowed_locations` | `ARRAY(String)` | - | No | Filtro geofísico de multi-tenancy. Funciona para esconder graneros. |
-| `allowed_ci_types` | `ARRAY(String)` | - | No | Restricciones operativas (Ej: Ver sólo Router, no Switches). |
-
-### Pydantic - RBAC/ACL Core Structure (App Memory)
-Modelos secundarios que alimentan las validaciones Auth y Roles integrados en FastApi (`user.py`):
-
-- **UserPermission (Enumeración Fija)**: 
-  - Subcategorías del sistema para: Eventos (`EVENT_VIEW`, `EVENT_ACK`, `EVENT_CLOSE`), CMDB/CIs (`CI_VIEW`, `CI_EDIT`, `CI_DELETE`), Diagnósticos avanzados (`RUN_DIAGNOSTICS`), Sistema (`USER_MANAGE`, `ROLE_MANAGE`) y Telemetría visual (`METRICS_VIEW`).
-- **Role (Clase lógica Pydantic)**:
-  - Estructuración de roles personalizados en IAM (`name`, `description`, Array de sub-permisos (`UserPermission`), bool de `is_system` asegurando el grupo Inmutable).
-
----
-
-## 🗺️ Mapa Interaccional del Ecosistema (Diagrama Relacional Virtual)
-
-```mermaid
-erDiagram
-    %% Capa Postgres/SQL (RBAC)
-    User ||--o{ Role : "Posee un (String Enum)"
-    
-    %% Capa Pydantic/Neo4j (CMDB Topológica)
-    Node ||--|| Category : "Clasificado Como (type)"
-    Node ||--o{ MetricDef : "Sondea OIDs por (HAS_METRIC)"
-    HardwareModel ||--o{ Node : "Define Fabricante de"
-    HardwareModel ||--o| Category : "Base categorizada"
-    Link ||--|| Node : "Enlaza (Source)"
-    Link ||--|| Node : "Afecta / Impacta (Target)"
-    Node }o--o{ OwnerGroup : "(owner) Operado por"
-
-    %% Capa TimescaleDB  (Métricas)
-    Node ||--o{ MetricValue : "(node_id) Produce historial de telemetría"
-    MetricDef ||--o{ MetricValue : "(metric_id) Definición atada al dato numérico"
+```json
+{
+  "event": {
+    "id": "evt-001",
+    "ci_id": "ci-001",
+    "ci_ref": {
+      "id": "ci-001",
+      "label": "Router-01",
+      "hostname": "10.0.0.1",
+      "location_name": "Madrid HQ"
+    }
+  },
+  "business_context": {
+    "source": "snapshot|resolved|mixed|unavailable",
+    "business_service": { "id": "svc-001", "name": "Corp-WAN" },
+    "service_catalog": { "id": "sla-001", "category": "NETWORK", "sla_minutes": 60 },
+    "impacted_users": 350,
+    "sla_remaining_minutes": 25,
+    "site": "Madrid HQ"
+  },
+  "itsm_context": {
+    "assignment_state": "unassigned|assigned",
+    "assigned_to": null,
+    "opened_by": "system",
+    "escalation_tier": "T1|T2|T3|null",
+    "external_ticket": null
+  }
+}
 ```
+
+## 4. Identificadores normalizados
+
+- `ci_ref.id` es el identificador canonico del CI en el endpoint de detalle.
+- `ci_id` sigue siendo la referencia del evento al CI.
+- `ci_node_id` queda relegado al resumen por compatibilidad con consumidores existentes.
+
+## 5. Persistencia relacional
+
+### TimescaleDB / PostgreSQL
+
+- `metric_values(time, node_id, metric_id, value)` mantiene historico de telemetria.
+
+### IAM / PostgreSQL
+
+- `users` mantiene credenciales, permisos, ubicaciones y `tier` operativo del usuario autenticado.
+
+## 6. Lecturas relacionadas
+
+- `README.md`
+- `docs/domain/business-model.md`
+- `docs/itsm/event-flow.md`


### PR DESCRIPTION
## Summary
- Implements real Phase 2 event detail modal with graph-backed business context instead of `node.metadata` fallback
- Adds dedicated `GET /api/events/{event_id}` endpoint with snapshot-first resolution and auth protection
- Hardens the entire event audit trail with atomic ack/close, server-side canonical entries, and permission-gated UI
- Creates living documentation: business model, ITSM flow, and README as documentation hub

## Changes

| Area | File | What changed |
|------|------|-------------|
| Backend models | `backend/models/core.py` | Added `EventDetailResponse`, `BusinessServiceRef`, `ServiceCatalogRef`, `ExternalTicketRef`, `EventFeedSummary` |
| Backend routes | `backend/routers/events.py` | Added detail endpoint, auth on detail + related, atomic close/ack payloads |
| Backend services | `backend/services/event_service.py` | Detail shaping, snapshot resolution, canonical audit, atomic close/ack, public summary stripping, close validation |
| Backend services | `backend/services/snmp_service.py` | Snapshot capture with tier separation at event creation |
| Frontend modal | `frontend/components/MonitoringConsole.tsx` | Dedicated detail query, permission-gated actions, real audit actor, degraded-state handling |
| Frontend hook | `frontend/hooks/queries/useEventDetailQuery.ts` | New non-polling detail query with enabled gate |
| Frontend mutations | `frontend/hooks/queries/useEventMutations.ts` | Atomic ownership, removed client-generated audit tags |
| Frontend types | `frontend/types.ts` | Extended Event with detail fields |
| Frontend queries | `frontend/services/queryKeys.ts`, `queryResources.ts` | Event detail key and fetcher |
| Docs | `README.md` | Documentation hub with links to deep docs |
| Docs | `docs/domain/business-model.md` | Business/domain model documentation (new) |
| Docs | `docs/itsm/event-flow.md` | ITSM event flow documentation (new) |
| Docs | `modelo_entidad_relacion.md` | Updated ER with new entities |

## Test Plan
- Backend: 76 tests passing (`pytest`)
- Frontend: 64+ tests passing (`vitest`)
- Regressions added for: snapshot shaping, detail 404, partial contract degradation, audit atomicity, forced-close parsing, permission gating, detail query lifecycle, close validation, summary redaction, related-events auth

## Known Issues (tracked separately)
- #25: summary-only modal depends on stripped audit fields
- #26: forced close accepts empty justification
- #27: frontend EventSummary type still declares stripped audit fields
- #28: related events sorted lexicographically by severity

## Judgment Day
4 rounds of adversarial review, 3 fix iterations. Escalated with the 4 issues above filed in the repo.