### PR TITLE
fix(admin): send Bearer token on template download to fix 401

### DIFF
--- a/frontend/components/AdminPage.tsx
+++ b/frontend/components/AdminPage.tsx
@@ -249,7 +249,7 @@ const AdminPage: React.FC = () => {
                                     </button>
                                     <div className="h-6 w-px bg-white/10 mx-2" />
                                     <button
-                                        onClick={() => window.open('/api/nodes/template', '_blank')}
+                                        onClick={() => api.download('/nodes/template')}
                                         className="btn-secondary text-xs"
                                     >
                                         <span className="material-symbols-outlined text-sm">download</span>

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -114,6 +114,25 @@ export const api = {
         method: 'DELETE',
         body: body ? JSON.stringify(body) : undefined
     }),
+    // Download a file with authentication (returns blob URL for download)
+    download: (endpoint: string) => {
+        return request<Blob>(endpoint, { responseType: 'blob', method: 'GET' })
+            .then(blob => {
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'template.xlsx';
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                // Revoke after a tick so browser finishes reading
+                setTimeout(() => URL.revokeObjectURL(url), 0);
+            })
+            .catch(err => {
+                console.error('Download failed:', err);
+                throw err;
+            });
+    },
     // raw request for custom config
     request
 };


### PR DESCRIPTION
## Summary
- Fix 401 authentication error when clicking Download Template button in admin inventory section
- Button was using window.open() which bypasses auth headers; now uses api.download() helper with Bearer token

## Changes
- frontend/services/api.ts: Added download() helper that sends Bearer token via request()
- frontend/components/AdminPage.tsx: Changed button to use api.download('/nodes/template') instead of window.open()

## Testing
- Judgment Day: 2 CRITICAL issues fixed (no catch handler, empty a.download)
- Manual test: Template downloads successfully with auth

## Related Issue
Fixes #81