### PR TITLE
fix(events): avoid related-events phantom query

### DIFF
--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -1864,9 +1864,13 @@ const StatCard = ({ label, value, icon, color, bg, animate, active, onClick }: a
  * Useful for spotting correlated issues (e.g. CPU High + Latency High).
  */
 const RelatedAlarmsPanel = ({ ciId, currentEventId, enabled }: { ciId?: string, currentEventId?: string | null, enabled: boolean }) => {
-    const { data: related = [] } = useRelatedEventsQuery(ciId, enabled);
+    if (!enabled || !ciId) return null;
 
-    if (!enabled) return null;
+    return <RelatedAlarmsPanelWithQuery ciId={ciId} currentEventId={currentEventId} />;
+};
+
+const RelatedAlarmsPanelWithQuery = ({ ciId, currentEventId }: { ciId: string, currentEventId?: string | null }) => {
+    const { data: related = [] } = useRelatedEventsQuery(ciId, true);
 
     // Filter out current event
     const displayed = related.filter(e => e.id !== currentEventId);

--- a/frontend/hooks/queries/useRelatedEventsQuery.ts
+++ b/frontend/hooks/queries/useRelatedEventsQuery.ts
@@ -2,9 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '../../services/queryKeys';
 import { fetchRelatedEvents } from '../../services/queryResources';
 
-export const useRelatedEventsQuery = (ciId?: string, enabled = true) => useQuery({
-  queryKey: ciId ? queryKeys.relatedEvents(ciId) : ['events', 'related', 'unknown'],
-  queryFn: ({ signal }) => fetchRelatedEvents(ciId as string, { signal }),
-  enabled: Boolean(ciId) && enabled,
+export const useRelatedEventsQuery = (ciId: string, enabled = true) => useQuery({
+  queryKey: queryKeys.relatedEvents(ciId),
+  queryFn: ({ signal }) => fetchRelatedEvents(ciId, { signal }),
+  enabled,
   refetchInterval: 10000,
 });


### PR DESCRIPTION
## Descripción del Cambio
Closes #32

- Prevents related-events query registration when `RelatedAlarmsPanel` has no valid `ciId`.
- Moves the query hook into a guarded child component to preserve React hook rules.
- Removes the `['events', 'related', 'unknown']` fallback query key.

| File | Change |
|------|--------|
| `frontend/components/MonitoringConsole.tsx` | Guards related-alarm rendering before mounting the query component. |
| `frontend/hooks/queries/useRelatedEventsQuery.ts` | Requires a concrete `ciId` and uses only real related-events query keys. |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `pnpm -C ../next-gen-issue-32/frontend test:run hooks/queries/resourceQueries.test.tsx` — 11 passed
- [x] `pnpm -C ../next-gen-issue-32/frontend test:run components/__tests__/MonitoringConsole.smoke.test.tsx` — 6 passed
- [x] Fresh reviewer pass — no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
