### PR TITLE
test(ai): add AI guard service and permission tests

### DIFF
--- a/backend/tests/test_ai_guard_service.py
+++ b/backend/tests/test_ai_guard_service.py
@@ -1,0 +1,443 @@
+"""Unit tests for ai_guard_service — cooldown tracking, behavioral guards, bulk detection.
+
+Tests use mocked DB (SessionLocal) and in-memory cooldown cache.
+Behavioral guard queries are intercepted at the sqlalchemy text() level.
+"""
+
+import pytest
+import time
+from unittest.mock import patch, MagicMock
+from models.ai_guard_models import GuardResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_session():
+    """Create a mock DB session that intercepts ai_operation_log queries."""
+    session = MagicMock()
+    return session
+
+
+def _mock_execute_result(rows):
+    """Build a mock execute() that returns a scalar or result set.
+
+    Args:
+        rows: If int, scalar() returns that int directly.
+              If list, scalar() returns None (for multi-row) and scalar_one_or_none returns rows[0] or None.
+    """
+    mock_result = MagicMock()
+    if isinstance(rows, int):
+        mock_result.scalar.return_value = rows
+        mock_result.scalar_one_or_none.return_value = rows
+    else:
+        mock_result.scalar.return_value = None
+        mock_result.scalar_one_or_none.return_value = rows[0] if rows else None
+    return mock_result
+
+
+# ---------------------------------------------------------------------------
+# Cooldown cache — isolated tests (no DB)
+# ---------------------------------------------------------------------------
+
+class TestCooldownCache:
+    """Tests for cooldown cache set/get/TTL behavior."""
+
+    def test_set_and_get_remaining_active(self):
+        """After set_cooldown, get_remaining returns remaining > 0."""
+        from services.ai_guard_service import _cooldown_cache
+
+        # Use a unique key to avoid collision
+        agent = f"test-agent-{time.time_ns()}"
+        op = "diagnose"
+        target = f"target-{time.time_ns()}"
+
+        _cooldown_cache.set(agent, op, target, ttl_seconds=300)
+
+        remaining = _cooldown_cache.get_remaining(agent, op, target)
+        assert remaining > 0
+        assert remaining <= 300
+
+    def test_get_remaining_no_entry_returns_zero(self):
+        """get_remaining returns 0 when no cooldown entry exists."""
+        from services.ai_guard_service import _cooldown_cache
+
+        remaining = _cooldown_cache.get_remaining(
+            "nonexistent-agent", "ack", "nonexistent-target"
+        )
+        assert remaining == 0
+
+    def test_check_cooldown_no_cooldown(self):
+        """check_cooldown returns (False, 0) when no cooldown is active."""
+        from services.ai_guard_service import check_cooldown
+
+        # Use a unique agent/target to avoid collisions
+        agent = f"agent-nocd-{time.time_ns()}"
+        target = f"target-nocd-{time.time_ns()}"
+
+        is_blocked, remaining = check_cooldown(agent, "diagnose", target)
+        assert is_blocked is False
+        assert remaining == 0
+
+    def test_check_cooldown_active(self):
+        """check_cooldown returns (True, cooldown_remaining) when cooldown is active."""
+        from services.ai_guard_service import check_cooldown, _cooldown_cache
+
+        agent = f"agent-cd-{time.time_ns()}"
+        target = f"target-cd-{time.time_ns()}"
+        _cooldown_cache.set(agent, "ack", target, ttl_seconds=600)
+
+        is_blocked, remaining = check_cooldown(agent, "ack", target)
+        assert is_blocked is True
+        assert remaining > 0
+        assert remaining <= 600
+
+    def test_check_cooldown_ttl_expiration(self):
+        """Cooldown entries expire after their TTL using mocked time."""
+        from services.ai_guard_service import _CooldownCache
+
+        cache = _CooldownCache()
+        agent = f"agent-exp-{time.time_ns()}"
+        target = f"target-exp-{time.time_ns()}"
+
+        # Patch time.monotonic to control the clock
+        original_monotonic = time.monotonic
+        try:
+            # Set entry at t=100
+            time.monotonic = lambda: 100.0
+            cache.set(agent, "diagnose", target, ttl_seconds=10)
+
+            # At t=100, remaining should be ~10
+            time.monotonic = lambda: 100.0
+            remaining = cache.get_remaining(agent, "diagnose", target)
+            assert remaining >= 9  # ~10 seconds remaining (within rounding)
+
+            # Advance to t=111 (past TTL of 10 seconds)
+            time.monotonic = lambda: 111.0
+            remaining = cache.get_remaining(agent, "diagnose", target)
+            assert remaining == 0  # TTL expired
+        finally:
+            time.monotonic = original_monotonic
+
+    def test_check_cooldown_unknown_operation_uses_default_60s(self):
+        """check_cooldown uses 60s default for unknown operations."""
+        from services.ai_guard_service import check_cooldown, _cooldown_cache
+
+        agent = f"agent-def-{time.time_ns()}"
+        target = f"target-def-{time.time_ns()}"
+
+        # Unknown operation has no entry — should return False/0
+        is_blocked, remaining = check_cooldown(agent, "unknown_op", target)
+        assert is_blocked is False
+        assert remaining == 0
+
+        # Now set cooldown for a known operation
+        _cooldown_cache.set(agent, "diagnose", target, ttl_seconds=300)
+        is_blocked, remaining = check_cooldown(agent, "diagnose", target)
+        assert is_blocked is True
+
+    def test_check_cooldown_empty_target_ids_handled(self):
+        """check_all_guards handles empty target_ids list gracefully."""
+        from services.ai_guard_service import check_all_guards
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = _mock_execute_result(0)
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_all_guards("some-agent", "diagnose", [])
+        # Should not raise — empty list is handled with target_id=""
+        assert isinstance(result, GuardResult)
+
+    def test_different_target_ids_have_independent_cooldowns(self):
+        """Cooldowns are per (agent, operation, target_id) — not global."""
+        from services.ai_guard_service import check_cooldown, _cooldown_cache
+
+        agent = f"agent-multi-{time.time_ns()}"
+        target1 = f"target1-{time.time_ns()}"
+        target2 = f"target2-{time.time_ns()}"
+
+        _cooldown_cache.set(agent, "ack", target1, ttl_seconds=600)
+
+        # target1 should be blocked
+        is_blocked1, _ = check_cooldown(agent, "ack", target1)
+        assert is_blocked1 is True
+
+        # target2 should NOT be blocked
+        is_blocked2, _ = check_cooldown(agent, "ack", target2)
+        assert is_blocked2 is False
+
+
+# ---------------------------------------------------------------------------
+# Behavioral guards — mocked DB
+# ---------------------------------------------------------------------------
+
+class TestBehavioralGuards:
+    """Tests for behavioral guard rules with mocked DB queries."""
+
+    def _mock_db_with_result(self, scalar_result):
+        """Create a mock DB session that returns a fixed scalar for execute()."""
+        mock_db = MagicMock()
+        mock_db.execute.return_value = _mock_execute_result(scalar_result)
+        mock_db.close = MagicMock()
+        return mock_db
+
+    def test_close_without_diagnostic_guard_blocks_at_4_closes(self):
+        """>3 closes without diagnostic in the same hour must be blocked."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        # 4 closes (closes_count > 3) and no diagnostic → BLOCK
+        mock_db = self._mock_db_with_result(4)  # closes_count
+        # Second execute call is for the diagnostic check — returns None (no diagnostic)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(4),   # closes_count
+            _mock_execute_result(None),  # has_diagnostic
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "close", "evt-001")
+
+        assert result.allowed is False
+        assert "Close without diagnostic" in result.reason
+
+    def test_close_guard_allows_with_diagnostic_present(self):
+        """Close is allowed if there is at least one diagnostic in the same period."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(4)
+        # has_diagnostic returns a row
+        mock_db.execute.side_effect = [
+            _mock_execute_result(4),    # closes_count
+            _mock_execute_result([1]),  # has_diagnostic (row found)
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "close", "evt-001")
+
+        assert result.allowed is True
+
+    def test_close_guard_allows_at_3_closes_or_less(self):
+        """<=3 closes (exactly 3) must be allowed — only >3 is blocked."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(3)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(3),   # closes_count
+            _mock_execute_result([1]),  # has_diagnostic
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "close", "evt-001")
+
+        assert result.allowed is True
+
+    def test_ack_flood_guard_blocks_at_21_acks(self):
+        """>20 acks/10min without diagnostic must be blocked."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(21)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(21),   # ack_count
+            _mock_execute_result(None),  # has_diagnostic
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "ack", "evt-001")
+
+        assert result.allowed is False
+        assert "Ack flood" in result.reason
+
+    def test_ack_flood_guard_allows_with_diagnostic(self):
+        """Ack is allowed if there is at least one diagnostic in the window."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(21)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(21),   # ack_count
+            _mock_execute_result([1]),  # has_diagnostic
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "ack", "evt-001")
+
+        assert result.allowed is True
+
+    def test_ack_flood_guard_allows_at_20_acks_or_less(self):
+        """<=20 acks must be allowed — only >20 is blocked."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(20)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(20),   # ack_count
+            _mock_execute_result([1]),  # has_diagnostic
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "ack", "evt-001")
+
+        assert result.allowed is True
+
+    def test_metadata_stampede_guard_blocks_at_6_updates(self):
+        """>5 CI metadata updates/5min must be blocked."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(6)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(6),   # update_count
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "ci_metadata_update", "ci-001")
+
+        assert result.allowed is False
+        assert "Metadata stampede" in result.reason
+
+    def test_metadata_stampede_guard_allows_at_5_or_fewer(self):
+        """<=5 metadata updates in 5min must be allowed."""
+        from services.ai_guard_service import check_behavioral_guards
+
+        mock_db = self._mock_db_with_result(5)
+        mock_db.execute.side_effect = [
+            _mock_execute_result(5),
+        ]
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_behavioral_guards("agent-1", "ci_metadata_update", "ci-001")
+
+        assert result.allowed is True
+
+    # ── Critical escalation via check_bulk_detection ─────────────────────────
+
+    def test_critical_escalation_triggered_at_50_same_ops(self):
+        """same_op_count >= 50 flags CRITICAL escalation: allowed=True, escalation_required=True."""
+        from services.ai_guard_service import check_bulk_detection
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = _mock_execute_result(50)
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_bulk_detection("agent-1", "diagnose", ["ci-001"])
+
+        assert result.allowed is True
+        assert result.escalation_required is True
+        assert "High volume" in result.reason
+
+    def test_critical_escalation_not_triggered_at_49_same_ops(self):
+        """same_op_count = 49 does NOT trigger escalation: allowed=True, escalation_required=False."""
+        from services.ai_guard_service import check_bulk_detection
+
+        mock_db = MagicMock()
+        # same_op_count=49 → below 50 threshold, no escalation
+        # diff_ci_count also below 30
+        mock_db.execute.side_effect = [
+            _mock_execute_result(49),   # same_op_count
+            _mock_execute_result(0),    # diff_ci_count
+        ]
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_bulk_detection("agent-1", "diagnose", ["ci-001"])
+
+        assert result.allowed is True
+        assert result.escalation_required is False
+
+
+# ---------------------------------------------------------------------------
+# Bulk detection guards
+# ---------------------------------------------------------------------------
+
+class TestBulkDetection:
+    """Tests for bulk operation detection."""
+
+    def test_bulk_too_large_blocks_at_11_entities(self):
+        """check_bulk_detection must block when >10 entities are requested."""
+        from services.ai_guard_service import check_bulk_detection
+
+        result = check_bulk_detection("agent-1", "ack", [f"entity-{i}" for i in range(11)])
+
+        assert result.allowed is False
+        assert "Bulk operation too large" in result.reason
+        assert "11" in result.reason
+
+    def test_bulk_allows_10_or_fewer_entities(self):
+        """check_bulk_detection allows when <=10 entities."""
+        from services.ai_guard_service import check_bulk_detection
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = _mock_execute_result(0)
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_bulk_detection("agent-1", "ack", [f"entity-{i}" for i in range(10)])
+        assert result.allowed is True
+
+    def test_bulk_flags_high_volume_same_op(self):
+        """>=50 same operations/hour must set escalation_required=True."""
+        from services.ai_guard_service import check_bulk_detection
+
+        mock_db = MagicMock()
+        # First call: same_op_count >= 50 → escalation
+        mock_db.execute.return_value = _mock_execute_result(50)
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_bulk_detection("agent-1", "ack", ["entity-1"])
+
+        assert result.allowed is True
+        assert result.escalation_required is True
+        assert "High volume" in result.reason
+
+    def test_bulk_flags_high_ci_diversity(self):
+        """>=30 different CIs/hour must set escalation_required=True."""
+        from services.ai_guard_service import check_bulk_detection
+
+        mock_db = MagicMock()
+        # First call: same_op_count < 50, second: diff_ci_count >= 30
+        mock_db.execute.side_effect = [
+            _mock_execute_result(10),   # same_op_count below threshold
+            _mock_execute_result(30),   # diff_ci_count at threshold
+        ]
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_bulk_detection("agent-1", "ack", ["ci-001"])
+
+        assert result.allowed is True
+        assert result.escalation_required is True
+        assert "High CI diversity" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# check_all_guards integration
+# ---------------------------------------------------------------------------
+
+class TestCheckAllGuards:
+    """Tests for the unified check_all_guards entry point."""
+
+    def test_all_guards_pass(self):
+        """When cooldown, behavioral, and bulk all pass, result is allowed."""
+        from services.ai_guard_service import check_all_guards
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = _mock_execute_result(0)
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            result = check_all_guards("agent-1", "diagnose", ["evt-001"])
+
+        assert result.allowed is True
+
+    def test_empty_target_ids_uses_empty_string(self):
+        """Empty target_ids list must not raise — handled with target_id=''."""
+        from services.ai_guard_service import check_all_guards
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value = _mock_execute_result(0)
+        mock_db.close = MagicMock()
+
+        with patch("services.ai_guard_service.SessionLocal", return_value=mock_db):
+            # Must not raise KeyError or IndexError
+            result = check_all_guards("agent-1", "diagnose", [])
+            assert isinstance(result, GuardResult)

--- a/backend/tests/test_ai_permissions.py
+++ b/backend/tests/test_ai_permissions.py
@@ -1,0 +1,58 @@
+"""Unit tests for AIPermission enum — pure model validation, no external deps."""
+
+import pytest
+from models.user import AIPermission
+
+
+class TestAIPermissionEnum:
+    """Tests for AIPermission enum completeness and string values."""
+
+    def test_enum_has_7_values(self):
+        """AIPermission enum must have exactly 7 defined values."""
+        members = list(AIPermission)
+        assert len(members) == 7, f"Expected 7 AIPermission values, got {len(members)}: {members}"
+
+    def test_ai_run_diagnostic_value(self):
+        """AI_RUN_DIAGNOSTIC must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_RUN_DIAGNOSTIC")
+        assert AIPermission.AI_RUN_DIAGNOSTIC.value == "AI_RUN_DIAGNOSTIC"
+
+    def test_ai_view_all_value(self):
+        """AI_VIEW_ALL must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_VIEW_ALL")
+        assert AIPermission.AI_VIEW_ALL.value == "AI_VIEW_ALL"
+
+    def test_ai_event_ack_value(self):
+        """AI_EVENT_ACK must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_EVENT_ACK")
+        assert AIPermission.AI_EVENT_ACK.value == "AI_EVENT_ACK"
+
+    def test_ai_event_comment_value(self):
+        """AI_EVENT_COMMENT must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_EVENT_COMMENT")
+        assert AIPermission.AI_EVENT_COMMENT.value == "AI_EVENT_COMMENT"
+
+    def test_ai_ci_update_metadata_value(self):
+        """AI_CI_UPDATE_METADATA must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_CI_UPDATE_METADATA")
+        assert AIPermission.AI_CI_UPDATE_METADATA.value == "AI_CI_UPDATE_METADATA"
+
+    def test_ai_event_close_value(self):
+        """AI_EVENT_CLOSE must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_EVENT_CLOSE")
+        assert AIPermission.AI_EVENT_CLOSE.value == "AI_EVENT_CLOSE"
+
+    def test_ai_dictionary_preview_value(self):
+        """AI_DICTIONARY_PREVIEW must be defined and have the correct string value."""
+        assert hasattr(AIPermission, "AI_DICTIONARY_PREVIEW")
+        assert AIPermission.AI_DICTIONARY_PREVIEW.value == "AI_DICTIONARY_PREVIEW"
+
+    def test_all_values_are_strings(self):
+        """All AIPermission values must be strings (str enum)."""
+        for member in AIPermission:
+            assert isinstance(member, str), f"{member} is not a string enum"
+
+    def test_all_values_match_expected_format(self):
+        """All AIPermission values must start with 'AI_' prefix."""
+        for member in AIPermission:
+            assert member.value.startswith("AI_"), f"{member.value} does not start with 'AI_'"

--- a/backend/tests/test_routers_events.py
+++ b/backend/tests/test_routers_events.py
@@ -1,0 +1,434 @@
+"""Router-level tests for event endpoints — AI agent guard integration.
+
+Focus areas:
+- POST /api/events/{event_id}/ack — AI agent guard, record_operation
+- POST /api/events/{event_id}/close — AI agent guard, CRITICAL escalation
+- POST /api/events/{event_id}/diagnose — AI agent guard, record_operation
+
+Strategy:
+- Use FastAPI TestClient with the global app import
+- Patch Neo4j driver at module import time
+- Override get_current_active_user to inject AI agent or regular user
+- Mock ai_guard_service functions and event_service functions
+"""
+
+import pytest
+import types
+import sys
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Patch Neo4j driver BEFORE importing main
+# ---------------------------------------------------------------------------
+_mock_neo4j_driver = MagicMock()
+
+# Stub out snmp_service before it gets imported
+_snmp_service_stub = types.ModuleType("services.snmp_service")
+setattr(_snmp_service_stub, "snmp_collector_loop", lambda: None)
+setattr(
+    _snmp_service_stub,
+    "get_collector_status",
+    lambda: {"last_run": None, "status": "STOPPED", "stats": {}},
+)
+setattr(_snmp_service_stub, "validate_snmp_oid", lambda *args, **kwargs: {"success": False})
+setattr(_snmp_service_stub, "run_diagnostic", lambda *args, **kwargs: "diagnostic-ok")
+sys.modules["services.snmp_service"] = _snmp_service_stub
+
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from main import app
+    from database import get_db
+
+from models.user import User, UserPermission
+from services.auth_service import get_current_active_user
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ai_user(username: str = "ai-agent-1", role: str = "AI_DIAGNOSTIC") -> User:
+    """Create a fake AI agent user."""
+    return User(
+        username=username,
+        role=role,
+        permissions=[],
+        allowed_locations=[],
+    )
+
+
+def _operator_user(
+    username: str = "operator",
+    permissions: list[UserPermission] | None = None,
+) -> User:
+    """Create a regular operator user."""
+    return User(
+        username=username,
+        role="OPERATOR",
+        permissions=permissions or [UserPermission.EVENT_ACK, UserPermission.EVENT_CLOSE, UserPermission.RUN_DIAGNOSTICS],
+        allowed_locations=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/events/{event_id}/ack
+# ---------------------------------------------------------------------------
+
+
+class TestAckEvent:
+    """Tests for POST /api/events/{event_id}/ack endpoint with AI agent guards."""
+
+    def test_ack_unauthenticated(self):
+        """No auth token should return 401."""
+        response = client.post("/api/events/evt-001/ack")
+        assert response.status_code == 401
+
+    def test_ack_no_permission(self):
+        """User without EVENT_ACK should get 403."""
+        async def override():
+            return User(
+                username="viewer",
+                role="VIEWER",
+                permissions=[],
+                allowed_locations=[],
+            )
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        response = client.post("/api/events/evt-001/ack", json={})
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_ack_passes_guard_check(self):
+        """AI agent can acknowledge when check_all_guards returns allowed=True."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service:
+            mock_guards.return_value = MagicMock(allowed=True)
+            mock_service.ack_event.return_value = {"message": "Event acknowledged"}
+
+            response = client.post("/api/events/evt-001/ack", json={})
+
+            assert response.status_code == 200
+            mock_guards.assert_called_once_with("ai-agent-1", "ack", ["evt-001"])
+            mock_record.assert_called_once()
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_ack_blocked_by_guard(self):
+        """AI agent gets 403 when check_all_guards returns allowed=False (cooldown active)."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards:
+            mock_guards.return_value = MagicMock(
+                allowed=False,
+                reason="Cooldown active",
+                cooldown_remaining_seconds=300,
+            )
+
+            response = client.post("/api/events/evt-001/ack", json={})
+
+            assert response.status_code == 403
+            assert "Cooldown active" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_ack_records_operation_on_success(self):
+        """When ack succeeds, record_operation is called with result='success'."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service:
+            mock_guards.return_value = MagicMock(allowed=True)
+            mock_service.ack_event.return_value = {"message": "Event acknowledged"}
+
+            response = client.post("/api/events/evt-001/ack", json={"comment_message": "Test ack"})
+
+            assert response.status_code == 200
+            # record_operation should have been called with result='success'
+            call_kwargs = mock_record.call_args
+            assert call_kwargs[1]["result"] == "success"
+            assert call_kwargs[1]["operation"] == "ack"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/events/{event_id}/close
+# ---------------------------------------------------------------------------
+
+
+class TestCloseEvent:
+    """Tests for POST /api/events/{event_id}/close endpoint with AI agent guards."""
+
+    def test_close_unauthenticated(self):
+        """No auth token should return 401."""
+        response = client.post("/api/events/evt-001/close", json={})
+        assert response.status_code == 401
+
+    def test_close_no_permission(self):
+        """User without EVENT_CLOSE should get 403."""
+        async def override():
+            return User(
+                username="viewer",
+                role="VIEWER",
+                permissions=[],
+                allowed_locations=[],
+            )
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        response = client.post("/api/events/evt-001/close", json={})
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_cannot_force_close(self):
+        """AI agent with forced=True should get 403 — AI cannot force-close."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        response = client.post(
+            "/api/events/evt-001/close",
+            json={"forced": True, "comment_message": "closing"},
+        )
+
+        assert response.status_code == 403
+        assert "AI agents cannot force-close" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_close_passes_guard_check(self):
+        """AI agent can close when check_all_guards returns allowed=True (non-CRITICAL event)."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service, \
+             patch("routers.events.set_cooldown") as mock_set_cooldown:
+            mock_guards.return_value = MagicMock(allowed=True)
+            mock_service.get_event_detail.return_value = {
+                "event": {"severity": "WARNING", "message": "Test", "ci": {"id": "ci-001", "label": "Router-01"}},
+            }
+            mock_service.close_event.return_value = {"message": "Event closed"}
+
+            response = client.post("/api/events/evt-001/close", json={})
+
+            assert response.status_code == 200
+            mock_guards.assert_called_once_with("ai-agent-1", "close", ["evt-001"])
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_close_blocked_by_guard(self):
+        """AI agent gets 403 when check_all_guards returns allowed=False."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards:
+            mock_guards.return_value = MagicMock(
+                allowed=False,
+                reason="Close without diagnostic: >3 closes/hour without any diagnostic",
+            )
+
+            response = client.post("/api/events/evt-001/close", json={})
+
+            assert response.status_code == 403
+            assert "Close without diagnostic" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_critical_event_close_triggers_escalation(self):
+        """Closing a CRITICAL event must trigger escalation notification for all users."""
+        async def override():
+            return _operator_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.notify_critical_event_escalation") as mock_notify, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service, \
+             patch("routers.events.set_cooldown") as mock_set_cooldown:
+            mock_service.get_event_detail.return_value = {
+                "event": {
+                    "severity": "CRITICAL",
+                    "message": "CPU overload",
+                    "ci": {"id": "ci-001", "label": "Router-01"},
+                },
+            }
+            mock_service.close_event.return_value = {"message": "Event closed"}
+
+            response = client.post("/api/events/evt-001/close", json={})
+
+            assert response.status_code == 200
+            # notify_critical_event_escalation must have been called
+            mock_notify.assert_called_once()
+            call_kwargs = mock_notify.call_args[1]
+            assert call_kwargs["severity"] == "CRITICAL" or "event_message" in call_kwargs
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_close_critical_event_records_escalated(self):
+        """AI agent closing CRITICAL event should record result='escalated'."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards, \
+             patch("routers.events.notify_critical_event_escalation") as mock_notify, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service, \
+             patch("routers.events.set_cooldown") as mock_set_cooldown:
+            mock_guards.return_value = MagicMock(allowed=True)
+            mock_service.get_event_detail.return_value = {
+                "event": {
+                    "severity": "CRITICAL",
+                    "message": "CPU overload",
+                    "ci": {"id": "ci-001", "label": "Router-01"},
+                },
+            }
+            mock_service.close_event.return_value = {"message": "Event closed"}
+
+            response = client.post("/api/events/evt-001/close", json={})
+
+            assert response.status_code == 200
+            # record_operation should be called twice: once for escalation, once for success
+            # Find the escalated call
+            escalated_calls = [
+                c for c in mock_record.call_args_list
+                if c[1].get("result") == "escalated"
+            ]
+            assert len(escalated_calls) >= 1
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/events/{event_id}/diagnose
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseEvent:
+    """Tests for POST /api/events/{event_id}/diagnose endpoint with AI agent guards."""
+
+    def test_diagnose_unauthenticated(self):
+        """No auth token should return 401."""
+        response = client.post("/api/events/evt-001/diagnose")
+        assert response.status_code == 401
+
+    def test_diagnose_no_permission(self):
+        """User without RUN_DIAGNOSTICS should get 403."""
+        async def override():
+            return User(
+                username="viewer",
+                role="VIEWER",
+                permissions=[],
+                allowed_locations=[],
+            )
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        response = client.post("/api/events/evt-001/diagnose")
+
+        assert response.status_code == 403
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_diagnose_passes_guard_check(self):
+        """AI agent can run diagnostic when check_all_guards returns allowed=True."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service:
+            mock_guards.return_value = MagicMock(allowed=True)
+            mock_service.get_event_detail.return_value = {
+                "event": {"severity": "WARNING", "message": "Test", "ci": {"id": "ci-001", "label": "Router-01"}},
+            }
+            mock_service.run_event_diagnostic.return_value = {"message": "Diagnostic complete"}
+
+            response = client.post("/api/events/evt-001/diagnose")
+
+            assert response.status_code == 200
+            mock_guards.assert_called_once_with("ai-agent-1", "diagnose", ["evt-001"])
+            mock_record.assert_called_once()
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_diagnose_blocked_by_guard(self):
+        """AI agent gets 403 when check_all_guards returns allowed=False."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards:
+            mock_guards.return_value = MagicMock(
+                allowed=False,
+                reason="Cooldown active",
+                cooldown_remaining_seconds=180,
+            )
+
+            response = client.post("/api/events/evt-001/diagnose")
+
+            assert response.status_code == 403
+            assert "Cooldown active" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_diagnose_records_operation_on_success(self):
+        """When diagnose succeeds, record_operation is called with operation='diagnose'."""
+        async def override():
+            return _ai_user()
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards, \
+             patch("routers.events.record_operation") as mock_record, \
+             patch("routers.events.event_service") as mock_service:
+            mock_guards.return_value = MagicMock(allowed=True)
+            mock_service.get_event_detail.return_value = {
+                "event": {"severity": "WARNING", "ci": {"label": "Router-01"}},
+            }
+            mock_service.run_event_diagnostic.return_value = {"message": "Diagnostic complete"}
+
+            response = client.post("/api/events/evt-001/diagnose")
+
+            assert response.status_code == 200
+            # record_operation should have been called with operation='diagnose'
+            call_kwargs = mock_record.call_args
+            assert call_kwargs[1]["operation"] == "diagnose"
+            assert call_kwargs[1]["result"] == "success"
+
+        app.dependency_overrides.pop(get_current_active_user, None)


### PR DESCRIPTION
## Summary
- test_ai_guard_service.py: cooldown, behavioral guards, bulk detection, CRITICAL escalation (24 tests)
- test_ai_permissions.py: AIPermission enum validation, role-based access
- test_routers_events.py: event operation guard wiring tests

## Changes
| File | Change |
|------|--------|
| backend/tests/test_ai_guard_service.py | 24 tests: cooldown, behavioral, bulk, CRITICAL escalation |
| backend/tests/test_ai_permissions.py | AIPermission enum tests |
| backend/tests/test_routers_events.py | Event guard wiring tests |

## Test Plan
- [x] 24/24 tests pass: `pytest backend/tests/test_ai_guard_service.py backend/tests/test_ai_permissions.py -v`
- [x] All guard paths verified