### PR TITLE
feat(polling): add runtime rollout commands

### DIFF
--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Backend operator and maintenance scripts."""

--- a/backend/scripts/polling_enqueue_cycle.py
+++ b/backend/scripts/polling_enqueue_cycle.py
@@ -1,0 +1,161 @@
+"""Operator command for enqueueing one polling cycle from explicit records.
+
+This is a minimal, testable runtime entrypoint for the PostgreSQL queue path. It
+does not discover production CI/metric definitions by itself; operators provide a
+JSON array of scheduler records exported by an approved source. The command is
+default-off through `POLLING_PG_QUEUE_ENABLED`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _load_settings():
+    from config import get_polling_pipeline_settings
+
+    return get_polling_pipeline_settings()
+
+
+def _load_session_factory():
+    from postgres_db import SessionLocal
+
+    return SessionLocal
+
+
+def _build_cycle(*, scheduled_for: datetime, config_version: str | None, target_cycle_seconds: int):
+    from polling.scheduler import build_cycle
+
+    return build_cycle(
+        scheduled_for=scheduled_for,
+        config_version=config_version,
+        target_cycle_seconds=target_cycle_seconds,
+    )
+
+
+def _build_tasks(records: list[dict[str, Any]], cycle):
+    from polling.scheduler import build_tasks_from_records
+
+    return build_tasks_from_records(records, cycle)
+
+
+def _stale_metadata_indexes(records: list[dict[str, Any]], *, current_metadata_version: str | None) -> list[int]:
+    from polling.scheduler import has_stale_metadata
+
+    if not current_metadata_version:
+        return []
+    return [
+        index
+        for index, record in enumerate(records)
+        if has_stale_metadata(record, current_metadata_version=current_metadata_version)
+    ]
+
+
+def _enqueue_cycle_tasks(db, cycle, tasks) -> None:
+    from polling.scheduler import enqueue_cycle_tasks
+
+    enqueue_cycle_tasks(db, cycle, tasks)
+
+
+def _parse_datetime(raw: str | None) -> datetime:
+    if not raw:
+        return datetime.now(timezone.utc)
+    return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _load_records(path: Path) -> list[dict[str, Any]]:
+    records = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(records, list) or not all(isinstance(record, dict) for record in records):
+        raise ValueError("records file must contain a JSON array of objects")
+    return records
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build and enqueue one durable polling cycle from JSON records.")
+    parser.add_argument("--records-file", required=True, type=Path, help="JSON array of scheduler records to enqueue.")
+    parser.add_argument("--scheduled-for", help="Cycle timestamp in ISO-8601; defaults to current UTC time.")
+    parser.add_argument("--config-version", help="Metadata/config version stamped on the cycle.")
+    parser.add_argument(
+        "--current-metadata-version",
+        help="When metadata cache is enabled, reject records whose metadata_version differs from this value. Defaults to --config-version.",
+    )
+    parser.add_argument("--target-cycle-seconds", type=int, default=900, help="Target polling cycle duration.")
+    parser.add_argument("--dry-run", action="store_true", help="Build tasks and print counts without writing queue rows.")
+    args = parser.parse_args(argv)
+
+    settings = _load_settings()
+    if not getattr(settings, "pg_queue_enabled", False):
+        print(json.dumps({"enabled": False, "reason": "POLLING_PG_QUEUE_ENABLED is false"}, indent=2))
+        return 0
+
+    records = _load_records(args.records_file)
+    if getattr(settings, "metadata_cache_enabled", False):
+        stale_indexes = _stale_metadata_indexes(
+            records,
+            current_metadata_version=args.current_metadata_version or args.config_version,
+        )
+        if stale_indexes:
+            print(
+                json.dumps(
+                    {
+                        "enabled": False,
+                        "reason": "metadata_version_mismatch",
+                        "stale_record_indexes": stale_indexes,
+                    },
+                    indent=2,
+                )
+            )
+            return 2
+
+    cycle = _build_cycle(
+        scheduled_for=_parse_datetime(args.scheduled_for),
+        config_version=args.config_version,
+        target_cycle_seconds=args.target_cycle_seconds,
+    )
+    tasks = _build_tasks(records, cycle)
+    if getattr(settings, "backpressure_enabled", False) and len(tasks) > int(getattr(settings, "backpressure_max_task_queue_depth", 100000)):
+        print(
+            json.dumps(
+                {
+                    "enabled": False,
+                    "reason": "backpressure_max_task_queue_depth",
+                    "task_count": len(tasks),
+                    "threshold": int(getattr(settings, "backpressure_max_task_queue_depth", 100000)),
+                },
+                indent=2,
+            )
+        )
+        return 2
+
+    if not args.dry_run:
+        db = _load_session_factory()()
+        try:
+            _enqueue_cycle_tasks(db, cycle, tasks)
+        finally:
+            db.close()
+
+    print(
+        json.dumps(
+            {
+                "enabled": True,
+                "dry_run": args.dry_run,
+                "cycle_id": str(cycle.cycle_id),
+                "scheduled_for": cycle.scheduled_for.isoformat(),
+                "task_count": len(tasks),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/polling_result_writer.py
+++ b/backend/scripts/polling_result_writer.py
@@ -1,0 +1,100 @@
+"""Operator command for one polling result-writer pass.
+
+The command is default-off through `POLLING_DB_WRITER_ENABLED`. It is intended
+for supervised process managers to invoke in a loop or on a schedule once the
+queue pipeline has been staged and validated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def _load_settings():
+    from config import get_polling_pipeline_settings
+
+    return get_polling_pipeline_settings()
+
+
+def _load_session_factory():
+    from postgres_db import SessionLocal
+
+    return SessionLocal
+
+
+def _load_neo4j_driver():
+    from database import get_db
+
+    return get_db()
+
+
+def _run_writer_once(queue_db, timescale_db, neo4j_driver, *, settings, worker_id: str, lease_ttl_seconds: int, writer_partitions: list[int] | None):
+    from polling.writer_pool import run_writer_once
+
+    return run_writer_once(
+        queue_db,
+        timescale_db,
+        neo4j_driver,
+        settings=settings,
+        worker_id=worker_id,
+        lease_ttl_seconds=lease_ttl_seconds,
+        writer_partitions=writer_partitions,
+    )
+
+
+def _partitions(raw: str | None) -> list[int] | None:
+    if not raw:
+        return None
+    return [int(part.strip()) for part in raw.split(",") if part.strip()]
+
+
+def _default_worker_id() -> str:
+    return f"polling-writer-{socket.gethostname()}-{os.getpid()}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run one gated polling result-writer batch.")
+    parser.add_argument("--worker-id", default=_default_worker_id(), help="Lease owner ID written to poll_result_queue.")
+    parser.add_argument("--lease-ttl-seconds", type=int, default=60, help="Result lease TTL for this writer pass.")
+    parser.add_argument("--writer-partitions", help="Optional comma-separated partition IDs for this writer.")
+    args = parser.parse_args(argv)
+
+    settings = _load_settings()
+    if not getattr(settings, "db_writer_enabled", False):
+        print(json.dumps({"enabled": False, "reason": "POLLING_DB_WRITER_ENABLED is false"}, indent=2))
+        return 0
+
+    session_factory = _load_session_factory()
+    queue_db = None
+    timescale_db = None
+    try:
+        queue_db = session_factory()
+        timescale_db = session_factory()
+        stats = _run_writer_once(
+            queue_db,
+            timescale_db,
+            _load_neo4j_driver(),
+            settings=settings,
+            worker_id=args.worker_id,
+            lease_ttl_seconds=args.lease_ttl_seconds,
+            writer_partitions=_partitions(args.writer_partitions),
+        )
+    finally:
+        if queue_db is not None:
+            queue_db.close()
+        if timescale_db is not None:
+            timescale_db.close()
+
+    print(json.dumps({"enabled": True, "worker_id": args.worker_id, "stats": stats}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/run_polling_migrations.py
+++ b/backend/scripts/run_polling_migrations.py
@@ -1,0 +1,51 @@
+"""Operator command for applying polling PostgreSQL migrations.
+
+This script is intentionally explicit: polling queue DDL is never applied on
+application startup. Operators run this command during the staged rollout before
+enabling `POLLING_PG_QUEUE_ENABLED=true`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from polling.migrations import POLLING_MIGRATIONS
+
+
+def _load_engine():
+    from postgres_db import engine
+
+    return engine
+
+
+def _run_pending_migrations(engine) -> list[str]:
+    from polling.migrations import run_pending_migrations
+
+    return run_pending_migrations(engine)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Apply explicit PostgreSQL migrations for the polling pipeline.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print known polling migration versions without connecting to PostgreSQL.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        print(json.dumps({"dry_run": True, "migrations": [m.version for m in POLLING_MIGRATIONS]}, indent=2))
+        return 0
+
+    applied = _run_pending_migrations(_load_engine())
+    print(json.dumps({"dry_run": False, "applied": applied, "applied_count": len(applied)}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_polling_docs_links.py
+++ b/backend/tests/test_polling_docs_links.py
@@ -18,6 +18,9 @@ def test_polling_docs_are_linked_from_readme_and_reference_existing_scripts():
     for path in [
         "backend/scripts/polling_host_benchmark.py",
         "backend/scripts/polling_load_simulator.py",
+        "backend/scripts/run_polling_migrations.py",
+        "backend/scripts/polling_enqueue_cycle.py",
+        "backend/scripts/polling_result_writer.py",
     ]:
         assert (REPO_ROOT / path).exists()
         assert path in combined

--- a/backend/tests/test_polling_runtime_scripts.py
+++ b/backend/tests/test_polling_runtime_scripts.py
@@ -1,0 +1,184 @@
+import json
+from types import SimpleNamespace
+
+
+class FakeSession:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_migration_script_dry_run_lists_polling_migrations(capsys):
+    from scripts import run_polling_migrations
+
+    assert run_polling_migrations.main(["--dry-run"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert "20260525_001_polling_queue" in payload["migrations"]
+
+
+def test_migration_script_calls_runner_with_app_engine(monkeypatch, capsys):
+    from scripts import run_polling_migrations
+
+    fake_engine = object()
+    calls = []
+    monkeypatch.setattr(run_polling_migrations, "_load_engine", lambda: fake_engine)
+    monkeypatch.setattr(run_polling_migrations, "_run_pending_migrations", lambda engine: calls.append(engine) or ["v1"])
+
+    assert run_polling_migrations.main([]) == 0
+
+    assert calls == [fake_engine]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"dry_run": False, "applied": ["v1"], "applied_count": 1}
+
+
+def test_result_writer_script_noops_when_writer_flag_disabled(monkeypatch, capsys):
+    from scripts import polling_result_writer
+
+    monkeypatch.setattr(polling_result_writer, "_load_settings", lambda: SimpleNamespace(db_writer_enabled=False))
+    monkeypatch.setattr(
+        polling_result_writer,
+        "_run_writer_once",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("writer should not run")),
+    )
+
+    assert polling_result_writer.main([]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["enabled"] is False
+    assert "POLLING_DB_WRITER_ENABLED" in payload["reason"]
+
+
+def test_result_writer_script_runs_one_gated_batch_and_closes_sessions(monkeypatch, capsys):
+    from scripts import polling_result_writer
+
+    sessions = [FakeSession(), FakeSession()]
+    calls = []
+    monkeypatch.setattr(polling_result_writer, "_load_settings", lambda: SimpleNamespace(db_writer_enabled=True, result_batch_size=10))
+    monkeypatch.setattr(polling_result_writer, "_load_session_factory", lambda: lambda: sessions.pop(0))
+    monkeypatch.setattr(polling_result_writer, "_load_neo4j_driver", lambda: "neo4j-driver")
+
+    def fake_run(queue_db, timescale_db, neo4j_driver, **kwargs):
+        calls.append((queue_db, timescale_db, neo4j_driver, kwargs))
+        return {"claimed": 1, "written": 1}
+
+    monkeypatch.setattr(polling_result_writer, "_run_writer_once", fake_run)
+
+    assert polling_result_writer.main(["--worker-id", "writer-test", "--lease-ttl-seconds", "45", "--writer-partitions", "1,2"]) == 0
+
+    queue_db, timescale_db, neo4j_driver, kwargs = calls[0]
+    assert queue_db.closed is True
+    assert timescale_db.closed is True
+    assert neo4j_driver == "neo4j-driver"
+    assert kwargs["worker_id"] == "writer-test"
+    assert kwargs["lease_ttl_seconds"] == 45
+    assert kwargs["writer_partitions"] == [1, 2]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["enabled"] is True
+    assert payload["stats"] == {"claimed": 1, "written": 1}
+
+
+def test_enqueue_script_noops_when_queue_flag_disabled(monkeypatch, tmp_path, capsys):
+    from scripts import polling_enqueue_cycle
+
+    records = tmp_path / "records.json"
+    records.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(polling_enqueue_cycle, "_load_settings", lambda: SimpleNamespace(pg_queue_enabled=False))
+    monkeypatch.setattr(
+        polling_enqueue_cycle,
+        "_load_session_factory",
+        lambda: (_ for _ in ()).throw(AssertionError("db should not be opened")),
+    )
+
+    assert polling_enqueue_cycle.main(["--records-file", str(records)]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["enabled"] is False
+    assert "POLLING_PG_QUEUE_ENABLED" in payload["reason"]
+
+
+def test_enqueue_script_rejects_stale_records_when_metadata_cache_flag_enabled(monkeypatch, tmp_path, capsys):
+    from scripts import polling_enqueue_cycle
+
+    records = tmp_path / "records.json"
+    records.write_text(json.dumps([{"node_id": "ci-1", "metric_id": "cpu", "protocol": "SNMP", "metadata_version": "old"}]), encoding="utf-8")
+    monkeypatch.setattr(
+        polling_enqueue_cycle,
+        "_load_settings",
+        lambda: SimpleNamespace(pg_queue_enabled=True, metadata_cache_enabled=True),
+    )
+
+    assert polling_enqueue_cycle.main(["--records-file", str(records), "--config-version", "current"]) == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reason"] == "metadata_version_mismatch"
+    assert payload["stale_record_indexes"] == [0]
+
+
+def test_enqueue_script_rejects_oversized_cycle_when_backpressure_flag_enabled(monkeypatch, tmp_path, capsys):
+    from scripts import polling_enqueue_cycle
+
+    records = tmp_path / "records.json"
+    records.write_text(
+        json.dumps([
+            {"node_id": "ci-1", "metric_id": "PING-CHECK", "protocol": "ICMP", "ip": "10.0.0.1"},
+            {"node_id": "ci-2", "metric_id": "PING-CHECK", "protocol": "ICMP", "ip": "10.0.0.2"},
+        ]),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        polling_enqueue_cycle,
+        "_load_settings",
+        lambda: SimpleNamespace(pg_queue_enabled=True, backpressure_enabled=True, backpressure_max_task_queue_depth=1),
+    )
+
+    assert polling_enqueue_cycle.main(["--records-file", str(records), "--dry-run"]) == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reason"] == "backpressure_max_task_queue_depth"
+    assert payload["task_count"] == 2
+    assert payload["threshold"] == 1
+
+
+def test_enqueue_script_builds_and_enqueues_cycle_when_enabled(monkeypatch, tmp_path, capsys):
+    from scripts import polling_enqueue_cycle
+
+    records = tmp_path / "records.json"
+    records.write_text(
+        json.dumps([
+            {
+                "node_id": "ci-1",
+                "metric_id": "PING-CHECK",
+                "protocol": "ICMP",
+                "ip": "10.0.0.1",
+            }
+        ]),
+        encoding="utf-8",
+    )
+    db = FakeSession()
+    enqueued = []
+    monkeypatch.setattr(polling_enqueue_cycle, "_load_settings", lambda: SimpleNamespace(pg_queue_enabled=True))
+    monkeypatch.setattr(polling_enqueue_cycle, "_load_session_factory", lambda: lambda: db)
+    monkeypatch.setattr(polling_enqueue_cycle, "_enqueue_cycle_tasks", lambda db_arg, cycle, tasks: enqueued.append((db_arg, cycle, list(tasks))))
+
+    assert polling_enqueue_cycle.main([
+        "--records-file",
+        str(records),
+        "--scheduled-for",
+        "2026-05-25T12:00:00Z",
+        "--config-version",
+        "v1",
+    ]) == 0
+
+    assert db.closed is True
+    assert enqueued[0][0] is db
+    assert len(enqueued[0][2]) == 1
+    assert enqueued[0][2][0]["ci_id"] == "ci-1"
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["enabled"] is True
+    assert payload["dry_run"] is False
+    assert payload["scheduled_for"] == "2026-05-25T12:00:00+00:00"
+    assert payload["task_count"] == 1

--- a/docs/polling-pipeline-runbook.md
+++ b/docs/polling-pipeline-runbook.md
@@ -4,16 +4,38 @@ Operational runbook for the scalable metric polling pipeline. The legacy serial 
 
 ## Enablement order
 
-Enable one layer at a time and keep the system observable between steps:
+Enable one layer at a time and keep the system observable between steps. All behavior-changing flags are default-off; do not enable the next step until the current command and metrics are understood.
 
 1. Set `POLLING_PIPELINE_OBSERVE_ONLY=true`; confirm current cycle duration and failure baseline.
-2. Apply PostgreSQL queue migrations; then set `POLLING_PG_QUEUE_ENABLED=true`.
-3. Run a synthetic benchmark with `backend/scripts/polling_host_benchmark.py` or `backend/scripts/polling_load_simulator.py` and attach the JSON report to the rollout notes.
-4. Set `POLLING_SNMP_LEASED_WORKER=true` with low `POLLING_WORKERS` and small `POLLING_TASK_BATCH_SIZE`.
-5. Set `POLLING_DB_WRITER_ENABLED=true` with `POLLING_DB_WRITERS=1` and conservative `POLLING_RESULT_BATCH_SIZE`.
-6. Set `POLLING_BACKPRESSURE_ENABLED=true`.
-7. Set `POLLING_METADATA_CACHE_ENABLED=true` after confirming cache TTL/version mismatch behavior in logs.
-8. Raise workers/batches only after simulator evidence and live observability show headroom.
+2. Apply PostgreSQL queue migrations explicitly; migrations are not auto-run on startup:
+
+   ```bash
+   python backend/scripts/run_polling_migrations.py --dry-run
+   python backend/scripts/run_polling_migrations.py
+   ```
+
+3. Set `POLLING_PG_QUEUE_ENABLED=true`, then enqueue a controlled test cycle from an approved JSON record export:
+
+   ```bash
+   python backend/scripts/polling_enqueue_cycle.py \
+     --records-file /path/to/polling-records.json \
+     --scheduled-for 2026-05-25T12:00:00Z \
+     --config-version rollout-v1
+   ```
+
+   When `POLLING_METADATA_CACHE_ENABLED=true`, pass `--current-metadata-version` or use `--config-version` so stale exported records are rejected before enqueue. When `POLLING_BACKPRESSURE_ENABLED=true`, the command refuses cycles larger than `POLLING_BACKPRESSURE_MAX_TASK_QUEUE_DEPTH`.
+
+4. Run a synthetic benchmark with `backend/scripts/polling_host_benchmark.py` or `backend/scripts/polling_load_simulator.py` and attach the JSON report to the rollout notes.
+5. Set `POLLING_SNMP_LEASED_WORKER=true` with low `POLLING_WORKERS` and small `POLLING_TASK_BATCH_SIZE`.
+6. Set `POLLING_DB_WRITER_ENABLED=true` with `POLLING_DB_WRITERS=1` and conservative `POLLING_RESULT_BATCH_SIZE`, then run the result writer under a supervisor:
+
+   ```bash
+   python backend/scripts/polling_result_writer.py --worker-id writer-1
+   ```
+
+7. Set `POLLING_BACKPRESSURE_ENABLED=true`; verify oversized cycle rejection with `backend/scripts/polling_enqueue_cycle.py --dry-run` before larger enqueues.
+8. Set `POLLING_METADATA_CACHE_ENABLED=true` after confirming cache TTL/version mismatch behavior through `backend/scripts/polling_enqueue_cycle.py --current-metadata-version`.
+9. Raise workers/batches only after simulator evidence and live observability show headroom.
 
 ## Evidence required before increasing concurrency
 
@@ -43,9 +65,9 @@ Rollback in reverse enablement order:
 
 1. Disable `POLLING_METADATA_CACHE_ENABLED`.
 2. Disable `POLLING_BACKPRESSURE_ENABLED` only if the queue is stable; otherwise leave it enabled while reducing concurrency.
-3. Disable `POLLING_DB_WRITER_ENABLED` and stop writer consumers.
+3. Disable `POLLING_DB_WRITER_ENABLED` and stop `backend/scripts/polling_result_writer.py` consumers.
 4. Disable `POLLING_SNMP_LEASED_WORKER`.
-5. Leave `POLLING_PG_QUEUE_ENABLED` data intact for replay/audit unless a maintainer approves cleanup.
+5. Disable `POLLING_PG_QUEUE_ENABLED` after queue consumers are stopped; leave queue data intact for replay/audit unless a maintainer approves cleanup.
 6. Disable `POLLING_PIPELINE_OBSERVE_ONLY` last if legacy behavior is fully restored.
 
 ## Queue replay guidance

--- a/docs/polling-pipeline-tuning.md
+++ b/docs/polling-pipeline-tuning.md
@@ -38,9 +38,10 @@ Do not use DB-backed mode on production without a maintenance window and rollbac
 Start with low `POLLING_WORKERS` and raise gradually:
 
 1. Run synthetic benchmark.
-2. Enable leased worker with `POLLING_SNMP_LEASED_WORKER=true`.
-3. Observe worker p95/p99, timeout rate, device CPU/link health, and queue depth.
-4. Raise workers only if queue depth drains and target safety limits are not frequently denying work.
+2. Apply migrations with `backend/scripts/run_polling_migrations.py` and enqueue only a controlled cycle with `backend/scripts/polling_enqueue_cycle.py` after `POLLING_PG_QUEUE_ENABLED=true`.
+3. Enable leased worker with `POLLING_SNMP_LEASED_WORKER=true`.
+4. Observe worker p95/p99, timeout rate, device CPU/link health, and queue depth.
+5. Raise workers only if queue depth drains and target safety limits are not frequently denying work.
 
 Suggested first production setting: `POLLING_WORKERS=4` to `8`, then tune by evidence.
 
@@ -56,12 +57,14 @@ Lease TTL should exceed normal p99 protocol latency plus batch overhead. Too sho
 
 - `POLLING_TASK_BATCH_SIZE`: start small, e.g. `100`; raise when workers are underutilized and queue claim overhead dominates.
 - `POLLING_RESULT_BATCH_SIZE`: start at `500`; tune against DB latency and writer lag.
+- Run `backend/scripts/polling_result_writer.py --worker-id writer-1` under a supervisor only after `POLLING_DB_WRITER_ENABLED=true`.
 - Keep DB writer transactions short enough to retry safely.
 - If DB latency rises, reduce result batch size before adding more writers.
 
 ## Retry/backoff/dead-letter
 
 - `POLLING_BACKPRESSURE_RETRY_MAX_ATTEMPTS` defaults to a capped value; do not raise it to hide credential/OID problems.
+- Use `backend/scripts/polling_enqueue_cycle.py --dry-run` to validate that `POLLING_BACKPRESSURE_ENABLED=true` rejects enqueues above `POLLING_BACKPRESSURE_MAX_TASK_QUEUE_DEPTH`.
 - Repeated SNMP/CLI/REST failures should enter cooldown or dead-letter with reason.
 - Under pressure, ICMP remains first; lower-priority work is delayed, not silently lost.
 
@@ -69,6 +72,7 @@ Lease TTL should exceed normal p99 protocol latency plus batch overhead. Too sho
 
 - `POLLING_METADATA_CACHE_TTL_SECONDS` defaults to 300 seconds.
 - Lower TTL when CI/metric definitions change frequently.
+- With `POLLING_METADATA_CACHE_ENABLED=true`, pass `--current-metadata-version` to `backend/scripts/polling_enqueue_cycle.py` so stale metadata is rejected before queue insertion.
 - Stale metadata must refresh or defer; it must not drive polling beyond the freshness window.
 - Cache only safe credential refs/session metadata. Do not cache secrets.
 


### PR DESCRIPTION
Closes #139

## Descripción del Cambio
PR 9 del feature-branch-chain para la arquitectura escalable de polling de métricas.

- Agrega comandos operativos explícitos para migraciones PostgreSQL, enqueue de ciclos y writer de resultados.
- Cablea los flags documentados a entrypoints concretos manteniendo default-off safety.
- Agrega tests unitarios para comandos, gating por flags, backpressure, metadata freshness y referencias de docs.
- Actualiza runbook/tuning para que el rollout documentado apunte a comandos reales.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && python -m pytest tests/test_polling_runtime_scripts.py tests/test_polling_docs_links.py tests/test_polling_*.py -q`
- Resultado: `66 passed, 1 warning`.
- [x] Fresh review PR9 diff: sin blockers.
- Nota: warning existente de SQLAlchemy `declarative_base()` en `postgres_db.py`.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | scalable-metric-polling-architecture |
| Tracker PR | #141 |
| Position | 9 of 9 |
| Base | `feat/scalable-metric-polling-08-docs` |
| Depends on | #148 |
| Follow-up | Final chain review / merge readiness |
| Review budget | ~552 changed lines / 700 |
| Starts at | PR 8 docs/runbook |
| Ends with | operator-facing runtime rollout commands |

### Chain Overview

```text
main
 └── #141 Tracker: scalable metric polling architecture
      └── #140 PR 1: pipeline config and contracts
           └── #142 PR 2: PostgreSQL queue and leases
                └── #143 PR 3: scheduler/idempotency/contracts
                     └── #144 PR 4: SNMP/ICMP leased worker
                          └── #145 PR 5: writer pool and event regression
                               └── #146 PR 6: backpressure/cache
                                    └── #147 PR 7: simulator/benchmarks
                                         └── #148 PR 8: docs/runbook
                                              └── 📍 PR 9: runtime rollout commands
```

### Scope
- Includes: explicit polling migration command, enqueue-cycle command, result-writer command, docs/tests updates.
- Excludes: automatic startup migration, production deployment, heavy load benchmark, production SSH execution.

### Autonomy
- [x] CI is expected to pass for this PR branch subject to existing unrelated suite failures.
- [x] This PR has one deliverable scope.
- [x] This PR can be rolled back without unrelated changes.
- [x] Tests cover this unit.

---
*Generado por Alex*
