### PR TITLE
fix(frontend): handle blob downloads and stabilize tooltip hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Nexgen-frontend proxy hostname conflict**: Vite proxy fallback changed from `localhost:8000` to `nexgen_backend:8000` to fix 404 on `GET /api/dictionaries/template-csv` caused by port conflict with netai-backend
 - **Neo4j ResultConsumedError in topology_repo**: `get_cis_relationship_summary()` now consumes result set inside session context, fixing 500 error on `POST /api/cis/relationships`
 - **Dictionary CSV template route ordering**: `GET /api/dictionaries/template-csv` now registers before `GET /api/dictionaries/{dictionary_id}` so FastAPI does not treat `template-csv` as a dictionary ID
+- **CSV template download blob handling**: `api.ts` now respects `responseType: 'blob'` before content-type inspection so `URL.createObjectURL()` receives a real `Blob`
+- **RelationshipTooltip hook ordering**: removed the early return that executed before `useEffect`, fixing the React hooks order crash in mass link views
 
 ## [1.8.0] — 2026-05-10
 

--- a/frontend/components/RelationshipTooltip.tsx
+++ b/frontend/components/RelationshipTooltip.tsx
@@ -27,11 +27,6 @@ const RelationshipTooltip: React.FC<RelationshipTooltipProps> = ({ ciId, relatio
 
   const rels = relationships.get(ciId);
 
-  // Early return AFTER all hooks — never before
-  if (!rels || (rels.asSource.length === 0 && rels.asTarget.length === 0)) {
-    return <>{children}</>;
-  }
-
   // Portal DOM leak fix: manage portal via ref with useEffect cleanup
   // When visible becomes true, create the portal container; when false or unmount, remove it
   useEffect(() => {

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -34,6 +34,7 @@ const getHeaders = (isJson = true) => {
  */
 async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T> {
     const url = `${API_BASE}${endpoint.startsWith('/') ? endpoint : '/' + endpoint}`;
+    const responseType = (config as RequestInit & { responseType?: string }).responseType;
 
     // Build headers — start with any caller-provided headers, then apply defaults
     const callerHeaders = config.headers as Record<string, string> || {};
@@ -65,6 +66,10 @@ async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T
     if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         throw new ApiError(errorData.detail || response.statusText, response.status);
+    }
+
+    if (responseType === 'blob') {
+        return response.blob() as unknown as T;
     }
 
     // Return JSON if content exists


### PR DESCRIPTION
## Summary

- Make `api.ts` honor `responseType: 'blob'` so CSV downloads return a real `Blob`
- Remove the early return before `useEffect` in `RelationshipTooltip`
- Update changelog with both frontend runtime fixes

## Changes

| File | Change |
|------|--------|
| `frontend/services/api.ts` | Return `response.blob()` when caller requests `responseType: 'blob'` |
| `frontend/components/RelationshipTooltip.tsx` | Remove pre-hook early return causing hook order mismatch |
| `CHANGELOG.md` | Add runtime fix entries |

## Test Plan

- [x] CSV template download path now hands a real `Blob` to `URL.createObjectURL()`
- [x] Tooltip component now executes hooks in a stable order across renders

Closes #77
