### PR TITLE
fix(dictionaries): register template CSV route before dictionary id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Nexgen-frontend proxy hostname conflict**: Vite proxy fallback changed from `localhost:8000` to `nexgen_backend:8000` to fix 404 on `GET /api/dictionaries/template-csv` caused by port conflict with netai-backend
 - **Neo4j ResultConsumedError in topology_repo**: `get_cis_relationship_summary()` now consumes result set inside session context, fixing 500 error on `POST /api/cis/relationships`
+- **Dictionary CSV template route ordering**: `GET /api/dictionaries/template-csv` now registers before `GET /api/dictionaries/{dictionary_id}` so FastAPI does not treat `template-csv` as a dictionary ID
 
 ## [1.8.0] — 2026-05-10
 

--- a/backend/routers/dictionaries.py
+++ b/backend/routers/dictionaries.py
@@ -65,6 +65,39 @@ async def create_dictionary(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
 
 
+@router.get("/template-csv")
+async def get_template_csv(
+    current_user: User = Depends(get_current_active_user),
+):
+    """
+    Download a CSV template pre-populated with distinct brand+model pairs
+    from existing CI nodes, plus one example row.
+    """
+    brands_models = dictionary_service.get_template_brands_models()
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["brand", "model", "name", "polling_interval", "metric_ids"])
+
+    # One example row (user can remove)
+    writer.writerow(["ExampleBrand", "ExampleModel", "My Dictionary Name", "60", "cpu-usage,mem-used"])
+
+    # Pre-populate with existing brand+model pairs
+    for brand, model in brands_models:
+        writer.writerow([brand, model, "", "60", ""])
+
+    output.seek(0)
+    csv_content = output.getvalue()
+
+    return StreamingResponse(
+        io.BytesIO(csv_content.encode("utf-8")),
+        media_type="text/csv",
+        headers={
+            "Content-Disposition": "attachment; filename=dictionary_template.csv",
+        },
+    )
+
+
 @router.get("/{dictionary_id}", response_model=Dict[str, Any])
 async def get_dictionary(
     dictionary_id: str,
@@ -280,39 +313,6 @@ async def delete_dictionary(
 # ---------------------------------------------------------------------------
 # Bulk CSV Upload Endpoints
 # ---------------------------------------------------------------------------
-
-@router.get("/template-csv")
-async def get_template_csv(
-    current_user: User = Depends(get_current_active_user),
-):
-    """
-    Download a CSV template pre-populated with distinct brand+model pairs
-    from existing CI nodes, plus one example row.
-    """
-    brands_models = dictionary_service.get_template_brands_models()
-
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerow(["brand", "model", "name", "polling_interval", "metric_ids"])
-
-    # One example row (user can remove)
-    writer.writerow(["ExampleBrand", "ExampleModel", "My Dictionary Name", "60", "cpu-usage,mem-used"])
-
-    # Pre-populate with existing brand+model pairs
-    for brand, model in brands_models:
-        writer.writerow([brand, model, "", "60", ""])
-
-    output.seek(0)
-    csv_content = output.getvalue()
-
-    return StreamingResponse(
-        io.BytesIO(csv_content.encode("utf-8")),
-        media_type="text/csv",
-        headers={
-            "Content-Disposition": "attachment; filename=dictionary_template.csv",
-        },
-    )
-
 
 class BulkValidateResponse(BaseModel):
     rows: List[Dict[str, Any]]


### PR DESCRIPTION
## Summary

- Move `GET /api/dictionaries/template-csv` before the dynamic `GET /api/dictionaries/{dictionary_id}` route
- Prevent FastAPI from interpreting `template-csv` as a dictionary ID
- Update changelog with the corrected route-order root cause

## Changes

| File | Change |
|------|--------|
| `backend/routers/dictionaries.py` | Register `/template-csv` before `/{dictionary_id}` |
| `CHANGELOG.md` | Add route-order bugfix entry |

## Test Plan

- [x] Verified root cause from browser error: valid token reached `get_dictionary("template-csv")`
- [x] Unauthenticated tests explain prior 401 false negative: auth dependency ran before handler

Closes #75
