### PR TITLE
perf(status): fast-fail status connectivity and eager-load nodes

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -34,10 +34,7 @@ def close_db():
     if driver:
         driver.close()
 
-def verify_connection():
-    max_retries = 30
-    retry_delay = 2
-    
+def verify_connection(max_retries: int = 30, retry_delay: float = 2.0) -> None:
     for i in range(max_retries):
         try:
             driver.verify_connectivity()
@@ -45,7 +42,8 @@ def verify_connection():
             return
         except Exception as e:
             print(f"Neo4j Connection Failed (Attempt {i+1}/{max_retries}): {e}")
-            time.sleep(retry_delay)
+            if i < max_retries - 1 and retry_delay > 0:
+                time.sleep(retry_delay)
     
     print("Neo4j Connection Failed after max retries")
     raise Exception("Could not connect to Neo4j Database")

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -201,6 +201,19 @@ def poll_snmp():
                 else:
                     failed_count += 1
 
+            # Update collector status in Neo4j
+            duration_current = time.time() - start_time
+            session.run("""
+                MERGE (c:CollectorStatus {id: 'main'})
+                SET c.last_run = datetime(),
+                    c.status = 'RUNNING',
+                    c.cis_monitored = $cis,
+                    c.metrics_collected = $collected,
+                    c.metrics_failed = $failed,
+                    c.cycle_duration = $duration,
+                    c.jobs_per_min = $jobs_per_min
+            """, cis=metrics_count, collected=len(metrics_to_save), failed=failed_count, duration=round(duration_current, 2), jobs_per_min=round((len(metrics_to_save) / duration_current) * 60, 1) if duration_current > 0 else 0.0)
+
             # Perform Bulk Insert at the end of the cycle
             if metrics_to_save:
                 bulk_insert_metrics(db, metrics_to_save)

--- a/backend/main.py
+++ b/backend/main.py
@@ -176,7 +176,12 @@ async def startup_event():
         logger.error(f"Failed to seed roles: {e}")
 
     # Start Background SNMP Collector
-    asyncio.create_task(snmp_collector_loop())
+    disable_collector = os.getenv("DISABLE_BACKEND_COLLECTOR", "false").lower() in ("true", "1", "yes", "on")
+    if not disable_collector:
+        asyncio.create_task(snmp_collector_loop())
+        logger.info("Background SNMP Collector started in backend process")
+    else:
+        logger.info("Background SNMP Collector in backend process is disabled (DISABLE_BACKEND_COLLECTOR=true)")
 
     # Start Backup Scheduler
     schedule_daily_backup()
@@ -244,7 +249,7 @@ def get_system_status():
     # 2. Service Status
     neo4j_status = "UNKNOWN"
     try:
-        verify_connection()
+        verify_connection(max_retries=1, retry_delay=0)
         neo4j_status = "CONNECTED"
     except:
         neo4j_status = "DISCONNECTED"

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -44,6 +44,36 @@ GLOBAL_STATS = {
 
 
 def get_collector_status():
+    driver = get_db()
+    try:
+        with driver.session() as session:
+            record = session.run("""
+                MATCH (c:CollectorStatus {id: 'main'})
+                RETURN c.last_run AS last_run,
+                       c.status AS status,
+                       c.cis_monitored AS cis_monitored,
+                       c.metrics_collected AS metrics_collected,
+                       c.metrics_failed AS metrics_failed,
+                       c.cycle_duration AS cycle_duration,
+                       c.jobs_per_min AS jobs_per_min
+            """).single()
+            if record:
+                last_run_val = record.get("last_run")
+                last_run_str = last_run_val.isoformat() if hasattr(last_run_val, "isoformat") else str(last_run_val) if last_run_val else None
+                return {
+                    "last_run": last_run_str,
+                    "status": record.get("status") or "UNKNOWN",
+                    "stats": {
+                        "cis_monitored": record.get("cis_monitored") or 0,
+                        "metrics_collected": record.get("metrics_collected") or 0,
+                        "metrics_failed": record.get("metrics_failed") or 0,
+                        "cycle_duration": record.get("cycle_duration") or 0.0,
+                        "jobs_per_min": record.get("jobs_per_min") or 0.0,
+                    }
+                }
+    except Exception as e:
+        logger.error("Failed to read collector status from Neo4j: %s", e)
+
     return {
         "last_run": LAST_COLLECTION_TIME,
         "status": COLLECTOR_STATUS,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
       - COOKIE_SECURE=${COOKIE_SECURE:-false}
       - PYTHONPATH=/app
       - FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-http://10.53.1.22:3010}
+      - DISABLE_BACKEND_COLLECTOR=true
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
       interval: 10s

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -6,6 +6,7 @@ import { GraphNode } from './types';
 import { api } from './services/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from './services/queryKeys';
+import { useNodesQuery } from './hooks/queries/useNodesQuery';
 
 // Components
 import GraphCMDB from './components/GraphCMDB';
@@ -52,7 +53,7 @@ const MainLayout: React.FC = () => {
   const { user, logout, hasPermission } = useAuth();
   const queryClient = useQueryClient();
   const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
-  const cachedNodes = queryClient.getQueryData<GraphNode[]>(queryKeys.nodes()) ?? [];
+  const { data: nodes = [] } = useNodesQuery();
 
   const [isEditing, setIsEditing] = useState(false);
   const [showDetailModal, setShowDetailModal] = useState(false);
@@ -161,7 +162,7 @@ const MainLayout: React.FC = () => {
             <h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">Platform Engine v3.2</h1>
             <div className="hidden md:flex items-center gap-2 bg-neutral-900 border border-white/5 px-3 py-1 rounded-full text-[10px] font-black text-accent-cyan">
               <span className="w-2 h-2 bg-accent-cyan rounded-full animate-pulse"></span>
-              SNMP Polling: ACTIVE ({cachedNodes.length} Nodes)
+              SNMP Polling: ACTIVE ({nodes.length} Nodes)
             </div>
           </div>
 


### PR DESCRIPTION
Closes #119

## Descripción del Cambio
Este PR optimiza la carga inicial del sistema y el rendimiento de la API mediante:
1. Hacer que el chequeo de conectividad con Neo4j en la ruta `/api/system/status` sea de un solo intento y sin delay (`fast-fail`), evitando que hilos de FastAPI se congelen hasta por 60 segundos ante demoras o desconexiones.
2. Registrar y guardar el estado y métricas del colector SNMP independiente en un nodo centralizado en Neo4j (`:CollectorStatus`) para que la API lo lea directamente en lugar de ejecutar un motor recolector interno redundante.
3. Desactivar el motor recolector en segundo plano del backend mediante la variable `DISABLE_BACKEND_COLLECTOR=true` en Docker Compose.
4. Cargar entusiastamente (eager load) los CIs en `MainLayout` usando el hook `useNodesQuery` global de React Query para poblar el caché en login y mostrar inmediatamente el conteo correcto de nodos en la cabecera.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [x] Performance (Optimización)

## ¿Cómo se probó?
- Se ejecutaron las pruebas unitarias locales del backend (`uv run pytest`), las cuales pasaron correctamente.
- Se verificó la lógica de persistencia del estado en Neo4j para el colector y su correspondiente lectura desacoplada en la API.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
