### PR TITLE
fix(frontend): pass search query as URL path param (#91)

### DIFF
--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -60,4 +60,4 @@ export const fetchOwners = ({ signal }: { signal?: AbortSignal } = {}) =>
   api.get<OwnerRecord[]>('/owners', { signal });
 
 export const fetchNodesSearch = ({ q, signal }: { q: string; signal?: AbortSignal } = {}) =>
-  api.get<GraphNode[]>('/nodes/search', { q, signal });
+  api.get<GraphNode[]>(`/nodes/search?q=${encodeURIComponent(q)}`, { signal });


### PR DESCRIPTION
## Summary
- Fix 422 error: API was treating search query as request body instead of URL parameter
- Changed  to use  format

## Changes
- : Pass query as URL-encoded path parameter

## Testing
- Direct API call returns 401 (auth required) instead of 422

Fixes #91