### PR TITLE
fix(metrics): show metric operation pending state

### DIFF
--- a/frontend/components/MetricsManager.test.tsx
+++ b/frontend/components/MetricsManager.test.tsx
@@ -254,7 +254,10 @@ describe('MetricsManager', () => {
 
       expect(window.alert).toHaveBeenCalledWith('Metric Saved');
       await waitFor(() => {
-        expect(mocks.apiGet).toHaveBeenCalledTimes(4);
+        expect(mocks.apiGet).toHaveBeenCalledWith('/metrics');
+      });
+      await waitFor(() => {
+        expect(mocks.apiGet).toHaveBeenCalledWith('/nodes');
       });
       expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument();
     });
@@ -287,6 +290,47 @@ describe('MetricsManager', () => {
         expect(window.alert).toHaveBeenCalledWith('Error saving metric');
       });
       expect(screen.getByText('New Metric')).toBeInTheDocument();
+    });
+
+    it('shows save pending state, guards duplicate submission, and refetches metrics and nodes', async () => {
+      const saveDeferred = createDeferred<{ ok: boolean }>();
+      mocks.apiPost.mockReturnValueOnce(saveDeferred.promise);
+      await openCreateForm();
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/nodes'));
+      mocks.apiGet.mockClear();
+
+      fireEvent.change(getInputByLabel(/metric id/i), { target: { value: 'temp.sensor' } });
+      clickSaveMetric();
+
+      expect(await screen.findByText(/saving metric and reconciling affected cis/i)).toBeInTheDocument();
+      const saveButton = screen.getByRole('button', { name: /save metric/i });
+      expect(saveButton).toBeDisabled();
+
+      fireEvent.click(saveButton);
+      expect(mocks.apiPost).toHaveBeenCalledTimes(1);
+
+      saveDeferred.resolve({ ok: true });
+
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/metrics'));
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/nodes'));
+      expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument();
+    });
+
+    it('handles duplicate save responses with a clear message and refreshes metrics and nodes', async () => {
+      mocks.apiPost.mockRejectedValueOnce({
+        status: 409,
+        message: { message: 'Metric operation already in progress', metric_id: 'temp.sensor' },
+      });
+      await openCreateForm();
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/nodes'));
+      mocks.apiGet.mockClear();
+
+      fireEvent.change(getInputByLabel(/metric id/i), { target: { value: 'temp.sensor' } });
+      clickSaveMetric();
+
+      expect(await screen.findByText(/metric operation already in progress/i)).toBeInTheDocument();
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/metrics'));
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/nodes'));
     });
   });
 
@@ -435,6 +479,62 @@ describe('MetricsManager', () => {
       });
     });
 
+    it('shows delete pending state, guards duplicate deletion, clears stale selection, and refetches metrics and nodes', async () => {
+      const usageDeferred = createDeferred<any>();
+      const deleteDeferred = createDeferred<{ ok: boolean }>();
+      mocks.apiGet.mockImplementation(async (endpoint: string) => {
+        if (endpoint === '/metrics') return [metricA, metricB];
+        if (endpoint === '/metrics/cpu.load') return metricADetail;
+        if (endpoint === '/hardware') return hardwareModels;
+        if (endpoint === '/metrics/cpu.load/usage') return usageDeferred.promise;
+        if (endpoint === '/metrics/mem.usage/usage') return { count: 0, cis: [] };
+        if (endpoint === '/nodes') return [];
+        throw new Error(`Unhandled GET ${endpoint}`);
+      });
+      mocks.apiDelete.mockReturnValueOnce(deleteDeferred.promise);
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(true);
+      mocks.apiGet.mockClear();
+
+      clickDeleteMetric();
+
+      expect(await screen.findByText(/checking metric usage before deletion/i)).toBeInTheDocument();
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      const deleteButton = deleteButtons[deleteButtons.length - 1];
+      expect(deleteButton).toBeDisabled();
+      fireEvent.click(deleteButton);
+      expect(mocks.apiGet).toHaveBeenCalledTimes(1);
+      expect(mocks.apiDelete).not.toHaveBeenCalled();
+
+      usageDeferred.resolve(usageData);
+      expect(await screen.findByText(/deleting metric and removing assignments/i)).toBeInTheDocument();
+      expect(mocks.apiDelete).toHaveBeenCalledTimes(1);
+
+      deleteDeferred.resolve({ ok: true });
+
+      await waitFor(() => expect(screen.getByText(/select a metric to edit/i)).toBeInTheDocument());
+      expect(screen.queryByText('Edit Metric')).not.toBeInTheDocument();
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/metrics'));
+      await waitFor(() => expect(mocks.apiGet).toHaveBeenCalledWith('/nodes'));
+    });
+
+    it('clears delete pending state but keeps the selected metric when delete fails', async () => {
+      const deleteDeferred = createDeferred<never>();
+      mocks.apiDelete.mockReturnValueOnce(deleteDeferred.promise);
+      await openEditForm();
+      vi.mocked(window.confirm).mockReturnValueOnce(true);
+
+      clickDeleteMetric();
+      expect(await screen.findByText(/deleting metric and removing assignments/i)).toBeInTheDocument();
+
+      deleteDeferred.reject(new Error('delete failed'));
+
+      await waitFor(() => expect(window.alert).toHaveBeenCalledWith('Error deleting metric'));
+      expect(screen.queryByText(/deleting metric and removing assignments/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Edit Metric')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('cpu.load')).toBeInTheDocument();
+    });
+
     it('does not delete a metric when the user cancels the confirmation', async () => {
       await openEditForm();
       vi.mocked(window.confirm).mockReturnValueOnce(false);
@@ -446,6 +546,9 @@ describe('MetricsManager', () => {
         expect(mocks.apiGet).toHaveBeenCalledWith('/metrics/cpu.load/usage');
       });
       expect(mocks.apiDelete).not.toHaveBeenCalled();
+      await waitFor(() => expect(screen.queryByText(/checking metric usage before deletion/i)).not.toBeInTheDocument());
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons[deleteButtons.length - 1]).not.toBeDisabled();
     });
 
     it('shows an alert when checking metric usage for delete fails', async () => {
@@ -463,6 +566,9 @@ describe('MetricsManager', () => {
       await waitFor(() => {
         expect(window.alert).toHaveBeenCalledWith('Error checking metric usage');
       });
+      await waitFor(() => expect(screen.queryByText(/checking metric usage before deletion/i)).not.toBeInTheDocument());
+      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(deleteButtons[deleteButtons.length - 1]).not.toBeDisabled();
     });
 
     it('does not remove an associated CI when confirm returns false', async () => {

--- a/frontend/components/MetricsManager.tsx
+++ b/frontend/components/MetricsManager.tsx
@@ -1,16 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { MetricDef } from '../types';
+import type React from 'react';
+import { useState, useEffect } from 'react';
+import type { MetricDef } from '../types';
 import { api } from '../services/api';
 
 interface MetricsManagerProps {
     onClose?: () => void;
 }
 
-const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
+const MetricsManager: React.FC<MetricsManagerProps> = () => {
     const [metrics, setMetrics] = useState<MetricDef[]>([]);
     const [loading, setLoading] = useState(false);
     const [selectedMetric, setSelectedMetric] = useState<MetricDef | null>(null);
     const [isEditing, setIsEditing] = useState(false);
+    const [savingMetric, setSavingMetric] = useState(false);
+    const [deletingMetricId, setDeletingMetricId] = useState<string | null>(null);
+    const [operationMessage, setOperationMessage] = useState<string | null>(null);
+    const [operationError, setOperationError] = useState<string | null>(null);
 
     // Form State
     const [formData, setFormData] = useState<Partial<MetricDef>>({});
@@ -112,6 +117,8 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
     };
 
     const handleEdit = async (metric: MetricDef) => {
+        setOperationMessage(null);
+        setOperationError(null);
         try {
             await loadMetricDetail(metric.id);
         } catch (e) {
@@ -121,6 +128,8 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
     };
 
     const handleCreate = () => {
+        setOperationMessage(null);
+        setOperationError(null);
         setSelectedMetric(null);
         setFormData({ protocol: 'SNMP', dataType: 'INTEGER', operator: '>=', criticality: 1, applicable_to: {} });
         setCriteria({ brands: '', models: '', layers: '', names: '', excluded_names: '' });
@@ -128,7 +137,30 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
         setTestResult(null);
     };
 
+    const resetMetricForm = () => {
+        setFormData({});
+        setCriteria({ brands: '', models: '', layers: '', names: '', excluded_names: '' });
+    };
+
+    const getOperationErrorMessage = (error: any) => {
+        const rawMessage = error?.message;
+        const nestedMessage = typeof rawMessage === 'object' ? rawMessage?.message : undefined;
+        if (error?.status === 409) {
+            return nestedMessage || (typeof rawMessage === 'string' && rawMessage !== '[object Object]' ? rawMessage : 'Metric operation already in progress');
+        }
+        return undefined;
+    };
+
+    const refreshMetricViews = async () => {
+        await Promise.all([fetchMetrics(), fetchNodes()]);
+    };
+
     const handleSave = async (overrideCriteria?: any) => {
+        if (savingMetric) return;
+        setSavingMetric(true);
+        setOperationMessage('Saving metric and reconciling affected CIs…');
+        setOperationError(null);
+
         // Prepare applicable_to
         const crit = overrideCriteria && typeof overrideCriteria === 'object' && 'brands' in overrideCriteria
             ? overrideCriteria
@@ -153,21 +185,72 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
             await api.post('/metrics', payload);
             alert('Metric Saved');
             setIsEditing(false);
-            setFormData({});
-            setCriteria({ brands: '', models: '', layers: '', names: '', excluded_names: '' });
-            fetchMetrics();
-        } catch (e) {
-            alert('Error saving metric');
+            resetMetricForm();
+            await refreshMetricViews();
+        } catch (e: any) {
+            const duplicateMessage = getOperationErrorMessage(e);
+            if (duplicateMessage) {
+                setOperationError(duplicateMessage);
+                await refreshMetricViews();
+            } else {
+                alert('Error saving metric');
+            }
+        } finally {
+            setSavingMetric(false);
+            setOperationMessage(null);
         }
     };
 
-    const buildCriteriaStrings = (applicableTo?: MetricDef['applicable_to']) => ({
-        brands: (applicableTo?.brands || []).join(', '),
-        models: (applicableTo?.models || []).join(', '),
-        layers: (applicableTo?.layers || []).join(', '),
-        names: (applicableTo?.names || []).join(', '),
-        excluded_names: (applicableTo?.excluded_names || []).join(', ')
-    });
+    const handleDeleteSelectedMetric = async () => {
+        if (!selectedMetric || deletingMetricId) return;
+
+        const metricId = selectedMetric.id;
+        setDeletingMetricId(metricId);
+        setOperationMessage('Checking metric usage before deletion…');
+        setOperationError(null);
+
+        try {
+            const usage = await api.get<any>(`/metrics/${metricId}/usage`);
+            const count = usage.count || 0;
+            const msg = `Are you sure you want to delete metric '${metricId}'?\n\n` +
+                `This metric is currently applicable to ${count} devices.\n` +
+                `Deleting it will stop monitoring this data point for all affected devices.\n\n` +
+                `This action cannot be undone.`;
+
+            if (!confirm(msg)) {
+                setDeletingMetricId(null);
+                setOperationMessage(null);
+                return;
+            }
+        } catch (e) {
+            alert('Error checking metric usage');
+            setDeletingMetricId(null);
+            setOperationMessage(null);
+            return;
+        }
+
+        setOperationMessage('Deleting metric and removing assignments…');
+
+        try {
+            await api.delete(`/metrics/${metricId}`);
+            setSelectedMetric(null);
+            setUsageData(null);
+            setIsEditing(false);
+            resetMetricForm();
+            await refreshMetricViews();
+        } catch (e: any) {
+            const duplicateMessage = getOperationErrorMessage(e);
+            if (duplicateMessage) {
+                setOperationError(duplicateMessage);
+                await refreshMetricViews();
+            } else {
+                alert('Error deleting metric');
+            }
+        } finally {
+            setDeletingMetricId(null);
+            setOperationMessage(null);
+        }
+    };
 
     const buildMetricPayload = (applicableTo: MetricDef['applicable_to']) => ({
         ...formData,
@@ -315,6 +398,7 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
                     </button>
                 </div>
                 <div className="flex-1 overflow-y-auto custom-scrollbar p-2 space-y-2">
+                    {loading && <div className="p-3 text-xs text-neutral-500">Loading metrics…</div>}
                     {metrics.map((m, i) => (
                         <div key={i} onClick={() => handleEdit(m)}
                             className={`p-3 rounded-lg border border-white/5 cursor-pointer hover:bg-white/5 transition-colors ${selectedMetric?.id === m.id ? 'bg-brand-500/10 border-brand-500/50' : 'bg-transparent'}`}>
@@ -781,30 +865,26 @@ const MetricsManager: React.FC<MetricsManagerProps> = ({ onClose }) => {
                             </div>
                         </div>
 
+                        {(operationMessage || operationError) && (
+                            <div className={`rounded-lg border p-3 text-sm ${operationError ? 'border-yellow-500/40 bg-yellow-500/10 text-yellow-200' : 'border-brand-500/40 bg-brand-500/10 text-brand-200'}`}>
+                                {operationError || operationMessage}
+                            </div>
+                        )}
+
                         <div className="flex gap-4 pt-4">
-                            <button onClick={() => handleSave()} className="flex-1 bg-brand-600 hover:bg-brand-500 text-white font-bold py-3 rounded-xl transition-colors">
+                            <button
+                                onClick={() => handleSave()}
+                                disabled={savingMetric}
+                                className="flex-1 bg-brand-600 hover:bg-brand-500 disabled:bg-neutral-600 disabled:cursor-not-allowed text-white font-bold py-3 rounded-xl transition-colors"
+                            >
                                 SAVE METRIC
                             </button>
                             {selectedMetric && (
-                                <button onClick={async () => {
-                                    // 1. Check Usage
-                                    try {
-                                        const usage = await api.get<any>(`/metrics/${selectedMetric.id}/usage`);
-                                        const count = usage.count || 0;
-                                        const msg = `Are you sure you want to delete metric '${selectedMetric.id}'?\n\n` +
-                                            `This metric is currently applicable to ${count} devices.\n` +
-                                            `Deleting it will stop monitoring this data point for all affected devices.\n\n` +
-                                            `This action cannot be undone.`;
-
-                                        if (confirm(msg)) {
-                                            await api.delete(`/metrics/${selectedMetric.id}`);
-                                            setIsEditing(false);
-                                            fetchMetrics();
-                                        }
-                                    } catch (e) {
-                                        alert('Error checking metric usage');
-                                    }
-                                }} className="px-6 bg-red-600/20 hover:bg-red-600/40 text-red-500 font-bold py-3 rounded-xl transition-colors">
+                                <button
+                                    onClick={handleDeleteSelectedMetric}
+                                    disabled={deletingMetricId === selectedMetric.id}
+                                    className="px-6 bg-red-600/20 hover:bg-red-600/40 disabled:bg-neutral-700 disabled:text-neutral-400 disabled:cursor-not-allowed text-red-500 font-bold py-3 rounded-xl transition-colors"
+                                >
                                     DELETE
                                 </button>
                             )}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -103,7 +103,11 @@ async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T
     // Handle other errors
     if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        throw new ApiError(errorData.detail || response.statusText, response.status);
+        const detail = errorData.detail;
+        const message = typeof detail === 'string'
+            ? detail
+            : detail?.message || response.statusText;
+        throw new ApiError(message, response.status);
     }
 
     if (responseType === 'blob') {


### PR DESCRIPTION
## Descripción del Cambio
Closes #153

PR2 frontend slice for the bulk metric freeze chain. This makes MetricsManager communicate long-running metric operations, guard duplicate local submissions, refresh relevant state after mutations, and avoid stale selected-metric UI after delete.

Chain context:

```text
main
└── tracker: fix/bulk-metrics-freeze
    └── PR1 backend: fix/bulk-metrics-freeze-backend
        └── 📍 PR2 frontend: fix/bulk-metrics-freeze-frontend
```

Start: PR1 backend mitigation.
End: frontend pending/refetch UX validated.
Prior dependencies: PR1 backend.
Follow-up: optional PR3 bulk upload timing if assigned.
Out of scope: global/persisted operation locks, job polling, async jobs, chunked delete, `/nodes` split.

| File | Change |
|------|--------|
| `frontend/components/MetricsManager.tsx` | Adds local save/delete pending state, duplicate-submission guards, operation messages, post-mutation `/metrics` + `/nodes` refresh, and stale delete cleanup. |
| `frontend/components/MetricsManager.test.tsx` | Adds focused coverage for save/delete pending state, duplicate guards, cancel/failure cleanup, 409 handling, and refresh behavior. |
| `frontend/services/api.ts` | Surfaces FastAPI nested `detail.message` as a useful `ApiError.message`. |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd frontend && PNPM_HOME=/home/alex/.local/share/pnpm PATH=/home/alex/.local/share/pnpm:$PATH pnpm install --frozen-lockfile`
- [x] `cd frontend && PNPM_HOME=/home/alex/.local/share/pnpm PATH=/home/alex/.local/share/pnpm:$PATH pnpm test:run MetricsManager.test.tsx` — 24 passed.
- [x] Judgment Day PR2 frontend: APPROVED.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
