### PR TITLE
fix(auth): validate AI agent permissions

### DIFF
--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -2,13 +2,11 @@ import os
 import secrets
 import hashlib
 from datetime import datetime, timedelta
-from typing import Optional
-
 from jose import JWTError, jwt
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
-from models.user import TokenData, User, UserRole, UserPermission, UserInDB
+from models.user import TokenData, User, UserRole, UserPermission, UserInDB, AIPermission
 from pydantic import BaseModel
 from typing import Optional, Dict, Any
 from postgres_db import get_pg_db
@@ -195,6 +193,7 @@ def check_permission(permission: UserPermission, user: User):
 # ── AI Agent Detection ─────────────────────────────────────────────────────────
 
 AI_PERSONAS = {"AI_DIAGNOSTIC", "AI_OPERATOR", "AI_ADMIN"}
+ALLOWED_AI_PERMISSIONS = {permission.value for permission in AIPermission}
 
 
 class AIAgentInfo(BaseModel):
@@ -209,8 +208,14 @@ async def get_current_ai_agent(
 ) -> AIAgentInfo:
     """FastAPI dependency that extracts AI agent info from JWT.
 
-    Returns AIAgentInfo dict with {ai_agent_id, persona, permissions}.
-    Raises 401 if not a valid AI agent token.
+    The function enforces a strict allow-list for `permissions`:
+    - missing claim => empty list
+    - claim must be a list when provided
+    - each item must be a non-empty string in `AIPermission`
+
+    Fail-closed behavior:
+    - unknown/invalid/human permissions and malformed claims return HTTP 403
+    - token decode/subject failures return HTTP 401
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -234,7 +239,7 @@ async def get_current_ai_agent(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Invalid AI persona: {persona}",
             )
-        permissions = payload.get("permissions", [])
+        permissions = _normalize_ai_agent_permissions(payload)
         return AIAgentInfo(
             ai_agent_id=ai_agent_id,
             persona=persona,
@@ -242,3 +247,38 @@ async def get_current_ai_agent(
         )
     except JWTError:
         raise credentials_exception
+
+
+def _normalize_ai_agent_permissions(payload: dict) -> list[str]:
+    """Normalize and validate AI-agent `permissions` claim values.
+
+    Returns:
+        list[str]: A validated permission list.
+
+    Raises:
+        HTTPException(403): For non-list payloads, non-string items, or values
+            not present in the `AIPermission` enum.
+    """
+    if "permissions" not in payload:
+        return []
+
+    raw_permissions = payload.get("permissions")
+    if not isinstance(raw_permissions, list):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="AI permissions claim must be a list when provided",
+        )
+
+    for permission in raw_permissions:
+        if not isinstance(permission, str) or not permission:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="AI permissions claim must contain non-empty string values",
+            )
+        if permission not in ALLOWED_AI_PERMISSIONS:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Invalid AI permission: {permission}",
+            )
+
+    return raw_permissions

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,14 +1,18 @@
 """Unit tests for services/auth_service.py — pure logic functions (no DB)."""
 
+import pytest
 from datetime import timedelta
+from fastapi import HTTPException
 from jose import jwt, JWTError
 from services.auth_service import (
     create_access_token,
     check_permission,
+    get_current_ai_agent,
+    AIAgentInfo,
     SECRET_KEY,
     ALGORITHM,
 )
-from models.user import UserPermission, User
+from models.user import UserPermission, User, AIPermission
 
 
 class TestCreateAccessToken:
@@ -100,3 +104,118 @@ class TestCheckPermission:
         assert check_permission(UserPermission.EVENT_ACK, user) is True
         assert check_permission(UserPermission.CI_VIEW, user) is True
         assert check_permission(UserPermission.CI_DELETE, user) is False
+
+
+class TestGetCurrentAiAgent:
+    """Tests for get_current_ai_agent permission claim hardening."""
+
+    @staticmethod
+    def _make_ai_token(extra_claims: dict):
+        """Build a minimal AI-agent token with required claims."""
+        base_payload = {
+            "sub": "agent-1",
+            "type": "ai_agent",
+            "role": "AI_OPERATOR",
+        }
+        base_payload.update(extra_claims)
+        return create_access_token(base_payload)
+
+    @pytest.mark.asyncio
+    async def test_ai_agent_with_missing_permissions_authenticates_with_empty_permissions(self):
+        """Missing permissions claim must authenticate with an empty permission list."""
+        token = self._make_ai_token({})
+        result = await get_current_ai_agent(token=token, db=None)
+
+        assert isinstance(result, AIAgentInfo)
+        assert result.ai_agent_id == "agent-1"
+        assert result.persona == "AI_OPERATOR"
+        assert result.permissions == []
+
+    @pytest.mark.asyncio
+    async def test_ai_agent_with_valid_permissions_authenticates(self):
+        """Valid AIPermission values are accepted and returned unchanged."""
+        token = self._make_ai_token(
+            {
+                "permissions": [
+                    AIPermission.AI_VIEW_ALL.value,
+                    AIPermission.AI_RUN_DIAGNOSTIC.value,
+                ]
+            }
+        )
+        result = await get_current_ai_agent(token=token, db=None)
+
+        assert result.permissions == [
+            AIPermission.AI_VIEW_ALL.value,
+            AIPermission.AI_RUN_DIAGNOSTIC.value,
+        ]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_permissions",
+        [
+            ["ADMIN"],
+            ["USER_MANAGE"],
+            ["BOGUS"],
+            ["AI_VIEW_ALL", 123],
+            "AI_VIEW_ALL",
+            {"permission": "AI_VIEW_ALL"},
+            None,
+        ],
+    )
+    async def test_ai_agent_permissions_are_strictly_validated(self, bad_permissions):
+        """Malformed or unauthorized permissions fail closed with HTTP 403."""
+        token = self._make_ai_token({"permissions": bad_permissions})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_ai_agent(token=token, db=None)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_ai_agent_with_wrong_token_type_is_rejected(self):
+        """AI agent auth must reject tokens whose `type` is not `ai_agent`."""
+        token = self._make_ai_token({"type": "human"})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_ai_agent(token=token, db=None)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_ai_agent_with_missing_persona_is_rejected(self):
+        """AI agent auth must reject tokens without a persona/role claim."""
+        payload = {
+            "sub": "agent-1",
+            "type": "ai_agent",
+        }
+        token = create_access_token(payload)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_ai_agent(token=token, db=None)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_ai_agent_with_unsupported_persona_is_rejected(self):
+        """AI agent auth must reject persona values outside the allow-list."""
+        token = self._make_ai_token({"role": "HUMAN_OPERATOR"})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_ai_agent(token=token, db=None)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_ai_agent_with_missing_subject_is_rejected(self):
+        """AI agent auth must reject tokens missing a `sub` claim."""
+        payload = {
+            "type": "ai_agent",
+            "role": "AI_OPERATOR",
+            "permissions": [AIPermission.AI_VIEW_ALL.value],
+        }
+        token = create_access_token(payload)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_ai_agent(token=token, db=None)
+
+        assert exc_info.value.status_code == 401


### PR DESCRIPTION
## Descripción del Cambio
Closes #108

- Valida los permisos de tokens AI-agent contra el enum AIPermission.
- Rechaza fail-closed permisos humanos/admin, desconocidos o claims malformados.
- Agrega cobertura runtime para permisos e identidad del AI-agent.

| File | Change |
|------|--------|
| ackend/services/auth_service.py | Agrega allow-list de AIPermission y normalización estricta de permissions. |
| ackend/tests/test_auth_service.py | Agrega tests async para permisos válidos/inválidos y restricciones de identidad. |

## Tipo de Cambio
- [x] Fix (Reparación de error)
- [ ] Feat (Nueva funcionalidad)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] python -m pytest backend/tests/test_auth_service.py backend/tests/test_ai_permissions.py — 35 passed
- [x] python -m compileall backend/services/auth_service.py backend/tests/test_auth_service.py — exit 0

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el .gitignore.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*