### PR TITLE
feat(auth): persist rate limit attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,5 @@ docker-compose.override.yml
 .artifacts/
 .atl/
 .engram/
+.pi/settings.json
 skills/worktree-manager/

--- a/backend/main.py
+++ b/backend/main.py
@@ -138,8 +138,9 @@ async def startup_event():
         from postgres_db import SessionLocal, engine, Base
         from repositories.metric_repo import create_hypertable
         from models.timescale_models import MetricValue  # Import to register model
+        from models.rate_limit_attempt import RateLimitAttempt  # Import to register model
 
-        # Create Tables (includes backup_config and backup_history)
+        # Create Tables (includes backup_config, backup_history, and rate_limit_attempts)
         Base.metadata.create_all(bind=engine)
 
         # Inline migration: add 'tier' column if it doesn't exist (safe for existing DBs)

--- a/backend/middleware/rate_limit.py
+++ b/backend/middleware/rate_limit.py
@@ -270,8 +270,9 @@ def check_rate_limit(identity_key: str, identity_type: str = "username") -> None
     """
     locked, retry_after = is_locked(identity_key, identity_type=identity_type)
     if locked:
+        retry_after_seconds = max(1, retry_after or 1)
         raise HTTPException(
             status_code=429,
             detail="Too many failed login attempts. Account temporarily locked.",
-            headers={"Retry-After": str(retry_after)}
+            headers={"Retry-After": str(retry_after_seconds)},
         )

--- a/backend/middleware/rate_limit.py
+++ b/backend/middleware/rate_limit.py
@@ -1,89 +1,236 @@
 """
 Login rate limiting middleware.
 
-In-memory store tracking failed login attempts per username.
-After 3 consecutive failed attempts, account is locked for 15 minutes.
+Persistent store tracking failed auth attempts in Postgres so lockouts are
+shared across uvicorn worker processes. After 3 consecutive failed attempts,
+the identity is locked for 15 minutes.
 """
+import hashlib
 from datetime import datetime, timedelta
-from typing import Dict, NamedTuple
+from typing import NamedTuple
 
 from fastapi import Request, HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
+
+from models.rate_limit_attempt import RateLimitAttempt
+from postgres_db import SessionLocal
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
 MAX_ATTEMPTS = 3
 LOCKOUT_DURATION = timedelta(minutes=15)
-
-# In-memory store: {username: AttemptInfo}
-RATE_LIMIT_STORE: Dict[str, "AttemptInfo"] = {}
+ATTEMPT_RETENTION = timedelta(days=1)
 
 
 class AttemptInfo(NamedTuple):
-    """Tracks failed login attempts for a username."""
+    """Tracks failed auth attempts for an identity."""
+
     count: int
     locked_until: datetime | None
 
 
-def get_attempt_info(username: str) -> AttemptInfo:
-    """Get current attempt info for a username."""
-    return RATE_LIMIT_STORE.get(username, AttemptInfo(count=0, locked_until=None))
+def refresh_token_rate_limit_key(refresh_token: str) -> str:
+    """Return a non-sensitive, namespaced rate-limit key for a refresh token."""
+    token_hash = hashlib.sha256(refresh_token.encode()).hexdigest()
+    return f"refresh:{token_hash}"
 
 
-def increment_attempts(username: str) -> AttemptInfo:
-    """Increment failed attempts. Returns updated AttemptInfo."""
-    info = get_attempt_info(username)
-    now = datetime.utcnow()
-
-    # Clear expired lock before incrementing
-    if info.locked_until and info.locked_until < now:
-        del RATE_LIMIT_STORE[username]
-        info = AttemptInfo(count=0, locked_until=None)
-
-    # If currently locked, return existing lock info
-    if info.locked_until and info.locked_until > now:
-        return info
-
-    new_count = info.count + 1
-
-    # Lockout is triggered AFTER 3 consecutive failures.
-    # 3 failed attempts → count=3, no lock yet.
-    # 4th attempt → count=4 > MAX_ATTEMPTS(3) → lockout begins.
-    if new_count > MAX_ATTEMPTS:
-        new_locked_until = now + LOCKOUT_DURATION
-        RATE_LIMIT_STORE[username] = AttemptInfo(count=new_count, locked_until=new_locked_until)
-    else:
-        RATE_LIMIT_STORE[username] = AttemptInfo(count=new_count, locked_until=None)
-
-    return RATE_LIMIT_STORE[username]
+def _stored_identity_key(identity_key: str, identity_type: str) -> str:
+    """Namespace persisted keys so identity domains cannot collide."""
+    if identity_type == "refresh_token":
+        return identity_key if identity_key.startswith("refresh:") else f"refresh:{identity_key}"
+    if identity_type == "username":
+        return f"user:{identity_key}"
+    return f"{identity_type}:{identity_key}"
 
 
-def clear_attempts(username: str) -> None:
-    """Clear failed attempts on successful login."""
-    if username in RATE_LIMIT_STORE:
-        del RATE_LIMIT_STORE[username]
+def _utcnow() -> datetime:
+    return datetime.utcnow()
 
 
-def is_locked(username: str) -> tuple[bool, int | None]:
+def _prune_expired_attempts(db: Session, now: datetime) -> None:
+    """Remove expired locks and stale unlocked counters opportunistically."""
+    stale_cutoff = now - ATTEMPT_RETENTION
+    db.query(RateLimitAttempt).filter(
+        (RateLimitAttempt.locked_until <= now)
+        | (
+            (RateLimitAttempt.locked_until.is_(None))
+            & (RateLimitAttempt.updated_at < stale_cutoff)
+        )
+    ).delete(synchronize_session=False)
+
+
+def _get_locked_attempt(
+    db: Session,
+    identity_key: str,
+    identity_type: str,
+) -> RateLimitAttempt | None:
+    """Load an attempt row with a row lock where the database supports it."""
+    return (
+        db.query(RateLimitAttempt)
+        .filter(
+            RateLimitAttempt.identity_key == identity_key,
+            RateLimitAttempt.identity_type == identity_type,
+        )
+        .with_for_update()
+        .one_or_none()
+    )
+
+
+def _create_locked_attempt(
+    db: Session,
+    identity_key: str,
+    identity_type: str,
+    now: datetime,
+) -> RateLimitAttempt:
     """
-    Check if username is currently locked.
+    Create an attempt row, handling a concurrent first insert by re-reading it.
+
+    The unique identity_key constraint prevents duplicate counters across
+    workers. Existing rows are re-selected with FOR UPDATE before mutation.
+    """
+    attempt = RateLimitAttempt(
+        identity_key=identity_key,
+        identity_type=identity_type,
+        attempt_count=0,
+        locked_until=None,
+        updated_at=now,
+    )
+    db.add(attempt)
+    try:
+        db.flush()
+        return attempt
+    except IntegrityError:
+        db.rollback()
+        attempt = _get_locked_attempt(db, identity_key, identity_type)
+        if attempt is None:
+            raise
+        return attempt
+
+
+def get_attempt_info(identity_key: str, identity_type: str = "username") -> AttemptInfo:
+    """Get current attempt info for an identity."""
+    db = SessionLocal()
+    try:
+        now = _utcnow()
+        _prune_expired_attempts(db, now)
+        stored_key = _stored_identity_key(identity_key, identity_type)
+        attempt = _get_locked_attempt(db, stored_key, identity_type)
+        if attempt is None:
+            db.commit()
+            return AttemptInfo(count=0, locked_until=None)
+
+        info = AttemptInfo(
+            count=attempt.attempt_count,
+            locked_until=attempt.locked_until,
+        )
+        db.commit()
+        return info
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def increment_attempts(identity_key: str, identity_type: str = "username") -> AttemptInfo:
+    """Increment failed attempts. Returns updated AttemptInfo."""
+    db = SessionLocal()
+    try:
+        now = _utcnow()
+        _prune_expired_attempts(db, now)
+        stored_key = _stored_identity_key(identity_key, identity_type)
+        attempt = _get_locked_attempt(db, stored_key, identity_type)
+        if attempt is None:
+            attempt = _create_locked_attempt(db, stored_key, identity_type, now)
+
+        # If currently locked, return existing lock info without extending it.
+        if attempt.locked_until and attempt.locked_until > now:
+            info = AttemptInfo(
+                count=attempt.attempt_count,
+                locked_until=attempt.locked_until,
+            )
+            db.commit()
+            return info
+
+        # Clear expired lock before incrementing. Expired rows are normally
+        # pruned above; this preserves behavior if pruning races or is skipped.
+        if attempt.locked_until and attempt.locked_until <= now:
+            attempt.attempt_count = 0
+            attempt.locked_until = None
+
+        new_count = attempt.attempt_count + 1
+        attempt.attempt_count = new_count
+        attempt.identity_type = identity_type
+        attempt.last_failed_at = now
+        attempt.updated_at = now
+
+        # Lockout is triggered AFTER 3 consecutive failures.
+        # 3 failed attempts → count=3, no lock yet.
+        # 4th attempt → count=4 > MAX_ATTEMPTS(3) → lockout begins.
+        if new_count > MAX_ATTEMPTS:
+            attempt.locked_until = now + LOCKOUT_DURATION
+        else:
+            attempt.locked_until = None
+
+        info = AttemptInfo(count=attempt.attempt_count, locked_until=attempt.locked_until)
+        db.commit()
+        return info
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def clear_attempts(identity_key: str, identity_type: str = "username") -> None:
+    """Clear failed attempts on successful auth."""
+    db = SessionLocal()
+    try:
+        stored_key = _stored_identity_key(identity_key, identity_type)
+        db.query(RateLimitAttempt).filter(
+            RateLimitAttempt.identity_key == stored_key,
+            RateLimitAttempt.identity_type == identity_type,
+        ).delete(synchronize_session=False)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+
+def is_locked(identity_key: str, identity_type: str = "username") -> tuple[bool, int | None]:
+    """
+    Check if identity is currently locked.
     Returns (is_locked, retry_after_seconds).
     """
-    info = get_attempt_info(username)
-    if info.locked_until is None:
-        return False, None
+    db = SessionLocal()
+    try:
+        now = _utcnow()
+        _prune_expired_attempts(db, now)
+        stored_key = _stored_identity_key(identity_key, identity_type)
+        attempt = _get_locked_attempt(db, stored_key, identity_type)
+        if attempt is None or attempt.locked_until is None:
+            db.commit()
+            return False, None
 
-    now = datetime.utcnow()
-    if info.locked_until <= now:
-        # Lock expired, clear it
-        if username in RATE_LIMIT_STORE:
-            del RATE_LIMIT_STORE[username]
-        return False, None
+        if attempt.locked_until <= now:
+            db.delete(attempt)
+            db.commit()
+            return False, None
 
-    # Still locked
-    retry_after = int((info.locked_until - now).total_seconds())
-    return True, retry_after
+        retry_after = int((attempt.locked_until - now).total_seconds())
+        db.commit()
+        return True, retry_after
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -105,13 +252,23 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-def check_rate_limit(username: str) -> None:
-    """
-    Check if username is rate limited. Raises HTTPException 429 if locked.
+def raise_rate_limit_locked(locked_until: datetime) -> None:
+    """Raise HTTP 429 for an active lock using the remaining lock duration."""
+    retry_after = max(1, int((locked_until - _utcnow()).total_seconds()))
+    raise HTTPException(
+        status_code=429,
+        detail="Too many failed login attempts. Account temporarily locked.",
+        headers={"Retry-After": str(retry_after)},
+    )
 
-    Call this from the auth router before processing login.
+
+def check_rate_limit(identity_key: str, identity_type: str = "username") -> None:
     """
-    locked, retry_after = is_locked(username)
+    Check if identity is rate limited. Raises HTTPException 429 if locked.
+
+    Call this from the auth router before processing login/refresh.
+    """
+    locked, retry_after = is_locked(identity_key, identity_type=identity_type)
     if locked:
         raise HTTPException(
             status_code=429,

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,4 +1,5 @@
 from models.backup_config import BackupConfig, BackupHistory
 from models.prune_lock import PruneLock
+from models.rate_limit_attempt import RateLimitAttempt
 
-__all__ = ["BackupConfig", "BackupHistory"]
+__all__ = ["BackupConfig", "BackupHistory", "PruneLock", "RateLimitAttempt"]

--- a/backend/models/rate_limit_attempt.py
+++ b/backend/models/rate_limit_attempt.py
@@ -1,0 +1,27 @@
+"""Persistent auth rate-limit state."""
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Index, Integer, String, Text, UniqueConstraint
+
+from postgres_db import Base
+
+
+class RateLimitAttempt(Base):
+    """SQLAlchemy model for shared auth rate-limit counters."""
+
+    __tablename__ = "rate_limit_attempts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    identity_key = Column(Text, nullable=False)
+    identity_type = Column(String(32), nullable=False, default="username")
+    attempt_count = Column(Integer, nullable=False, default=0)
+    locked_until = Column(DateTime, nullable=True)
+    last_failed_at = Column(DateTime, nullable=True)
+    updated_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("identity_type", "identity_key", name="uq_rate_limit_identity"),
+        CheckConstraint("attempt_count >= 0", name="ck_rate_limit_attempt_count_nonnegative"),
+        Index("ix_rate_limit_identity", "identity_type", "identity_key"),
+        Index("ix_rate_limit_cleanup", "locked_until", "updated_at"),
+    )

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -22,7 +22,13 @@ from postgres_db import get_pg_db
 from repositories import user_repo
 from models.user import Token, User, PasswordChangeRequest
 from models.refresh_token import RefreshTokenResponse
-from middleware.rate_limit import check_rate_limit, clear_attempts, increment_attempts
+from middleware.rate_limit import (
+    check_rate_limit,
+    clear_attempts,
+    increment_attempts,
+    raise_rate_limit_locked,
+    refresh_token_rate_limit_key,
+)
 
 # ── Cookie domain and security (parsed once at import) ─────────────────────────
 
@@ -116,9 +122,10 @@ async def login_for_access_token(
     user = user_repo.get_user_by_username(db, form_data.username)
 
     if not user or not verify_password(form_data.password, user.hashed_password):
-        # Increment failed attempts
-        from middleware.rate_limit import increment_attempts
-        increment_attempts(form_data.username)
+        # Increment failed attempts and return 429 as soon as this failure locks the identity.
+        attempt_info = increment_attempts(form_data.username)
+        if attempt_info.locked_until:
+            raise_rate_limit_locked(attempt_info.locked_until)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Incorrect username or password",
@@ -183,13 +190,16 @@ async def refresh_tokens(
             detail="Missing refresh token cookie",
         )
 
-    # Track failed attempts (for existing token identifier) before token verification.
-    check_rate_limit(refresh_token)
+    # Track failed attempts by hashed token identifier before token verification.
+    rate_limit_key = refresh_token_rate_limit_key(refresh_token)
+    check_rate_limit(rate_limit_key, identity_type="refresh_token")
 
     # Verify refresh token
     user_id = verify_refresh_token(refresh_token, db)
     if user_id is None:
-        increment_attempts(refresh_token)
+        attempt_info = increment_attempts(rate_limit_key, identity_type="refresh_token")
+        if attempt_info.locked_until:
+            raise_rate_limit_locked(attempt_info.locked_until)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired refresh token",
@@ -201,11 +211,13 @@ async def refresh_tokens(
     # Get user by ID
     db_user = user_repo.get_user_by_id(db, user_id)
     if db_user is None or not db_user.is_active:
-        increment_attempts(refresh_token)
+        attempt_info = increment_attempts(rate_limit_key, identity_type="refresh_token")
+        if attempt_info.locked_until:
+            raise_rate_limit_locked(attempt_info.locked_until)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
 
     # Successful refresh — clear failed attempts for this token
-    clear_attempts(refresh_token)
+    clear_attempts(rate_limit_key, identity_type="refresh_token")
 
     # Create new access token
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)

--- a/backend/tests/test_auth_router_refresh.py
+++ b/backend/tests/test_auth_router_refresh.py
@@ -1,12 +1,18 @@
 """Integration tests for auth router cookie and refresh token flow."""
 
+import hashlib
 import os
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
-from middleware.rate_limit import MAX_ATTEMPTS, RATE_LIMIT_STORE, increment_attempts
+from middleware import rate_limit
+from middleware.rate_limit import MAX_ATTEMPTS, increment_attempts, refresh_token_rate_limit_key
+from models.rate_limit_attempt import RateLimitAttempt
+from postgres_db import Base
 
 # Patch Neo4j driver BEFORE importing anything
 _mock_neo4j_driver = MagicMock()
@@ -21,11 +27,18 @@ client = TestClient(app)
 
 
 @pytest.fixture(autouse=True)
-def _clear_rate_limit_store():
+def rate_limit_db(monkeypatch):
     """Ensure rate-limit state is isolated between tests."""
-    RATE_LIMIT_STORE.clear()
-    yield
-    RATE_LIMIT_STORE.clear()
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine, tables=[RateLimitAttempt.__table__])
+    monkeypatch.setattr(rate_limit, "SessionLocal", TestingSessionLocal)
+    yield TestingSessionLocal
+    Base.metadata.drop_all(bind=engine, tables=[RateLimitAttempt.__table__])
 
 
 def _make_mock_pg_user(
@@ -159,25 +172,58 @@ class TestAuthRefresh:
 
         with patch("routers.auth.verify_refresh_token", return_value=None) as mock_verify:
             responses = []
-            for _ in range(MAX_ATTEMPTS + 2):  # 4th fail then lock checked on 5th attempt
+            for _ in range(MAX_ATTEMPTS + 1):  # 4th failure locks immediately
                 response = client.post(
                     "/api/auth/refresh",
                     cookies={"refresh_token": "bad_refresh_token"},
                 )
                 responses.append(response)
 
-        assert [r.status_code for r in responses[: MAX_ATTEMPTS + 1]] == [401] * (MAX_ATTEMPTS + 1)
-        assert responses[MAX_ATTEMPTS + 1].status_code == 429
-        assert "Retry-After" in responses[MAX_ATTEMPTS + 1].headers
+        assert [r.status_code for r in responses[:MAX_ATTEMPTS]] == [401] * MAX_ATTEMPTS
+        assert responses[MAX_ATTEMPTS].status_code == 429
+        assert "Retry-After" in responses[MAX_ATTEMPTS].headers
         assert mock_verify.call_count == MAX_ATTEMPTS + 1
 
         app.dependency_overrides.pop(get_pg_db, None)
 
-    def test_refresh_success_clears_rate_limit_counter(self):
+    def test_refresh_rate_limit_persists_hashed_token_key(self, rate_limit_db):
+        """Refresh rate limiting should persist a token hash, never the raw token."""
+        raw_token = "bad_refresh_token"
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_refresh_token", return_value=None):
+            response = client.post(
+                "/api/auth/refresh",
+                cookies={"refresh_token": raw_token},
+            )
+
+        assert response.status_code == 401
+
+        session = rate_limit_db()
+        try:
+            attempts = session.query(RateLimitAttempt).all()
+        finally:
+            session.close()
+
+        assert len(attempts) == 1
+        assert attempts[0].identity_key == f"refresh:{hashlib.sha256(raw_token.encode()).hexdigest()}"
+        assert attempts[0].identity_key != raw_token
+        assert attempts[0].identity_type == "refresh_token"
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_refresh_success_clears_rate_limit_counter(self, rate_limit_db):
         """Successful refresh should reset rate-limit state for that token."""
         refresh_token = "old_refresh_token"
-        increment_attempts(refresh_token)
-        increment_attempts(refresh_token)
+        rate_limit_key = refresh_token_rate_limit_key(refresh_token)
+        increment_attempts(rate_limit_key, identity_type="refresh_token")
+        increment_attempts(rate_limit_key, identity_type="refresh_token")
 
         mock_user = _make_mock_pg_user(
             username="testuser",
@@ -205,7 +251,12 @@ class TestAuthRefresh:
                     )
 
         assert response.status_code == 200
-        assert refresh_token not in RATE_LIMIT_STORE
+
+        session = rate_limit_db()
+        try:
+            assert session.query(RateLimitAttempt).filter_by(identity_key=rate_limit_key).first() is None
+        finally:
+            session.close()
 
         app.dependency_overrides.pop(get_pg_db, None)
 

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -223,3 +223,11 @@ class TestCheckRateLimit:
             check_rate_limit("lockeduser")
         retry_after = int(exc_info.value.headers["Retry-After"])
         assert retry_after >= 800
+
+    def test_retry_after_header_minimum_one_second(self, rate_limit_db, monkeypatch):
+        monkeypatch.setattr(rate_limit, "is_locked", lambda *_args, **_kwargs: (True, 0))
+
+        with pytest.raises(HTTPException) as exc_info:
+            check_rate_limit("lockeduser")
+
+        assert exc_info.value.headers["Retry-After"] == "1"

--- a/backend/tests/test_rate_limit.py
+++ b/backend/tests/test_rate_limit.py
@@ -1,31 +1,44 @@
-"""Unit tests for middleware/rate_limit.py — login rate limiting logic."""
+"""Unit tests for middleware/rate_limit.py — persistent auth rate limiting."""
 
-import pytest
 from datetime import datetime, timedelta
 
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from middleware import rate_limit
 from middleware.rate_limit import (
-    RATE_LIMIT_STORE,
     MAX_ATTEMPTS,
-    LOCKOUT_DURATION,
     AttemptInfo,
+    check_rate_limit,
+    clear_attempts,
     get_attempt_info,
     increment_attempts,
-    clear_attempts,
     is_locked,
-    check_rate_limit,
 )
+from models.rate_limit_attempt import RateLimitAttempt
+from postgres_db import Base
 
 
-@pytest.fixture(autouse=True)
-def clean_store():
-    """Clear the rate limit store before and after each test."""
-    RATE_LIMIT_STORE.clear()
-    yield
-    RATE_LIMIT_STORE.clear()
+@pytest.fixture
+def rate_limit_db(monkeypatch):
+    """Use an isolated SQLite DB for persistent rate-limit tests."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine, tables=[RateLimitAttempt.__table__])
+    monkeypatch.setattr(rate_limit, "SessionLocal", TestingSessionLocal)
+    yield TestingSessionLocal
+    Base.metadata.drop_all(bind=engine, tables=[RateLimitAttempt.__table__])
 
 
 class TestAttemptInfo:
-    """Tests for AttemptInfo NamedTuple."""
+    """Tests for AttemptInfo NamedTuple compatibility."""
 
     def test_attempt_info_default(self):
         info = AttemptInfo(count=0, locked_until=None)
@@ -36,24 +49,20 @@ class TestAttemptInfo:
 class TestIncrementAttempts:
     """Tests for failed attempt tracking."""
 
-    def test_first_attempt_increments_count(self):
+    def test_first_attempt_increments_count(self, rate_limit_db):
         info = increment_attempts("user1")
         assert info.count == 1
         assert info.locked_until is None
 
-    def test_third_attempt_still_no_lockout(self):
-        """3 attempts should NOT trigger lockout — lockout is on the 4th attempt (after 3 consecutive failures)."""
+    def test_third_attempt_still_no_lockout(self, rate_limit_db):
+        """3 attempts should NOT trigger lockout; lockout is on the 4th failed attempt."""
         for _ in range(3):
             info = increment_attempts("user1")
         assert info.count == 3
         assert info.locked_until is None
 
-    def test_fourth_attempt_triggers_lockout(self):
-        """
-        4th consecutive failed attempt triggers 15-min lockout.
-        Spec: "After 3 consecutive failed attempts, account is locked for 15 minutes"
-        → 3 failures → lockout → 4th attempt blocked.
-        """
+    def test_fourth_attempt_triggers_lockout(self, rate_limit_db):
+        """4th consecutive failed attempt triggers 15-minute lockout."""
         for _ in range(3):
             increment_attempts("user1")
         info = increment_attempts("user1")
@@ -61,35 +70,99 @@ class TestIncrementAttempts:
         assert info.locked_until is not None
         assert info.locked_until > datetime.utcnow()
 
-    def test_separate_users_have_separate_counters(self):
+    def test_separate_users_have_separate_counters(self, rate_limit_db):
         increment_attempts("user1")
         increment_attempts("user1")
         info_user2 = increment_attempts("user2")
         assert info_user2.count == 1
 
+    def test_user_and_refresh_namespaces_do_not_collide(self, rate_limit_db):
+        shared_key = "refresh:shared"
+        user_info = increment_attempts(shared_key)
+        refresh_info = increment_attempts(shared_key, identity_type="refresh_token")
+
+        assert user_info.count == 1
+        assert refresh_info.count == 1
+
+        session = rate_limit_db()
+        try:
+            rows = session.query(RateLimitAttempt).order_by(RateLimitAttempt.identity_type).all()
+        finally:
+            session.close()
+
+        assert {(row.identity_type, row.identity_key) for row in rows} == {
+            ("refresh_token", "refresh:shared"),
+            ("username", "user:refresh:shared"),
+        }
+
+    def test_long_username_key_is_persisted_without_length_failure(self, rate_limit_db):
+        long_username = "u" * 300
+        info = increment_attempts(long_username)
+        assert info.count == 1
+
+        session = rate_limit_db()
+        try:
+            row = session.query(RateLimitAttempt).filter_by(identity_type="username").one()
+        finally:
+            session.close()
+
+        assert row.identity_key == f"user:{long_username}"
+
+    def test_username_prefix_sentinel_does_not_collide(self, rate_limit_db):
+        increment_attempts("alice")
+        increment_attempts("user:alice")
+
+        session = rate_limit_db()
+        try:
+            rows = session.query(RateLimitAttempt).order_by(RateLimitAttempt.identity_key).all()
+        finally:
+            session.close()
+
+        assert [row.identity_key for row in rows] == ["user:alice", "user:user:alice"]
+
+    def test_expired_lock_resets_before_incrementing(self, rate_limit_db):
+        session = rate_limit_db()
+        try:
+            session.add(
+                RateLimitAttempt(
+                    identity_key="user:expired_user",
+                    identity_type="username",
+                    attempt_count=4,
+                    locked_until=datetime.utcnow() - timedelta(minutes=1),
+                    updated_at=datetime.utcnow() - timedelta(minutes=20),
+                )
+            )
+            session.commit()
+        finally:
+            session.close()
+
+        info = increment_attempts("expired_user")
+        assert info.count == 1
+        assert info.locked_until is None
+
 
 class TestClearAttempts:
-    """Tests for clearing attempts on successful login."""
+    """Tests for clearing attempts on successful auth."""
 
-    def test_clear_removes_user_from_store(self):
+    def test_clear_removes_user_from_store(self, rate_limit_db):
         increment_attempts("user1")
         increment_attempts("user1")
         clear_attempts("user1")
-        assert "user1" not in RATE_LIMIT_STORE
+        assert get_attempt_info("user1") == AttemptInfo(count=0, locked_until=None)
 
-    def test_clear_nonexistent_user_no_error(self):
+    def test_clear_nonexistent_user_no_error(self, rate_limit_db):
         clear_attempts("nonexistent")  # Should not raise
 
 
 class TestIsLocked:
     """Tests for lockout detection."""
 
-    def test_not_locked_when_no_attempts(self):
+    def test_not_locked_when_no_attempts(self, rate_limit_db):
         locked, retry_after = is_locked("anyone")
         assert locked is False
         assert retry_after is None
 
-    def test_locked_after_exceeding_attempts(self):
+    def test_locked_after_exceeding_attempts(self, rate_limit_db):
         for _ in range(MAX_ATTEMPTS):
             increment_attempts("locked_user")
         increment_attempts("locked_user")  # 4th triggers lockout
@@ -98,44 +171,55 @@ class TestIsLocked:
         assert retry_after is not None
         assert retry_after > 0
 
-    def test_expired_lock_returns_not_locked(self):
-        # Manually set an expired lock
-        RATE_LIMIT_STORE["user_with_expired_lock"] = AttemptInfo(
-            count=4,
-            locked_until=datetime.utcnow() - timedelta(minutes=1),  # expired
-        )
+    def test_expired_lock_returns_not_locked_and_cleans_row(self, rate_limit_db):
+        session = rate_limit_db()
+        try:
+            session.add(
+                RateLimitAttempt(
+                    identity_key="user:user_with_expired_lock",
+                    identity_type="username",
+                    attempt_count=4,
+                    locked_until=datetime.utcnow() - timedelta(minutes=1),
+                    updated_at=datetime.utcnow() - timedelta(minutes=20),
+                )
+            )
+            session.commit()
+        finally:
+            session.close()
+
         locked, retry_after = is_locked("user_with_expired_lock")
         assert locked is False
-        # Lock should be cleared from store
-        assert "user_with_expired_lock" not in RATE_LIMIT_STORE
+        assert retry_after is None
+
+        session = rate_limit_db()
+        try:
+            assert session.query(RateLimitAttempt).filter_by(identity_key="user:user_with_expired_lock").first() is None
+        finally:
+            session.close()
 
 
 class TestCheckRateLimit:
     """Tests for the check_rate_limit utility function."""
 
-    def test_no_exception_for_unlocked_user(self):
-        # Should not raise
+    def test_no_exception_for_unlocked_user(self, rate_limit_db):
         check_rate_limit("anyuser")
 
-    def test_raises_http_429_for_locked_user(self):
+    def test_raises_http_429_for_locked_user(self, rate_limit_db):
         for _ in range(MAX_ATTEMPTS):
             increment_attempts("lockeduser")
         increment_attempts("lockeduser")
 
-        from fastapi import HTTPException
         with pytest.raises(HTTPException) as exc_info:
             check_rate_limit("lockeduser")
         assert exc_info.value.status_code == 429
         assert "Retry-After" in exc_info.value.headers
 
-    def test_retry_after_header_value(self):
+    def test_retry_after_header_value(self, rate_limit_db):
         for _ in range(MAX_ATTEMPTS):
             increment_attempts("lockeduser")
         increment_attempts("lockeduser")
 
-        from fastapi import HTTPException
         with pytest.raises(HTTPException) as exc_info:
             check_rate_limit("lockeduser")
         retry_after = int(exc_info.value.headers["Retry-After"])
-        # Should be approximately 15 minutes in seconds (900), allow some tolerance
         assert retry_after >= 800

--- a/backend/tests/test_routers_auth_users_roles.py
+++ b/backend/tests/test_routers_auth_users_roles.py
@@ -24,7 +24,9 @@ Strategy:
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 # Patch Neo4j driver BEFORE importing anything that touches database.py
 # The driver is created at module import time and tries to connect immediately
@@ -45,9 +47,11 @@ from models.user import (
     Role,
     RoleCreate,
 )
-from postgres_db import get_pg_db
+from postgres_db import Base, get_pg_db
 from services.auth_service import get_current_active_user
 from repositories import user_repo
+from middleware import rate_limit
+from models.rate_limit_attempt import RateLimitAttempt
 
 # ---------------------------------------------------------------------------
 # TestClient
@@ -125,6 +129,21 @@ def _make_mock_pg_user(
 # ---------------------------------------------------------------------------
 # Fixtures — mock DB session
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def rate_limit_db(monkeypatch):
+    """Use an isolated DB for auth rate-limit helpers in router tests."""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine, tables=[RateLimitAttempt.__table__])
+    monkeypatch.setattr(rate_limit, "SessionLocal", TestingSessionLocal)
+    yield TestingSessionLocal
+    Base.metadata.drop_all(bind=engine, tables=[RateLimitAttempt.__table__])
 
 
 @pytest.fixture
@@ -218,6 +237,36 @@ class TestAuthToken:
         )
 
         assert response.status_code == 401
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_login_rate_limits_on_threshold_crossing_failure(self, mock_db):
+        """Fourth failed login attempt should lock immediately with HTTP 429."""
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            is_active=True,
+            hashed_password="$pbkdf2-sha256$29000$abc",
+        )
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch("routers.auth.verify_password", return_value=False) as mock_verify:
+            responses = [
+                client.post(
+                    "/api/auth/token",
+                    data={"username": "testuser", "password": "wrong_password"},
+                )
+                for _ in range(4)
+            ]
+
+        assert [response.status_code for response in responses[:3]] == [401, 401, 401]
+        assert responses[3].status_code == 429
+        assert "Retry-After" in responses[3].headers
+        assert mock_verify.call_count == 4
 
         app.dependency_overrides.pop(get_pg_db, None)
 


### PR DESCRIPTION
## Descripción del Cambio
Closes #110

- Reemplaza el rate-limit auth en memoria por una tabla persistente `rate_limit_attempts` compartida vía SQLAlchemy/Postgres.
- Agrega namespacing y hashing para identidades sensibles: usuarios como `user:<username>` y refresh tokens como `refresh:<sha256>`.
- Endurece concurrencia/esquema con unicidad compuesta, row locking, limpieza oportunista y respuesta `429` inmediata al cruzar el umbral de lockout.

| File | Change |
|------|--------|
| `.gitignore` | Ignora `.pi/settings.json` local. |
| `backend/models/rate_limit_attempt.py` | Nuevo modelo persistente para intentos de rate-limit. |
| `backend/models/__init__.py` | Exporta `RateLimitAttempt`. |
| `backend/main.py` | Registra el modelo para `Base.metadata.create_all`. |
| `backend/middleware/rate_limit.py` | Migra de dict en memoria a store persistente con locking y cleanup. |
| `backend/routers/auth.py` | Usa keys hasheadas/namespaced y devuelve `429` al bloquear. |
| `backend/tests/*` | Actualiza/agrega cobertura para persistencia, refresh hash, namespaces, usernames largos y login/refresh `429`. |

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] Targeted auth/rate-limit suite:
  ```bash
  python -m pytest backend/tests/test_rate_limit.py backend/tests/test_auth_router_refresh.py backend/tests/test_routers_auth_users_roles.py -k 'change_password or rate_limit or refresh or token' -q
  ```
  Resultado: `42 passed, 31 deselected`.
- [x] `git diff --check` sin errores de whitespace; solo warnings CRLF locales.
- [x] Fresh post-hardening review: sin blockers.
- [x] Full backend suite ejecutada para señal amplia:
  ```bash
  python -m pytest backend/tests -q
  ```
  Resultado observado: `108 failed, 669 passed, 1 skipped`; fallos amplios/preexistentes o de entorno/mocks legacy, no concentrados en este cambio.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notas
- El locking cross-worker real depende de PostgreSQL; los tests locales usan SQLite para validar semántica secuencial y rutas.
- No se agrega Redis porque no existe dependencia/stack Redis en el proyecto.

---
*Generado por Alex*
