### PR TITLE
fix(metrics): protect backend metric mutations

### DIFF
--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -8,8 +8,10 @@ from services.auth_service import get_current_active_user, check_permission
 from models.user import User, UserPermission
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
+from starlette.concurrency import run_in_threadpool
 from postgres_db import get_pg_db
 from repositories import metric_repo
+from services.metric_operation_guard import MetricOperationInProgress
 
 router = APIRouter(
     prefix="/metrics",
@@ -60,7 +62,16 @@ async def create_metric(
     """
     if not check_permission(UserPermission.CI_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to create metrics")
-    return metric_service.create_metric(metric)
+    try:
+        return await run_in_threadpool(metric_service.create_metric, metric)
+    except MetricOperationInProgress as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Metric operation already in progress",
+                "metric_id": exc.metric_id,
+            },
+        ) from exc
 
 
 @router.delete("/{metric_id}")
@@ -71,7 +82,16 @@ async def delete_metric(
     """Delete a Metric Definition. Requires authentication and CI_EDIT permission."""
     if not check_permission(UserPermission.CI_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to delete metrics")
-    return metric_service.delete_metric(metric_id)
+    try:
+        return await run_in_threadpool(metric_service.delete_metric, metric_id)
+    except MetricOperationInProgress as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "message": "Metric operation already in progress",
+                "metric_id": exc.metric_id,
+            },
+        ) from exc
 
 
 @router.get("/{metric_id}/usage")

--- a/backend/services/metric_operation_guard.py
+++ b/backend/services/metric_operation_guard.py
@@ -1,0 +1,65 @@
+"""Process-local same-metric mutation guard."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import threading
+from typing import Iterator
+
+
+class MetricOperationInProgress(RuntimeError):
+    """Raised when a same-metric create/delete mutation is already running."""
+
+    def __init__(self, metric_id: str):
+        self.metric_id = metric_id
+        super().__init__(f"Metric operation already in progress: {metric_id}")
+
+
+@dataclass
+class _LockEntry:
+    lock: threading.Lock
+    users: int = 0
+
+
+_locks_guard = threading.Lock()
+_metric_locks: dict[str, _LockEntry] = {}
+
+
+def _entry_for(metric_id: str) -> _LockEntry:
+    with _locks_guard:
+        entry = _metric_locks.get(metric_id)
+        if entry is None:
+            entry = _LockEntry(lock=threading.Lock())
+            _metric_locks[metric_id] = entry
+        entry.users += 1
+        return entry
+
+
+def _release_entry(metric_id: str, entry: _LockEntry) -> None:
+    with _locks_guard:
+        entry.users -= 1
+        if entry.users == 0 and not entry.lock.locked() and _metric_locks.get(metric_id) is entry:
+            _metric_locks.pop(metric_id, None)
+
+
+def _lock_registry_size() -> int:
+    """Return current registry size for tests and diagnostics."""
+    with _locks_guard:
+        return len(_metric_locks)
+
+
+@contextmanager
+def metric_operation_guard(metric_id: str) -> Iterator[None]:
+    """Acquire a non-blocking process-local lock for one metric id."""
+    entry = _entry_for(metric_id)
+    acquired = entry.lock.acquire(blocking=False)
+    if not acquired:
+        _release_entry(metric_id, entry)
+        raise MetricOperationInProgress(metric_id)
+
+    try:
+        yield
+    finally:
+        entry.lock.release()
+        _release_entry(metric_id, entry)

--- a/backend/services/metric_service.py
+++ b/backend/services/metric_service.py
@@ -4,6 +4,8 @@ import logging
 from typing import List, Dict, Any, Optional
 from database import get_db
 from models.core import MetricDef
+from services.metric_operation_guard import metric_operation_guard
+from services.operation_timing import timed_operation
 
 logger = logging.getLogger(__name__)
 
@@ -136,71 +138,87 @@ def get_metric(metric_id: str) -> Optional[Dict[str, Any]]:
 
 def _reconcile_metric_assignments(metric_id: str, criteria: Optional[Dict[str, List[str]]]) -> None:
     """Keep persisted HAS_METRIC links aligned with criteria-based applicability."""
-    driver = get_db()
-    with driver.session() as session:
-        result = session.run(
-            """
-            MATCH (n:CI)
-            OPTIONAL MATCH (n)-[:HAS_METRIC]->(m:MetricDef {id: $metric_id})
-            RETURN n AS node, m IS NOT NULL AS currently_linked
-            """,
-            metric_id=metric_id,
-        )
-        affected_nodes = [
-            dict(record["node"])
-            for record in result
-            if record["currently_linked"] or metric_matches_ci(criteria, dict(record["node"]))
-        ]
+    affected_nodes: list[Dict[str, Any]] = []
+    with timed_operation(logger, "metric.reconcile_assignments", metric_id=metric_id):
+        driver = get_db()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (n:CI)
+                OPTIONAL MATCH (n)-[:HAS_METRIC]->(m:MetricDef {id: $metric_id})
+                RETURN n AS node, m IS NOT NULL AS currently_linked
+                """,
+                metric_id=metric_id,
+            )
+            affected_nodes = [
+                dict(record["node"])
+                for record in result
+                if record["currently_linked"] or metric_matches_ci(criteria, dict(record["node"]))
+            ]
 
-    for node in affected_nodes:
-        reconcile_node_metrics(node)
+        for node in affected_nodes:
+            reconcile_node_metrics(node)
+
+    logger.info(
+        "Metric assignment reconciliation affected %s nodes",
+        len(affected_nodes),
+        extra={
+            "operation": "metric.reconcile_assignments.counts",
+            "metric_id": metric_id,
+            "affected_count": len(affected_nodes),
+        },
+    )
 
 def create_metric(metric: MetricDef) -> Dict[str, str]:
     """
     Define a new Metric for monitoring.
     """
-    driver = get_db()
-    criteria_str = json.dumps(metric.applicable_to) if metric.applicable_to else "{}"
+    with metric_operation_guard(metric.id):
+        with timed_operation(logger, "metric.create", metric_id=metric.id):
+            driver = get_db()
+            criteria_str = json.dumps(metric.applicable_to) if metric.applicable_to else "{}"
 
-    with driver.session() as session:
-        session.run("""
-            MERGE (m:MetricDef {id: $id})
-            SET m.protocol = $prot, m.warning = $warn, m.critical = $crit,
-                m.oid = $oid, m.dataType = $dtype, m.unit = $unit,
-                m.description = $desc, m.applicable_to = $criteria,
-                m.operator = $operator, m.criticality = $criticality,
-                m.polling_interval = $polling_interval,
-                m.can_propagate = $can_propagate,
-                m.cli_command = $cli_command,
-                m.cli_target = $cli_target,
-                m.cli_value_extractor = $cli_value_extractor,
-                m.cli_credential_ref = $cli_credential_ref,
-                m.cli_escalation_script = $cli_escalation_script,
-                m.cli_protocol = $cli_protocol,
-                m.cli_timeout = $cli_timeout
-        """, id=metric.id, prot=metric.protocol, warn=metric.warning,
-             crit=metric.critical, oid=metric.oid, dtype=metric.dataType,
-             unit=metric.unit, desc=metric.description, criteria=criteria_str,
-             operator=metric.operator or ">=", criticality=metric.criticality or 1,
-             polling_interval=metric.polling_interval or 60,
-             can_propagate=metric.can_propagate,
-             cli_command=metric.cli_command,
-             cli_target=metric.cli_target,
-             cli_value_extractor=metric.cli_value_extractor,
-             cli_credential_ref=metric.cli_credential_ref,
-             cli_escalation_script=metric.cli_escalation_script,
-             cli_protocol=metric.cli_protocol,
-             cli_timeout=metric.cli_timeout)
+            with driver.session() as session:
+                session.run("""
+                    MERGE (m:MetricDef {id: $id})
+                    SET m.protocol = $prot, m.warning = $warn, m.critical = $crit,
+                        m.oid = $oid, m.dataType = $dtype, m.unit = $unit,
+                        m.description = $desc, m.applicable_to = $criteria,
+                        m.operator = $operator, m.criticality = $criticality,
+                        m.polling_interval = $polling_interval,
+                        m.can_propagate = $can_propagate,
+                        m.cli_command = $cli_command,
+                        m.cli_target = $cli_target,
+                        m.cli_value_extractor = $cli_value_extractor,
+                        m.cli_credential_ref = $cli_credential_ref,
+                        m.cli_escalation_script = $cli_escalation_script,
+                        m.cli_protocol = $cli_protocol,
+                        m.cli_timeout = $cli_timeout
+                """, id=metric.id, prot=metric.protocol, warn=metric.warning,
+                     crit=metric.critical, oid=metric.oid, dtype=metric.dataType,
+                     unit=metric.unit, desc=metric.description, criteria=criteria_str,
+                     operator=metric.operator or ">=", criticality=metric.criticality or 1,
+                     polling_interval=metric.polling_interval or 60,
+                     can_propagate=metric.can_propagate,
+                     cli_command=metric.cli_command,
+                     cli_target=metric.cli_target,
+                     cli_value_extractor=metric.cli_value_extractor,
+                     cli_credential_ref=metric.cli_credential_ref,
+                     cli_escalation_script=metric.cli_escalation_script,
+                     cli_protocol=metric.cli_protocol,
+                     cli_timeout=metric.cli_timeout)
 
-    _reconcile_metric_assignments(metric.id, metric.applicable_to)
-    return {"message": "Metric defined"}
+            _reconcile_metric_assignments(metric.id, metric.applicable_to)
+            return {"message": "Metric defined"}
 
 def delete_metric(metric_id: str) -> Dict[str, str]:
     """Delete a Metric Definition."""
-    driver = get_db()
-    with driver.session() as session:
-        session.run("MATCH (m:MetricDef {id: $id}) DETACH DELETE m", id=metric_id)
-    return {"message": "Metric deleted"}
+    with metric_operation_guard(metric_id):
+        with timed_operation(logger, "metric.delete", metric_id=metric_id):
+            driver = get_db()
+            with driver.session() as session:
+                session.run("MATCH (m:MetricDef {id: $id}) DETACH DELETE m", id=metric_id)
+            return {"message": "Metric deleted"}
 
 def get_metric_usage(metric_id: str) -> Dict[str, Any]:
     """
@@ -327,91 +345,108 @@ def reconcile_node_metrics(node: Dict[str, Any]):
     if not node_id:
         return
 
-    # Get currently applicable metrics based on brand/model criteria
-    applicable = get_applicable_metrics(node_id)
-    applicable_ids = set(m["id"] for m in applicable)
+    with timed_operation(logger, "metric.reconcile_node", ci_id=node_id):
+        # Get currently applicable metrics based on brand/model criteria
+        applicable = get_applicable_metrics(node_id)
+        applicable_ids = set(m["id"] for m in applicable)
 
-    # Lookup AppliedDictionary overlay (if any)
-    dict_metric_ids: set[str] = set()
-    excluded: set[str] = set()
-    extra: set[str] = set()
+        # Lookup AppliedDictionary overlay (if any)
+        dict_metric_ids: set[str] = set()
+        excluded: set[str] = set()
+        extra: set[str] = set()
 
-    with driver.session() as session:
-        ad_result = session.run("""
-            MATCH (ci:CI {id: $nid})-[:HAS_DICTIONARY]->(ad:AppliedDictionary)
-            OPTIONAL MATCH (ad)-[:REFERENCE_DICTIONARY]->(md:MetricDictionary)
-            RETURN ad.dictionary_id AS dictionary_id,
-                   ad.excluded_metrics AS excluded_metrics,
-                   ad.extra_metrics AS extra_metrics,
-                   md.id AS md_id
-        """, nid=node_id).single()
+        with driver.session() as session:
+            ad_result = session.run("""
+                MATCH (ci:CI {id: $nid})-[:HAS_DICTIONARY]->(ad:AppliedDictionary)
+                OPTIONAL MATCH (ad)-[:REFERENCE_DICTIONARY]->(md:MetricDictionary)
+                RETURN ad.dictionary_id AS dictionary_id,
+                       ad.excluded_metrics AS excluded_metrics,
+                       ad.extra_metrics AS extra_metrics,
+                       md.id AS md_id
+            """, nid=node_id).single()
 
-        if ad_result and ad_result.get("dictionary_id"):
-            dictionary_id = ad_result["dictionary_id"]
-            excluded = set(ad_result.get("excluded_metrics") or [])
-            extra = set(ad_result.get("extra_metrics") or [])
+            if ad_result and ad_result.get("dictionary_id"):
+                dictionary_id = ad_result["dictionary_id"]
+                excluded = set(ad_result.get("excluded_metrics") or [])
+                extra = set(ad_result.get("extra_metrics") or [])
 
-            # Fetch dictionary metric_ids via HAS_METRIC rel (handle deleted dict gracefully)
-            if ad_result.get("md_id") and dictionary_id:
-                try:
-                    dict_metric_ids = set(get_metrics_from_dictionary(dictionary_id))
-                except Exception:
-                    logger.warning(f"Failed to fetch dictionary '{dictionary_id}' metrics — treating as empty")
-                    dict_metric_ids = set()
+                # Fetch dictionary metric_ids via HAS_METRIC rel (handle deleted dict gracefully)
+                if ad_result.get("md_id") and dictionary_id:
+                    try:
+                        dict_metric_ids = set(get_metrics_from_dictionary(dictionary_id))
+                    except Exception:
+                        logger.warning(f"Failed to fetch dictionary '{dictionary_id}' metrics — treating as empty")
+                        dict_metric_ids = set()
 
-            logger.info(
-                f"AppliedDictionary overlay: dict={dictionary_id}, "
-                f"excluded={excluded}, extra={extra}"
-            )
+                logger.info(
+                    f"AppliedDictionary overlay: dict={dictionary_id}, "
+                    f"excluded={excluded}, extra={extra}"
+                )
 
-    # Compute effective metric set
-    # Formula: (applicable ∪ dict_metrics) - excluded ∪ extra
-    # Parentheses required because | and - have same precedence and left-to-right would mis-evaluate
-    effective_ids = ((applicable_ids | dict_metric_ids) - excluded) | extra
+        # Compute effective metric set
+        # Formula: (applicable ∪ dict_metrics) - excluded ∪ extra
+        # Parentheses required because | and - have same precedence and left-to-right would mis-evaluate
+        effective_ids = ((applicable_ids | dict_metric_ids) - excluded) | extra
 
-    with driver.session() as session:
-        # 1. Fetch CURRENTLY LINKED metrics
-        result = session.run("""
-            MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef)
-            RETURN m.id as mid, m.applicable_to as apt
-        """, nid=node_id)
+        with driver.session() as session:
+            # 1. Fetch CURRENTLY LINKED metrics
+            result = session.run("""
+                MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef)
+                RETURN m.id as mid, m.applicable_to as apt
+            """, nid=node_id)
 
-        linked_metrics = {rec["mid"]: rec["apt"] for rec in result}
+            linked_metrics = {rec["mid"]: rec["apt"] for rec in result}
+            add_count = 0
+            remove_count = 0
 
-        # 2. Determine Removals
-        for mid, apt_json in linked_metrics.items():
-            if mid not in effective_ids:
-                # Check if explicitly named (Safety check)
-                is_explicit = False
-                try:
-                    apt = json.loads(apt_json or "{}")
-                    names = apt.get("names", [])
-                    if node.get("name") in names or node_id in names:
-                        is_explicit = True
-                except Exception:
-                    pass
+            # 2. Determine Removals
+            for mid, apt_json in linked_metrics.items():
+                if mid not in effective_ids:
+                    # Check if explicitly named (Safety check)
+                    is_explicit = False
+                    try:
+                        apt = json.loads(apt_json or "{}")
+                        names = apt.get("names", [])
+                        if node.get("name") in names or node_id in names:
+                            is_explicit = True
+                    except Exception:
+                        pass
 
-                if not is_explicit:
-                    logger.info(f"Removing obsolete metric {mid} from Node {node_id}")
-                    session.run("""
-                        MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef {id: $mid})
-                        DELETE r
+                    if not is_explicit:
+                        logger.info(f"Removing obsolete metric {mid} from Node {node_id}")
+                        session.run("""
+                            MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef {id: $mid})
+                            DELETE r
+                        """, nid=node_id, mid=mid)
+                        remove_count += 1
+
+            # 3. Determine Additions — use effective_ids so dictionary/extras are included
+            for mid in effective_ids:
+                if mid not in linked_metrics:
+                    logger.info(f"Auto-assigning metric {mid} to Node {node_id}")
+                    result = session.run("""
+                        MATCH (n:CI {id: $nid})
+                        MATCH (m:MetricDef {id: $mid})
+                        MERGE (n)-[:HAS_METRIC]->(m)
+                        SET n.updated_at = datetime()
                     """, nid=node_id, mid=mid)
+                    add_count += 1
+                    # Log warning if MetricDef doesn't exist (MERGE silently skipped)
+                    # Only check nodes_created when result supports it (not in test FakeResult)
+                    try:
+                        if hasattr(result, 'consume') and result.consume().counters.nodes_created == 0:
+                            logger.warning(f"MetricDef '{mid}' not found — skipped for Node {node_id}")
+                    except (AttributeError, TypeError):
+                        pass  # FakeResult in tests or other mock doesn't support consume()
 
-        # 3. Determine Additions — use effective_ids so dictionary/extras are included
-        for mid in effective_ids:
-            if mid not in linked_metrics:
-                logger.info(f"Auto-assigning metric {mid} to Node {node_id}")
-                result = session.run("""
-                    MATCH (n:CI {id: $nid})
-                    MATCH (m:MetricDef {id: $mid})
-                    MERGE (n)-[:HAS_METRIC]->(m)
-                    SET n.updated_at = datetime()
-                """, nid=node_id, mid=mid)
-                # Log warning if MetricDef doesn't exist (MERGE silently skipped)
-                # Only check nodes_created when result supports it (not in test FakeResult)
-                try:
-                    if hasattr(result, 'consume') and result.consume().counters.nodes_created == 0:
-                        logger.warning(f"MetricDef '{mid}' not found — skipped for Node {node_id}")
-                except (AttributeError, TypeError):
-                    pass  # FakeResult in tests or other mock doesn't support consume()
+        logger.info(
+            "Node metric reconciliation counts",
+            extra={
+                "operation": "metric.reconcile_node.counts",
+                "ci_id": node_id,
+                "applicable_count": len(applicable_ids),
+                "linked_count": len(linked_metrics),
+                "add_count": add_count,
+                "remove_count": remove_count,
+            },
+        )

--- a/backend/services/operation_timing.py
+++ b/backend/services/operation_timing.py
@@ -1,0 +1,53 @@
+"""Small synchronous timing helper for service hot paths."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import logging
+import time
+from typing import Any, Iterator
+
+
+@contextmanager
+def timed_operation(
+    logger: logging.Logger,
+    operation: str,
+    **context: Any,
+) -> Iterator[None]:
+    """Log elapsed time and outcome for a synchronous operation.
+
+    The helper deliberately does not alter return values or exception flow.
+    Context values are attached to the LogRecord via ``extra`` so tests and log
+    formatters can consume structured fields without parsing message text.
+    """
+    started_at = time.perf_counter()
+    try:
+        yield
+    except Exception:
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        logger.warning(
+            "%s failed in %.2f ms",
+            operation,
+            duration_ms,
+            extra={
+                "operation": operation,
+                "duration_ms": duration_ms,
+                "outcome": "failure",
+                **context,
+            },
+            exc_info=True,
+        )
+        raise
+    else:
+        duration_ms = (time.perf_counter() - started_at) * 1000
+        logger.info(
+            "%s completed in %.2f ms",
+            operation,
+            duration_ms,
+            extra={
+                "operation": operation,
+                "duration_ms": duration_ms,
+                "outcome": "success",
+                **context,
+            },
+        )

--- a/backend/tests/test_metric_operation_guard.py
+++ b/backend/tests/test_metric_operation_guard.py
@@ -1,0 +1,60 @@
+import threading
+
+import pytest
+
+
+def test_same_metric_second_acquire_raises_and_release_allows_retry():
+    from services.metric_operation_guard import (
+        MetricOperationInProgress,
+        _lock_registry_size,
+        metric_operation_guard,
+    )
+
+    with metric_operation_guard("cpu-load"):
+        with pytest.raises(MetricOperationInProgress) as exc_info:
+            with metric_operation_guard("cpu-load"):
+                pass
+
+    assert exc_info.value.metric_id == "cpu-load"
+
+    with metric_operation_guard("cpu-load"):
+        pass
+
+    assert _lock_registry_size() == 0
+
+
+def test_lock_releases_after_exception():
+    from services.metric_operation_guard import _lock_registry_size, metric_operation_guard
+
+    with pytest.raises(RuntimeError):
+        with metric_operation_guard("cpu-load"):
+            raise RuntimeError("boom")
+
+    with metric_operation_guard("cpu-load"):
+        pass
+
+    assert _lock_registry_size() == 0
+
+
+def test_different_metric_ids_can_run_concurrently():
+    from services.metric_operation_guard import _lock_registry_size, metric_operation_guard
+
+    entered_other_metric = threading.Event()
+    release = threading.Event()
+
+    def hold_other_metric():
+        with metric_operation_guard("memory-used"):
+            entered_other_metric.set()
+            release.wait(timeout=2)
+
+    with metric_operation_guard("cpu-load"):
+        thread = threading.Thread(target=hold_other_metric)
+        thread.start()
+        try:
+            assert entered_other_metric.wait(timeout=1)
+        finally:
+            release.set()
+            thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert _lock_registry_size() == 0

--- a/backend/tests/test_operation_timing.py
+++ b/backend/tests/test_operation_timing.py
@@ -1,0 +1,41 @@
+import logging
+
+import pytest
+
+
+def test_timed_operation_logs_success_with_context(caplog):
+    from services.operation_timing import timed_operation
+
+    logger = logging.getLogger("tests.operation_timing.success")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        with timed_operation(logger, "metric.create", metric_id="cpu-load"):
+            pass
+
+    record = next(record for record in caplog.records if record.name == logger.name)
+    assert record.operation == "metric.create"
+    assert record.outcome == "success"
+    assert record.metric_id == "cpu-load"
+    assert isinstance(record.duration_ms, float)
+    assert record.duration_ms >= 0
+
+
+def test_timed_operation_logs_failure_and_reraises(caplog):
+    from services.operation_timing import timed_operation
+
+    logger = logging.getLogger("tests.operation_timing.failure")
+    original = RuntimeError("boom")
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with pytest.raises(RuntimeError) as exc_info:
+            with timed_operation(logger, "metric.delete", metric_id="cpu-load"):
+                raise original
+
+    assert exc_info.value is original
+    record = next(record for record in caplog.records if record.name == logger.name)
+    assert record.operation == "metric.delete"
+    assert record.outcome == "failure"
+    assert record.metric_id == "cpu-load"
+    assert record.exc_info is not None
+    assert isinstance(record.duration_ms, float)
+    assert record.duration_ms >= 0

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -14,8 +14,10 @@ Strategy:
 - Override get_current_active_user for auth-protected event endpoints
 """
 
+import asyncio
 import pytest
 import sys
+import threading
 import types
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
@@ -273,6 +275,77 @@ class TestMetricsList:
 class TestMetricsCreate:
     """Tests for POST /api/metrics — create/update metric definition."""
 
+    @pytest.mark.asyncio
+    async def test_create_metric_offloads_sync_service_work(self):
+        """The async route should not block unrelated coroutine startup."""
+        from routers import metrics as metrics_router
+        from models.core import MetricDef
+
+        fake_user = _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_create(metric):
+            started.set()
+            release.wait(timeout=2)
+            return {"message": "Metric defined"}
+
+        async def unrelated(marker: asyncio.Event):
+            marker.set()
+
+        with (
+            patch("routers.metrics.check_permission", return_value=True),
+            patch.object(metrics_router.metric_service, "create_metric", side_effect=blocking_create),
+        ):
+            metric = MetricDef(id="slow-metric", protocol="SNMP")
+            route_task = asyncio.create_task(metrics_router.create_metric(metric, fake_user))
+            timer = threading.Timer(1.0, release.set)
+            timer.start()
+            try:
+                await asyncio.sleep(0)
+                assert not route_task.done()
+                assert await asyncio.to_thread(started.wait, 1)
+
+                marker = asyncio.Event()
+                marker_task = asyncio.create_task(unrelated(marker))
+                await asyncio.wait_for(marker.wait(), timeout=0.1)
+
+                release.set()
+                result = await route_task
+            finally:
+                release.set()
+                timer.cancel()
+                await asyncio.gather(route_task, return_exceptions=True)
+                if 'marker_task' in locals():
+                    await asyncio.gather(marker_task, return_exceptions=True)
+
+        assert result == {"message": "Metric defined"}
+
+    @pytest.mark.asyncio
+    async def test_create_metric_duplicate_operation_maps_to_409(self):
+        from routers import metrics as metrics_router
+        from models.core import MetricDef
+        from services.metric_operation_guard import MetricOperationInProgress
+
+        fake_user = _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+
+        with (
+            patch("routers.metrics.check_permission", return_value=True),
+            patch.object(
+                metrics_router.metric_service,
+                "create_metric",
+                side_effect=MetricOperationInProgress("slow-metric"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await metrics_router.create_metric(MetricDef(id="slow-metric", protocol="SNMP"), fake_user)
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == {
+            "message": "Metric operation already in progress",
+            "metric_id": "slow-metric",
+        }
+
     def test_create_metric_success(self, mock_neo4j_driver):
         """Should create a metric definition."""
         fake_user = _make_pydantic_user(
@@ -366,6 +439,74 @@ class TestMetricsCreate:
 
 class TestMetricsDelete:
     """Tests for DELETE /api/metrics/{metric_id} — delete metric definition."""
+
+    @pytest.mark.asyncio
+    async def test_delete_metric_offloads_sync_service_work(self):
+        """The async route should not block unrelated coroutine startup."""
+        from routers import metrics as metrics_router
+
+        fake_user = _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking_delete(metric_id):
+            started.set()
+            release.wait(timeout=2)
+            return {"message": "Metric deleted"}
+
+        async def unrelated(marker: asyncio.Event):
+            marker.set()
+
+        with (
+            patch("routers.metrics.check_permission", return_value=True),
+            patch.object(metrics_router.metric_service, "delete_metric", side_effect=blocking_delete),
+        ):
+            route_task = asyncio.create_task(metrics_router.delete_metric("slow-metric", fake_user))
+            timer = threading.Timer(1.0, release.set)
+            timer.start()
+            try:
+                await asyncio.sleep(0)
+                assert not route_task.done()
+                assert await asyncio.to_thread(started.wait, 1)
+
+                marker = asyncio.Event()
+                marker_task = asyncio.create_task(unrelated(marker))
+                await asyncio.wait_for(marker.wait(), timeout=0.1)
+
+                release.set()
+                result = await route_task
+            finally:
+                release.set()
+                timer.cancel()
+                await asyncio.gather(route_task, return_exceptions=True)
+                if 'marker_task' in locals():
+                    await asyncio.gather(marker_task, return_exceptions=True)
+
+        assert result == {"message": "Metric deleted"}
+
+    @pytest.mark.asyncio
+    async def test_delete_metric_duplicate_operation_maps_to_409(self):
+        from routers import metrics as metrics_router
+        from services.metric_operation_guard import MetricOperationInProgress
+
+        fake_user = _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+
+        with (
+            patch("routers.metrics.check_permission", return_value=True),
+            patch.object(
+                metrics_router.metric_service,
+                "delete_metric",
+                side_effect=MetricOperationInProgress("slow-metric"),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await metrics_router.delete_metric("slow-metric", fake_user)
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail == {
+            "message": "Metric operation already in progress",
+            "metric_id": "slow-metric",
+        }
 
     def test_delete_metric_success(self, mock_neo4j_driver):
         """Should delete a metric definition."""


### PR DESCRIPTION
## Descripción del Cambio
Closes #153

PR1 backend slice for the bulk metric freeze chain. This keeps API success response shapes intact while reducing FastAPI event-loop starvation and adding same-process duplicate mutation safety.

Chain context:

```text
main
└── tracker: fix/bulk-metrics-freeze
    └── 📍 PR1 backend: fix/bulk-metrics-freeze-backend
        └── PR2 frontend: fix/bulk-metrics-freeze-frontend
```

Start: tracker branch with diagnosis/plan docs.
End: backend mitigation validated and ready for PR2 frontend.
Prior dependencies: tracker PR.
Follow-up: PR2 frontend pending-state UX.
Out of scope: persisted/global locks, async jobs, chunked delete, batch reconciliation, `/nodes` split.

Size exception: accepted because PR1 backend is one cohesive mitigation unit: route offload + duplicate guard + timing instrumentation + tests. Splitting further would separate helpers/tests from the behavior they verify.

| File | Change |
|------|--------|
| `backend/routers/metrics.py` | Offloads metric create/delete service calls through `run_in_threadpool`; maps duplicate metric operations to HTTP 409. |
| `backend/services/metric_operation_guard.py` | Adds process-local same-metric non-blocking mutation guard with registry cleanup. |
| `backend/services/operation_timing.py` | Adds small synchronous timing/logging helper. |
| `backend/services/metric_service.py` | Applies duplicate guard and timing instrumentation to metric create/delete/reconciliation paths without changing metric semantics. |
| `backend/tests/*` | Adds focused tests for offload behavior, duplicate guard, timing helper, and preserves metric reconciliation coverage. |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && uv run --python 3.11 --with-requirements requirements.txt --with-requirements requirements-dev.txt pytest tests/test_operation_timing.py tests/test_metric_operation_guard.py tests/test_routers_metrics_events.py -k 'offloads or duplicate_operation'` — 4 passed.
- [x] `cd backend && uv run --python 3.11 --with-requirements requirements.txt --with-requirements requirements-dev.txt pytest tests/test_operation_timing.py tests/test_metric_operation_guard.py tests/test_metric_service_smoke.py tests/test_metric_reconciliation.py` — 25 passed.
- [x] `cd backend && uv run --python 3.11 --with-requirements requirements.txt --with-requirements requirements-dev.txt pytest tests/test_routers_metrics_events.py -k metric` — 64 passed.
- [x] Judgment Day PR1 backend: APPROVED.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
