### PR TITLE
feat(metrics): multi-CI metric comparison in Analytics

### DIFF
--- a/backend/repositories/metric_repo.py
+++ b/backend/repositories/metric_repo.py
@@ -95,3 +95,178 @@ def get_latest_metrics(db: Session, node_id: str) -> Dict[str, Any]:
     """)
     results = db.execute(query, {"node_id": node_id}).fetchall()
     return {r.metric_id: {"value": r.value, "time": r.time} for r in results}
+
+
+def _interpolate_to_grid(
+    data: List[Dict[str, Any]], grid: List[datetime]
+) -> List[Dict[str, Any]]:
+    """
+    Linearly interpolate metric values onto a common time grid.
+    
+    Args:
+        data: List of {time, value} dicts sorted by time ascending
+        grid: Target datetime grid (30-second intervals)
+    
+    Returns:
+        List of {time, value} dicts aligned to grid, missing values filled via linear interpolation
+    """
+    if not data or not grid:
+        return []
+    
+    # Build a lookup: find the two source points surrounding each grid point
+    result = []
+    for target_time in grid:
+        # Find surrounding points in source data
+        before = None
+        after = None
+        for pt in data:
+            pt_time = pt["time"]
+            if isinstance(pt_time, str):
+                pt_time = datetime.fromisoformat(pt_time.replace('Z', '+00:00'))
+            if pt_time <= target_time:
+                before = pt
+            if pt_time >= target_time and after is None:
+                after = pt
+        
+        if before is None and after is None:
+            # No source data at all — skip
+            continue
+        elif before is None:
+            # Before first source point — use first available
+            result.append({"time": target_time, "value": after["value"]})
+        elif after is None:
+            # After last source point — use last available
+            result.append({"time": target_time, "value": before["value"]})
+        elif before["time"] == after["time"]:
+            # Exact match
+            result.append({"time": target_time, "value": before["value"]})
+        else:
+            # Linear interpolation
+            before_time = before["time"]
+            after_time = after["time"]
+            if isinstance(before_time, str):
+                before_time = datetime.fromisoformat(before_time.replace('Z', '+00:00'))
+            if isinstance(after_time, str):
+                after_time = datetime.fromisoformat(after_time.replace('Z', '+00:00'))
+            
+            total_range = (after_time - before_time).total_seconds()
+            if total_range == 0:
+                result.append({"time": target_time, "value": before["value"]})
+            else:
+                elapsed = (target_time - before_time).total_seconds()
+                ratio = elapsed / total_range
+                interpolated = before["value"] + ratio * (after["value"] - before["value"])
+                result.append({"time": target_time, "value": interpolated})
+    
+    return result
+
+
+def get_metric_history_batch(
+    db: Session,
+    node_ids: List[str],
+    metric_id: str,
+    hours: int = 24,
+    start_time: str = None,
+    end_time: str = None,
+    limit: int = 1000
+) -> List[Dict[str, Any]]:
+    """
+    Fetch historical data for the same metric across multiple CIs,
+    interpolating timestamps to a common 30-second grid.
+    
+    Args:
+        db: SQLAlchemy session
+        node_ids: List of node IDs (max 10 enforced by router)
+        metric_id: Metric identifier
+        hours: Lookback window in hours
+        start_time: Optional ISO start time override
+        end_time: Optional ISO end time override
+        limit: Max points per CI
+    
+    Returns:
+        List of {node_id, label, data: [{time, value}]} dicts
+    """
+    from database import get_neo4j_session
+    from models.core import Node
+    
+    # Determine time range
+    if start_time and end_time:
+        try:
+            start_dt = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
+            end_dt = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
+        except ValueError:
+            end_dt = datetime.utcnow()
+            start_dt = end_dt - timedelta(hours=hours)
+    else:
+        end_dt = datetime.utcnow()
+        start_dt = end_dt - timedelta(hours=hours)
+    
+    # Build 30-second interpolation grid
+    grid = []
+    current = start_dt
+    while current <= end_dt:
+        grid.append(current)
+        current += timedelta(seconds=30)
+    
+    # Fetch node labels from Neo4j (batch query - single round trip)
+    node_labels: Dict[str, str] = {}
+    try:
+        neo4j_session = get_neo4j_session()
+        result = neo4j_session.run(
+            "MATCH (n:CiNode) WHERE n.nodeId IN $nodeIds RETURN n.nodeId AS nodeId, n.label AS label",
+            nodeIds=node_ids
+        )
+        for record in result:
+            node_labels[record["nodeId"]] = record["label"] or record["nodeId"]
+        # Fill missing with node_id
+        for node_id in node_ids:
+            if node_id not in node_labels:
+                node_labels[node_id] = node_id
+    except Exception as e:
+        logger.error(f"Failed to fetch node labels: {e}")
+        # Fallback: use node_id as label
+        for node_id in node_ids:
+            node_labels[node_id] = node_id
+    
+    # Fetch per-CI data
+    results = []
+    for node_id in node_ids:
+        # Query TimescaleDB for this node's metric data
+        query = db.query(MetricValue).filter(
+            MetricValue.node_id == node_id,
+            MetricValue.metric_id == metric_id,
+            MetricValue.time >= start_dt,
+            MetricValue.time <= end_dt
+        ).order_by(MetricValue.time.asc()).limit(limit)
+        
+        raw_data = [
+            {"time": r.time, "value": r.value}
+            for r in query.all()
+        ]
+        
+        # Interpolate to common grid
+        interpolated = _interpolate_to_grid(raw_data, grid)
+        
+        # Format timestamps as ISO strings (normalize to UTC with Z suffix)
+        formatted_data = []
+        for pt in interpolated:
+            ts = pt["time"]
+            if hasattr(ts, 'isoformat'):
+                # datetime object - convert to UTC and format
+                ts_str = ts.isoformat()
+                if ts_str.endswith('+00:00'):
+                    ts_str = ts_str[:-6] + 'Z'
+                elif not ts_str.endswith('Z'):
+                    ts_str = ts_str + 'Z'
+                formatted_data.append({"time": ts_str, "value": pt["value"]})
+            else:
+                # String already
+                formatted_data.append({"time": str(pt["time"]), "value": pt["value"]})
+        
+        results.append({
+            "node_id": node_id,
+            "label": node_labels.get(node_id, node_id),
+            "data": formatted_data
+        })
+    
+    return results

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from typing import List, Dict, Any, Optional
 from models.core import MetricDef, Node
 from pydantic import BaseModel
@@ -110,20 +110,62 @@ async def validate_oid_endpoint(
     return result
 
 
+# Original single-CI history endpoint — preserved for backward compatibility
 @router.get("/{node_id}/{metric_id}/history")
-async def get_metric_history(
+async def get_metric_history_single(
     node_id: str,
     metric_id: str,
     hours: int = 24,
-    limit: int = 1000,  # Increased limit for charts
+    limit: int = 1000,
     start_time: Optional[str] = None,
     end_time: Optional[str] = None,
     db: Session = Depends(get_pg_db),
 ):
     """
-    Fetch historical data for a specific metric on a node.
+    Fetch historical data for a specific metric on a single node.
     Supports fixed 'hours' lookback or custom 'start_time'/'end_time' range (ISO format).
     """
     return metric_repo.get_metric_history(
         db, node_id, metric_id, limit, hours, start_time, end_time
+    )
+
+
+# New multi-CI history endpoint
+@router.get("/{metric_id}/history")
+async def get_metric_history(
+    metric_id: str,
+    hours: int = 24,
+    limit: int = 1000,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    node_ids: Optional[str] = Query(None, description="Comma-separated list of node IDs, max 10"),
+    db: Session = Depends(get_pg_db),
+):
+    """
+    Fetch historical data for a specific metric.
+
+    Supports two modes:
+    - Single-CI: GET /api/metrics/{node_id}/{metric_id}/history (backward compatible)
+    - Multi-CI: GET /api/metrics/{metric_id}/history?node_ids=ci1,ci2,ci3&hours=24
+
+    When node_ids is provided (comma-separated list), returns batch data for all CIs
+    with server-side 30-second interpolation onto a common time grid.
+    Maximum 10 CIs allowed per request.
+    """
+    if node_ids:
+        # Multi-CI batch mode
+        node_id_list = [n.strip() for n in node_ids.split(",") if n.strip()]
+        if len(node_id_list) > 10:
+            raise HTTPException(status_code=400, detail="Max 10 CIs allowed")
+        if not node_id_list:
+            raise HTTPException(status_code=400, detail="node_ids must not be empty")
+
+        return metric_repo.get_metric_history_batch(
+            db, node_id_list, metric_id, hours, start_time, end_time, limit
+        )
+
+    # No node_ids — require single-CI path
+    raise HTTPException(
+        status_code=400,
+        detail="Use GET /api/metrics/{node_id}/{metric_id}/history for single-CI or include node_ids for multi-CI"
     )

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -716,6 +716,132 @@ class TestMetricsHistory:
         app.dependency_overrides.pop(get_pg_db, None)
 
 
+class TestMultiMetricsHistory:
+    """Tests for GET /api/metrics/{metric_id}/history?node_ids=... — multi-CI batch endpoint."""
+
+    def test_multi_history_returns_nodes_array(self, mock_db):
+        """Multi-CI history with valid node_ids returns nodes array."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        # Mock the query chain for TimescaleDB
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = []
+        mock_db.query.return_value = mock_query
+
+        response = client.get("/api/metrics/cpu-load/history?node_ids=ci-001,ci-002&hours=24")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "nodes" in data
+        assert isinstance(data["nodes"], list)
+        assert len(data["nodes"]) == 2
+        assert data["nodes"][0]["node_id"] == "ci-001"
+        assert data["nodes"][1]["node_id"] == "ci-002"
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_multi_history_max_10_cis_enforced(self, mock_db):
+        """Request with more than 10 node_ids returns HTTP 400."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        too_many_ids = ",".join([f"ci-{i}" for i in range(15)])
+        response = client.get(f"/api/metrics/cpu-load/history?node_ids={too_many_ids}&hours=24")
+
+        assert response.status_code == 400
+        assert "Max 10 CIs allowed" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_multi_history_empty_node_ids_returns_400(self, mock_db):
+        """Request with empty node_ids returns HTTP 400."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.get("/api/metrics/cpu-load/history?node_ids=&hours=24")
+
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_multi_history_single_ci_still_returns_nodes_array(self, mock_db):
+        """Single CI in node_ids still returns nodes array (not flat array)."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = []
+        mock_db.query.return_value = mock_query
+
+        response = client.get("/api/metrics/cpu-load/history?node_ids=ci-001&hours=24")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "nodes" in data
+        assert len(data["nodes"]) == 1
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_multi_history_no_node_ids_returns_400(self, mock_db):
+        """Request without node_ids on multi-CI endpoint returns HTTP 400."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        response = client.get("/api/metrics/cpu-load/history?hours=24")
+
+        assert response.status_code == 400
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_multi_history_node_with_no_data_returns_empty_data_array(self, mock_db):
+        """CI with no metric data returns node entry with empty data array."""
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = []  # No data for this CI
+        mock_db.query.return_value = mock_query
+
+        response = client.get("/api/metrics/cpu-load/history?node_ids=ci-empty&hours=24")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "nodes" in data
+        ci_node = next((n for n in data["nodes"] if n["node_id"] == "ci-empty"), None)
+        assert ci_node is not None
+        assert ci_node["data"] == []
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+
 # ===========================================================================
 # EVENTS ROUTER TESTS
 # ===========================================================================

--- a/frontend/components/ChartPanel.tsx
+++ b/frontend/components/ChartPanel.tsx
@@ -1,0 +1,155 @@
+import React, { useMemo } from 'react';
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Brush, ReferenceArea } from 'recharts';
+
+interface BrushRange {
+  startIndex?: number;
+  endIndex?: number;
+}
+
+interface DataPoint {
+  time: string;
+  value: number;
+}
+
+interface ChartPanelProps {
+  nodeId: string;
+  label: string;
+  data: DataPoint[];
+  brushRange: BrushRange | null;
+  onBrushChange: (range: BrushRange | null) => void;
+  unit?: string;
+  metricName?: string;
+}
+
+const ChartPanel: React.FC<ChartPanelProps> = ({
+  nodeId,
+  label,
+  data,
+  brushRange,
+  onBrushChange,
+  unit,
+  metricName,
+}) => {
+  const isSelecting = false;
+  const selectionStart = null;
+  const selectionEnd = null;
+
+  const formattedData = useMemo(() => {
+    return data
+      .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
+      .map(d => ({
+        ...d,
+        displayTime: new Date(d.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', day: 'numeric', month: 'short' }),
+        rawTime: d.time,
+        value: typeof d.value === 'string' ? parseFloat(d.value) : d.value,
+      }));
+  }, [data]);
+
+  const displayData = brushRange && brushRange.startIndex !== undefined && brushRange.endIndex !== undefined
+    ? formattedData.slice(brushRange.startIndex, brushRange.endIndex + 1)
+    : formattedData;
+
+  const hasBrushApplied = brushRange !== null;
+
+  const handleResetView = () => {
+    onBrushChange(null);
+  };
+
+  const hasData = data.length > 0;
+
+  return (
+    <div className="bg-surface-800 rounded-xl p-6 border border-white/5 shadow-inner flex flex-col h-full min-h-[250px]">
+      <div className="flex justify-between items-center mb-4 flex-shrink-0">
+        <div>
+          <h4 className="text-white font-bold uppercase tracking-tight">{label}</h4>
+          <p className="text-xs text-neutral-500">
+            {hasBrushApplied
+              ? `${displayData.length} points selected`
+              : `${data.length} data points`}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasBrushApplied && (
+            <button
+              onClick={handleResetView}
+              className="flex items-center gap-1 px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-xs font-bold transition-all text-neutral-300"
+            >
+              <span className="material-symbols-outlined text-sm">restart_alt</span>
+              Reset
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!hasData ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-neutral-500">
+          <span className="material-symbols-outlined text-4xl mb-2 opacity-50">data_loss_prevention</span>
+          <p className="text-sm font-mono uppercase">No telemetry data</p>
+        </div>
+      ) : (
+        <div className="flex-1 w-full min-h-0 relative" style={{ minWidth: 0, minHeight: 0 }}>
+          <ResponsiveContainer width="99%" height="99%">
+            <AreaChart
+              data={displayData}
+              margin={{ top: 10, right: 10, left: -20, bottom: hasBrushApplied ? 50 : 0 }}
+            >
+              <defs>
+                <linearGradient id={`colorValue-${nodeId}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.3} />
+                  <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" vertical={false} />
+              <XAxis
+                dataKey="displayTime"
+                stroke="#525252"
+                tick={{ fill: '#525252', fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+                minTickGap={30}
+              />
+              <YAxis
+                stroke="#525252"
+                tick={{ fill: '#525252', fontSize: 10 }}
+                tickLine={false}
+                axisLine={false}
+                width={30}
+              />
+              <Tooltip
+                contentStyle={{ backgroundColor: '#171717', borderColor: '#333', borderRadius: '8px', fontSize: '12px' }}
+                itemStyle={{ color: '#fff' }}
+                labelStyle={{ color: '#a3a3a3', marginBottom: '4px' }}
+              />
+              <Area
+                type="monotone"
+                dataKey="value"
+                stroke="#0ea5e9"
+                strokeWidth={2}
+                fillOpacity={1}
+                fill={`url(#colorValue-${nodeId})`}
+              />
+              <Brush
+                dataKey="displayTime"
+                height={30}
+                stroke="#525252"
+                fill="#171717"
+                tickFormatter={() => ''}
+                startIndex={brushRange?.startIndex}
+                endIndex={brushRange?.endIndex}
+                onChange={(range: any) => {
+                  if (range.startIndex !== undefined && range.endIndex !== undefined) {
+                    onBrushChange({ startIndex: range.startIndex, endIndex: range.endIndex });
+                  } else {
+                    onBrushChange(null);
+                  }
+                }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChartPanel;

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -33,10 +33,11 @@ const MetricAnalytics: React.FC = () => {
     const [secondaryMetricId, setSecondaryMetricId] = useState<string>('');
     const [secondaryMultiCiData, setSecondaryMultiCiData] = useState<NodeMetricData[]>([]);
 
-    // Reset brush when node selection changes (indices are specific to each node's data)
+    // Reset brush when node selection, date range, or metric changes
+    // (indices are specific to each dataset)
     useEffect(() => {
         setBrushRange(null);
-    }, [selectedNodeIds]);
+    }, [selectedNodeIds, startDate, endDate, selectedMetric]);
 
     // Fetch Nodes on Mount
     useEffect(() => {

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -1,11 +1,19 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { GraphNode, MetricDef } from '../types';
+import { GraphNode, MetricDef, NodeMetricData } from '../types';
 import MetricHistoryChart from './MetricHistoryChart';
-import { fetchNodesSearch } from '../services/queryResources';
+import MultiSelectCIs from './MultiSelectCIs';
+import MultiMetricChart from './MultiMetricChart';
+import { fetchNodesSearch, fetchMetricsHistory } from '../services/queryResources';
+
+interface BrushRange {
+  startIndex?: number;
+  endIndex?: number;
+}
 
 const MetricAnalytics: React.FC = () => {
     const [nodes, setNodes] = useState<GraphNode[]>([]);
     const [selectedNodeId, setSelectedNodeId] = useState<string>('');
+    const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
     const [selectedMetric, setSelectedMetric] = useState<any | null>(null);
     const [loading, setLoading] = useState(true);
     const [startDate, setStartDate] = useState('');
@@ -17,7 +25,20 @@ const MetricAnalytics: React.FC = () => {
     const abortControllerRef = useRef<AbortController | null>(null);
     const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    // Fetch Nodes on Mount (original behavior)
+    // Multi-CI state
+    const [brushRange, setBrushRange] = useState<BrushRange | null>(null);
+    const [multiCiData, setMultiCiData] = useState<NodeMetricData[]>([]);
+    const [multiCiLoading, setMultiCiLoading] = useState(false);
+    const [showSecondary, setShowSecondary] = useState(false);
+    const [secondaryMetricId, setSecondaryMetricId] = useState<string>('');
+    const [secondaryMultiCiData, setSecondaryMultiCiData] = useState<NodeMetricData[]>([]);
+
+    // Reset brush when node selection changes (indices are specific to each node's data)
+    useEffect(() => {
+        setBrushRange(null);
+    }, [selectedNodeIds]);
+
+    // Fetch Nodes on Mount
     useEffect(() => {
         const token = localStorage.getItem('token');
         fetch('/api/nodes', {
@@ -28,29 +49,31 @@ const MetricAnalytics: React.FC = () => {
                 if (Array.isArray(data)) {
                     setNodes(data);
                     // Default select first one if available
-                    if (data.length > 0 && !selectedNodeId) setSelectedNodeId(data[0].id);
+                    if (data.length > 0) {
+                        const firstId = data[0].id;
+                        setSelectedNodeId(firstId);
+                        setSelectedNodeIds([firstId]);
+                    }
                 }
                 setLoading(false);
             })
             .catch(err => {
                 console.error(err);
                 setLoading(false);
+                // On fetch failure, ensure consistent state by not setting any defaults
+                // User can still manually select from the dropdown if nodes were previously loaded
             });
     }, []);
 
     // Debounced search effect
     useEffect(() => {
-        // Abort any in-flight request from previous effect run
         if (abortControllerRef.current) {
             abortControllerRef.current.abort();
         }
-
-        // Clear previous timer
         if (debounceTimerRef.current) {
             clearTimeout(debounceTimerRef.current);
         }
 
-        // Skip if less than 2 characters or if searchTerm is empty (user cleared it to show dropdown)
         if (!searchTerm.trim()) {
             setSearchResults([]);
             setIsSearching(false);
@@ -65,11 +88,9 @@ const MetricAnalytics: React.FC = () => {
             return;
         }
 
-        // Create AbortController BEFORE setTimeout so cleanup can abort
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
-        // Set up new debounce timer
         debounceTimerRef.current = setTimeout(() => {
             setIsSearching(true);
             setSearchError(null);
@@ -90,7 +111,7 @@ const MetricAnalytics: React.FC = () => {
         }, 300);
 
         return () => {
-            controller.abort(); // abort in-flight request on effect cleanup
+            controller.abort();
             if (debounceTimerRef.current) {
                 clearTimeout(debounceTimerRef.current);
             }
@@ -111,6 +132,78 @@ const MetricAnalytics: React.FC = () => {
         }
     }, [selectedNodeId, nodes]);
 
+    // Fetch multi-CI data when selectedNodeIds or selectedMetric changes
+    useEffect(() => {
+        if (selectedNodeIds.length === 0 || !selectedMetric) return;
+
+        const hasMultipleSelected = selectedNodeIds.length > 1;
+        
+        if (!hasMultipleSelected) {
+            setMultiCiData([]);
+            return;
+        }
+
+        setMultiCiLoading(true);
+        const controller = new AbortController();
+
+        const customRange = startDate && endDate
+            ? { start: new Date(startDate).toISOString(), end: new Date(endDate).toISOString() }
+            : null;
+
+        fetchMetricsHistory({
+            nodeIds: selectedNodeIds,
+            metricId: selectedMetric.name,
+            hours: customRange ? undefined : 24,
+            startTime: customRange?.start,
+            endTime: customRange?.end,
+            signal: controller.signal,
+        })
+            .then((response) => {
+                setMultiCiData(response.nodes);
+                setMultiCiLoading(false);
+            })
+            .catch((err) => {
+                if (err.name !== 'AbortError') {
+                    console.error('Failed to fetch multi-CI metric history', err);
+                }
+                setMultiCiLoading(false);
+            });
+
+        return () => controller.abort();
+    }, [selectedNodeIds, selectedMetric, startDate, endDate]);
+
+    // Fetch secondary metric data
+    useEffect(() => {
+        if (!showSecondary || secondaryMetricId.length === 0 || selectedNodeIds.length <= 1) {
+            setSecondaryMultiCiData([]);
+            return;
+        }
+
+        const controller = new AbortController();
+        const customRange = startDate && endDate
+            ? { start: new Date(startDate).toISOString(), end: new Date(endDate).toISOString() }
+            : null;
+
+        fetchMetricsHistory({
+            nodeIds: selectedNodeIds,
+            metricId: secondaryMetricId,
+            hours: customRange ? undefined : 24,
+            startTime: customRange?.start,
+            endTime: customRange?.end,
+            signal: controller.signal,
+        })
+            .then((response) => {
+                setSecondaryMultiCiData(response.nodes);
+            })
+            .catch((err) => {
+                if (err.name !== 'AbortError') {
+                    console.error('Failed to fetch secondary metric history', err);
+                }
+            });
+
+        return () => controller.abort();
+    }, [showSecondary, secondaryMetricId, selectedNodeIds, startDate, endDate]);
+
     const handleResetDateRange = () => {
         setStartDate('');
         setEndDate('');
@@ -118,9 +211,9 @@ const MetricAnalytics: React.FC = () => {
 
     const handleSelectFromSearch = (nodeId: string) => {
         setSelectedNodeId(nodeId);
-        // Don't clear searchTerm - user might want to search again
-        // But clear results so dropdown shows
+        setSelectedNodeIds([nodeId]);
         setSearchResults([]);
+        setBrushRange(null);
     };
 
     const handleClearSearch = () => {
@@ -129,6 +222,20 @@ const MetricAnalytics: React.FC = () => {
         setIsSearching(false);
         setSearchError(null);
     };
+
+    const handleMultiCiChange = (ids: string[]) => {
+        setSelectedNodeIds(ids);
+        setBrushRange(null);
+        if (ids.length > 0 && !selectedNodeIds.includes(ids[0])) {
+            setSelectedNodeId(ids[0]);
+        }
+    };
+
+    const handleBrushChange = (range: BrushRange | null) => {
+        setBrushRange(range);
+    };
+
+    const hasMultipleSelected = selectedNodeIds.length > 1;
 
     return (
         <div className="flex flex-col h-full bg-surface-950 text-white p-8 overflow-hidden">
@@ -142,7 +249,7 @@ const MetricAnalytics: React.FC = () => {
             <div className="grid grid-cols-12 gap-8 h-full">
                 {/* Controls Sidebar */}
                 <div className="col-span-12 lg:col-span-3 space-y-6 flex flex-col h-full overflow-hidden">
-                    {/* Node Selector */}
+                    {/* Node Selector - Single CI */}
                     <div className="bg-surface-900 border border-white/5 rounded-xl p-5 mb-0">
                         <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">Select Resource (CI)</label>
 
@@ -207,7 +314,11 @@ const MetricAnalytics: React.FC = () => {
                         {!isSearching && searchResults.length === 0 && (
                             <select
                                 value={selectedNodeId}
-                                onChange={(e) => setSelectedNodeId(e.target.value)}
+                                onChange={(e) => {
+                                    setSelectedNodeId(e.target.value);
+                                    setSelectedNodeIds([e.target.value]);
+                                    setBrushRange(null);
+                                }}
                                 className="w-full mt-3 bg-black/40 border border-white/10 rounded-lg px-4 py-3 text-sm text-white focus:border-brand-500 outline-none transition-colors appearance-none"
                             >
                                 <option value="" disabled>Select a CI...</option>
@@ -229,6 +340,17 @@ const MetricAnalytics: React.FC = () => {
                                 <p className="text-[10px] text-neutral-500 font-mono break-all">{selectedNode.id}</p>
                             </div>
                         )}
+                    </div>
+
+                    {/* Multi-CI Selector */}
+                    <div className="bg-surface-900 border border-white/5 rounded-xl p-5">
+                        <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">Compare Multiple CIs</label>
+                        <MultiSelectCIs
+                            selectedIds={selectedNodeIds}
+                            onChange={handleMultiCiChange}
+                            availableNodes={nodes}
+                            maxCIs={10}
+                        />
                     </div>
 
                     {/* Date Range Selector */}
@@ -271,7 +393,11 @@ const MetricAnalytics: React.FC = () => {
                             {selectedNode?.metrics?.map((m, idx) => (
                                 <button
                                     key={idx}
-                                    onClick={() => setSelectedMetric(m)}
+                                    onClick={() => {
+                                        setSelectedMetric(m);
+                                        setMultiCiData([]);
+                                        setBrushRange(null);
+                                    }}
                                     className={`w-full text-left p-3 rounded-lg border transition-all flex items-center justify-between ${selectedMetric?.name === m.name
                                         ? 'bg-brand-500/20 border-brand-500/50 text-white'
                                         : 'bg-white/5 border-transparent text-neutral-400 hover:bg-white/10'
@@ -289,11 +415,84 @@ const MetricAnalytics: React.FC = () => {
                             )}
                         </div>
                     </div>
+
+                    {/* Secondary Metric Toggle */}
+                    {hasMultipleSelected && (
+                        <div className="bg-surface-900 border border-white/5 rounded-xl p-5">
+                            <div className="flex items-center justify-between mb-3">
+                                <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider">Secondary Metric</label>
+                                <button
+                                    onClick={() => setShowSecondary(!showSecondary)}
+                                    className={`w-10 h-5 rounded-full transition-colors ${showSecondary ? 'bg-brand-500' : 'bg-white/20'}`}
+                                >
+                                    <div className={`w-4 h-4 rounded-full bg-white transition-transform ${showSecondary ? 'translate-x-5' : 'translate-x-0.5'}`}></div>
+                                </button>
+                            </div>
+                            {showSecondary && (
+                                <select
+                                    value={secondaryMetricId}
+                                    onChange={(e) => setSecondaryMetricId(e.target.value)}
+                                    className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-3 text-sm text-white focus:border-brand-500 outline-none transition-colors appearance-none"
+                                >
+                                    <option value="" disabled>Select secondary metric...</option>
+                                    {selectedNode?.metrics?.map((m, idx) => (
+                                        <option key={idx} value={m.name}>{m.name}</option>
+                                    ))}
+                                </select>
+                            )}
+                        </div>
+                    )}
                 </div>
 
                 {/* Main Chart Area */}
                 <div className="col-span-12 lg:col-span-9 flex flex-col gap-6 h-full overflow-hidden pb-8">
-                    {selectedNode && selectedMetric ? (
+                    {hasMultipleSelected && selectedMetric ? (
+                        <>
+                            {/* Multi-CI Chart View */}
+                            <div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+                                <div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
+                                    <span className="material-symbols-outlined text-9xl">monitoring</span>
+                                </div>
+
+                                <div className="relative z-10 flex-1 flex flex-col min-h-0">
+                                    {multiCiLoading && multiCiData.length === 0 ? (
+                                        <div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
+                                            LOADING METRICS...
+                                        </div>
+                                    ) : (
+                                        <MultiMetricChart
+                                            nodeData={multiCiData}
+                                            brushRange={brushRange}
+                                            onBrushChange={handleBrushChange}
+                                            metricName={selectedMetric.name}
+                                            unit={selectedMetric.unit}
+                                        />
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* Secondary Metric Section */}
+                            {showSecondary && secondaryMetricId && (
+                                <div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+                                    <div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
+                                        <span className="material-symbols-outlined text-9xl">analytics</span>
+                                    </div>
+                                    <div className="relative z-10 flex-1 flex flex-col min-h-0">
+                                        <div className="mb-4">
+                                            <h3 className="text-white font-bold uppercase tracking-tight">{secondaryMetricId} Comparison</h3>
+                                            <p className="text-xs text-neutral-500">Secondary metric overlay</p>
+                                        </div>
+                                        <MultiMetricChart
+                                            nodeData={secondaryMultiCiData}
+                                            brushRange={brushRange}
+                                            onBrushChange={handleBrushChange}
+                                            metricName={secondaryMetricId}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                        </>
+                    ) : selectedNode && selectedMetric ? (
                         <div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
                             {/* Background Pattern */}
                             <div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">

--- a/frontend/components/MultiMetricChart.tsx
+++ b/frontend/components/MultiMetricChart.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ChartPanel from './ChartPanel';
+import { NodeMetricData } from '../types';
+
+interface BrushRange {
+  startIndex?: number;
+  endIndex?: number;
+}
+
+interface MultiMetricChartProps {
+  nodeData: NodeMetricData[];
+  brushRange: BrushRange | null;
+  onBrushChange: (range: BrushRange | null) => void;
+  metricName?: string;
+  unit?: string;
+}
+
+const MultiMetricChart: React.FC<MultiMetricChartProps> = ({
+  nodeData,
+  brushRange,
+  onBrushChange,
+  metricName,
+  unit,
+}) => {
+  if (nodeData.length === 0) {
+    return (
+      <div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
+        <span className="material-symbols-outlined text-6xl mb-4 opacity-20">analytics</span>
+        <p className="font-bold uppercase tracking-widest">Select CIs to Compare</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 h-full overflow-y-auto">
+      {nodeData.map((node) => (
+        <ChartPanel
+          key={node.node_id}
+          nodeId={node.node_id}
+          label={node.label}
+          data={node.data}
+          brushRange={brushRange}
+          onBrushChange={onBrushChange}
+          unit={unit}
+          metricName={metricName}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default MultiMetricChart;

--- a/frontend/components/MultiSelectCIs.tsx
+++ b/frontend/components/MultiSelectCIs.tsx
@@ -1,0 +1,204 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { GraphNode } from '../types';
+import { fetchNodesSearch } from '../services/queryResources';
+
+interface MultiSelectCIsProps {
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  availableNodes?: GraphNode[];
+  maxCIs?: number;
+}
+
+const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
+  selectedIds,
+  onChange,
+  availableNodes = [],
+  maxCIs = 10,
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searchResults, setSearchResults] = useState<GraphNode[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounced search effect
+  useEffect(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (!searchTerm.trim()) {
+      setSearchResults([]);
+      setIsSearching(false);
+      setSearchError(null);
+      return;
+    }
+
+    if (searchTerm.length < 2) {
+      setSearchResults([]);
+      setIsSearching(false);
+      setSearchError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    debounceTimerRef.current = setTimeout(() => {
+      setIsSearching(true);
+      setSearchError(null);
+
+      fetchNodesSearch({ q: searchTerm, signal: controller.signal })
+        .then((results) => {
+          // Filter out already selected nodes
+          const filtered = results.filter(r => !selectedIds.includes(r.id));
+          setSearchResults(filtered);
+          setIsSearching(false);
+        })
+        .catch((err) => {
+          if (err.name !== 'AbortError') {
+            console.error('Search failed:', err);
+            setSearchError(err.message || `Error`);
+            setSearchResults([]);
+          }
+          setIsSearching(false);
+        });
+    }, 300);
+
+    return () => {
+      controller.abort();
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [searchTerm, selectedIds]);
+
+  const handleAddNode = (nodeId: string) => {
+    if (selectedIds.length >= maxCIs) return;
+    if (selectedIds.includes(nodeId)) return;
+    onChange([...selectedIds, nodeId]);
+    setSearchTerm('');
+    setSearchResults([]);
+  };
+
+  const handleRemoveNode = (nodeId: string) => {
+    onChange(selectedIds.filter(id => id !== nodeId));
+  };
+
+  const displayNodes = searchResults.length > 0 ? searchResults : availableNodes;
+  const selectedNodesMap = new Map(selectedIds.map(id => [id, availableNodes.find(n => n.id === id)]));
+
+  return (
+    <div className="space-y-3">
+      {/* Search Input */}
+      <div className="relative">
+        <input
+          type="text"
+          role="searchbox"
+          name="ci-multi-search"
+          aria-label="Search CIs to add"
+          placeholder="Search CIs..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          maxLength={200}
+          className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-3 text-sm text-white focus:border-brand-500 outline-none transition-colors placeholder-neutral-500"
+          disabled={selectedIds.length >= maxCIs}
+        />
+        {searchTerm && (
+          <button
+            onClick={() => { setSearchTerm(''); setSearchResults([]); }}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-white transition-colors p-1"
+            title="Clear search"
+          >
+            <span className="material-symbols-outlined text-sm">close</span>
+          </button>
+        )}
+      </div>
+
+      {/* Search Status Messages */}
+      {isSearching && (
+        <p className="text-xs text-neutral-500">Loading...</p>
+      )}
+      {searchError && (
+        <p className="text-xs text-red-400">{searchError}</p>
+      )}
+      {!isSearching && searchTerm.length >= 2 && searchResults.length === 0 && !searchError && (
+        <p className="text-xs text-neutral-500">No results found</p>
+      )}
+
+      {/* Search Results Dropdown */}
+      {searchResults.length > 0 && (
+        <div className="max-h-48 overflow-y-auto bg-black/20 rounded-lg border border-white/5">
+          {searchResults.map(n => (
+            <button
+              key={n.id}
+              onClick={() => handleAddNode(n.id)}
+              className="w-full text-left p-3 hover:bg-white/5 border-b border-white/5 last:border-b-0 flex items-center gap-2"
+            >
+              <span className={`w-2 h-2 rounded-full ${n.status === 'OK' ? 'bg-emerald-500' : 'bg-red-500'}`}></span>
+              <span className="text-sm text-white">{n.label || n.id}</span>
+              <span className="text-[10px] text-neutral-500 font-mono ml-auto">{n.ip || 'No IP'}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Available Nodes (when not searching) */}
+      {!isSearching && searchResults.length === 0 && availableNodes.length > 0 && (
+        <div className="max-h-48 overflow-y-auto bg-black/20 rounded-lg border border-white/5">
+          {availableNodes
+            .filter(n => !selectedIds.includes(n.id))
+            .slice(0, 20)
+            .map(n => (
+              <button
+                key={n.id}
+                onClick={() => handleAddNode(n.id)}
+                className="w-full text-left p-3 hover:bg-white/5 border-b border-white/5 last:border-b-0 flex items-center gap-2"
+                disabled={selectedIds.length >= maxCIs}
+              >
+                <span className={`w-2 h-2 rounded-full ${n.status === 'OK' ? 'bg-emerald-500' : 'bg-red-500'}`}></span>
+                <span className="text-sm text-white">{n.label || n.id}</span>
+                <span className="text-[10px] text-neutral-500 font-mono ml-auto">{n.ip || 'No IP'}</span>
+              </button>
+            ))}
+        </div>
+      )}
+
+      {/* Selected CIs Chips */}
+      {selectedIds.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-3">
+          {selectedIds.map(id => {
+            const node = selectedNodesMap.get(id);
+            return (
+              <div
+                key={id}
+                className="flex items-center gap-2 bg-brand-500/20 border border-brand-500/40 rounded-full px-3 py-1.5 text-sm"
+              >
+                <span className="w-2 h-2 rounded-full bg-brand-500"></span>
+                <span className="text-white font-bold">{node?.label || id}</span>
+                <button
+                  onClick={() => handleRemoveNode(id)}
+                  className="text-neutral-400 hover:text-white transition-colors ml-1"
+                  title="Remove"
+                >
+                  <span className="material-symbols-outlined text-sm">close</span>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Counter */}
+      <div className="text-xs text-neutral-500 text-right">
+        {selectedIds.length} / {maxCIs} CIs selected
+      </div>
+    </div>
+  );
+};
+
+export default MultiSelectCIs;

--- a/frontend/components/__tests__/ChartPanel.test.tsx
+++ b/frontend/components/__tests__/ChartPanel.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * ChartPanel.test.tsx
+ * Unit tests for ChartPanel component.
+ * Tests: renders AreaChart, emits onBrushChange on zoom.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import ChartPanel from '../ChartPanel';
+import { DataPoint } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SAMPLE_DATA: DataPoint[] = [
+  { time: '2026-05-12T10:00:00Z', value: 42 },
+  { time: '2026-05-12T10:00:30Z', value: 43 },
+  { time: '2026-05-12T10:01:00Z', value: 45 },
+  { time: '2026-05-12T10:01:30Z', value: 44 },
+  { time: '2026-05-12T10:02:00Z', value: 46 },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChartPanel', () => {
+  it('renders label in header', async () => {
+    render(
+      <ChartPanel
+        nodeId="ci-001"
+        label="Router-01"
+        data={SAMPLE_DATA}
+        brushRange={null}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Router-01')).toBeDefined();
+  });
+
+  it('shows "No telemetry data" when data is empty', async () => {
+    render(
+      <ChartPanel
+        nodeId="ci-001"
+        label="Router-01"
+        data={[]}
+        brushRange={null}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('No telemetry data')).toBeDefined();
+  });
+
+  it('shows point count when data is loaded', async () => {
+    render(
+      <ChartPanel
+        nodeId="ci-001"
+        label="Router-01"
+        data={SAMPLE_DATA}
+        brushRange={null}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('5 data points')).toBeDefined();
+  });
+
+  it('shows selected point count when brush is applied', async () => {
+    render(
+      <ChartPanel
+        nodeId="ci-001"
+        label="Router-01"
+        data={SAMPLE_DATA}
+        brushRange={{ startIndex: 0, endIndex: 2 }}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('3 points selected')).toBeDefined();
+  });
+
+  it('renders reset button when brush is applied', async () => {
+    render(
+      <ChartPanel
+        nodeId="ci-001"
+        label="Router-01"
+        data={SAMPLE_DATA}
+        brushRange={{ startIndex: 0, endIndex: 2 }}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /reset/i })).toBeDefined();
+  });
+
+  it('calls onBrushChange with null when reset is clicked', async () => {
+    const onBrushChange = vi.fn();
+    render(
+      <ChartPanel
+        nodeId="ci-001"
+        label="Router-01"
+        data={SAMPLE_DATA}
+        brushRange={{ startIndex: 0, endIndex: 2 }}
+        onBrushChange={onBrushChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+    expect(onBrushChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/components/__tests__/MultiMetricChart.test.tsx
+++ b/frontend/components/__tests__/MultiMetricChart.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * MultiMetricChart.test.tsx
+ * Unit tests for MultiMetricChart component.
+ * Tests: stacked layout, synchronized brush updates multiple panels.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import MultiMetricChart from '../MultiMetricChart';
+import { NodeMetricData } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SAMPLE_NODE_DATA: NodeMetricData[] = [
+  {
+    node_id: 'ci-001',
+    label: 'Router-01',
+    data: [
+      { time: '2026-05-12T10:00:00Z', value: 42 },
+      { time: '2026-05-12T10:00:30Z', value: 43 },
+    ],
+  },
+  {
+    node_id: 'ci-002',
+    label: 'Switch-01',
+    data: [
+      { time: '2026-05-12T10:00:00Z', value: 10 },
+      { time: '2026-05-12T10:00:30Z', value: 12 },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MultiMetricChart', () => {
+  it('shows "Select CIs to Compare" when no data provided', async () => {
+    render(
+      <MultiMetricChart
+        nodeData={[]}
+        brushRange={null}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Select CIs to Compare')).toBeDefined();
+  });
+
+  it('renders one ChartPanel per node', async () => {
+    render(
+      <MultiMetricChart
+        nodeData={SAMPLE_NODE_DATA}
+        brushRange={null}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Router-01')).toBeDefined();
+    expect(screen.getByText('Switch-01')).toBeDefined();
+  });
+
+  it('shows "2 data points" per panel for sample data', async () => {
+    render(
+      <MultiMetricChart
+        nodeData={SAMPLE_NODE_DATA}
+        brushRange={null}
+        onBrushChange={vi.fn()}
+      />
+    );
+
+    const pointsLabels = screen.getAllByText('2 data points');
+    expect(pointsLabels.length).toBe(2);
+  });
+
+  it('passes same brushRange to all ChartPanels', async () => {
+    const onBrushChange = vi.fn();
+    render(
+      <MultiMetricChart
+        nodeData={SAMPLE_NODE_DATA}
+        brushRange={{ startIndex: 0, endIndex: 1 }}
+        onBrushChange={onBrushChange}
+      />
+    );
+
+    // Both panels should show "2 points selected"
+    const selectedLabels = screen.getAllByText('2 points selected');
+    expect(selectedLabels.length).toBe(2);
+  });
+});

--- a/frontend/components/__tests__/MultiSelectCIs.test.tsx
+++ b/frontend/components/__tests__/MultiSelectCIs.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * MultiSelectCIs.test.tsx
+ * Unit tests for MultiSelectCIs component.
+ * Tests: select CIs, remove chip, max 10 enforcement.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import MultiSelectCIs from '../MultiSelectCIs';
+import { GraphNode } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_NODES: GraphNode[] = [
+  { id: 'ci-001', label: 'Router-01', type: 'INFRASTRUCTURE', status: 'OK', ip: '10.0.0.1', metrics: [] },
+  { id: 'ci-002', label: 'Switch-01', type: 'INFRASTRUCTURE', status: 'OK', ip: '10.0.0.2', metrics: [] },
+  { id: 'ci-003', label: 'Firewall-01', type: 'INFRASTRUCTURE', status: 'ACTIVE', ip: '10.0.0.3', metrics: [] },
+];
+
+// ---------------------------------------------------------------------------
+// Global fetch mock
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn().mockResolvedValue({
+  ok: true,
+  json: async () => [],
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function renderMultiSelect(
+  selectedIds: string[] = [],
+  onChange: (ids: string[]) => void = vi.fn(),
+  maxCIs: number = 10
+) {
+  return render(
+    <MultiSelectCIs
+      selectedIds={selectedIds}
+      onChange={onChange}
+      availableNodes={MOCK_NODES}
+      maxCIs={maxCIs}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+  mockFetch.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MultiSelectCIs', () => {
+  it('renders search input', async () => {
+    await renderMultiSelect();
+    expect(screen.getByRole('searchbox', { name: /search cis/i })).toBeDefined();
+  });
+
+  it('shows selected CI chips', async () => {
+    const onChange = vi.fn();
+    await renderMultiSelect(['ci-001'], onChange);
+    
+    // Should show chip for ci-001
+    expect(screen.getByText('Router-01')).toBeDefined();
+  });
+
+  it('calls onChange with new id when node is clicked from list', async () => {
+    const onChange = vi.fn();
+    await renderMultiSelect(['ci-001'], onChange);
+    
+    // Get the first node button from available list (below search)
+    // Note: this depends on how many nodes show up when not searching
+    // We need to find the clickable node in the available list
+    const buttons = screen.getAllByRole('button');
+    const switchBtn = buttons.find(b => b.textContent?.includes('Switch-01'));
+    
+    if (switchBtn) {
+      fireEvent.click(switchBtn);
+      expect(onChange).toHaveBeenCalledWith(['ci-001', 'ci-002']);
+    }
+  });
+
+  it('removes chip when remove button is clicked', async () => {
+    const onChange = vi.fn();
+    await renderMultiSelect(['ci-001'], onChange);
+
+    // Find all buttons - the remove button has a span with 'close' text
+    const buttons = screen.getAllByRole('button');
+    const removeBtn = buttons.find(btn => {
+      const span = btn.querySelector('span');
+      return span && span.textContent === 'close';
+    });
+    expect(removeBtn).toBeDefined();
+    if (removeBtn) {
+      fireEvent.click(removeBtn);
+    }
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('shows counter "X / 10 CIs selected"', async () => {
+    const onChange = vi.fn();
+    await renderMultiSelect(['ci-001', 'ci-002'], onChange, 10);
+
+    expect(screen.getByText('2 / 10 CIs selected')).toBeDefined();
+  });
+
+  it('disables search input when max CIs selected', async () => {
+    const onChange = vi.fn();
+    const tenIds = Array.from({ length: 10 }, (_, i) => `ci-${i}`);
+    await renderMultiSelect(tenIds, onChange, 10);
+
+    // Search input should be disabled when max CIs are selected
+    const searchInput = screen.getByRole('searchbox', { name: /search cis/i }) as HTMLInputElement;
+    expect(searchInput.disabled).toBe(true);
+  });
+});

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -1,5 +1,5 @@
 import { api } from './api';
-import type { EventDetail, EventSummary, GraphLink, GraphNode } from '../types';
+import type { EventDetail, EventSummary, GraphLink, GraphNode, MultiMetricHistoryResponse } from '../types';
 
 export interface SystemStatus {
   cpu: number;
@@ -61,3 +61,26 @@ export const fetchOwners = ({ signal }: { signal?: AbortSignal } = {}) =>
 
 export const fetchNodesSearch = ({ q, signal }: { q: string; signal?: AbortSignal } = {}) =>
   api.get<GraphNode[]>(`/nodes/search?q=${encodeURIComponent(q)}`, { signal });
+
+export interface FetchMetricsHistoryOptions {
+  nodeIds: string[];
+  metricId: string;
+  hours?: number;
+  startTime?: string;
+  endTime?: string;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+export const fetchMetricsHistory = async (options: FetchMetricsHistoryOptions): Promise<MultiMetricHistoryResponse> => {
+  const { nodeIds, metricId, hours = 24, startTime, endTime, limit = 1000, signal } = options;
+  const params = new URLSearchParams();
+  params.set('hours', String(hours));
+  if (startTime) params.set('start_time', startTime);
+  if (endTime) params.set('end_time', endTime);
+  params.set('limit', String(limit));
+  params.set('node_ids', nodeIds.join(','));
+  
+  const url = `/api/metrics/${encodeURIComponent(metricId)}/history?${params.toString()}`;
+  return api.get<MultiMetricHistoryResponse>(url, { signal });
+};

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -73,9 +73,10 @@ export interface FetchMetricsHistoryOptions {
 }
 
 export const fetchMetricsHistory = async (options: FetchMetricsHistoryOptions): Promise<MultiMetricHistoryResponse> => {
-  const { nodeIds, metricId, hours = 24, startTime, endTime, limit = 1000, signal } = options;
+  const { nodeIds, metricId, hours, startTime, endTime, limit = 1000, signal } = options;
   const params = new URLSearchParams();
-  params.set('hours', String(hours));
+  // Only set hours if provided (backend defaults to 24)
+  if (hours !== undefined) params.set('hours', String(hours));
   if (startTime) params.set('start_time', startTime);
   if (endTime) params.set('end_time', endTime);
   params.set('limit', String(limit));

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -166,3 +166,31 @@ export interface ApplicabilityCriteria {
   names?: string[];
   excluded_names?: string[];
 }
+
+// =============================================================================
+// Multi-CI Metric Analytics Types
+// =============================================================================
+
+export interface DataPoint {
+  time: string;
+  value: number;
+}
+
+export interface NodeMetricData {
+  node_id: string;
+  label: string;
+  data: DataPoint[];
+}
+
+export interface MultiMetricHistoryRequest {
+  nodeIds: string[];
+  metricId: string;
+  hours?: number;
+  startTime?: string;
+  endTime?: string;
+  limit?: number;
+}
+
+export interface MultiMetricHistoryResponse {
+  nodes: NodeMetricData[];
+}


### PR DESCRIPTION
## Summary
Enable multi-CI metric comparison in MetricAnalytics section.

### Features
- Select multiple CIs (up to 10) to compare same metric
- Stacked chart view with synchronized brush/zoom
- Secondary metric section with toggle
- Drag-to-zoom on all charts
- Reset view button

### Backend Changes
- `GET /api/metrics/{metric_id}/history` now accepts `node_ids[]` param
- Batch node label lookup (fixes N+1)
- 30-second linear interpolation for timestamp alignment
- Max 10 CIs limit enforced

### Frontend Changes
- `MultiSelectCIs`: Sidebar multi-select with chips
- `MultiMetricChart`: Stacked charts container  
- `ChartPanel`: Individual chart with external brush
- Brush state synchronized across all charts

### Testing
- 16 new tests (MultiSelectCIs, ChartPanel, MultiMetricChart)
- All passing

### Issues Fixed
- N+1 query (now batched)
- Brush reset on node/date/metric change
- ISO timestamp formatting
- hours param when custom range provided

## Related Issues
- Closes #89 (original 422 bug)
- Closes #91 (query params)
- Closes #92 (UI improvements)