### PR TITLE
fix(deploy): separate postgres internal and external ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,11 +14,14 @@ POSTGRES_USER=nexgen_admin
 POSTGRES_PASSWORD='YourStrongPassword#2026'
 POSTGRES_DB=nexgen_auth
 
-# --- CONNECTION STRINGS (Docker internal) ---
-# Estos valores son los correctos para correr dentro de Docker Compose
+# --- POSTGRES NETWORKING ---
+# Dentro de Docker Compose, los servicios se conectan a postgres:5432.
+# Si necesitas publicar PostgreSQL en otro puerto del host, cambia solo
+# POSTGRES_EXTERNAL_PORT. No uses POSTGRES_PORT=5433 con POSTGRES_HOST=postgres.
 NEO4J_URI=bolt://neo4j:7687
 POSTGRES_HOST=postgres
-POSTGRES_PORT=5432
+POSTGRES_INTERNAL_PORT=5432
+POSTGRES_EXTERNAL_PORT=5432
 
 # Host directory mounted into backend for PostgreSQL dumps.
 BACKUP_DIR=./docker/backups

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ NEX-GEN es una plataforma ITOM para operar infraestructura desde una CMDB basada
 4. Backend docs: `http://localhost:8000/docs`.
 5. Neo4j Browser: `http://localhost:7474`.
 
+PostgreSQL dentro de Docker siempre debe usar `POSTGRES_HOST=postgres` y `POSTGRES_INTERNAL_PORT=5432`. Si necesitas exponer PostgreSQL en otro puerto del host, configura `POSTGRES_EXTERNAL_PORT=5433`; no uses `POSTGRES_PORT=5433` para servicios internos porque el contenedor PostgreSQL escucha en `5432` dentro de la red Docker.
+
 Backups PostgreSQL/Neo4j y rebuild seguro: despues de actualizar codigo, ejecuta `sh scripts/validate-env.sh --check-backup-dir` para confirmar que `.env` contiene todas las variables de `.env.example`, que los secretos sensibles no estan vacios/default, y que `BACKUP_DIR` existe y es escribible. Luego ejecuta `sh scripts/pre-rebuild-backup.sh`, reconstruye con `docker compose build && docker compose up -d`, y verifica con `docker compose ps`. `BACKUP_DIR` se resuelve desde el entorno de shell, luego `.env`, y si no existe usa `./docker/backups`; el validador no crea el directorio, asi que usa `mkdir -p ./docker/backups` o PowerShell `New-Item -ItemType Directory -Force -Path .\docker\backups` antes de correrlo. Ejecuta los scripts desde Linux/macOS/Git Bash/WSL, no desde PowerShell. No uses `docker compose down -v` en rebuilds porque elimina volumenes. La configuracion guardada de backups solo puede usar `/backups` o subrutas como `/backups/daily`; cualquier ruta fuera de ese mount se normaliza a `/backups` para no escribir en almacenamiento efimero del contenedor. Ver [`docs/backup-restore.md`](docs/backup-restore.md) para restore y limitaciones de Neo4j Community.
 
 ## Tests focalizados

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-nexgen_password}
       - POSTGRES_DB=${POSTGRES_DB:-nexgen_auth}
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
-      - POSTGRES_PORT=${POSTGRES_PORT:-5432}
+      - POSTGRES_PORT=${POSTGRES_INTERNAL_PORT:-5432}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - COOKIE_SECURE=${COOKIE_SECURE:-false}
       - PYTHONPATH=/app
@@ -120,6 +120,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-nexgen_password}
       - POSTGRES_DB=${POSTGRES_DB:-nexgen_auth}
       - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
+      - POSTGRES_PORT=${POSTGRES_INTERNAL_PORT:-5432}
       # ICMP polling: timeout in ms (default 3000), retries (default 2), debounce_count (default 3)
       - ICMP_TIMEOUT_MS=${ICMP_TIMEOUT_MS:-3000}
       - ICMP_RETRIES=${ICMP_RETRIES:-2}

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -30,6 +30,7 @@ The validator is intentionally conservative for production-sensitive values:
 | `.env.example` vs `.env` | Fails when `.env` is missing any variable declared in `.env.example`, which catches stale deploy env files after new config is added. |
 | Safe parsing | Reads assignments as text and never sources `.env` or `.env.example`, so arbitrary shell code is not executed. |
 | Sensitive values | Fails empty or obvious placeholder/default values for secrets and passwords such as `JWT_SECRET_KEY`, `POSTGRES_PASSWORD`, and `NEO4J_PASSWORD`. |
+| PostgreSQL ports | Fails when `POSTGRES_HOST=postgres` is paired with an internal port other than `5432`; host exposure belongs in `POSTGRES_EXTERNAL_PORT`. |
 | Dev-only values | Warns, rather than fails, for empty non-sensitive values to avoid making local/dev config brittle. |
 | `BACKUP_DIR` | Resolves shell env first, then `.env`, then `./docker/backups`; with `--check-backup-dir`, fails if the directory does not exist or is not writable. |
 

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -213,6 +213,30 @@ validate_backup_dir() {
     rm -f "$test_file"
 }
 
+validate_postgres_ports() {
+    [ -f .env ] || return
+
+    postgres_host=$(env_value .env POSTGRES_HOST)
+    postgres_host=$(trim_value "$postgres_host")
+    [ "$postgres_host" ] || postgres_host=postgres
+
+    postgres_internal_port=$(env_value .env POSTGRES_INTERNAL_PORT)
+    postgres_internal_port=$(trim_value "$postgres_internal_port")
+    [ "$postgres_internal_port" ] || postgres_internal_port=5432
+
+    if [ "$postgres_host" = "postgres" ] && [ "$postgres_internal_port" != "5432" ]; then
+        fail "POSTGRES_INTERNAL_PORT must be 5432 when POSTGRES_HOST=postgres; use POSTGRES_EXTERNAL_PORT for the host published port."
+    fi
+
+    if has_env_name .env POSTGRES_PORT; then
+        postgres_port=$(env_value .env POSTGRES_PORT)
+        postgres_port=$(trim_value "$postgres_port")
+        if [ "$postgres_host" = "postgres" ] && [ "$postgres_port" ] && [ "$postgres_port" != "5432" ]; then
+            fail "POSTGRES_PORT=$postgres_port looks like a host/external port, but POSTGRES_HOST=postgres requires internal port 5432. Use POSTGRES_EXTERNAL_PORT=$postgres_port instead."
+        fi
+    fi
+}
+
 if [ ! -f .env.example ]; then
     fail '.env.example is missing; cannot validate the environment contract.'
 fi
@@ -258,6 +282,7 @@ if [ -f .env.example ] && [ -f .env ]; then
 fi
 
 backup_dir=$(resolve_backup_dir)
+validate_postgres_ports
 if [ "$check_backup_dir" -eq 1 ]; then
     validate_backup_dir "$backup_dir"
 fi


### PR DESCRIPTION
Closes #127

## Descripción del Cambio
- Separa explícitamente el puerto interno de Postgres usado dentro de Docker del puerto publicado en el host.
- Backend y `snmp-engine` ahora reciben `POSTGRES_PORT` desde `POSTGRES_INTERNAL_PORT` con default `5432`.
- `POSTGRES_EXTERNAL_PORT` queda reservado para publicar Postgres hacia el host.
- El validador de entorno falla si detecta la configuración peligrosa `POSTGRES_HOST=postgres` con puerto interno distinto de `5432` o legado `POSTGRES_PORT=5433`.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `bash -n scripts/validate-env.sh`
- [x] `bash -n scripts/pre-rebuild-backup.sh`
- [x] `docker compose config --quiet`
- [x] `git diff --check HEAD~1..HEAD`
- [x] Revisión fresca sin blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Previene que un puerto host como `5433` sea usado como puerto interno Docker.

## Nota de migración para servidor
Si el `.env` antiguo tiene:

```env
POSTGRES_PORT=5433
```

cambiar a:

```env
POSTGRES_INTERNAL_PORT=5432
POSTGRES_EXTERNAL_PORT=5433
```

Dentro de Docker, backend debe conectar a `postgres:5432`. El puerto `5433` es solo para acceso desde el host.

---
*Generado por Alex*