### PR TITLE
fix(metric-analytics): use nodes service helper

### DIFF
--- a/frontend/components/MetricAnalytics.test.tsx
+++ b/frontend/components/MetricAnalytics.test.tsx
@@ -5,12 +5,16 @@ import MetricAnalytics from './MetricAnalytics';
 import { fetchNodesSearch } from '../services/queryResources';
 import { GraphNode } from '../types';
 
-const { mockFetchNodesSearch } = vi.hoisted(() => ({
+const { mockFetchNodes, mockFetchNodesSearch, mockFetchMetricsHistory } = vi.hoisted(() => ({
+  mockFetchNodes: vi.fn(),
   mockFetchNodesSearch: vi.fn(),
+  mockFetchMetricsHistory: vi.fn(),
 }));
 
 vi.mock('../services/queryResources', () => ({
+  fetchNodes: mockFetchNodes,
   fetchNodesSearch: mockFetchNodesSearch,
+  fetchMetricsHistory: mockFetchMetricsHistory,
 }));
 
 // Mock global fetch for initial node loading
@@ -28,6 +32,7 @@ describe('MetricAnalytics', () => {
       label: 'Core Router',
       type: 'INFRASTRUCTURE',
       status: 'OK',
+      metadata: {},
       ip: '192.168.1.1',
       brand: 'Cisco',
       model: 'ASR-1000',
@@ -41,6 +46,7 @@ describe('MetricAnalytics', () => {
       label: 'Backup Router',
       type: 'INFRASTRUCTURE',
       status: 'ACTIVE',
+      metadata: {},
       ip: '192.168.1.2',
       brand: 'Juniper',
       model: 'MX204',
@@ -50,7 +56,9 @@ describe('MetricAnalytics', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    mockFetchNodes.mockReset();
     mockFetchNodesSearch.mockReset();
+    mockFetchMetricsHistory.mockReset();
     // Mock localStorage for MetricAnalytics component
     Object.defineProperty(globalThis, 'localStorage', {
       value: {
@@ -61,13 +69,8 @@ describe('MetricAnalytics', () => {
       },
       writable: true,
     });
-    // Mock fetch for initial node loading
-    vi.mocked(fetch).mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: { get: () => 'application/json' },
-      json: () => Promise.resolve([]),
-    } as Response);
+    mockFetchNodes.mockResolvedValue([]);
+    mockFetchMetricsHistory.mockResolvedValue({ nodes: [] });
   });
 
   afterEach(() => {

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -3,7 +3,7 @@ import { GraphNode, MetricValue, NodeMetricData } from '../types';
 import MetricHistoryChart from './MetricHistoryChart';
 import MultiSelectCIs from './MultiSelectCIs';
 import MultiMetricChart from './MultiMetricChart';
-import { fetchNodesSearch, fetchMetricsHistory } from '../services/queryResources';
+import { fetchNodes, fetchNodesSearch, fetchMetricsHistory } from '../services/queryResources';
 
 interface BrushRange {
   startIndex?: number;
@@ -47,7 +47,7 @@ const MetricAnalytics: React.FC = () => {
 
     // Fetch Nodes on Mount (original behavior)
     useEffect(() => {
-        api.get<GraphNode[]>('/nodes')
+        fetchNodes()
             .then(data => {
                 if (Array.isArray(data)) {
                     setNodes(data);

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -21,6 +21,7 @@ export interface MetricValue {
   protocol: string;
   oid: string;
   value: string | null;
+  unit?: string;
   status: string | null; // CRITICAL, WARNING, OK
   last_updated: string | null;
 }


### PR DESCRIPTION
Closes #164

## Descripción del Cambio
Corrige el crash de `MetricAnalytics` al montar: el componente llamaba a `api.get('/nodes')` sin tener `api` definido/importado. Ahora usa el helper existente `fetchNodes()` desde `queryResources`.

También actualiza el test del componente para mockear las dependencias del servicio y agrega `unit?: string` a `MetricValue`, alineando el tipo con el uso existente en los charts.

## Alcance posterior al merge
Después del merge/release `v1.12.5`, el test manual de Metric Analytics encontró un crash equivalente en `MetricHistoryChart` y una limitación de comparación multi-CI con modelos/marcas heterogéneas.

Ese alcance extendido quedó separado en el follow-up:
- PR #167
- Issue #166

No se publica release nuevo para ese follow-up; queda documentado en `CHANGELOG.md` bajo `Unreleased`.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd frontend && pnpm test:run components/MetricAnalytics.test.tsx`
- [x] LSP diagnostics sin errores en archivos tocados
- [x] Fresh review subagent: PASS

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
