### PR TITLE
fix(backend): copy engines/ folder into Docker container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Install ping for ICMP checks
 RUN apt-get update && apt-get install -y iputils-ping && rm -rf /var/lib/apt/lists/*
 
+COPY engines /app/engines
 COPY . .
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

`backend/Dockerfile` was only copying the `backend/` directory into the container. `routers/cli.py` imports `cli_worker` from `../../engines/` which resolves to `/app/engines/`, but that path did not exist in the container — causing the CLI test endpoint to fail with a misleading "paramiko may not be installed" error.

Fix: add `COPY engines /app/engines` before `COPY . .` in `backend/Dockerfile`.

Closes #103