### PR TITLE
fix(polling): refresh legacy latest readings

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -91,10 +91,11 @@ def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2) -> float:
             if result.returncode == 0:
                 return 1.0
         except OSError as e:
-            logger.warning(f"Ping failed for {ip}: {e}")
-            return 0.0
-        except subprocess.TimeoutExpired:
-            return 0.0
+            logger.warning(f"Ping attempt {attempt + 1}/{attempts} failed for {ip}: {e}")
+            continue
+        except subprocess.TimeoutExpired as e:
+            logger.warning(f"Ping attempt {attempt + 1}/{attempts} timed out for {ip}: {e}")
+            continue
     return 0.0
 
 def fetch_snmp_value(ip, community, oid, port=161):
@@ -150,6 +151,7 @@ def poll_snmp():
     print(f"[{datetime.now().isoformat()}] Starting Real-World Polling Cycle...")
     db = SessionLocal()
     metrics_to_save = []
+    latest_updates = []
     metrics_count = 0
     failed_count = 0
     try:
@@ -213,11 +215,12 @@ def poll_snmp():
                         "time": datetime.utcnow()
                     })
 
-                    # Update last_polled to respect the interval
-                    session.run("""
-                        MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef {id: $mid})
-                        SET r.last_polled = datetime()
-                    """, nid=node_id, mid=mid)
+                    latest_updates.append({
+                        "node_id": node_id,
+                        "metric_id": mid,
+                        "value": val,
+                        "protocol": protocol,
+                    })
                 else:
                     failed_count += 1
 
@@ -243,9 +246,26 @@ def poll_snmp():
                 jobs_per_min,
             )
 
-            # Perform Bulk Insert at the end of the cycle
+            # Perform Bulk Insert at the end of the cycle. Only publish latest
+            # values to Neo4j after Timescale persistence succeeds, so the UI
+            # does not advertise samples that failed durable storage.
             if metrics_to_save:
                 bulk_insert_metrics(db, metrics_to_save)
+                for update in latest_updates:
+                    if update["protocol"].upper() == "ICMP" and update["value"] == 1.0:
+                        session.run(
+                            "MATCH (n:CI {id: $id}) SET n.status = $status, n.last_seen = datetime()",
+                            id=update["node_id"],
+                            status="OK",
+                        )
+                    session.run("""
+                        MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef {id: $mid})
+                        SET r.last_polled = datetime(),
+                            r.last_value = $val,
+                            r.last_updated = datetime(),
+                            r.status = $status,
+                            r.last_message = $msg
+                    """, nid=update["node_id"], mid=update["metric_id"], val=update["value"], status="OK", msg="Latest sample collected by legacy SNMP worker")
                 print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")
 
         duration = time.time() - start_time

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -95,11 +95,11 @@ class TestFetchICMPPing:
         assert mock_run.call_count == 1
 
     @patch("engines.snmp_worker.subprocess.run")
-    def test_fetch_icmp_ping_exception_fails_attempt(self, mock_run):
-        """Exception during ping attempt fails that attempt, retry continues."""
+    def test_fetch_icmp_ping_os_error_fails_attempt(self, mock_run):
+        """Expected OS/subprocess failures fail that attempt, retry continues."""
         mock_run.side_effect = [
-            Exception("network error"),  # first attempt throws
-            MagicMock(returncode=0),      # retry succeeds
+            OSError("network error"),  # first attempt throws
+            MagicMock(returncode=0),    # retry succeeds
         ]
         from engines.snmp_worker import fetch_icmp_ping
         result = fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=2)
@@ -185,6 +185,15 @@ class TestSNMPWorkerObservability:
         assert saved_metrics[0]["node_id"] == "ci-001"
         assert saved_metrics[0]["metric_id"] == "CPU"
         assert saved_metrics[0]["value"] == 42.0
+
+        latest_update_calls = [
+            call for call in mock_session.queries
+            if "r.last_value" in call["query"] and call["params"].get("nid") == "ci-001"
+        ]
+        assert latest_update_calls
+        assert latest_update_calls[0]["params"]["mid"] == "CPU"
+        assert latest_update_calls[0]["params"]["val"] == 42.0
+        assert latest_update_calls[0]["params"]["status"] == "OK"
 
         observe_calls = [
             call for call in mock_logger.info.call_args_list


### PR DESCRIPTION
Closes #150

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Refreshes Neo4j `HAS_METRIC` latest fields from the legacy SNMP worker after Timescale bulk persistence succeeds.
- Keeps ICMP recovery status behavior intact while preserving debounce suppression.
- Adds regression coverage for the UI-facing latest-value update.

## Changes
| File | Change |
|------|--------|
| `backend/engines/snmp_worker.py` | Stages latest updates during polling and publishes `last_value`, `last_updated`, `status`, and `last_message` after successful Timescale bulk insert. |
| `backend/tests/test_snmp_worker.py` | Adds assertion that a successful legacy poll refreshes Neo4j latest fields. |

## Test Plan
- [x] `backend/.venv/bin/python -m pytest backend/tests/test_snmp_worker.py backend/tests/test_polling_runtime_scripts.py` — 24 passed
- [x] Fresh review found no blockers after latest-update ordering and ICMP exception handling fixes.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant tests
- [x] Docs updated if behavior changed, not needed for this bugfix
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
