### PR TITLE
fix(frontend): use nexgen_backend hostname in Vite proxy fallback

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(({ mode }) => {
       host: '0.0.0.0',
       proxy: {
         '/api': {
-          target: process.env.VITE_API_TARGET || 'http://localhost:8000',
+          target: process.env.VITE_API_TARGET || 'http://nexgen_backend:8000',
           changeOrigin: true,
           secure: false,
         }


### PR DESCRIPTION
## Summary

- Change Vite proxy fallback from http://localhost:8000 to http://nexgen_backend:8000
- Fixes 404 on /api/dictionaries/template-csv caused by port conflict with netai-backend
- The container name ackend in Docker DNS was resolving incorrectly due to port 8000 being shared with netai project

## Changes

| File | Change |
|------|--------|
| rontend/vite.config.ts | Use 
exgen_backend as fallback proxy target |

## Test Plan

- [x] Tested curl from server: curl localhost:8010/api/dictionaries/template-csv returns 401 (correct)
- [x] Verified nexgen_backend container has /template-csv route
- [x] Verified nexgen_frontend and nexgen_backend share 
extgen_default Docker network

Closes #73