### PR TITLE
fix(metrics): clarify metric deletion flow

### DIFF
--- a/backend/services/metric_service.py
+++ b/backend/services/metric_service.py
@@ -211,14 +211,66 @@ def create_metric(metric: MetricDef) -> Dict[str, str]:
             _reconcile_metric_assignments(metric.id, metric.applicable_to)
             return {"message": "Metric defined"}
 
-def delete_metric(metric_id: str) -> Dict[str, str]:
-    """Delete a Metric Definition."""
+def delete_metric(metric_id: str) -> Dict[str, Any]:
+    """Delete a Metric Definition and retire active collection failures.
+
+    Historical Timescale samples are intentionally retained. Metric deletion is
+    about stopping future collection and removing graph applicability, not
+    purging telemetry history.
+    """
     with metric_operation_guard(metric_id):
         with timed_operation(logger, "metric.delete", metric_id=metric_id):
             driver = get_db()
             with driver.session() as session:
-                session.run("MATCH (m:MetricDef {id: $id}) DETACH DELETE m", id=metric_id)
-            return {"message": "Metric deleted"}
+                with session.begin_transaction() as tx:
+                    event_result = tx.run(
+                        """
+                        MATCH (e:Event)
+                        WHERE e.status IN ['OPEN', 'ACK']
+                          AND (
+                            e.metric_id = $id
+                            OR EXISTS {
+                              MATCH (e)-[:TRIGGERED_BY]->(:MetricDef {id: $id})
+                            }
+                          )
+                          AND (
+                            e.event_type = 'COLLECTION_FAILURE'
+                            OR (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
+                          )
+                        SET e.status = 'RECOVERED',
+                            e.recovered_at = datetime(),
+                            e.last_seen = datetime(),
+                            e.message = 'Metric collection retired because metric definition was deleted',
+                            e.ack = false
+                        RETURN count(DISTINCT e) AS events_recovered
+                        """,
+                        id=metric_id,
+                    )
+                    event_record = event_result.single()
+                    raw_events_recovered = event_record.get("events_recovered", 0) if event_record else 0
+                    events_recovered = raw_events_recovered if isinstance(raw_events_recovered, int) else 0
+
+                    delete_result = tx.run(
+                        """
+                        MATCH (m:MetricDef {id: $id})
+                        WITH collect(m) AS metrics
+                        FOREACH (metric IN metrics | DETACH DELETE metric)
+                        RETURN size(metrics) AS deleted
+                        """,
+                        id=metric_id,
+                    )
+                    delete_record = delete_result.single()
+                    raw_deleted_count = delete_record.get("deleted", 0) if delete_record else 0
+                    deleted_count = raw_deleted_count if isinstance(raw_deleted_count, int) else 1
+
+            deleted = deleted_count > 0
+            return {
+                "message": "Metric deleted" if deleted else "Metric not found",
+                "metric_id": metric_id,
+                "deleted": deleted,
+                "events_recovered": events_recovered,
+                "history_retained": True,
+            }
 
 def get_metric_usage(metric_id: str) -> Dict[str, Any]:
     """

--- a/backend/tests/test_metric_service_smoke.py
+++ b/backend/tests/test_metric_service_smoke.py
@@ -92,14 +92,103 @@ class TestMetricServiceSmoke:
         assert "merge" in mock_neo4j_session.queries[0]["query"].lower()
         mock_reconcile.assert_called_once_with("test-metric", None)
 
-    def test_delete_metric_calls_detach_delete(self, mock_neo4j_session):
-        """delete_metric should execute a DETACH DELETE query."""
+    def test_delete_metric_recovers_active_collection_failures_before_detach_delete(self, mock_neo4j_session):
+        """delete_metric should make active collection failures stale before deleting the definition."""
         from services.metric_service import delete_metric
 
-        delete_metric("test-metric")
+        mock_neo4j_session.set_response("RETURN count(DISTINCT e) AS events_recovered", [{"events_recovered": 3}])
+        mock_neo4j_session.set_response("RETURN size(metrics) AS deleted", [{"deleted": 1}])
 
-        assert len(mock_neo4j_session.queries) >= 1
-        assert "detach delete" in mock_neo4j_session.queries[0]["query"].lower()
+        result = delete_metric("test-metric")
+
+        assert result == {
+            "message": "Metric deleted",
+            "metric_id": "test-metric",
+            "deleted": True,
+            "events_recovered": 3,
+            "history_retained": True,
+        }
+        assert len(mock_neo4j_session.queries) >= 2
+        first_query = mock_neo4j_session.queries[0]["query"].lower()
+        second_query = mock_neo4j_session.queries[1]["query"].lower()
+        assert "match (e:event)" in first_query
+        assert "collection_failure" in first_query
+        assert "recovered" in first_query
+        assert "detach delete" in second_query
+
+    def test_delete_metric_is_idempotent_when_definition_missing(self, mock_neo4j_session):
+        """delete_metric should return a deterministic response when the MetricDef is absent."""
+        from services.metric_service import delete_metric
+
+        mock_neo4j_session.set_response("RETURN count(DISTINCT e) AS events_recovered", [{"events_recovered": 0}])
+        mock_neo4j_session.set_response("RETURN size(metrics) AS deleted", [{"deleted": 0}])
+
+        result = delete_metric("missing-metric")
+
+        assert result["message"] == "Metric not found"
+        assert result["metric_id"] == "missing-metric"
+        assert result["deleted"] is False
+        assert result["events_recovered"] == 0
+        assert result["history_retained"] is True
+
+    def test_delete_metric_rolls_back_event_recovery_when_delete_fails(self):
+        """Event recovery and MetricDef deletion should be one atomic transaction."""
+        from services.metric_service import delete_metric
+
+        class Result:
+            def __init__(self, record):
+                self.record = record
+
+            def single(self):
+                return self.record
+
+        class FailingTransaction:
+            def __init__(self):
+                self.rolled_back = False
+                self.committed = False
+                self.calls = 0
+
+            def run(self, query, **params):
+                self.calls += 1
+                if self.calls == 1:
+                    return Result({"events_recovered": 2})
+                raise RuntimeError("delete failed")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.rolled_back = exc_type is not None
+                self.committed = exc_type is None
+                return False
+
+        class Session:
+            def __init__(self, tx):
+                self.tx = tx
+
+            def begin_transaction(self):
+                return self.tx
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class Driver:
+            def __init__(self, tx):
+                self.tx = tx
+
+            def session(self):
+                return Session(self.tx)
+
+        tx = FailingTransaction()
+        with patch("services.metric_service.get_db", return_value=Driver(tx)):
+            with pytest.raises(RuntimeError, match="delete failed"):
+                delete_metric("test-metric")
+
+        assert tx.rolled_back is True
+        assert tx.committed is False
 
 
 class TestMetricMatching:

--- a/frontend/components/MetricsManager.test.tsx
+++ b/frontend/components/MetricsManager.test.tsx
@@ -130,7 +130,7 @@ const clickSaveMetric = () => {
 };
 
 const clickDeleteMetric = () => {
-  const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+  const deleteButtons = screen.getAllByRole('button', { name: /delete metric/i });
   fireEvent.click(deleteButtons[deleteButtons.length - 1]);
 };
 
@@ -462,7 +462,7 @@ describe('MetricsManager', () => {
   });
 
   describe('delete and association removal', () => {
-    it('deletes a metric when the user confirms the action', async () => {
+    it('deletes a metric definition globally when the user confirms the action', async () => {
       await openEditForm();
       vi.mocked(window.confirm).mockReturnValueOnce(true);
       mocks.apiGet.mockClear();
@@ -472,7 +472,8 @@ describe('MetricsManager', () => {
       await waitFor(() => {
         expect(mocks.apiGet).toHaveBeenCalledWith('/metrics/cpu.load/usage');
       });
-      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("This action cannot be undone."));
+      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("delete metric definition 'cpu.load' globally"));
+      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("Historical metric samples will be retained"));
 
       await waitFor(() => {
         expect(mocks.apiDelete).toHaveBeenCalledWith('/metrics/cpu.load');
@@ -498,8 +499,8 @@ describe('MetricsManager', () => {
 
       clickDeleteMetric();
 
-      expect(await screen.findByText(/checking metric usage before deletion/i)).toBeInTheDocument();
-      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      expect(await screen.findByText(/checking metric usage before global deletion/i)).toBeInTheDocument();
+      const deleteButtons = screen.getAllByRole('button', { name: /delete metric/i });
       const deleteButton = deleteButtons[deleteButtons.length - 1];
       expect(deleteButton).toBeDisabled();
       fireEvent.click(deleteButton);
@@ -507,7 +508,7 @@ describe('MetricsManager', () => {
       expect(mocks.apiDelete).not.toHaveBeenCalled();
 
       usageDeferred.resolve(usageData);
-      expect(await screen.findByText(/deleting metric and removing assignments/i)).toBeInTheDocument();
+      expect(await screen.findByText(/deleting metric definition globally/i)).toBeInTheDocument();
       expect(mocks.apiDelete).toHaveBeenCalledTimes(1);
 
       deleteDeferred.resolve({ ok: true });
@@ -525,12 +526,12 @@ describe('MetricsManager', () => {
       vi.mocked(window.confirm).mockReturnValueOnce(true);
 
       clickDeleteMetric();
-      expect(await screen.findByText(/deleting metric and removing assignments/i)).toBeInTheDocument();
+      expect(await screen.findByText(/deleting metric definition globally/i)).toBeInTheDocument();
 
       deleteDeferred.reject(new Error('delete failed'));
 
       await waitFor(() => expect(window.alert).toHaveBeenCalledWith('Error deleting metric'));
-      expect(screen.queryByText(/deleting metric and removing assignments/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/deleting metric definition globally/i)).not.toBeInTheDocument();
       expect(screen.getByText('Edit Metric')).toBeInTheDocument();
       expect(screen.getByDisplayValue('cpu.load')).toBeInTheDocument();
     });
@@ -546,8 +547,8 @@ describe('MetricsManager', () => {
         expect(mocks.apiGet).toHaveBeenCalledWith('/metrics/cpu.load/usage');
       });
       expect(mocks.apiDelete).not.toHaveBeenCalled();
-      await waitFor(() => expect(screen.queryByText(/checking metric usage before deletion/i)).not.toBeInTheDocument());
-      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      await waitFor(() => expect(screen.queryByText(/checking metric usage before global deletion/i)).not.toBeInTheDocument());
+      const deleteButtons = screen.getAllByRole('button', { name: /delete metric/i });
       expect(deleteButtons[deleteButtons.length - 1]).not.toBeDisabled();
     });
 
@@ -566,28 +567,30 @@ describe('MetricsManager', () => {
       await waitFor(() => {
         expect(window.alert).toHaveBeenCalledWith('Error checking metric usage');
       });
-      await waitFor(() => expect(screen.queryByText(/checking metric usage before deletion/i)).not.toBeInTheDocument());
-      const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+      await waitFor(() => expect(screen.queryByText(/checking metric usage before global deletion/i)).not.toBeInTheDocument());
+      const deleteButtons = screen.getAllByRole('button', { name: /delete metric/i });
       expect(deleteButtons[deleteButtons.length - 1]).not.toBeDisabled();
     });
 
-    it('does not remove an associated CI when confirm returns false', async () => {
+    it('does not exclude an associated CI when confirm returns false', async () => {
       await openEditForm();
       vi.mocked(window.confirm).mockReturnValueOnce(false);
       mocks.apiPost.mockClear();
 
-      const deleteButtons = await screen.findAllByTitle('Remove specific association');
-      fireEvent.click(deleteButtons[0]);
+      const excludeButtons = await screen.findAllByTitle('Exclude this CI from the metric');
+      fireEvent.click(excludeButtons[0]);
 
+      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining("exclude 'router-01' from this metric"));
       expect(mocks.apiPost).not.toHaveBeenCalled();
+      expect(mocks.apiDelete).not.toHaveBeenCalled();
     });
 
-    it('removes an associated CI and persists excluded names when confirm returns true', async () => {
+    it('excludes an associated CI and persists excluded names without deleting the metric', async () => {
       await openEditForm();
       vi.mocked(window.confirm).mockReturnValueOnce(true);
 
-      const deleteButtons = await screen.findAllByTitle('Remove specific association');
-      fireEvent.click(deleteButtons[0]);
+      const excludeButtons = await screen.findAllByTitle('Exclude this CI from the metric');
+      fireEvent.click(excludeButtons[0]);
 
       await waitFor(() => {
         expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', expect.objectContaining({
@@ -602,6 +605,7 @@ describe('MetricsManager', () => {
         }));
       });
 
+      expect(mocks.apiDelete).not.toHaveBeenCalled();
       expect(window.alert).not.toHaveBeenCalledWith('Metric Saved');
       expect(screen.getByText('Edit Metric')).toBeInTheDocument();
     });
@@ -622,8 +626,8 @@ describe('MetricsManager', () => {
       });
       fireEvent.change(getInputByLabel(/quick add model/i), { target: { value: 'R750' } });
 
-      const deleteButtons = await screen.findAllByTitle('Remove specific association');
-      fireEvent.click(deleteButtons[0]);
+      const excludeButtons = await screen.findAllByTitle('Exclude this CI from the metric');
+      fireEvent.click(excludeButtons[0]);
 
       await waitFor(() => {
         expect(mocks.apiPost).toHaveBeenCalledWith('/metrics', expect.objectContaining({

--- a/frontend/components/MetricsManager.tsx
+++ b/frontend/components/MetricsManager.tsx
@@ -206,15 +206,17 @@ const MetricsManager: React.FC<MetricsManagerProps> = () => {
 
         const metricId = selectedMetric.id;
         setDeletingMetricId(metricId);
-        setOperationMessage('Checking metric usage before deletion…');
+        setOperationMessage('Checking metric usage before global deletion…');
         setOperationError(null);
 
         try {
             const usage = await api.get<any>(`/metrics/${metricId}/usage`);
             const count = usage.count || 0;
-            const msg = `Are you sure you want to delete metric '${metricId}'?\n\n` +
+            const msg = `Are you sure you want to delete metric definition '${metricId}' globally?\n\n` +
                 `This metric is currently applicable to ${count} devices.\n` +
-                `Deleting it will stop monitoring this data point for all affected devices.\n\n` +
+                `Deleting it will stop future monitoring of this data point for all affected devices.\n` +
+                `Active collection-failure events for this metric will be marked recovered.\n` +
+                `Historical metric samples will be retained.\n\n` +
                 `This action cannot be undone.`;
 
             if (!confirm(msg)) {
@@ -229,7 +231,7 @@ const MetricsManager: React.FC<MetricsManagerProps> = () => {
             return;
         }
 
-        setOperationMessage('Deleting metric and removing assignments…');
+        setOperationMessage('Deleting metric definition globally…');
 
         try {
             await api.delete(`/metrics/${metricId}`);
@@ -843,14 +845,14 @@ const MetricsManager: React.FC<MetricsManagerProps> = () => {
                                                         <button
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
-                                                                if (confirm(`Are you sure you want to remove '${ci.name}' from this metric's applicability list?`)) {
+                                                                if (confirm(`Are you sure you want to exclude '${ci.name}' from this metric?\n\nThis only removes this CI association by updating the metric applicability exclusions. It does not delete the metric definition.`)) {
                                                                     handleExcludeAssociatedCI(ci);
                                                                 }
                                                             }}
                                                             className="text-neutral-600 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
-                                                            title="Remove specific association"
+                                                            title="Exclude this CI from the metric"
                                                         >
-                                                            <span className="material-symbols-outlined text-sm">delete</span>
+                                                            <span className="material-symbols-outlined text-sm">block</span>
                                                         </button>
                                                     </td>
                                                 </tr>
@@ -885,7 +887,7 @@ const MetricsManager: React.FC<MetricsManagerProps> = () => {
                                     disabled={deletingMetricId === selectedMetric.id}
                                     className="px-6 bg-red-600/20 hover:bg-red-600/40 disabled:bg-neutral-700 disabled:text-neutral-400 disabled:cursor-not-allowed text-red-500 font-bold py-3 rounded-xl transition-colors"
                                 >
-                                    DELETE
+                                    DELETE METRIC
                                 </button>
                             )}
                             <button onClick={() => setIsEditing(false)} className="px-6 bg-white/10 hover:bg-white/20 text-white font-bold py-3 rounded-xl transition-colors">


### PR DESCRIPTION
Closes #160

## Descripción del Cambio
- Clarifica en la UI la diferencia entre borrar una definición de métrica globalmente y excluir un CI específico.
- Hace que el borrado backend recupere eventos activos `COLLECTION_FAILURE` dentro de la misma transacción que elimina el `MetricDef`.
- Conserva el histórico de Timescale por defecto y agrega cobertura de regresión frontend/backend.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `frontend/components/MetricsManager.tsx` | Copy explícito para DELETE METRIC global vs Exclude CI |
| `frontend/components/MetricsManager.test.tsx` | Tests para confirmar DELETE global y exclusión sin DELETE |
| `backend/services/metric_service.py` | Recupera eventos activos y elimina MetricDef en una transacción |
| `backend/tests/test_metric_service_smoke.py` | Tests de recuperación, idempotencia y rollback |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend run test:run MetricsManager.test.tsx`
- [x] `cd backend && .venv/bin/python -m pytest tests/test_metric_service_smoke.py tests/test_routers_metrics_events.py::TestMetricsDelete -q`
- [x] Fresh reviewer sin blockers después del fix de atomicidad

Nota: las suites completas se intentaron y fallan por problemas preexistentes no relacionados (frontend localStorage/test setup y backend auth/router/repo failures).

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
