### PR TITLE
fix(polling): treat SNMP no-response as warning

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -6,7 +6,7 @@ import random
 import sys
 import subprocess
 from datetime import datetime
-from typing import Dict
+from typing import Any, Dict
 
 # Add root and backend to python path to verify imports work
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -20,6 +20,13 @@ logger = logging.getLogger(__name__)
 from repositories.metric_repo import insert_metric_value, bulk_insert_metrics
 from postgres_db import SessionLocal
 from config import get_icmp_settings, get_polling_pipeline_settings
+from services.polling_event_lifecycle import (
+    EVENT_TYPE_COLLECTION_FAILURE,
+    FAILURE_FAMILY_SNMP_NO_RESPONSE,
+    SOURCE_PROTOCOL_SNMP,
+    is_snmp_no_response_failure,
+    normalized_protocol,
+)
 
 # SNMP Support
 try:
@@ -98,10 +105,18 @@ def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2) -> float:
             continue
     return 0.0
 
-def fetch_snmp_value(ip, community, oid, port=161):
-    """Perform a real SNMP GET."""
+def fetch_snmp_value(ip, community, oid, port=161, include_status=False):
+    """Perform a real SNMP GET.
+
+    By default this preserves the legacy float/None contract. The active worker
+    requests structured status so only real timeout/no-data failures become
+    SNMP_NO_RESPONSE collection-failure events.
+    """
+    def result(value, status, error):
+        return (value, status, error) if include_status else value
+
     if not SNMP_AVAILABLE:
-        return None
+        return result(None, "ERROR", "PySNMP not installed")
 
     try:
         error_indication, error_status, error_index, var_binds = next(
@@ -114,16 +129,34 @@ def fetch_snmp_value(ip, community, oid, port=161):
             )
         )
 
-        if error_indication or error_status:
-            return None
+        if error_indication:
+            error_message = str(error_indication)
+            status = (
+                "TIMEOUT"
+                if is_snmp_no_response_failure(SOURCE_PROTOCOL_SNMP, "ERROR", {"message": error_message})
+                else "ERROR"
+            )
+            return result(None, status, error_message)
+        if error_status:
+            error = f"{error_status.prettyPrint()} at {error_index and var_binds[int(error_index) - 1][0] or '?'}"
+            return result(None, "ERROR", error)
 
         value = var_binds[0][1]
         try:
-            return float(value)
-        except (ValueError, TypeError):
-            return None
-    except Exception:
-        return None
+            return result(float(value), "OK", None)
+        except (ValueError, TypeError) as exc:
+            return result(None, "ERROR", str(exc))
+    except Exception as exc:
+        return result(None, "ERROR", str(exc))
+
+
+def _coerce_snmp_fetch_result(raw: Any) -> tuple[float | None, str, str | None]:
+    if isinstance(raw, tuple) and len(raw) == 3:
+        value, status, error = raw
+        return value, str(status or "ERROR"), None if error is None else str(error)
+    if raw is None:
+        return None, "TIMEOUT", "No SNMP response received before timeout"
+    return raw, "OK", None
 
 
 def _log_observe_only_cycle(settings, metrics_count, collected_count, failed_count, duration, jobs_per_min):
@@ -145,6 +178,88 @@ def _log_observe_only_cycle(settings, metrics_count, collected_count, failed_cou
     )
 
 
+def _dedupe_snmp_collection_failures(failures):
+    deduped = {}
+    for row in failures:
+        key = (row.get("node_id"), row.get("metric_id"), row.get("failure_family"))
+        deduped[key] = row
+    return list(deduped.values())
+
+
+def _refresh_snmp_collection_failures(session, failures):
+    failures = _dedupe_snmp_collection_failures(failures)
+    if not failures:
+        return
+    session.run("""
+        UNWIND $failures AS row
+        MATCH (n:CI {id: row.node_id})
+        MATCH (m:MetricDef {id: row.metric_id})
+        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+          AND (
+            existing.event_type = 'COLLECTION_FAILURE'
+            OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+          )
+          AND (existing.failure_family = 'SNMP_NO_RESPONSE' OR existing.failure_family IS NULL)
+          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+        WITH row, n, m, head(collect(existing)) AS existing
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+            CREATE (created:Event {
+                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                status: 'OPEN', severity: row.severity, message: row.message,
+                event_type: row.event_type, failure_family: row.failure_family,
+                source_protocol: row.source_protocol, created_at: datetime(),
+                last_seen: datetime(), ack: false, correlation_type: 'ROOT',
+                root_cause_ci_id: row.node_id
+            })
+            MERGE (n)-[:HAS_EVENT]->(created)
+            MERGE (created)-[:TRIGGERED_BY]->(m)
+        )
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+            SET existing.status = 'OPEN', existing.severity = row.severity,
+                existing.message = row.message, existing.last_seen = datetime(),
+                existing.recovered_at = NULL, existing.ack = false,
+                existing.event_type = row.event_type,
+                existing.failure_family = row.failure_family,
+                existing.source_protocol = row.source_protocol
+            MERGE (n)-[:HAS_EVENT]->(existing)
+            MERGE (existing)-[:TRIGGERED_BY]->(m)
+        )
+    """, failures=failures)
+
+
+def _recover_snmp_collection_failures(session, updates):
+    recoveries = [u for u in updates if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_SNMP]
+    if not recoveries:
+        return
+    session.run("""
+        UNWIND $recoveries AS row
+        MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
+        WHERE e.status IN ['OPEN', 'ACK']
+          AND (
+            e.event_type = 'COLLECTION_FAILURE'
+            OR (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
+          )
+          AND (e.failure_family = 'SNMP_NO_RESPONSE' OR e.failure_family IS NULL)
+          AND (e.source_protocol IS NULL OR toUpper(e.source_protocol) = row.protocol)
+        SET e.status = 'RECOVERED',
+            e.recovered_at = datetime(),
+            e.message = 'Metric collection recovered. Latest sample collected by legacy SNMP worker'
+        WITH e
+        CALL {
+            WITH e
+            MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+            WHERE pe.root_cause_ci_id = e.ci_id
+              AND pe.correlation_type = 'PROPAGATED'
+              AND pe.status IN ['OPEN', 'ACK']
+              AND coalesce(m.can_propagate, true) = true
+            SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
+            RETURN count(pe) AS propagated_recovered
+        }
+        RETURN e
+    """, recoveries=recoveries)
+
+
 def poll_snmp():
     start_time = time.time()
     polling_settings = get_polling_pipeline_settings()
@@ -152,6 +267,7 @@ def poll_snmp():
     db = SessionLocal()
     metrics_to_save = []
     latest_updates = []
+    failure_updates = []
     metrics_count = 0
     failed_count = 0
     try:
@@ -175,7 +291,7 @@ def poll_snmp():
                 metrics_count += 1
                 node_id = record["node_id"]
                 mid = record["metric_id"]
-                protocol = record["protocol"]
+                protocol = normalized_protocol(record["protocol"])
                 ip = record["ip"]
                 
                 if not ip:
@@ -184,7 +300,7 @@ def poll_snmp():
 
                 val = None
                 icmp_settings = get_icmp_settings()
-                if protocol.upper() == "ICMP":
+                if protocol == "ICMP":
                     val = fetch_icmp_ping(ip, timeout_ms=icmp_settings.timeout_ms, retries=icmp_settings.retries)
                     # Debounce logic: track consecutive failures per node
                     if val == 0:
@@ -204,8 +320,18 @@ def poll_snmp():
                     else:
                         # Success: reset counter and proceed normally
                         _consecutive_failures[node_id] = 0
-                elif protocol == "SNMP" and record["oid"]:
-                    val = fetch_snmp_value(ip, record["community"], record["oid"], int(record["port"]))
+                snmp_status = "OK"
+                snmp_error = None
+                if protocol == SOURCE_PROTOCOL_SNMP and record["oid"]:
+                    val, snmp_status, snmp_error = _coerce_snmp_fetch_result(
+                        fetch_snmp_value(
+                            ip,
+                            record["community"],
+                            record["oid"],
+                            int(record["port"]),
+                            include_status=True,
+                        )
+                    )
                 
                 if val is not None:
                     metrics_to_save.append({
@@ -223,6 +349,20 @@ def poll_snmp():
                     })
                 else:
                     failed_count += 1
+                    if is_snmp_no_response_failure(
+                        protocol,
+                        snmp_status,
+                        {"message": snmp_error},
+                    ):
+                        failure_updates.append({
+                            "node_id": node_id,
+                            "metric_id": mid,
+                            "severity": "WARNING",
+                            "message": f"Metric Collection Failed: {snmp_error or 'No SNMP response received before timeout'}",
+                            "event_type": EVENT_TYPE_COLLECTION_FAILURE,
+                            "failure_family": FAILURE_FAMILY_SNMP_NO_RESPONSE,
+                            "source_protocol": SOURCE_PROTOCOL_SNMP,
+                        })
 
             # Update collector status in Neo4j
             duration_current = time.time() - start_time
@@ -245,6 +385,7 @@ def poll_snmp():
                 duration_current,
                 jobs_per_min,
             )
+            _refresh_snmp_collection_failures(session, failure_updates)
 
             # Perform Bulk Insert at the end of the cycle. Only publish latest
             # values to Neo4j after Timescale persistence succeeds, so the UI
@@ -266,6 +407,7 @@ def poll_snmp():
                             r.status = $status,
                             r.last_message = $msg
                     """, nid=update["node_id"], mid=update["metric_id"], val=update["value"], status="OK", msg="Latest sample collected by legacy SNMP worker")
+                _recover_snmp_collection_failures(session, latest_updates)
                 print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")
 
         duration = time.time() - start_time

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -7,6 +7,18 @@ from enum import Enum
 from typing import Any, Iterable, Mapping
 from uuid import UUID
 
+from services.polling_event_lifecycle import (
+    COLLECTION_FAILURE_PREFIX,
+    EVENT_TYPE_AVAILABILITY,
+    EVENT_TYPE_COLLECTION_FAILURE,
+    EVENT_TYPE_THRESHOLD_BREACH,
+    FAILURE_FAMILY_SNMP_NO_RESPONSE,
+    SOURCE_PROTOCOL_SNMP,
+    collection_failure_message,
+    is_snmp_no_response_failure,
+    normalized_protocol,
+)
+
 
 def _value(item: Any) -> Any:
     if isinstance(item, Enum):
@@ -41,41 +53,70 @@ def _base_severity(metadata: Mapping[str, Any]) -> str:
     return {2: "WARNING", 3: "CRITICAL"}.get(int(metadata.get("criticality") or 1), "INFO")
 
 
+def _collection_failure_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: dict[tuple[Any, Any, Any, Any], dict[str, Any]] = {}
+    for row in rows:
+        if not (row.get("is_breach") and row.get("event_type") == EVENT_TYPE_COLLECTION_FAILURE):
+            continue
+        key = (row.get("ci_id"), row.get("metric_id"), row.get("event_type"), row.get("failure_family"))
+        deduped[key] = row
+    return list(deduped.values())
+
+
 def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     """Derive latest-value/event rows from normalized result envelopes."""
     rows: list[dict[str, Any]] = []
     for envelope in envelopes:
         metadata = envelope.get("metadata") or {}
-        protocol = str(_value(envelope.get("protocol")) or "")
+        protocol = normalized_protocol(envelope.get("protocol"))
         metric_id = str(envelope.get("metric_id"))
         metric_name = str(metadata.get("name") or metric_id)
         numeric = _num(envelope)
         result_status = str(_value(envelope.get("status")) or "OK")
         severity = "INFO"
         is_breach = False
+        event_type = None
+        failure_family = None
+        source_protocol = protocol or None
+        recover_collection_failure = numeric is not None
+        recover_non_collection_event = False
         display_value = "N/A" if numeric is None else str(numeric)
         message = f"Metric {metric_name} is OK. Value: {display_value}"
+        collection_recovery_message = f"Metric collection recovered. Value: {display_value}"
 
-        if result_status not in {"OK", "WARNING", "CRITICAL"}:
+        if is_snmp_no_response_failure(protocol, result_status, envelope.get("error") or {}):
+            severity = "WARNING"
+            is_breach = True
+            event_type = EVENT_TYPE_COLLECTION_FAILURE
+            failure_family = FAILURE_FAMILY_SNMP_NO_RESPONSE
+            source_protocol = SOURCE_PROTOCOL_SNMP
+            message = collection_failure_message(envelope.get("error") or {}, result_status)
+        elif result_status not in {"OK", "WARNING", "CRITICAL"}:
             severity = _base_severity(metadata)
             is_breach = True
-            message = f"Metric Collection Failed: {(envelope.get('error') or {}).get('message') or result_status}"
+            event_type = EVENT_TYPE_COLLECTION_FAILURE
+            message = collection_failure_message(envelope.get("error") or {}, result_status)
         elif numeric is not None:
             availability = protocol == "ICMP" or metric_name == "mariadb-GS"
             if availability and numeric == 0:
                 severity = _base_severity(metadata)
                 is_breach = True
+                event_type = EVENT_TYPE_AVAILABILITY
                 message = f"Service/Host Down: {metric_name}"
             elif not availability:
                 op = str(metadata.get("operator") or ">=")
                 if metadata.get("critical") is not None and _check(numeric, float(metadata["critical"]), op):
                     severity = "CRITICAL"
                     is_breach = True
+                    event_type = EVENT_TYPE_THRESHOLD_BREACH
                     message = f"Critical Threshold Breached: {display_value} {op} {metadata['critical']}"
                 elif metadata.get("warning") is not None and _check(numeric, float(metadata["warning"]), op):
                     severity = "WARNING"
                     is_breach = True
+                    event_type = EVENT_TYPE_THRESHOLD_BREACH
                     message = f"Warning Threshold Breached: {display_value} {op} {metadata['warning']}"
+
+        recover_non_collection_event = numeric is not None and not is_breach
 
         rows.append({
             "idempotency_key": envelope.get("idempotency_key"),
@@ -86,6 +127,12 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
             "severity": severity,
             "message": message,
             "is_breach": is_breach,
+            "event_type": event_type,
+            "failure_family": failure_family,
+            "source_protocol": source_protocol,
+            "recover_collection_failure": recover_collection_failure,
+            "recover_non_collection_event": recover_non_collection_event,
+            "collection_recovery_message": collection_recovery_message,
             "observed_at": _value(envelope.get("observed_at")),
             "correlation_type": metadata.get("correlation_type") or "ROOT",
             "propagated_from": metadata.get("propagated_from"),
@@ -111,6 +158,7 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
     rows = build_event_rows(envelopes)
     if not rows:
         return 0
+    collection_failure_rows = _collection_failure_event_rows(rows)
     with driver.session() as session:
         session.run(
             """
@@ -128,12 +176,57 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
         session.run(
             """
             UNWIND $rows AS row
-            WITH row WHERE row.is_breach
+            WITH row WHERE row.is_breach AND row.event_type = 'COLLECTION_FAILURE'
             MATCH (n:CI {id: row.ci_id})
             MATCH (m:MetricDef {id: row.metric_id})
-            MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN'})
+            OPTIONAL MATCH (existing:Event {ci_id: row.ci_id, metric_id: row.metric_id})
+            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+              AND (
+                existing.event_type = row.event_type
+                OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+              )
+              AND (
+                (row.failure_family IS NOT NULL AND (existing.failure_family = row.failure_family OR existing.failure_family IS NULL))
+                OR (row.failure_family IS NULL AND existing.failure_family IS NULL)
+              )
+              AND (row.source_protocol IS NULL OR existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN',
+                    event_type: row.event_type, failure_family: row.failure_family, source_protocol: row.source_protocol,
+                    severity: row.severity, message: row.message, created_at: datetime(), last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type, propagated_from: row.propagated_from, root_cause_ci_id: row.root_cause_ci_id,
+                    business_service_id: row.business_service_id, business_service_name: row.business_service_name,
+                    business_service_tier: row.business_service_tier, owner_t1: row.owner_t1, owner_t2: row.owner_t2,
+                    owner_t3: row.owner_t3, impacted_users: row.impacted_users, site: row.site,
+                    service_catalog_id: row.service_catalog_id, service_category: row.service_category,
+                    service_tier: row.service_tier, sla_minutes: row.sla_minutes
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.status = 'OPEN', existing.severity = row.severity, existing.message = row.message,
+                    existing.last_seen = datetime(), existing.ack = false, existing.recovered_at = NULL,
+                    existing.event_type = row.event_type, existing.failure_family = row.failure_family,
+                    existing.source_protocol = row.source_protocol
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+            """,
+            rows=collection_failure_rows,
+        )
+        session.run(
+            """
+            UNWIND $rows AS row
+            WITH row WHERE row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'
+            MATCH (n:CI {id: row.ci_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN'})
             SET e.severity = row.severity,
                 e.message = row.message,
+                e.source_protocol = row.source_protocol,
                 e.last_seen = datetime(),
                 e.ack = false,
                 e.correlation_type = coalesce(e.correlation_type, row.correlation_type),
@@ -159,9 +252,43 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
         session.run(
             """
             UNWIND $rows AS row
-            WITH row WHERE NOT row.is_breach
+            WITH row WHERE row.recover_collection_failure
             MATCH (:CI {id: row.ci_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
             WHERE e.status IN ['OPEN', 'ACK']
+              AND (
+                e.event_type = 'COLLECTION_FAILURE'
+                OR (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
+              )
+              AND (row.source_protocol IS NULL OR e.source_protocol IS NULL OR toUpper(e.source_protocol) = row.source_protocol)
+              AND (
+                row.source_protocol <> 'SNMP'
+                OR e.failure_family = 'SNMP_NO_RESPONSE'
+                OR e.failure_family IS NULL
+              )
+            SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = row.collection_recovery_message
+            WITH e
+            CALL {
+                WITH e
+                MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+                WHERE pe.root_cause_ci_id = e.ci_id
+                  AND pe.correlation_type = 'PROPAGATED'
+                  AND pe.status IN ['OPEN', 'ACK']
+                  AND coalesce(m.can_propagate, true) = true
+                SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
+                RETURN count(pe) AS propagated_recovered
+            }
+            RETURN e
+            """,
+            rows=rows,
+        )
+        session.run(
+            """
+            UNWIND $rows AS row
+            WITH row WHERE row.recover_non_collection_event
+            MATCH (:CI {id: row.ci_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
+            WHERE e.status IN ['OPEN', 'ACK']
+              AND (e.event_type IS NULL OR e.event_type <> 'COLLECTION_FAILURE')
+              AND NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
             SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = row.message
             WITH e
             CALL {

--- a/backend/polling/snmp_executor.py
+++ b/backend/polling/snmp_executor.py
@@ -16,8 +16,9 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 
 from polling.contracts import PollResultEnvelope, PollingProtocol, PollingResultStatus
 from polling.idempotency import generate_idempotency_key
+from services.polling_event_lifecycle import is_snmp_no_response_failure
 
-Fetcher = Callable[..., float | None]
+Fetcher = Callable[..., Any]
 
 
 def _utc_now() -> datetime:
@@ -48,10 +49,16 @@ def _default_icmp_fetcher(**kwargs) -> float:
     return fetch_icmp_ping(kwargs["ip"], timeout_ms=kwargs.get("timeout_ms", 3000), retries=kwargs.get("retries", 2))
 
 
-def _default_snmp_fetcher(**kwargs) -> float | None:
+def _default_snmp_fetcher(**kwargs) -> Any:
     from engines.snmp_worker import fetch_snmp_value
 
-    return fetch_snmp_value(kwargs["ip"], kwargs.get("community", "public"), kwargs["oid"], int(kwargs.get("port", 161)))
+    return fetch_snmp_value(
+        kwargs["ip"],
+        kwargs.get("community", "public"),
+        kwargs["oid"],
+        int(kwargs.get("port", 161)),
+        include_status=True,
+    )
 
 
 def _result_id(task_id: Any, observed_at: datetime, status: PollingResultStatus) -> Any:
@@ -97,7 +104,35 @@ def execute_poll_task(
                 oid=payload.get("oid"),
                 port=int(payload.get("port") or 161),
             )
-            if raw is None:
+            if isinstance(raw, tuple) and len(raw) == 3:
+                raw_value, raw_status, raw_error = raw
+                normalized_status = str(raw_status or "ERROR").upper()
+                if normalized_status == "OK" and raw_value is not None:
+                    status = PollingResultStatus.OK
+                    value = {"numeric": float(raw_value), "text": None, "raw": raw_value}
+                    error = {"code": None, "message": None, "retryable": False}
+                elif normalized_status == "TIMEOUT":
+                    status = PollingResultStatus.TIMEOUT
+                    error = {"code": "timeout", "message": raw_error or "SNMP request timed out", "retryable": True}
+                elif normalized_status == "NO_DATA":
+                    status = PollingResultStatus.NO_DATA
+                    error = {"code": "no_data", "message": raw_error or "SNMP returned no data", "retryable": True}
+                elif normalized_status == "ERROR" and is_snmp_no_response_failure(
+                    PollingProtocol.SNMP,
+                    normalized_status,
+                    {"message": raw_error},
+                ):
+                    message = raw_error or "SNMP request timed out"
+                    if "no data" in str(message).lower():
+                        status = PollingResultStatus.NO_DATA
+                        error = {"code": "no_data", "message": message, "retryable": True}
+                    else:
+                        status = PollingResultStatus.TIMEOUT
+                        error = {"code": "timeout", "message": message, "retryable": True}
+                else:
+                    status = PollingResultStatus.ERROR
+                    error = {"code": "snmp_error", "message": raw_error or "SNMP collection failed", "retryable": True}
+            elif raw is None:
                 status = PollingResultStatus.NO_DATA
                 error = {"code": "no_data", "message": "SNMP returned no data", "retryable": True}
             else:

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -12,6 +12,7 @@ markers =
     metric: Tests related to metric reconciliation and definitions
     event: Tests related to event lifecycle management
     auth: Authentication and authorization tests
+    api: API/router tests
 addopts =
     --strict-markers
     -v

--- a/backend/services/polling_event_lifecycle.py
+++ b/backend/services/polling_event_lifecycle.py
@@ -1,0 +1,58 @@
+"""Shared polling event discriminator constants and helpers."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping
+
+EVENT_TYPE_COLLECTION_FAILURE = "COLLECTION_FAILURE"
+EVENT_TYPE_THRESHOLD_BREACH = "THRESHOLD_BREACH"
+EVENT_TYPE_AVAILABILITY = "AVAILABILITY"
+FAILURE_FAMILY_SNMP_NO_RESPONSE = "SNMP_NO_RESPONSE"
+SOURCE_PROTOCOL_SNMP = "SNMP"
+COLLECTION_FAILURE_PREFIX = "Metric Collection Failed:"
+
+_NO_RESPONSE_STATUSES = {"NO_DATA", "TIMEOUT"}
+_NO_RESPONSE_ERROR_CODES = {"NO_DATA", "NO_RESPONSE", "TIMEOUT", "TIMED_OUT", "REQUEST_TIMEOUT"}
+_NO_RESPONSE_MESSAGE_MARKERS = (
+    "no snmp response",
+    "no response",
+    "timed out",
+    "timeout",
+    "returned no data",
+    "no data",
+)
+
+
+def enum_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def normalized_protocol(value: Any) -> str:
+    return str(enum_value(value) or "").upper()
+
+
+def is_snmp_no_response_failure(protocol: Any, status: Any, error: Mapping[str, Any] | None = None) -> bool:
+    if normalized_protocol(protocol) != SOURCE_PROTOCOL_SNMP:
+        return False
+    normalized_status = str(enum_value(status) or "").upper()
+    if normalized_status in _NO_RESPONSE_STATUSES:
+        return True
+    if normalized_status != "ERROR":
+        return False
+    error = error or {}
+    code = str(enum_value(error.get("code")) or "").upper()
+    if code in _NO_RESPONSE_ERROR_CODES:
+        return True
+    message = str(error.get("message") or "").lower()
+    return any(marker in message for marker in _NO_RESPONSE_MESSAGE_MARKERS)
+
+
+def collection_failure_message(error: Mapping[str, Any] | None = None, status: Any = None) -> str:
+    reason = None
+    if error:
+        reason = error.get("message")
+    reason = reason or str(enum_value(status) or "No SNMP response received before timeout")
+    return f"{COLLECTION_FAILURE_PREFIX} {reason}"

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -13,6 +13,15 @@ from database import get_db
 from postgres_db import SessionLocal
 from repositories.metric_repo import insert_metric_value
 from services.metric_service import metric_matches_ci
+from services.polling_event_lifecycle import (
+    EVENT_TYPE_AVAILABILITY,
+    EVENT_TYPE_COLLECTION_FAILURE,
+    EVENT_TYPE_THRESHOLD_BREACH,
+    FAILURE_FAMILY_SNMP_NO_RESPONSE,
+    SOURCE_PROTOCOL_SNMP,
+    is_snmp_no_response_failure,
+    normalized_protocol,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -292,7 +301,13 @@ def poll_metric(ci, metric_def, snmp_conf):
             )
 
             if error_indication:
-                return None, "TIMEOUT", str(error_indication)
+                error_message = str(error_indication)
+                status = (
+                    "TIMEOUT"
+                    if is_snmp_no_response_failure(SOURCE_PROTOCOL_SNMP, "ERROR", {"message": error_message})
+                    else "ERROR"
+                )
+                return None, status, error_message
             if error_status:
                 error = f"{error_status.prettyPrint()} at {error_index and var_binds[int(error_index) - 1][0] or '?'}"
                 return None, "ERROR", error
@@ -315,13 +330,23 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
     status = "OK"
     severity = "INFO"
     is_breach = False
+    event_type = None
+    failure_family = None
+    source_protocol = normalized_protocol(metric_def.get("protocol")) or None
     message = f"Metric {metric_def.get('name', metric_def['id'])} is OK. Value: {val}"
     numeric_value = None
 
     if poll_status != "OK":
-        status = "CRITICAL"
-        severity = base_severity
+        is_snmp_no_response = is_snmp_no_response_failure(
+            source_protocol,
+            poll_status,
+            {"message": err_msg},
+        )
+        status = "WARNING" if is_snmp_no_response else base_severity
+        severity = "WARNING" if is_snmp_no_response else base_severity
         is_breach = True
+        event_type = EVENT_TYPE_COLLECTION_FAILURE
+        failure_family = FAILURE_FAMILY_SNMP_NO_RESPONSE if is_snmp_no_response else None
         message = f"Metric Collection Failed: {err_msg or 'Timeout'}"
         val = "N/A"
     elif val is not None:
@@ -329,7 +354,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
             num_val = float(val)
             numeric_value = num_val
             is_availability_metric = (
-                metric_def.get("protocol") == "ICMP"
+                source_protocol == "ICMP"
                 or metric_def.get("name") == "mariadb-GS"
             )
 
@@ -353,6 +378,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     status = "CRITICAL"
                     severity = "CRITICAL"
                     is_breach = True
+                    event_type = EVENT_TYPE_THRESHOLD_BREACH
                     message = f"Critical Threshold Breached: {val} {operator} {metric_def['critical']}"
                 elif metric_def.get("warning") is not None and check_op(
                     num_val, float(metric_def["warning"]), operator
@@ -360,12 +386,14 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     status = "WARNING"
                     severity = "WARNING"
                     is_breach = True
+                    event_type = EVENT_TYPE_THRESHOLD_BREACH
                     message = f"Warning Threshold Breached: {val} {operator} {metric_def['warning']}"
 
             if is_availability_metric and float(val) == 0:
                 status = "CRITICAL"
                 severity = base_severity
                 is_breach = True
+                event_type = EVENT_TYPE_AVAILABILITY
                 message = f"Service/Host Down: {metric_def.get('name')}"
         except ValueError:
             pass
@@ -407,35 +435,87 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
             msg=message,
         )
 
+        if numeric_value is not None:
+            session.run(
+                """
+                MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
+                WHERE e.status IN ['OPEN', 'ACK']
+                  AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
+                  AND (
+                    e.event_type = 'COLLECTION_FAILURE'
+                    OR (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
+                  )
+                  AND ($source_protocol IS NULL OR e.source_protocol IS NULL OR toUpper(e.source_protocol) = $source_protocol)
+                  AND (
+                    $source_protocol <> 'SNMP'
+                    OR e.failure_family = 'SNMP_NO_RESPONSE'
+                    OR e.failure_family IS NULL
+                  )
+                SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
+                WITH e
+                CALL {
+                    WITH e
+                    MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+                    WHERE pe.root_cause_ci_id = e.ci_id
+                      AND pe.correlation_type = 'PROPAGATED'
+                      AND pe.status IN ['OPEN', 'ACK']
+                      AND coalesce(m.can_propagate, true) = true
+                    SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
+                    RETURN count(pe) AS propagated_recovered
+                }
+                RETURN e
+            """,
+                nid=ci.get("id"),
+                mid=metric_def["id"],
+                source_protocol=source_protocol,
+                msg=f"Metric collection recovered. Value: {val}",
+            )
+
         if is_breach:
             existing = session.run(
                 """
                 MATCH (existing:Event)
                 WHERE existing.ci_id = $nid AND existing.metric_id = $mid AND existing.status IN ['OPEN', 'ACK', 'RECOVERED']
-                RETURN existing
+                  AND (
+                    existing.event_type = $event_type
+                    OR ($event_type = 'COLLECTION_FAILURE' AND existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+                  )
+                  AND (
+                    ($failure_family IS NOT NULL AND (existing.failure_family = $failure_family OR existing.failure_family IS NULL))
+                    OR ($failure_family IS NULL AND existing.failure_family IS NULL)
+                  )
+                  AND ($source_protocol IS NULL OR existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = $source_protocol)
+                RETURN elementId(existing) AS existing_element_id, existing.status AS existing_status
                 LIMIT 1
             """,
                 nid=ci.get("id"),
                 mid=metric_def["id"],
+                event_type=event_type,
+                failure_family=failure_family,
+                source_protocol=source_protocol,
             ).single()
 
             if existing:
-                existing_status = existing["existing"].get("status")
+                existing_element_id = existing.get("existing_element_id")
                 session.run(
                     """
                     MATCH (existing:Event)
-                    WHERE existing.ci_id = $nid AND existing.metric_id = $mid AND existing.status = $old_status
+                    WHERE elementId(existing) = $existing_element_id
                     SET existing.status = 'OPEN',
                         existing.last_seen = datetime(),
                         existing.message = $msg,
                         existing.severity = $sev,
-                        existing.recovered_at = NULL
+                        existing.recovered_at = NULL,
+                        existing.event_type = $event_type,
+                        existing.failure_family = $failure_family,
+                        existing.source_protocol = $source_protocol
                 """,
-                    nid=ci.get("id"),
-                    mid=metric_def["id"],
-                    old_status=existing_status,
+                    existing_element_id=existing_element_id,
                     msg=message,
                     sev=severity,
+                    event_type=event_type,
+                    failure_family=failure_family,
+                    source_protocol=source_protocol,
                 )
             else:
                 snapshot = resolve_event_snapshot(session, ci.get("id"))
@@ -469,6 +549,9 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         status: 'OPEN',
                         severity: $sev,
                         message: $msg,
+                        event_type: $event_type,
+                        failure_family: $failure_family,
+                        source_protocol: $source_protocol,
                         created_at: datetime(),
                         last_seen: datetime(),
                         ack: false,
@@ -495,18 +578,24 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     mid=metric_def["id"],
                     sev=severity,
                     msg=message,
+                    event_type=event_type,
+                    failure_family=failure_family,
+                    source_protocol=source_protocol,
                     propagated_from=propagated_from,
                     correlation_type=correlation_type,
                     root_cause_ci_id=root_cause_ci_id,
                     **snapshot,
                 )
         else:
-            # Recovery path - check if ROOT event to trigger propagation
+            # Recovery path for threshold/availability events; SNMP collection failures
+            # are recovered independently above so threshold lifecycles stay separate.
             session.run(
                 """
                 MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
                 WHERE e.status IN ['OPEN', 'ACK']
-                  AND e.correlation_type = 'ROOT'
+                  AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
+                  AND (e.event_type IS NULL OR e.event_type <> 'COLLECTION_FAILURE')
+                  AND NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
                 SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
                 WITH e
                 CALL {
@@ -515,7 +604,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     WHERE pe.root_cause_ci_id = e.ci_id
                       AND pe.correlation_type = 'PROPAGATED'
                       AND pe.status IN ['OPEN', 'ACK']
-                      AND m.can_propagate = true
+                      AND coalesce(m.can_propagate, true) = true
                     SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
                     RETURN count(pe) AS propagated_recovered
                 }
@@ -528,7 +617,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
 
 
 def run_diagnostic(ci, metric):
-    protocol = metric.get("protocol")
+    protocol = normalized_protocol(metric.get("protocol"))
     if protocol == "ICMP":
         try:
             ping_flag = "-n" if subprocess.os.name == "nt" else "-c"

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from tests.conftest import MockNeo4jDriver
 
 
-def _event_row(value=97.0, status="OK", metadata=None):
+def _event_row(value: float | None = 97.0, status="OK", metadata=None):
     return {
         "idempotency_key": "idem-1",
         "ci_id": "ci-1",
@@ -76,3 +76,189 @@ def test_event_writer_preserves_propagated_correlation_metadata():
     assert rows[0]["propagated_from"] == "event-root"
     assert rows[0]["root_cause_ci_id"] == "ci-root"
     assert rows[0]["business_service_id"] == "bs-1"
+
+
+def test_event_writer_derives_snmp_no_data_as_warning_collection_failure():
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        _event_row(
+            None,
+            status="NO_DATA",
+            metadata={"name": "ifInOctets", "criticality": 1},
+        )
+    ])
+
+    assert rows[0]["is_breach"] is True
+    assert rows[0]["severity"] == "WARNING"
+    assert rows[0]["event_type"] == "COLLECTION_FAILURE"
+    assert rows[0]["failure_family"] == "SNMP_NO_RESPONSE"
+    assert rows[0]["source_protocol"] == "SNMP"
+    assert rows[0]["message"].startswith("Metric Collection Failed:")
+
+
+def test_event_writer_does_not_label_generic_snmp_error_as_no_response():
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        {
+            **_event_row(
+                None,
+                status="ERROR",
+                metadata={"name": "ifInOctets", "criticality": 3},
+            ),
+            "error": {"code": "value_error", "message": "could not convert string to float"},
+        }
+    ])
+
+    assert rows[0]["is_breach"] is True
+    assert rows[0]["severity"] == "CRITICAL"
+    assert rows[0]["event_type"] == "COLLECTION_FAILURE"
+    assert rows[0]["failure_family"] is None
+    assert "SNMP_NO_RESPONSE" not in rows[0]["message"]
+
+
+def test_event_writer_labels_explicit_snmp_timeout_error_as_no_response_warning():
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        {
+            **_event_row(None, status="ERROR", metadata={"name": "ifInOctets", "criticality": 3}),
+            "error": {"code": "timeout", "message": "No SNMP response received before timeout"},
+        }
+    ])
+
+    assert rows[0]["severity"] == "WARNING"
+    assert rows[0]["event_type"] == "COLLECTION_FAILURE"
+    assert rows[0]["failure_family"] == "SNMP_NO_RESPONSE"
+
+
+def test_event_writer_marks_valid_rows_for_collection_failure_recovery_even_on_breach():
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        _event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90}),
+        _event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90, "operator": ">="}),
+        {
+            **_event_row(97.0, metadata={"name": "cli-health", "criticality": 3, "critical": 90, "operator": ">="}),
+            "protocol": "CLI",
+            "metric_id": "cli-health",
+        },
+    ])
+
+    assert rows[0]["is_breach"] is False
+    assert rows[0]["recover_collection_failure"] is True
+    assert rows[0]["event_type"] is None
+    assert rows[1]["is_breach"] is True
+    assert rows[1]["recover_collection_failure"] is True
+    assert rows[1]["event_type"] == "THRESHOLD_BREACH"
+    assert rows[2]["is_breach"] is True
+    assert rows[2]["recover_collection_failure"] is True
+    assert rows[2]["event_type"] == "THRESHOLD_BREACH"
+
+
+def test_event_writer_uses_discriminator_aware_event_queries():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [_event_row(None, status="NO_DATA"), _event_row(42.0)])
+
+    queries = "\n".join(q["query"] for q in driver.mock_session.queries)
+    assert "event_type" in queries
+    assert "failure_family" in queries
+    assert "Metric Collection Failed:" in queries
+    assert "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN'})" not in queries
+    assert "COLLECTION_FAILURE" in queries
+    assert "SNMP_NO_RESPONSE" in queries
+
+
+def test_event_writer_collection_failure_matching_does_not_treat_null_family_as_wildcard():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        {
+            **_event_row(
+                None,
+                status="ERROR",
+                metadata={"name": "ifInOctets", "criticality": 3},
+            ),
+            "error": {"code": "value_error", "message": "could not convert string to float"},
+        }
+    ])
+
+    collection_query = next(
+        q for q in driver.mock_session.queries
+        if "row.event_type = 'COLLECTION_FAILURE'" in q["query"]
+    )["query"]
+    assert "row.failure_family IS NULL OR existing.failure_family = row.failure_family" not in collection_query
+    assert "row.failure_family IS NULL AND existing.failure_family IS NULL" in collection_query
+    assert "row.failure_family IS NOT NULL" in collection_query
+
+
+def test_event_writer_recovers_non_collection_events_on_normal_rows():
+    from polling.event_writer import batch_update_events, build_event_rows
+
+    rows = build_event_rows([_event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+    assert rows[0]["recover_collection_failure"] is True
+    assert rows[0]["recover_non_collection_event"] is True
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [_event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+
+    queries = "\n".join(q["query"] for q in driver.mock_session.queries)
+    assert "row.recover_non_collection_event" in queries
+    assert "e.event_type <> 'COLLECTION_FAILURE'" in queries
+    assert "NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')" in queries
+
+
+def test_event_writer_recovers_non_snmp_collection_failures_on_valid_rows_even_when_breaching():
+    from polling.event_writer import batch_update_events, build_event_rows
+
+    envelope = {
+        **_event_row(97.0, metadata={"name": "cli-health", "criticality": 3, "critical": 90, "operator": ">="}),
+        "protocol": "CLI",
+        "metric_id": "cli-health",
+    }
+    rows = build_event_rows([envelope])
+    assert rows[0]["is_breach"] is True
+    assert rows[0]["recover_collection_failure"] is True
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [envelope])
+
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_collection_failure" in q["query"])
+    assert "e.event_type = 'COLLECTION_FAILURE'" in recovery_query["query"]
+    assert "e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:'" in recovery_query["query"]
+    assert "toUpper(e.source_protocol) = row.source_protocol" in recovery_query["query"]
+
+
+def test_event_writer_deduplicates_collection_failure_rows_before_event_write():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        _event_row(None, status="NO_DATA"),
+        {**_event_row(None, status="NO_DATA"), "idempotency_key": "idem-2"},
+    ])
+
+    collection_query = next(
+        q for q in driver.mock_session.queries
+        if "row.event_type = 'COLLECTION_FAILURE'" in q["query"]
+    )
+    assert len(collection_query["params"]["rows"]) == 1
+
+
+def test_event_writer_uses_collection_recovery_message_for_threshold_breach_recovery():
+    from polling.event_writer import batch_update_events, build_event_rows
+
+    rows = build_event_rows([_event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+    assert rows[0]["is_breach"] is True
+    assert rows[0]["message"].startswith("Critical Threshold Breached")
+    assert rows[0]["collection_recovery_message"].startswith("Metric collection recovered")
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [_event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_collection_failure" in q["query"])
+    assert "row.collection_recovery_message" in recovery_query["query"]

--- a/backend/tests/test_polling_snmp_executor.py
+++ b/backend/tests/test_polling_snmp_executor.py
@@ -51,6 +51,27 @@ def test_snmp_executor_maps_no_data_and_errors_to_retryable_results():
     assert no_data.error["code"] == "no_data"
     assert no_data.error["retryable"] is True
 
+    structured_error = execute_poll_task(_task(), snmp_fetcher=lambda **kwargs: (None, "ERROR", "noSuchName at 1.2.3"))
+    assert structured_error.status == PollingResultStatus.ERROR
+    assert structured_error.error["code"] == "snmp_error"
+    assert structured_error.error["message"] == "noSuchName at 1.2.3"
+
+    structured_timeout = execute_poll_task(
+        _task(),
+        snmp_fetcher=lambda **kwargs: (None, "TIMEOUT", "No SNMP response received before timeout"),
+    )
+    assert structured_timeout.status == PollingResultStatus.TIMEOUT
+    assert structured_timeout.error["code"] == "timeout"
+    assert structured_timeout.error["retryable"] is True
+
+    explicit_timeout_error = execute_poll_task(
+        _task(),
+        snmp_fetcher=lambda **kwargs: (None, "ERROR", "No SNMP response received before timeout"),
+    )
+    assert explicit_timeout_error.status == PollingResultStatus.TIMEOUT
+    assert explicit_timeout_error.error["code"] == "timeout"
+    assert explicit_timeout_error.error["retryable"] is True
+
     def boom(**kwargs):
         raise RuntimeError("snmp exploded")
 

--- a/backend/tests/test_snmp_service_collection_failures.py
+++ b/backend/tests/test_snmp_service_collection_failures.py
@@ -1,0 +1,234 @@
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _load_snmp_service_module():
+    sys.modules.pop("services.snmp_service", None)
+    return importlib.import_module("services.snmp_service")
+
+
+def test_snmp_collection_failure_on_critical_metric_is_warning_with_discriminators(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+
+    snmp_service.store_metric_result(
+        {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+        {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
+        None,
+        "TIMEOUT",
+        "No SNMP response received before timeout",
+        mock_neo4j_driver,
+    )
+
+    create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
+    assert create_event["params"]["sev"] == "WARNING"
+    assert create_event["params"]["event_type"] == "COLLECTION_FAILURE"
+    assert create_event["params"]["failure_family"] == "SNMP_NO_RESPONSE"
+    assert create_event["params"]["source_protocol"] == "SNMP"
+
+
+def test_snmp_generic_error_is_not_labeled_no_response(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+
+    snmp_service.store_metric_result(
+        {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+        {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
+        None,
+        "ERROR",
+        "could not convert string to float",
+        mock_neo4j_driver,
+    )
+
+    create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
+    assert create_event["params"]["sev"] == "CRITICAL"
+    assert create_event["params"]["event_type"] == "COLLECTION_FAILURE"
+    assert create_event["params"]["failure_family"] is None
+
+
+def test_snmp_valid_value_recovers_only_collection_failure(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    fake_pg = MagicMock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3},
+            "42",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    queries = "\n".join(q["query"] for q in mock_neo4j_driver.mock_session.queries)
+    assert "COLLECTION_FAILURE" in queries
+    assert "Metric Collection Failed:" in queries
+    assert "THRESHOLD_BREACH" not in queries
+
+
+def test_snmp_threshold_breach_uses_threshold_event_type_not_collection_failure(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+    fake_pg = MagicMock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            "97",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
+    assert create_event["params"]["sev"] == "CRITICAL"
+    assert create_event["params"]["event_type"] == "THRESHOLD_BREACH"
+    assert create_event["params"]["failure_family"] is None
+
+
+def test_snmp_threshold_breach_still_recovers_existing_collection_failure(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+    fake_pg = MagicMock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "snmp", "criticality": 3, "critical": 90, "operator": ">="},
+            "97",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    recovery_queries = [
+        q for q in session.queries
+        if "SET e.status = 'RECOVERED'" in q["query"] and "COLLECTION_FAILURE" in q["query"]
+    ]
+    assert recovery_queries, "valid SNMP values must recover collection failures before threshold handling"
+    assert "coalesce(m.can_propagate, true) = true" in recovery_queries[0]["query"]
+    create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
+    assert create_event["params"]["event_type"] == "THRESHOLD_BREACH"
+
+
+def test_repeated_collection_failure_updates_exact_matched_event(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [{"existing_status": "OPEN", "existing_element_id": "element-collection"}])
+
+    snmp_service.store_metric_result(
+        {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+        {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
+        None,
+        "TIMEOUT",
+        "No SNMP response received before timeout",
+        mock_neo4j_driver,
+    )
+
+    lookup_event = next(q for q in session.queries if "MATCH (existing:Event)" in q["query"])
+    assert "$failure_family IS NULL OR existing.failure_family = $failure_family" not in lookup_event["query"]
+    assert "$failure_family IS NULL AND existing.failure_family IS NULL" in lookup_event["query"]
+    assert "$failure_family IS NOT NULL" in lookup_event["query"]
+    update_event = next(q for q in session.queries if "elementId(existing) = $existing_element_id" in q["query"])
+    assert update_event["params"]["existing_element_id"] == "element-collection"
+    assert "existing.status = $old_status" not in update_event["query"]
+
+
+def test_non_breach_value_recovers_non_collection_events(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    fake_pg = MagicMock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90},
+            "42",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    queries = "\n".join(q["query"] for q in mock_neo4j_driver.mock_session.queries)
+    assert "e.event_type <> 'COLLECTION_FAILURE'" in queries
+    assert "NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')" in queries
+
+
+def test_valid_non_snmp_threshold_breach_recovers_collection_failures(mock_neo4j_driver):
+    snmp_service = _load_snmp_service_module()
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+    fake_pg = MagicMock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cli-health", "name": "cli-health", "protocol": "CLI", "criticality": 3, "critical": 90},
+            "97",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    recovery_queries = [
+        q for q in session.queries
+        if "SET e.status = 'RECOVERED'" in q["query"] and "Metric Collection Failed:" in q["query"]
+    ]
+    assert recovery_queries, "valid non-SNMP samples must recover collection failures even when breaching"
+    assert "toUpper(e.source_protocol) = $source_protocol" in recovery_queries[0]["query"]
+    assert "e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:'" in recovery_queries[0]["query"]
+
+
+def test_poll_metric_non_timeout_error_indication_returns_error_not_timeout():
+    snmp_service = _load_snmp_service_module()
+
+    with patch("services.snmp_service.getCmd", return_value=iter([("authorization failure", None, None, [])])):
+        value, status, error = snmp_service.poll_metric(
+            {"id": "ci-1", "ip": "10.0.0.1"},
+            {"id": "ifInOctets", "protocol": "SNMP", "oid": "1.2.3"},
+            {"readCommunity": "public", "port": 161},
+        )
+
+    assert value is None
+    assert status == "ERROR"
+    assert error == "authorization failure"
+
+
+def test_poll_metric_timeout_error_indication_returns_timeout():
+    snmp_service = _load_snmp_service_module()
+
+    with patch("services.snmp_service.getCmd", return_value=iter([("No SNMP response received before timeout", None, None, [])])):
+        value, status, error = snmp_service.poll_metric(
+            {"id": "ci-1", "ip": "10.0.0.1"},
+            {"id": "ifInOctets", "protocol": "SNMP", "oid": "1.2.3"},
+            {"readCommunity": "public", "port": 161},
+        )
+
+    assert value is None
+    assert status == "TIMEOUT"
+    assert error == "No SNMP response received before timeout"

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -257,6 +257,158 @@ class TestSNMPWorkerObservability:
         db.close.assert_called_once()
 
 
+class TestSNMPCollectionFailures:
+    """Regression tests for SNMP no-response collection-failure lifecycle."""
+
+    @patch("engines.snmp_worker.fetch_snmp_value")
+    @patch("engines.snmp_worker.bulk_insert_metrics")
+    @patch("engines.snmp_worker.SessionLocal")
+    def test_snmp_no_response_creates_warning_collection_failure(
+        self, mock_session_local, mock_bulk_insert, mock_fetch_snmp
+    ):
+        mock_fetch_snmp.return_value = None
+        mock_session_local.return_value = MagicMock()
+
+        mock_session = MockNeo4jSession()
+        mock_session.set_response("match", [{
+            "node_id": "ci-001",
+            "metric_id": "ifInOctets",
+            "protocol": "SNMP",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": "1.3.6.1.2.1.2.2.1.10.1",
+            "port": 161,
+        }])
+        mock_session.set_default_response([])
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+        with patch("engines.snmp_worker.driver", mock_driver):
+            from engines.snmp_worker import poll_snmp
+            poll_snmp()
+
+        mock_bulk_insert.assert_not_called()
+        queries = "\n".join(q["query"] for q in mock_session.queries)
+        failure_batches = [q["params"].get("failures", []) for q in mock_session.queries]
+        assert "COLLECTION_FAILURE" in queries
+        assert "SNMP_NO_RESPONSE" in queries
+        assert any(item.get("severity") == "WARNING" for batch in failure_batches for item in batch)
+
+    @patch("engines.snmp_worker.fetch_snmp_value")
+    @patch("engines.snmp_worker.bulk_insert_metrics")
+    @patch("engines.snmp_worker.SessionLocal")
+    def test_valid_snmp_sample_recovers_matching_collection_failure(
+        self, mock_session_local, mock_bulk_insert, mock_fetch_snmp
+    ):
+        mock_fetch_snmp.return_value = 42.0
+        mock_session_local.return_value = MagicMock()
+
+        mock_session = MockNeo4jSession()
+        mock_session.set_response("match", [{
+            "node_id": "ci-001",
+            "metric_id": "ifInOctets",
+            "protocol": "SNMP",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": "1.3.6.1.2.1.2.2.1.10.1",
+            "port": 161,
+        }])
+        mock_session.set_default_response([])
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+        with patch("engines.snmp_worker.driver", mock_driver):
+            from engines.snmp_worker import poll_snmp
+            poll_snmp()
+
+        queries = "\n".join(q["query"] for q in mock_session.queries)
+        assert "RECOVERED" in queries
+        assert "COLLECTION_FAILURE" in queries
+        assert "Metric Collection Failed:" in queries
+        assert "PROPAGATED" in queries
+        assert "coalesce(m.can_propagate, true) = true" in queries
+
+    @patch("engines.snmp_worker.fetch_snmp_value")
+    @patch("engines.snmp_worker.bulk_insert_metrics")
+    @patch("engines.snmp_worker.SessionLocal")
+    def test_snmp_no_response_failures_are_deduplicated_before_event_write(
+        self, mock_session_local, mock_bulk_insert, mock_fetch_snmp
+    ):
+        mock_fetch_snmp.return_value = None
+        mock_session_local.return_value = MagicMock()
+
+        mock_session = MockNeo4jSession()
+        mock_session.set_response("match", [
+            {
+                "node_id": "ci-001",
+                "metric_id": "ifInOctets",
+                "protocol": "SNMP",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                "port": 161,
+            },
+            {
+                "node_id": "ci-001",
+                "metric_id": "ifInOctets",
+                "protocol": "SNMP",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                "port": 161,
+            },
+        ])
+        mock_session.set_default_response([])
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+        with patch("engines.snmp_worker.driver", mock_driver):
+            from engines.snmp_worker import poll_snmp
+            poll_snmp()
+
+        failure_batches = [q["params"].get("failures", []) for q in mock_session.queries]
+        assert any(len(batch) == 1 for batch in failure_batches)
+
+    @patch("engines.snmp_worker.fetch_snmp_value")
+    @patch("engines.snmp_worker.bulk_insert_metrics")
+    @patch("engines.snmp_worker.SessionLocal")
+    def test_generic_snmp_error_does_not_create_no_response_collection_failure(
+        self, mock_session_local, mock_bulk_insert, mock_fetch_snmp
+    ):
+        mock_fetch_snmp.return_value = (None, "ERROR", "noSuchName at 1.2.3")
+        mock_session_local.return_value = MagicMock()
+
+        mock_session = MockNeo4jSession()
+        mock_session.set_response("match", [{
+            "node_id": "ci-001",
+            "metric_id": "ifInOctets",
+            "protocol": "SNMP",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": "1.3.6.1.2.1.2.2.1.10.1",
+            "port": 161,
+        }])
+        mock_session.set_default_response([])
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+        with patch("engines.snmp_worker.driver", mock_driver):
+            from engines.snmp_worker import poll_snmp
+            poll_snmp()
+
+        failure_batches = [q["params"].get("failures", []) for q in mock_session.queries]
+        assert not any(batch for batch in failure_batches)
+        mock_bulk_insert.assert_not_called()
+
+
 class TestICMPDebounce:
     """Tests for ICMP debounce counter in poll_snmp."""
 


### PR DESCRIPTION
## Descripción del Cambio
Closes #152

Normaliza el ciclo de vida de eventos de falla de colección para SNMP no-response/timeout/no-data.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Fuerza SNMP no-response/timeout/no-data a eventos `WARNING` con `event_type=COLLECTION_FAILURE`, `failure_family=SNMP_NO_RESPONSE`, `source_protocol=SNMP`.
- Separa recuperación de fallas de colección de eventos de threshold/availability, incluyendo muestras válidas que también disparan threshold.
- Preserva estados estructurados desde el executor SNMP y agrega tests para legacy worker, service helper y leased writer.

## Cambios principales
| Archivo | Cambio |
|---|---|
| `backend/services/polling_event_lifecycle.py` | Helper/constantes para discriminar eventos de collection failure, threshold y availability. |
| `backend/polling/event_writer.py` | Persistencia batched con discriminadores, recuperación por protocolo/familia y deduplicación de collection failures. |
| `backend/polling/snmp_executor.py` | Propaga resultados SNMP estructurados para no colapsar errores genéricos como no-response. |
| `backend/services/snmp_service.py` | Normaliza severidad WARNING para no-response y separa recovery de collection failures vs threshold/availability. |
| `backend/engines/snmp_worker.py` | Active legacy worker crea/refresca/recover eventos SNMP no-response y deduplica fallas. |
| `backend/pytest.ini` | Registra marker existente `api` para que la suite completa colecte bajo strict markers. |
| `backend/tests/*` | Cobertura regression para writer, executor, service helper y active worker. |

## ¿Cómo se probó?
- [x] Focused suite verde:
  ```bash
  cd backend && uv run --python 3.12 --with-requirements requirements.txt --with-requirements requirements-dev.txt python -m pytest tests/test_polling_event_writer.py tests/test_snmp_service_snapshots.py tests/test_snmp_service_collection_failures.py tests/test_snmp_worker.py tests/test_polling_writer_pool.py tests/test_polling_snmp_executor.py tests/test_event_correlation.py -q
  ```
  Resultado reportado: `68 passed, 5 warnings`.
- [x] `git diff --check` passed.
- [x] `py_compile` passed para archivos Python modificados.
- [x] Judgment Day ejecutado en 4 rondas; riesgos de migración legacy quedaron derivados a #155.

## Caveats / follow-ups
- La full backend suite corre tras registrar el marker `api`, pero tiene fallos preexistentes/no relacionados fuera de #152; quedan documentados como deuda externa.
- La normalización/migración de eventos legacy sin discriminadores queda separada en #155.
- Recordatorios/recomendaciones de eventos stale quedan separados en #154.
- Diff grande por cobertura y compatibilidad entre legacy worker, service helper y leased path; revisar con foco en lifecycle de eventos.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Checklist Gentle AI
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shell scripts: N/A, no shell scripts modified
- [x] Docs/SDD archived locally; OpenSpec files are ignored in this repo
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
