### PR TITLE
fix(auth): rate limit refresh endpoint

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -22,7 +22,7 @@ from postgres_db import get_pg_db
 from repositories import user_repo
 from models.user import Token, User, PasswordChangeRequest
 from models.refresh_token import RefreshTokenResponse
-from middleware.rate_limit import check_rate_limit, clear_attempts
+from middleware.rate_limit import check_rate_limit, clear_attempts, increment_attempts
 
 # ── Cookie domain and security (parsed once at import) ─────────────────────────
 
@@ -183,9 +183,13 @@ async def refresh_tokens(
             detail="Missing refresh token cookie",
         )
 
+    # Track failed attempts (for existing token identifier) before token verification.
+    check_rate_limit(refresh_token)
+
     # Verify refresh token
     user_id = verify_refresh_token(refresh_token, db)
     if user_id is None:
+        increment_attempts(refresh_token)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
@@ -197,7 +201,11 @@ async def refresh_tokens(
     # Get user by ID
     db_user = user_repo.get_user_by_id(db, user_id)
     if db_user is None or not db_user.is_active:
+        increment_attempts(refresh_token)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
+
+    # Successful refresh — clear failed attempts for this token
+    clear_attempts(refresh_token)
 
     # Create new access token
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)

--- a/backend/tests/test_auth_router_refresh.py
+++ b/backend/tests/test_auth_router_refresh.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from middleware.rate_limit import MAX_ATTEMPTS, RATE_LIMIT_STORE, increment_attempts
+
 # Patch Neo4j driver BEFORE importing anything
 _mock_neo4j_driver = MagicMock()
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
@@ -16,6 +18,14 @@ with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
 
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _clear_rate_limit_store():
+    """Ensure rate-limit state is isolated between tests."""
+    RATE_LIMIT_STORE.clear()
+    yield
+    RATE_LIMIT_STORE.clear()
 
 
 def _make_mock_pg_user(
@@ -134,6 +144,68 @@ class TestAuthRefresh:
             )
 
         assert response.status_code == 401
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_refresh_token_rate_limits_after_repeated_failures(self):
+        """Too many invalid refresh token attempts should eventually return 429."""
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_refresh_token", return_value=None) as mock_verify:
+            responses = []
+            for _ in range(MAX_ATTEMPTS + 2):  # 4th fail then lock checked on 5th attempt
+                response = client.post(
+                    "/api/auth/refresh",
+                    cookies={"refresh_token": "bad_refresh_token"},
+                )
+                responses.append(response)
+
+        assert [r.status_code for r in responses[: MAX_ATTEMPTS + 1]] == [401] * (MAX_ATTEMPTS + 1)
+        assert responses[MAX_ATTEMPTS + 1].status_code == 429
+        assert "Retry-After" in responses[MAX_ATTEMPTS + 1].headers
+        assert mock_verify.call_count == MAX_ATTEMPTS + 1
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_refresh_success_clears_rate_limit_counter(self):
+        """Successful refresh should reset rate-limit state for that token."""
+        refresh_token = "old_refresh_token"
+        increment_attempts(refresh_token)
+        increment_attempts(refresh_token)
+
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            role="OPERATOR",
+            user_id=42,
+        )
+
+        # Mock the refresh token verification to return the user_id
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.add = MagicMock()
+        mock_db.commit = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_refresh_token", return_value=42):
+            with patch("routers.auth.create_refresh_token", return_value="new_refresh_token"):
+                with patch("routers.auth.create_access_token", return_value="new_access_token"):
+                    response = client.post(
+                        "/api/auth/refresh",
+                        cookies={"refresh_token": refresh_token},
+                    )
+
+        assert response.status_code == 200
+        assert refresh_token not in RATE_LIMIT_STORE
 
         app.dependency_overrides.pop(get_pg_db, None)
 


### PR DESCRIPTION
## Descripción del Cambio
Closes #109

- Applies existing rate-limit checks to `POST /api/auth/refresh`.
- Increments failed attempts for invalid/expired token and missing/inactive user cases.
- Clears refresh-token failed-attempt state after a successful refresh.
- Adds focused tests for repeated refresh failures and successful counter clearing.

| File | Change |
|------|--------|
| `backend/routers/auth.py` | Adds refresh endpoint rate-limit check/increment/clear behavior. |
| `backend/tests/test_auth_router_refresh.py` | Adds refresh rate-limit tests and rate-limit store isolation. |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd ../next-gen-issue-109 && python -m pytest backend/tests/test_auth_router_refresh.py backend/tests/test_rate_limit.py` — 29 passed
- [x] Fresh reviewer pass — no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
