### PR TITLE
feat(metrics): add can_propagate field to MetricDef model

### DIFF
--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -58,6 +58,7 @@ class MetricDef(BaseModel):
     criticality: Optional[int] = 1  # 1: Info, 2: Warning, 3: Exception
     applicable_to: Optional[Dict[str, List[str]]] = None
     polling_interval: Optional[int] = 60
+    can_propagate: bool = True
 
 
 class HardwareModel(BaseModel):

--- a/backend/services/metric_service.py
+++ b/backend/services/metric_service.py
@@ -64,7 +64,8 @@ def get_metrics() -> List[Dict[str, Any]]:
             criteria = {}
             if m.get("applicable_to"):
                 try: criteria = json.loads(m.get("applicable_to"))
-                except: pass
+                except Exception:
+                    logger.warning("Failed to parse applicable_to for metric %s", m.get("id"), exc_info=True)
 
             metrics.append({
                 "id": m.get("id"),
@@ -78,7 +79,8 @@ def get_metrics() -> List[Dict[str, Any]]:
                 "operator": m.get("operator", ">="),
                 "criticality": m.get("criticality", 1),
                 "applicable_to": criteria,
-                "polling_interval": m.get("polling_interval", 60)
+                "polling_interval": m.get("polling_interval", 60),
+                "can_propagate": m.get("can_propagate", True)
             })
         return metrics
 
@@ -112,6 +114,7 @@ def get_metric(metric_id: str) -> Optional[Dict[str, Any]]:
             "criticality": m.get("criticality", 1),
             "applicable_to": criteria,
             "polling_interval": m.get("polling_interval", 60),
+            "can_propagate": m.get("can_propagate", True),
         }
 
 
@@ -181,7 +184,8 @@ def get_metric_usage(metric_id: str) -> Dict[str, Any]:
         
         criteria = {}
         try: criteria = json.loads(record["apt"] or "{}")
-        except: pass
+        except Exception:
+            logger.warning("Failed to parse applicable_to for metric %s", metric_id, exc_info=True)
             
         models = criteria.get("models", [])
         brands = criteria.get("brands", [])

--- a/backend/services/metric_service.py
+++ b/backend/services/metric_service.py
@@ -150,12 +150,14 @@ def create_metric(metric: MetricDef) -> Dict[str, str]:
                 m.oid = $oid, m.dataType = $dtype, m.unit = $unit,
                 m.description = $desc, m.applicable_to = $criteria,
                 m.operator = $operator, m.criticality = $criticality,
-                m.polling_interval = $polling_interval
+                m.polling_interval = $polling_interval,
+                m.can_propagate = $can_propagate
         """, id=metric.id, prot=metric.protocol, warn=metric.warning, 
              crit=metric.critical, oid=metric.oid, dtype=metric.dataType,
              unit=metric.unit, desc=metric.description, criteria=criteria_str,
              operator=metric.operator or ">=", criticality=metric.criticality or 1,
-             polling_interval=metric.polling_interval or 60)
+             polling_interval=metric.polling_interval or 60,
+             can_propagate=metric.can_propagate)
 
     _reconcile_metric_assignments(metric.id, metric.applicable_to)
     return {"message": "Metric defined"}

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -409,28 +409,21 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
             else:
                 snapshot = resolve_event_snapshot(session, ci.get("id"))
 
-                # --- Correlation check: find open parent event ---
-                parent_info = None
-                try:
-                    from repositories.topology_repo import find_open_parent_event
-                    parent_info = find_open_parent_event(ci.get("id"), max_depth=3)
-                except Exception:
-                    pass  # If topology check fails, create as ROOT
+                # --- Correlation check: only if metric CAN propagate ---
+                correlation_type = "ROOT"
+                propagated_from = None
+                root_cause_ci_id = ci.get("id")
 
-                # Check can_propagate BEFORE expensive graph traversal
-                if parent_info:
-                    if not metric_def.get("can_propagate", True):
-                        correlation_type = "ROOT"
-                        propagated_from = None
-                        root_cause_ci_id = ci.get("id")
-                    else:
-                        correlation_type = "PROPAGATED"
-                        propagated_from = parent_info["parent_event_id"]
-                        root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
-                else:
-                    correlation_type = "ROOT"
-                    propagated_from = None
-                    root_cause_ci_id = ci.get("id")
+                if metric_def.get("can_propagate", True):
+                    try:
+                        from repositories.topology_repo import find_open_parent_event
+                        parent_info = find_open_parent_event(ci.get("id"), max_depth=3)
+                        if parent_info:
+                            correlation_type = "PROPAGATED"
+                            propagated_from = parent_info["parent_event_id"]
+                            root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
+                    except Exception:
+                        pass  # If topology check fails, keep ROOT
                 # --- End correlation check ---
 
                 session.run(

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -177,6 +177,7 @@ def run_snmp_cycle_sync(driver):
                     "critical": metric.get("critical"),
                     "operator": metric.get("operator", ">="),
                     "applicable_to": criteria,
+                    "can_propagate": metric.get("can_propagate", True),
                 }
             )
 
@@ -422,8 +423,9 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                             correlation_type = "PROPAGATED"
                             propagated_from = parent_info["parent_event_id"]
                             root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
-                    except Exception:
-                        pass  # If topology check fails, keep ROOT
+                    except Exception as exc:
+                        logger.warning("Topology correlation check failed for CI %s metric %s: %s",
+                                       ci.get("id"), metric_def.get("id"), exc)
                 # --- End correlation check ---
 
                 session.run(
@@ -479,10 +481,11 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                 WITH e
                 CALL {
                     WITH e
-                    MATCH (pe:Event)
+                    MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
                     WHERE pe.root_cause_ci_id = e.ci_id
                       AND pe.correlation_type = 'PROPAGATED'
                       AND pe.status IN ['OPEN', 'ACK']
+                      AND m.can_propagate = true
                     SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
                     RETURN count(pe) AS propagated_recovered
                 }

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -417,10 +417,16 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                 except Exception:
                     pass  # If topology check fails, create as ROOT
 
+                # Check can_propagate BEFORE expensive graph traversal
                 if parent_info:
-                    correlation_type = "PROPAGATED"
-                    propagated_from = parent_info["parent_event_id"]
-                    root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
+                    if not metric_def.get("can_propagate", True):
+                        correlation_type = "ROOT"
+                        propagated_from = None
+                        root_cause_ci_id = ci.get("id")
+                    else:
+                        correlation_type = "PROPAGATED"
+                        propagated_from = parent_info["parent_event_id"]
+                        root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
                 else:
                     correlation_type = "ROOT"
                     propagated_from = None

--- a/backend/tests/test_event_correlation.py
+++ b/backend/tests/test_event_correlation.py
@@ -23,6 +23,7 @@ from datetime import datetime
 def determine_correlation_fields(
     parent_event: dict | None,
     ci_id: str,
+    can_propagate: bool = True,
 ) -> dict:
     """
     Pure function that determines correlation fields from parent event context.
@@ -37,6 +38,12 @@ def determine_correlation_fields(
             "root_cause_ci_id": ci_id,
         }
     else:
+        if not can_propagate:
+            return {
+                "correlation_type": "ROOT",
+                "propagated_from": None,
+                "root_cause_ci_id": ci_id,
+            }
         return {
             "correlation_type": "PROPAGATED",
             "propagated_from": parent_event["id"],
@@ -369,3 +376,72 @@ class TestPropagatedFlagInAPI:
         assert "propagated" not in result
         assert "correlation_type" not in result
         assert "root_cause_ci_id" not in result
+
+
+# ---------------------------------------------------------------------------
+# Task 4 (new) — can_propagate field tests
+# ---------------------------------------------------------------------------
+
+class TestCanPropagate:
+    """Unit tests for can_propagate field behavior."""
+
+    def test_can_propagate_false_creates_root_event(self):
+        """
+        GIVEN a parent CI has an OPEN event
+        AND can_propagate=False
+        WHEN determine_correlation_fields is called
+        THEN correlation_type='ROOT' (no propagation, even with parent event)
+        """
+        parent_event = {
+            "id": "evt-parent-001",
+            "ci_id": "ci-parent-001",
+            "root_cause_ci_id": "ci-parent-001",
+            "correlation_type": "ROOT",
+        }
+        result = determine_correlation_fields(
+            parent_event=parent_event,
+            ci_id="ci-child-001",
+            can_propagate=False,
+        )
+        assert result["correlation_type"] == "ROOT"
+        assert result["propagated_from"] is None
+        assert result["root_cause_ci_id"] == "ci-child-001"
+
+    def test_can_propagate_true_propagates_with_parent(self):
+        """
+        GIVEN a parent CI has an OPEN event
+        AND can_propagate=True
+        WHEN determine_correlation_fields is called
+        THEN correlation_type='PROPAGATED' with inherited root cause
+        """
+        parent_event = {
+            "id": "evt-parent-001",
+            "ci_id": "ci-parent-001",
+            "root_cause_ci_id": "ci-parent-001",
+            "correlation_type": "ROOT",
+        }
+        result = determine_correlation_fields(
+            parent_event=parent_event,
+            ci_id="ci-child-001",
+            can_propagate=True,
+        )
+        assert result["correlation_type"] == "PROPAGATED"
+        assert result["propagated_from"] == "evt-parent-001"
+        assert result["root_cause_ci_id"] == "ci-parent-001"
+
+    def test_default_can_propagate_is_true_for_backward_compat(self):
+        """
+        GIVEN no explicit can_propagate value passed
+        WHEN determine_correlation_fields is called with parent_event
+        THEN correlation_type='PROPAGATED' (backward compatible default)
+        """
+        parent_event = {
+            "id": "evt-parent-001",
+            "ci_id": "ci-parent-001",
+            "root_cause_ci_id": "ci-parent-001",
+            "correlation_type": "ROOT",
+        }
+        # can_propagate defaults to True
+        result = determine_correlation_fields(parent_event=parent_event, ci_id="ci-child-001")
+        assert result["correlation_type"] == "PROPAGATED"
+        assert result["propagated_from"] == "evt-parent-001"


### PR DESCRIPTION
## Summary
- Add `can_propagate: bool = True` to MetricDef to gate event correlation
- Correlation guard skips topology traversal for metrics with `can_propagate=False`
- Recovery propagation respects `can_propagate` flag
- Fix bare `except: pass` with proper logging in metric service

## Testing
- 15/15 correlation tests pass