### PR TITLE
fix(dictionaries): move template references to separate xlsx sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dictionary CSV template route ordering**: `GET /api/dictionaries/template-csv` now registers before `GET /api/dictionaries/{dictionary_id}` so FastAPI does not treat `template-csv` as a dictionary ID
 - **CSV template download blob handling**: `api.ts` now respects `responseType: 'blob'` before content-type inspection so `URL.createObjectURL()` receives a real `Blob`
 - **RelationshipTooltip hook ordering**: removed the early return that executed before `useEffect`, fixing the React hooks order crash in mass link views
+- **Dictionary template visual cleanup**: template download now returns `.xlsx` with brand/model references on a separate sheet, and bulk upload accepts `.xlsx` as well as `.csv`
 
 ## [1.8.0] — 2026-05-10
 

--- a/backend/routers/dictionaries.py
+++ b/backend/routers/dictionaries.py
@@ -3,6 +3,7 @@ Dictionary Router — CRUD endpoints for MetricDictionary nodes.
 """
 import csv
 import io
+import openpyxl
 from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile, Form
 from fastapi.responses import StreamingResponse
 from typing import List, Dict, Any, Optional
@@ -24,6 +25,62 @@ router = APIRouter(
 def _require_editor(current_user: User):
     if not check_permission(UserPermission.CI_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to manage dictionaries")
+
+
+def _parse_bulk_csv(content: bytes) -> List[Dict[str, Any]]:
+    lines = content.decode("utf-8", errors="replace").splitlines()
+    if len(lines) > 10001:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="CSV exceeds 10,000 row limit",
+        )
+
+    try:
+        reader = csv.DictReader(lines)
+        rows = []
+        for i, row in enumerate(reader):
+            row["row_index"] = i + 2  # +2 because row 1 is header, csv is 1-indexed
+            rows.append(row)
+        return rows
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"CSV parse error: {str(e)}",
+        )
+
+
+def _parse_bulk_xlsx(content: bytes) -> List[Dict[str, Any]]:
+    try:
+        workbook = openpyxl.load_workbook(filename=io.BytesIO(content), data_only=True)
+        worksheet = workbook[workbook.sheetnames[0]]
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Excel parse error: {str(e)}",
+        )
+
+    if worksheet.max_row > 10001:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Excel exceeds 10,000 row limit",
+        )
+
+    rows_iter = worksheet.iter_rows(values_only=True)
+    header_row = next(rows_iter, None)
+    if not header_row:
+        return []
+
+    headers = [str(value).strip() if value is not None else "" for value in header_row]
+    rows: List[Dict[str, Any]] = []
+    for i, row in enumerate(rows_iter, start=2):
+        values = ["" if value is None else str(value).strip() for value in row]
+        if not any(values):
+            continue
+        parsed_row = {headers[idx]: values[idx] if idx < len(values) else "" for idx in range(len(headers))}
+        parsed_row["row_index"] = i
+        rows.append(parsed_row)
+
+    return rows
 
 
 @router.get("", response_model=List[Dict[str, Any]])
@@ -75,25 +132,26 @@ async def get_template_csv(
     """
     brands_models = dictionary_service.get_template_brands_models()
 
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerow(["brand", "model", "name", "polling_interval", "metric_ids"])
+    workbook = openpyxl.Workbook()
+    template_sheet = workbook.active
+    template_sheet.title = "dictionary_template"
+    template_sheet.append(["brand", "model", "name", "polling_interval", "metric_ids"])
+    template_sheet.append(["ExampleBrand", "ExampleModel", "My Dictionary Name", "60", "cpu-usage,mem-used"])
 
-    # One example row (user can remove)
-    writer.writerow(["ExampleBrand", "ExampleModel", "My Dictionary Name", "60", "cpu-usage,mem-used"])
-
-    # Pre-populate with existing brand+model pairs
+    reference_sheet = workbook.create_sheet(title="brand_model_reference")
+    reference_sheet.append(["brand", "model"])
     for brand, model in brands_models:
-        writer.writerow([brand, model, "", "60", ""])
+        reference_sheet.append([brand, model])
 
+    output = io.BytesIO()
+    workbook.save(output)
     output.seek(0)
-    csv_content = output.getvalue()
 
     return StreamingResponse(
-        io.BytesIO(csv_content.encode("utf-8")),
-        media_type="text/csv",
+        output,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={
-            "Content-Disposition": "attachment; filename=dictionary_template.csv",
+            "Content-Disposition": "attachment; filename=dictionary_template.xlsx",
         },
     )
 
@@ -332,32 +390,21 @@ async def bulk_upload(
     """
     _require_editor(current_user)
 
-    if not file.filename or not file.filename.lower().endswith(".csv"):
+    if not file.filename:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="File must be a .csv",
+            detail="File is required",
+        )
+
+    filename = file.filename.lower()
+    if not (filename.endswith(".csv") or filename.endswith(".xlsx")):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="File must be a .csv or .xlsx",
         )
 
     content = await file.read()
-    # Reject files > 10k rows as a safeguard
-    lines = content.decode("utf-8", errors="replace").splitlines()
-    if len(lines) > 10001:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="CSV exceeds 10,000 row limit",
-        )
-
-    try:
-        reader = csv.DictReader(lines)
-        rows = []
-        for i, row in enumerate(reader):
-            row["row_index"] = i + 2  # +2 because row 1 is header, csv is 1-indexed
-            rows.append(row)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"CSV parse error: {str(e)}",
-        )
+    rows = _parse_bulk_xlsx(content) if filename.endswith(".xlsx") else _parse_bulk_csv(content)
 
     valid_rows, errors = dictionary_service.bulk_validate_rows(rows)
 

--- a/frontend/components/DictionaryBulkUpload.tsx
+++ b/frontend/components/DictionaryBulkUpload.tsx
@@ -141,7 +141,7 @@ const DictionaryBulkUpload: React.FC<DictionaryBulkUploadProps> = ({ onClose }) 
             const url = URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = 'dictionary_template.csv';
+            a.download = 'dictionary_template.xlsx';
             a.click();
             URL.revokeObjectURL(url);
         });
@@ -426,7 +426,7 @@ const UploadPanel: React.FC<UploadPanelProps> = ({
                     className="flex items-center gap-2 px-4 py-2 bg-cyan-900/40 hover:bg-cyan-800/40 border border-cyan-700/50 text-cyan-400 rounded-lg font-bold text-sm transition-colors"
                 >
                     <span className="material-symbols-outlined text-sm">download</span>
-                    Download Template CSV
+                    Download Template XLSX
                 </button>
 
                 <label className="flex items-center gap-2 px-4 py-2 bg-white/10 hover:bg-white/20 border border-white/20 text-white rounded-lg font-bold text-sm cursor-pointer transition-colors">
@@ -435,7 +435,7 @@ const UploadPanel: React.FC<UploadPanelProps> = ({
                     <input
                         ref={fileInputRef}
                         type="file"
-                        accept=".csv"
+                        accept=".csv,.xlsx"
                         onChange={onFileChange}
                         className="hidden"
                     />
@@ -549,7 +549,7 @@ const UploadPanel: React.FC<UploadPanelProps> = ({
             {uploadStep === 'idle' && (
                 <div className="flex flex-col items-center justify-center h-48 text-neutral-500 border border-dashed border-white/10 rounded-xl">
                     <span className="material-symbols-outlined text-4xl mb-2">upload_file</span>
-                    <p className="text-sm italic">Download the template, fill it, then upload the CSV</p>
+                    <p className="text-sm italic">Download the template, fill it in the main sheet, and upload the CSV or XLSX</p>
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Summary

- Change dictionary template download from a noisy one-sheet CSV to a two-sheet `.xlsx`
- Keep the editable template rows on the first sheet and move brand/model references to a separate sheet
- Allow bulk upload to parse `.xlsx` files in addition to `.csv`

## Changes

| File | Change |
|------|--------|
| `backend/routers/dictionaries.py` | Generate `.xlsx` template and parse `.xlsx` bulk uploads |
| `frontend/components/DictionaryBulkUpload.tsx` | Download `.xlsx`, accept `.xlsx,.csv`, update helper copy |
| `CHANGELOG.md` | Add template visual cleanup note |

## Test Plan

- [x] Template now downloads as `dictionary_template.xlsx`
- [x] First sheet remains clean for editing
- [x] Reference pairs are written to a second sheet
- [x] Upload endpoint accepts `.xlsx` and still supports `.csv`

Closes #79
