### PR TITLE
chore(frontend): harden pnpm dependency installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ NEX-GEN es una plataforma ITOM para operar infraestructura desde una CMDB basada
 - [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md) - manual del operador: login, consola, eventos, metricas, troubleshooting.
 - [`docs/AI_AGENT_GUIDE.md`](docs/AI_AGENT_GUIDE.md) - guia para agentes IA que operan via REST API: permisos, operaciones permitidas, guards y campos restringidos.
 - [`docs/backup-restore.md`](docs/backup-restore.md) - runbook de backups pre-rebuild, restore PostgreSQL y limitaciones seguras de Neo4j.
+- [`docs/supply-chain.md`](docs/supply-chain.md) - politica de dependencias frontend: pnpm/Corepack, lockfile congelado y aprobacion explicita de build scripts.
 - [`docs/domain/business-model.md`](docs/domain/business-model.md) - vocabulario de dominio, relaciones `CI -> BusinessService -> ServiceCatalog`, snapshot/fallback y bootstrap manual.
 - [`docs/itsm/event-flow.md`](docs/itsm/event-flow.md) - lifecycle del evento, ownership, SLA, escalacion y puntos de integracion Jira/ServiceNow.
 - [`docs/reference/modelo_entidad_relacion.md`](docs/reference/modelo_entidad_relacion.md) - referencia tecnica de entidades, relaciones y payloads relevantes.
@@ -73,7 +74,7 @@ Comandos check-only: `sh scripts/safe-rebuild.sh --dry-run`, `sh -n scripts/*.sh
 
 - Desde la raiz del repo:
   - Backend: `python -m pytest backend/tests/test_event_service_smoke.py backend/tests/test_routers_metrics_events.py backend/tests/test_snmp_service_snapshots.py`
-  - Frontend: `pnpm --dir frontend run test:run -- hooks/queries/resourceQueries.test.tsx components/__tests__/EventDetailModal.acceptance.test.tsx`
+  - Frontend: `corepack pnpm --dir frontend run test:run -- hooks/queries/resourceQueries.test.tsx components/__tests__/EventDetailModal.acceptance.test.tsx`
 
 ## Estado actual
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -1,0 +1,41 @@
+# Supply-Chain Policy
+
+NEX-GEN frontend dependencies are installed with pnpm through Corepack. Do not run remote installer scripts or switch package managers to fix dependency warnings.
+
+## Quick Path
+
+1. Enable Corepack if needed: `corepack enable`.
+2. Install from `frontend`: `corepack pnpm install --frozen-lockfile`.
+3. Add dependencies from `frontend`: `corepack pnpm add <package>`.
+4. Never run `npm install` in `frontend`; the package has a `preinstall` guard that fails non-pnpm installs.
+5. Commit `frontend/pnpm-lock.yaml` with dependency changes.
+
+## Dependency Rules
+
+| Rule | Policy |
+| --- | --- |
+| Package manager | `frontend/package.json` pins `pnpm@10.12.1`; use Corepack so the pinned version is used. |
+| Version ranges | `frontend/.npmrc` sets `save-exact=true` so newly added dependencies are pinned exactly by default. |
+| Lockfile | Docker and CI-style installs must use `corepack pnpm install --frozen-lockfile`. |
+| Lifecycle scripts | `frontend/pnpm-workspace.yaml` sets `strictDepBuilds: true` so new dependency build scripts must be reviewed. |
+| Remote scripts | Do not pipe `curl` or remote shell scripts into the terminal. Read the source, adapt project-local config, then verify locally. |
+
+## Build-Script Decisions
+
+pnpm 10.12.1 reports ignored builds with `corepack pnpm ignored-builds`. The current policy is stored in `frontend/pnpm-workspace.yaml`, which is the effective location for strict dependency-build policy during `pnpm install --frozen-lockfile`.
+
+| Dependency | Decision | Why |
+| --- | --- | --- |
+| `esbuild` | Approved in `onlyBuiltDependencies`. | Vite depends on `esbuild`, and the lockfile shows `vite@6.4.1` using `esbuild@0.25.12`. esbuild's install step selects the platform binary used by local and Docker builds. |
+| `@google/genai` | Ignored in `ignoredBuiltDependencies`. | It is an app dependency, but its install build is not proven necessary for the Vite build. Keep blocked until a concrete runtime/build failure proves otherwise. |
+| `protobufjs` | Ignored in `ignoredBuiltDependencies`. | It is transitive through `@google/genai`; no current app build requirement justifies approving its build script blindly. |
+
+## When pnpm Warns About New Builds
+
+1. Run `corepack pnpm ignored-builds` from `frontend`.
+2. Identify why the package wants a build script by checking the lockfile and package metadata.
+3. If the app needs the build to compile or run, add the package to `onlyBuiltDependencies` in `frontend/pnpm-workspace.yaml` with a short explanation in this doc.
+4. If the app does not need it, add the package to `ignoredBuiltDependencies` in `frontend/pnpm-workspace.yaml`.
+5. Re-run `corepack pnpm install --frozen-lockfile` and `corepack pnpm run build` from `frontend`.
+
+Do not enable newer pnpm settings such as `minimumReleaseAge` while `packageManager` is pinned to pnpm `10.12.1`. Revisit that setting only with an intentional pnpm bump and verification.

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+package-manager-strict=true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine
 
 WORKDIR /app
 RUN corepack enable
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml .npmrc pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.12.1",
   "type": "module",
   "scripts": {
+    "preinstall": "node -e \"const ua = process.env.npm_config_user_agent || ''; if (!ua.includes('pnpm/')) { console.error('Use pnpm via Corepack: corepack pnpm install --frozen-lockfile'); process.exit(1); }\"",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+packages:
+  - .
+
+strictDepBuilds: true
+
+onlyBuiltDependencies:
+  - esbuild
+
+ignoredBuiltDependencies:
+  - '@google/genai'
+  - protobufjs


### PR DESCRIPTION
## Descripción del Cambio
Closes #131

Endurece el flujo de dependencias del frontend para reducir riesgo de supply-chain:

- Bloquea instalaciones accidentales con npm y documenta Corepack/pnpm como camino oficial.
- Agrega política explícita de build scripts para pnpm 10.12.1.
- Asegura que Docker copie `.npmrc` y `pnpm-workspace.yaml` antes de `pnpm install`.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)
- [x] Chore (Mantenimiento/tooling)

## Cambios
| File | Change |
|------|--------|
| `frontend/.npmrc` | Activa `save-exact` y strict package-manager checks para pnpm. |
| `frontend/pnpm-workspace.yaml` | Activa `strictDepBuilds`, aprueba `esbuild` e ignora `@google/genai`/`protobufjs`. |
| `frontend/package.json` | Agrega guard `preinstall` para bloquear installs no-pnpm. |
| `frontend/Dockerfile` | Copia la configuración pnpm antes del install Docker. |
| `docs/supply-chain.md` | Documenta política de dependencias, Corepack, lockfile congelado y revisión de build scripts. |
| `README.md` | Enlaza la política y cambia el comando frontend a `corepack pnpm`. |

## ¿Cómo se probó?
- [x] `corepack pnpm config list`
- [x] `corepack pnpm ignored-builds` → `None`
- [x] `corepack pnpm install --frozen-lockfile --force`
- [x] `corepack pnpm install --frozen-lockfile`
- [x] `corepack pnpm run build`
- [x] `git diff --check`
- [x] Judgment Day Round 2 aprobado por dos jueces sin blockers ni warnings reales.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label: `type:chore`.
- [x] Docs updated because dependency workflow changed.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.