### PR TITLE
fix(metric-analytics): support heterogeneous CI metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Metric Analytics heterogeneous CI comparison follow-up** (extends PR #165):
+  - Fixes `MetricHistoryChart` single-CI history loading by routing through the shared `fetchNodeMetricHistory()` API helper instead of an undefined `api` reference.
+  - Allows primary and secondary multi-CI comparisons to choose metrics per selected CI, so different hardware models/brands can be compared before metric homologation.
+  - Synchronizes multi-chart brush/zoom by timestamp range instead of shared point indices to avoid misleading windows across metrics with different sampling cadence.
+  - Adds focused coverage for single-node metric history URL construction, heterogeneous multi-CI defaults, and timestamp-based chart brush ranges.
+
 ## [1.12.4] — 2026-05-25
 
 ### Fixed
@@ -130,8 +139,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added Pydantic Field validation to prevent invalid configs (0 timeout, -1 retries, 0 debounce)
   - Added 12 unit tests covering ICMPSettings, fetch_icmp_ping retry, and debounce counter
   - Added `ICMP_TIMEOUT_MS`, `ICMP_RETRIES`, `ICMP_DEBOUNCE_COUNT` env vars to docker-compose.yml
-
-## [Unreleased]
 
 ## [1.11.5] — 2026-05-21
 

--- a/frontend/components/ChartPanel.tsx
+++ b/frontend/components/ChartPanel.tsx
@@ -1,151 +1,213 @@
-import React, { useMemo } from 'react';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Brush, ReferenceArea } from 'recharts';
+import React, { useMemo } from "react";
+import {
+	AreaChart,
+	Area,
+	XAxis,
+	YAxis,
+	CartesianGrid,
+	Tooltip,
+	ResponsiveContainer,
+	Brush,
+} from "recharts";
 
 interface BrushRange {
-  startIndex?: number;
-  endIndex?: number;
+	startTime?: string;
+	endTime?: string;
 }
 
 interface DataPoint {
-  time: string;
-  value: number;
+	time: string;
+	value: number;
 }
 
 interface ChartPanelProps {
-  nodeId: string;
-  label: string;
-  data: DataPoint[];
-  brushRange: BrushRange | null;
-  onBrushChange: (range: BrushRange | null) => void;
-  unit?: string;
-  metricName?: string;
+	nodeId: string;
+	label: string;
+	data: DataPoint[];
+	brushRange: BrushRange | null;
+	onBrushChange: (range: BrushRange | null) => void;
+	unit?: string;
+	metricName?: string;
 }
 
 const ChartPanel: React.FC<ChartPanelProps> = ({
-  nodeId,
-  label,
-  data,
-  brushRange,
-  onBrushChange,
-  unit,
-  metricName,
+	nodeId,
+	label,
+	data,
+	brushRange,
+	onBrushChange,
+	unit,
+	metricName,
 }) => {
-  const formattedData = useMemo(() => {
-    return data
-      .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
-      .map(d => ({
-        ...d,
-        displayTime: new Date(d.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', day: 'numeric', month: 'short' }),
-        rawTime: d.time,
-        value: typeof d.value === 'string' ? parseFloat(d.value) : d.value,
-      }));
-  }, [data]);
+	const formattedData = useMemo(() => {
+		return data
+			.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
+			.map((d) => ({
+				...d,
+				displayTime: new Date(d.time).toLocaleTimeString([], {
+					hour: "2-digit",
+					minute: "2-digit",
+					day: "numeric",
+					month: "short",
+				}),
+				rawTime: d.time,
+				value: typeof d.value === "string" ? parseFloat(d.value) : d.value,
+			}));
+	}, [data]);
 
-  const displayData = brushRange && brushRange.startIndex !== undefined && brushRange.endIndex !== undefined
-    ? formattedData.slice(brushRange.startIndex, brushRange.endIndex + 1)
-    : formattedData;
+	const displayData =
+		brushRange?.startTime && brushRange?.endTime
+			? formattedData.filter(
+					(d) =>
+						d.rawTime >= brushRange.startTime! &&
+						d.rawTime <= brushRange.endTime!,
+				)
+			: formattedData;
 
-  const hasBrushApplied = brushRange !== null;
+	const hasBrushApplied = brushRange !== null;
 
-  const handleResetView = () => {
-    onBrushChange(null);
-  };
+	const handleResetView = () => {
+		onBrushChange(null);
+	};
 
-  const hasData = data.length > 0;
+	const hasData = data.length > 0;
 
-  return (
-    <div className="bg-surface-800 rounded-xl p-6 border border-white/5 shadow-inner flex flex-col h-full min-h-[250px]">
-      <div className="flex justify-between items-center mb-4 flex-shrink-0">
-        <div>
-          <h4 className="text-white font-bold uppercase tracking-tight">{label}</h4>
-          <p className="text-xs text-neutral-500">
-            {hasBrushApplied
-              ? `${displayData.length} points selected`
-              : `${data.length} data points`}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {hasBrushApplied && (
-            <button
-              onClick={handleResetView}
-              className="flex items-center gap-1 px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-xs font-bold transition-all text-neutral-300"
-            >
-              <span className="material-symbols-outlined text-sm">restart_alt</span>
-              Reset
-            </button>
-          )}
-        </div>
-      </div>
+	return (
+		<div className="bg-surface-800 rounded-xl p-6 border border-white/5 shadow-inner flex flex-col h-full min-h-[250px]">
+			<div className="flex justify-between items-center mb-4 flex-shrink-0">
+				<div>
+					<h4 className="text-white font-bold uppercase tracking-tight">
+						{label}
+					</h4>
+					{metricName && (
+						<p className="text-[10px] text-brand-300 font-mono uppercase mt-0.5">
+							{metricName}
+						</p>
+					)}
+					<p className="text-xs text-neutral-500">
+						{hasBrushApplied
+							? `${displayData.length} points selected`
+							: `${data.length} data points`}
+					</p>
+				</div>
+				<div className="flex items-center gap-2">
+					{hasBrushApplied && (
+						<button
+							onClick={handleResetView}
+							className="flex items-center gap-1 px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-xs font-bold transition-all text-neutral-300"
+						>
+							<span className="material-symbols-outlined text-sm">
+								restart_alt
+							</span>
+							Reset
+						</button>
+					)}
+				</div>
+			</div>
 
-      {!hasData ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-neutral-500">
-          <span className="material-symbols-outlined text-4xl mb-2 opacity-50">data_loss_prevention</span>
-          <p className="text-sm font-mono uppercase">No telemetry data</p>
-        </div>
-      ) : (
-        <div className="flex-1 w-full min-h-0 relative" style={{ minWidth: 0, minHeight: 0 }}>
-          <ResponsiveContainer width="99%" height="99%">
-            <AreaChart
-              data={displayData}
-              margin={{ top: 10, right: 10, left: -20, bottom: hasBrushApplied ? 50 : 0 }}
-            >
-              <defs>
-                <linearGradient id={`colorValue-${nodeId}`} x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0} />
-                </linearGradient>
-              </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" vertical={false} />
-              <XAxis
-                dataKey="displayTime"
-                stroke="#525252"
-                tick={{ fill: '#525252', fontSize: 10 }}
-                tickLine={false}
-                axisLine={false}
-                minTickGap={30}
-              />
-              <YAxis
-                stroke="#525252"
-                tick={{ fill: '#525252', fontSize: 10 }}
-                tickLine={false}
-                axisLine={false}
-                width={30}
-              />
-              <Tooltip
-                contentStyle={{ backgroundColor: '#171717', borderColor: '#333', borderRadius: '8px', fontSize: '12px' }}
-                itemStyle={{ color: '#fff' }}
-                labelStyle={{ color: '#a3a3a3', marginBottom: '4px' }}
-              />
-              <Area
-                type="monotone"
-                dataKey="value"
-                stroke="#0ea5e9"
-                strokeWidth={2}
-                fillOpacity={1}
-                fill={`url(#colorValue-${nodeId})`}
-              />
-              <Brush
-                dataKey="displayTime"
-                height={30}
-                stroke="#525252"
-                fill="#171717"
-                tickFormatter={() => ''}
-                startIndex={brushRange?.startIndex}
-                endIndex={brushRange?.endIndex}
-                onChange={(range: any) => {
-                  if (range.startIndex !== undefined && range.endIndex !== undefined) {
-                    onBrushChange({ startIndex: range.startIndex, endIndex: range.endIndex });
-                  } else {
-                    onBrushChange(null);
-                  }
-                }}
-              />
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
-      )}
-    </div>
-  );
+			{!hasData ? (
+				<div className="flex-1 flex flex-col items-center justify-center text-neutral-500">
+					<span className="material-symbols-outlined text-4xl mb-2 opacity-50">
+						data_loss_prevention
+					</span>
+					<p className="text-sm font-mono uppercase">No telemetry data</p>
+				</div>
+			) : (
+				<div
+					className="flex-1 w-full min-h-0 relative"
+					style={{ minWidth: 0, minHeight: 0 }}
+				>
+					<ResponsiveContainer width="99%" height="99%">
+						<AreaChart
+							data={displayData}
+							margin={{
+								top: 10,
+								right: 10,
+								left: -20,
+								bottom: hasBrushApplied ? 50 : 0,
+							}}
+						>
+							<defs>
+								<linearGradient
+									id={`colorValue-${nodeId}`}
+									x1="0"
+									y1="0"
+									x2="0"
+									y2="1"
+								>
+									<stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.3} />
+									<stop offset="95%" stopColor="#0ea5e9" stopOpacity={0} />
+								</linearGradient>
+							</defs>
+							<CartesianGrid
+								strokeDasharray="3 3"
+								stroke="#ffffff10"
+								vertical={false}
+							/>
+							<XAxis
+								dataKey="displayTime"
+								stroke="#525252"
+								tick={{ fill: "#525252", fontSize: 10 }}
+								tickLine={false}
+								axisLine={false}
+								minTickGap={30}
+							/>
+							<YAxis
+								stroke="#525252"
+								tick={{ fill: "#525252", fontSize: 10 }}
+								tickLine={false}
+								axisLine={false}
+								width={30}
+							/>
+							<Tooltip
+								contentStyle={{
+									backgroundColor: "#171717",
+									borderColor: "#333",
+									borderRadius: "8px",
+									fontSize: "12px",
+								}}
+								itemStyle={{ color: "#fff" }}
+								labelStyle={{ color: "#a3a3a3", marginBottom: "4px" }}
+								formatter={(value) => [
+									`${value}${unit ? ` ${unit}` : ""}`,
+									metricName ?? "value",
+								]}
+							/>
+							<Area
+								type="monotone"
+								dataKey="value"
+								stroke="#0ea5e9"
+								strokeWidth={2}
+								fillOpacity={1}
+								fill={`url(#colorValue-${nodeId})`}
+							/>
+							<Brush
+								dataKey="displayTime"
+								height={30}
+								stroke="#525252"
+								fill="#171717"
+								tickFormatter={() => ""}
+								onChange={(range: any) => {
+									if (
+										range.startIndex !== undefined &&
+										range.endIndex !== undefined
+									) {
+										const start = displayData[range.startIndex]?.rawTime;
+										const end = displayData[range.endIndex]?.rawTime;
+										onBrushChange(
+											start && end ? { startTime: start, endTime: end } : null,
+										);
+									} else {
+										onBrushChange(null);
+									}
+								}}
+							/>
+						</AreaChart>
+					</ResponsiveContainer>
+				</div>
+			)}
+		</div>
+	);
 };
 
 export default ChartPanel;

--- a/frontend/components/MetricAnalytics.test.tsx
+++ b/frontend/components/MetricAnalytics.test.tsx
@@ -1,289 +1,365 @@
-import React from 'react';
-import { act, render, screen, waitFor, cleanup } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import MetricAnalytics from './MetricAnalytics';
-import { fetchNodesSearch } from '../services/queryResources';
-import { GraphNode } from '../types';
+import { act, render, screen, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import MetricAnalytics from "./MetricAnalytics";
+import { GraphNode } from "../types";
 
-const { mockFetchNodes, mockFetchNodesSearch, mockFetchMetricsHistory } = vi.hoisted(() => ({
-  mockFetchNodes: vi.fn(),
-  mockFetchNodesSearch: vi.fn(),
-  mockFetchMetricsHistory: vi.fn(),
+const {
+	mockFetchNodes,
+	mockFetchNodesSearch,
+	mockFetchMetricsHistory,
+	mockFetchNodeMetricHistory,
+} = vi.hoisted(() => ({
+	mockFetchNodes: vi.fn(),
+	mockFetchNodesSearch: vi.fn(),
+	mockFetchMetricsHistory: vi.fn(),
+	mockFetchNodeMetricHistory: vi.fn(),
 }));
 
-vi.mock('../services/queryResources', () => ({
-  fetchNodes: mockFetchNodes,
-  fetchNodesSearch: mockFetchNodesSearch,
-  fetchMetricsHistory: mockFetchMetricsHistory,
+vi.mock("../services/queryResources", () => ({
+	fetchNodes: mockFetchNodes,
+	fetchNodesSearch: mockFetchNodesSearch,
+	fetchMetricsHistory: mockFetchMetricsHistory,
+	fetchNodeMetricHistory: mockFetchNodeMetricHistory,
 }));
 
 // Mock global fetch for initial node loading
-vi.stubGlobal('fetch', vi.fn());
+vi.stubGlobal("fetch", vi.fn());
 
 // Mock MetricHistoryChart
-vi.mock('./MetricHistoryChart', () => ({
-  default: () => <span data-testid="metric-history-chart">Mock Chart</span>,
+vi.mock("./MetricHistoryChart", () => ({
+	default: () => <span data-testid="metric-history-chart">Mock Chart</span>,
 }));
 
-describe('MetricAnalytics', () => {
-  const mockNodes: GraphNode[] = [
-    {
-      id: 'CI-001',
-      label: 'Core Router',
-      type: 'INFRASTRUCTURE',
-      status: 'OK',
-      metadata: {},
-      ip: '192.168.1.1',
-      brand: 'Cisco',
-      model: 'ASR-1000',
-      metrics: [
-        { name: 'cpu-load', protocol: 'snmp', oid: '1.3.6.1', value: '45', status: 'OK', last_updated: '2026-05-11T10:00:00Z' },
-        { name: 'memory-usage', protocol: 'snmp', oid: '1.3.6.2', value: '60', status: 'OK', last_updated: '2026-05-11T10:00:00Z' },
-      ],
-    },
-    {
-      id: 'CI-002',
-      label: 'Backup Router',
-      type: 'INFRASTRUCTURE',
-      status: 'ACTIVE',
-      metadata: {},
-      ip: '192.168.1.2',
-      brand: 'Juniper',
-      model: 'MX204',
-      metrics: [],
-    },
-  ];
+describe("MetricAnalytics", () => {
+	const mockNodes: GraphNode[] = [
+		{
+			id: "CI-001",
+			label: "Core Router",
+			type: "INFRASTRUCTURE",
+			status: "OK",
+			metadata: {},
+			ip: "192.168.1.1",
+			brand: "Cisco",
+			model: "ASR-1000",
+			metrics: [
+				{
+					name: "cpu-load",
+					protocol: "snmp",
+					oid: "1.3.6.1",
+					value: "45",
+					status: "OK",
+					last_updated: "2026-05-11T10:00:00Z",
+				},
+				{
+					name: "memory-usage",
+					protocol: "snmp",
+					oid: "1.3.6.2",
+					value: "60",
+					status: "OK",
+					last_updated: "2026-05-11T10:00:00Z",
+				},
+			],
+		},
+		{
+			id: "CI-002",
+			label: "Backup Router",
+			type: "INFRASTRUCTURE",
+			status: "ACTIVE",
+			metadata: {},
+			ip: "192.168.1.2",
+			brand: "Juniper",
+			model: "MX204",
+			metrics: [],
+		},
+	];
 
-  beforeEach(() => {
-    vi.useFakeTimers();
-    mockFetchNodes.mockReset();
-    mockFetchNodesSearch.mockReset();
-    mockFetchMetricsHistory.mockReset();
-    // Mock localStorage for MetricAnalytics component
-    Object.defineProperty(globalThis, 'localStorage', {
-      value: {
-        getItem: vi.fn(() => 'fake-token'),
-        setItem: vi.fn(),
-        removeItem: vi.fn(),
-        clear: vi.fn(),
-      },
-      writable: true,
-    });
-    mockFetchNodes.mockResolvedValue([]);
-    mockFetchMetricsHistory.mockResolvedValue({ nodes: [] });
-  });
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mockFetchNodes.mockReset();
+		mockFetchNodesSearch.mockReset();
+		mockFetchMetricsHistory.mockReset();
+		mockFetchNodeMetricHistory.mockReset();
+		// Mock localStorage for MetricAnalytics component
+		Object.defineProperty(globalThis, "localStorage", {
+			value: {
+				getItem: vi.fn(() => "fake-token"),
+				setItem: vi.fn(),
+				removeItem: vi.fn(),
+				clear: vi.fn(),
+			},
+			writable: true,
+		});
+		mockFetchNodes.mockResolvedValue([]);
+		mockFetchMetricsHistory.mockResolvedValue({ nodes: [] });
+		mockFetchNodeMetricHistory.mockResolvedValue([]);
+	});
 
-  afterEach(() => {
-    vi.useRealTimers();
-    cleanup();
-  });
+	afterEach(() => {
+		vi.useRealTimers();
+		cleanup();
+	});
 
-  describe('search input', () => {
-    it('renders search input replacing select dropdown', () => {
-      mockFetchNodesSearch.mockResolvedValue([]);
-      render(<MetricAnalytics />);
+	describe("search input", () => {
+		it("renders search input replacing select dropdown", () => {
+			mockFetchNodesSearch.mockResolvedValue([]);
+			render(<MetricAnalytics />);
 
-      expect(screen.getByRole('searchbox')).toBeInTheDocument();
-    });
+			expect(screen.getByRole("searchbox")).toBeInTheDocument();
+		});
 
-    it('debounces API call by 300ms after last keystroke', async () => {
-      mockFetchNodesSearch.mockResolvedValue(mockNodes);
-      render(<MetricAnalytics />);
+		it("debounces API call by 300ms after last keystroke", async () => {
+			mockFetchNodesSearch.mockResolvedValue(mockNodes);
+			render(<MetricAnalytics />);
 
-      const searchInput = screen.getByRole('searchbox');
+			const searchInput = screen.getByRole("searchbox");
 
-      // Type "router" - 6 chars, simulating 50ms between keystrokes
-      await act(async () => {
-        searchInput.focus();
-        searchInput.setAttribute('value', 'r');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			// Type "router" - 6 chars, simulating 50ms between keystrokes
+			await act(async () => {
+				searchInput.focus();
+				searchInput.setAttribute("value", "r");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      // Advance timer by 100ms
-      await act(async () => {
-        vi.advanceTimersByTime(100);
-      });
+			// Advance timer by 100ms
+			await act(async () => {
+				vi.advanceTimersByTime(100);
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'ro');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				searchInput.setAttribute("value", "ro");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      await act(async () => {
-        vi.advanceTimersByTime(100);
-      });
+			await act(async () => {
+				vi.advanceTimersByTime(100);
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'rou');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				searchInput.setAttribute("value", "rou");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      await act(async () => {
-        vi.advanceTimersByTime(100);
-      });
+			await act(async () => {
+				vi.advanceTimersByTime(100);
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'rout');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				searchInput.setAttribute("value", "rout");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      await act(async () => {
-        vi.advanceTimersByTime(100);
-      });
+			await act(async () => {
+				vi.advanceTimersByTime(100);
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'route');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				searchInput.setAttribute("value", "route");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      await act(async () => {
-        vi.advanceTimersByTime(100);
-      });
+			await act(async () => {
+				vi.advanceTimersByTime(100);
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'router');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				searchInput.setAttribute("value", "router");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      // At this point we're 500ms from first char, 50ms from last
-      // Advance to fire the debounced call
-      await act(async () => {
-        vi.advanceTimersByTime(300);
-      });
+			// At this point we're 500ms from first char, 50ms from last
+			// Advance to fire the debounced call
+			await act(async () => {
+				vi.advanceTimersByTime(300);
+			});
 
-      // Only ONE call should have been made after 300ms from last keystroke
-      expect(mockFetchNodesSearch).toHaveBeenCalledTimes(1);
-      expect(mockFetchNodesSearch).toHaveBeenCalledWith({ q: 'router', signal: expect.any(AbortSignal) });
-    });
+			// Only ONE call should have been made after 300ms from last keystroke
+			expect(mockFetchNodesSearch).toHaveBeenCalledTimes(1);
+			expect(mockFetchNodesSearch).toHaveBeenCalledWith({
+				q: "router",
+				signal: expect.any(AbortSignal),
+			});
+		});
 
-    it('does not fetch when term has fewer than 2 characters', async () => {
-      mockFetchNodesSearch.mockResolvedValue([]);
-      render(<MetricAnalytics />);
+		it("does not fetch when term has fewer than 2 characters", async () => {
+			mockFetchNodesSearch.mockResolvedValue([]);
+			render(<MetricAnalytics />);
 
-      const searchInput = screen.getByRole('searchbox');
+			const searchInput = screen.getByRole("searchbox");
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'a');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				searchInput.setAttribute("value", "a");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      await act(async () => {
-        vi.advanceTimersByTime(500);
-      });
+			await act(async () => {
+				vi.advanceTimersByTime(500);
+			});
 
-      expect(mockFetchNodesSearch).not.toHaveBeenCalled();
-    });
+			expect(mockFetchNodesSearch).not.toHaveBeenCalled();
+		});
 
-    it('aborts previous request when new keystroke occurs', async () => {
-      const firstAbortController = { abort: vi.fn() };
-      const secondAbortController = { abort: vi.fn() };
+		it("aborts previous request when new keystroke occurs", async () => {
+			mockFetchNodesSearch
+				.mockResolvedValueOnce(
+					new Promise((resolve) => {
+						setTimeout(() => resolve(mockNodes), 1000);
+					}),
+				)
+				.mockResolvedValueOnce(mockNodes);
 
-      mockFetchNodesSearch
-        .mockResolvedValueOnce(
-          new Promise((resolve) => {
-            setTimeout(() => resolve(mockNodes), 1000);
-          })
-        )
-        .mockResolvedValueOnce(mockNodes);
+			render(<MetricAnalytics />);
 
-      render(<MetricAnalytics />);
+			const searchInput = screen.getByRole("searchbox");
 
-      const searchInput = screen.getByRole('searchbox');
+			// First keystroke
+			await act(async () => {
+				searchInput.setAttribute("value", "rou");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      // First keystroke
-      await act(async () => {
-        searchInput.setAttribute('value', 'rou');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			// Advance 200ms - not yet at 300ms debounce
+			await act(async () => {
+				vi.advanceTimersByTime(200);
+			});
 
-      // Advance 200ms - not yet at 300ms debounce
-      await act(async () => {
-        vi.advanceTimersByTime(200);
-      });
+			// Second keystroke (should abort first)
+			await act(async () => {
+				searchInput.setAttribute("value", "router");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      // Second keystroke (should abort first)
-      await act(async () => {
-        searchInput.setAttribute('value', 'router');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await act(async () => {
+				vi.advanceTimersByTime(350);
+			});
 
-      await act(async () => {
-        vi.advanceTimersByTime(350);
-      });
+			// Only the second call should have been made
+			expect(mockFetchNodesSearch).toHaveBeenCalledTimes(1);
+		});
+	});
 
-      // Only the second call should have been made
-      expect(mockFetchNodesSearch).toHaveBeenCalledTimes(1);
-    });
-  });
+	describe("multi-CI metrics", () => {
+		it("fetches each selected CI with its own default metric", async () => {
+			vi.useRealTimers();
+			const heterogeneousNodes: GraphNode[] = [
+				mockNodes[0],
+				{
+					id: "CI-003",
+					label: "Access Switch",
+					type: "INFRASTRUCTURE",
+					status: "OK",
+					metadata: {},
+					ip: "192.168.1.3",
+					brand: "Huawei",
+					model: "S5735",
+					metrics: [
+						{
+							name: "temperature-celsius",
+							protocol: "snmp",
+							oid: "1.3.6.3",
+							value: "40",
+							status: "OK",
+							last_updated: "2026-05-11T10:00:00Z",
+						},
+					],
+				},
+			];
+			mockFetchNodes.mockResolvedValue(heterogeneousNodes);
 
-  describe('search results display', () => {
-    it('shows loading state while searching', async () => {
-      let resolveSearch!: (value: GraphNode[]) => void;
-      mockFetchNodesSearch.mockImplementation(
-        () =>
-          new Promise<GraphNode[]>((resolve) => {
-            resolveSearch = resolve;
-          })
-      );
+			render(<MetricAnalytics />);
 
-      render(<MetricAnalytics />);
+			await waitFor(() =>
+				expect(screen.getByText("Core Router")).toBeInTheDocument(),
+			);
 
-      const searchInput = screen.getByRole('searchbox');
+			await act(async () => {
+				screen.getByText("Core Router").click();
+			});
+			await act(async () => {
+				screen.getByText("Access Switch").click();
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'router');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			await waitFor(() => {
+				expect(mockFetchNodeMetricHistory).toHaveBeenCalledWith(
+					expect.objectContaining({ nodeId: "CI-001", metricId: "cpu-load" }),
+				);
+				expect(mockFetchNodeMetricHistory).toHaveBeenCalledWith(
+					expect.objectContaining({
+						nodeId: "CI-003",
+						metricId: "temperature-celsius",
+					}),
+				);
+			});
+		});
+	});
 
-      await act(async () => {
-        vi.advanceTimersByTime(350);
-      });
+	describe("search results display", () => {
+		it("shows loading state while searching", async () => {
+			let resolveSearch!: (value: GraphNode[]) => void;
+			mockFetchNodesSearch.mockImplementation(
+				() =>
+					new Promise<GraphNode[]>((resolve) => {
+						resolveSearch = resolve;
+					}),
+			);
 
-      expect(screen.getByText(/loading/i)).toBeInTheDocument();
+			render(<MetricAnalytics />);
 
-      // Resolve the search
-      await act(async () => {
-        resolveSearch(mockNodes);
-      });
-    });
+			const searchInput = screen.getByRole("searchbox");
 
-    it('shows "No results found" when search returns empty array', async () => {
-      mockFetchNodesSearch.mockResolvedValue([]);
+			await act(async () => {
+				searchInput.setAttribute("value", "router");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      render(<MetricAnalytics />);
+			await act(async () => {
+				vi.advanceTimersByTime(350);
+			});
 
-      const searchInput = screen.getByRole('searchbox');
+			expect(screen.getByText(/loading/i)).toBeInTheDocument();
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'nonexistent');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			// Resolve the search
+			await act(async () => {
+				resolveSearch(mockNodes);
+			});
+		});
 
-      await act(async () => {
-        vi.advanceTimersByTime(350);
-      });
+		it('shows "No results found" when search returns empty array', async () => {
+			mockFetchNodesSearch.mockResolvedValue([]);
 
-      expect(screen.getByText(/no results/i)).toBeInTheDocument();
-    });
+			render(<MetricAnalytics />);
 
-    it('displays search results in a list', async () => {
-      mockFetchNodesSearch.mockResolvedValue(mockNodes);
+			const searchInput = screen.getByRole("searchbox");
 
-      render(<MetricAnalytics />);
+			await act(async () => {
+				searchInput.setAttribute("value", "nonexistent");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
 
-      const searchInput = screen.getByRole('searchbox');
+			await act(async () => {
+				vi.advanceTimersByTime(350);
+			});
 
-      await act(async () => {
-        searchInput.setAttribute('value', 'router');
-        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
-      });
+			expect(screen.getByText(/no results/i)).toBeInTheDocument();
+		});
 
-      await act(async () => {
-        vi.advanceTimersByTime(350);
-      });
+		it("displays search results in a list", async () => {
+			mockFetchNodesSearch.mockResolvedValue(mockNodes);
 
-      expect(screen.getByText('Core Router')).toBeInTheDocument();
-      expect(screen.getByText('Backup Router')).toBeInTheDocument();
-    });
-  });
+			render(<MetricAnalytics />);
+
+			const searchInput = screen.getByRole("searchbox");
+
+			await act(async () => {
+				searchInput.setAttribute("value", "router");
+				searchInput.dispatchEvent(new Event("input", { bubbles: true }));
+			});
+
+			await act(async () => {
+				vi.advanceTimersByTime(350);
+			});
+
+			expect(screen.getByText("Core Router")).toBeInTheDocument();
+			expect(screen.getByText("Backup Router")).toBeInTheDocument();
+		});
+	});
 });

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -1,446 +1,674 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { GraphNode, MetricValue, NodeMetricData } from '../types';
-import MetricHistoryChart from './MetricHistoryChart';
-import MultiSelectCIs from './MultiSelectCIs';
-import MultiMetricChart from './MultiMetricChart';
-import { fetchNodes, fetchNodesSearch, fetchMetricsHistory } from '../services/queryResources';
+import React, { useState, useEffect } from "react";
+import { GraphNode, MetricValue, NodeMetricData } from "../types";
+import MetricHistoryChart from "./MetricHistoryChart";
+import MultiSelectCIs from "./MultiSelectCIs";
+import MultiMetricChart from "./MultiMetricChart";
+import { fetchNodes, fetchNodeMetricHistory } from "../services/queryResources";
 
 interface BrushRange {
-  startIndex?: number;
-  endIndex?: number;
+	startTime?: string;
+	endTime?: string;
 }
 
 const MetricAnalytics: React.FC = () => {
-    const [nodes, setNodes] = useState<GraphNode[]>([]);
-    const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
-    const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
-    const [selectedMetric, setSelectedMetric] = useState<MetricValue | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [startDate, setStartDate] = useState('');
-    const [endDate, setEndDate] = useState('');
-    const [searchTerm, setSearchTerm] = useState('');
-    const [searchResults, setSearchResults] = useState<GraphNode[]>([]);
-    const [isSearching, setIsSearching] = useState(false);
-    const [searchError, setSearchError] = useState<string | null>(null);
-    const abortControllerRef = useRef<AbortController | null>(null);
-    const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [nodes, setNodes] = useState<GraphNode[]>([]);
+	const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
+	const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+	const [selectedMetric, setSelectedMetric] = useState<MetricValue | null>(
+		null,
+	);
+	const [, setLoading] = useState(true);
+	const [startDate, setStartDate] = useState("");
+	const [endDate, setEndDate] = useState("");
 
-    // Multi-CI state
-    const [brushRange, setBrushRange] = useState<BrushRange | null>(null);
-    const [multiCiData, setMultiCiData] = useState<NodeMetricData[]>([]);
-    const [multiCiLoading, setMultiCiLoading] = useState(false);
-    const [showSecondary, setShowSecondary] = useState(false);
-    const [secondaryMetricId, setSecondaryMetricId] = useState<string>('');
-    const [secondaryMultiCiData, setSecondaryMultiCiData] = useState<NodeMetricData[]>([]);
-    const [secondaryMultiCiLoading, setSecondaryMultiCiLoading] = useState(false);
+	// Multi-CI state
+	const [brushRange, setBrushRange] = useState<BrushRange | null>(null);
+	const [multiCiData, setMultiCiData] = useState<NodeMetricData[]>([]);
+	const [multiCiLoading, setMultiCiLoading] = useState(false);
+	const [showSecondary, setShowSecondary] = useState(false);
+	const [selectedMetricByNodeId, setSelectedMetricByNodeId] = useState<
+		Record<string, string>
+	>({});
+	const [secondaryMetricByNodeId, setSecondaryMetricByNodeId] = useState<
+		Record<string, string>
+	>({});
+	const [secondaryMultiCiData, setSecondaryMultiCiData] = useState<
+		NodeMetricData[]
+	>([]);
+	const [secondaryMultiCiLoading, setSecondaryMultiCiLoading] = useState(false);
 
-    // Reset brush when node selection, date range, or metric changes
-    // (indices are specific to each dataset)
-    useEffect(() => {
-        setBrushRange(null);
-    }, [selectedNodeIds, startDate, endDate, selectedMetric]);
+	// Reset brush when node selection, date range, or metric changes
+	// (indices are specific to each dataset)
+	useEffect(() => {
+		setBrushRange(null);
+	}, [
+		selectedNodeIds,
+		startDate,
+		endDate,
+		selectedMetric,
+		selectedMetricByNodeId,
+		secondaryMetricByNodeId,
+	]);
 
-    // Derive selectedNode from selectedNodeIds[0]
-    useEffect(() => {
-        setSelectedNode(nodes.find(n => n.id === selectedNodeIds[0]) || null);
-    }, [selectedNodeIds, nodes]);
+	// Derive selectedNode from selectedNodeIds[0]
+	useEffect(() => {
+		setSelectedNode(nodes.find((n) => n.id === selectedNodeIds[0]) || null);
+	}, [selectedNodeIds, nodes]);
 
-    // Fetch Nodes on Mount (original behavior)
-    useEffect(() => {
-        fetchNodes()
-            .then(data => {
-                if (Array.isArray(data)) {
-                    setNodes(data);
-                }
-                setLoading(false);
-            })
-            .catch(err => {
-                console.error(err);
-                setLoading(false);
-                // On fetch failure, ensure consistent state by not setting any defaults
-                // User can still manually select from the dropdown if nodes were previously loaded
-            });
-    }, []);
+	// Fetch Nodes on Mount (original behavior)
+	useEffect(() => {
+		fetchNodes()
+			.then((data) => {
+				if (Array.isArray(data)) {
+					setNodes(data);
+				}
+				setLoading(false);
+			})
+			.catch((err) => {
+				console.error(err);
+				setLoading(false);
+				// On fetch failure, ensure consistent state by not setting any defaults
+				// User can still manually select from the dropdown if nodes were previously loaded
+			});
+	}, []);
 
-    // Debounced search effect
-    useEffect(() => {
-        if (abortControllerRef.current) {
-            abortControllerRef.current.abort();
-        }
-        if (debounceTimerRef.current) {
-            clearTimeout(debounceTimerRef.current);
-        }
+	// Update available metrics when node changes
+	useEffect(() => {
+		if (
+			selectedNode &&
+			selectedNode.metrics &&
+			selectedNode.metrics.length > 0
+		) {
+			setSelectedMetric(selectedNode.metrics[0]);
+		} else {
+			setSelectedMetric(null);
+		}
+	}, [selectedNode]);
 
-        if (!searchTerm.trim()) {
-            setSearchResults([]);
-            setIsSearching(false);
-            setSearchError(null);
-            return;
-        }
+	// Each selected CI can use its own metrics for heterogeneous models/brands.
+	useEffect(() => {
+		setSelectedMetricByNodeId((previous) => {
+			const next: Record<string, string> = {};
+			selectedNodeIds.forEach((nodeId) => {
+				const node = nodes.find((n) => n.id === nodeId);
+				const metrics = node?.metrics ?? [];
+				const previousMetric = previous[nodeId];
+				const hasPreviousMetric = metrics.some(
+					(metric) => metric.name === previousMetric,
+				);
+				next[nodeId] = hasPreviousMetric
+					? previousMetric
+					: (metrics[0]?.name ?? "");
+			});
+			return next;
+		});
 
-        if (searchTerm.length < 2) {
-            setSearchResults([]);
-            setIsSearching(false);
-            setSearchError(null);
-            return;
-        }
+		setSecondaryMetricByNodeId((previous) => {
+			const next: Record<string, string> = {};
+			selectedNodeIds.forEach((nodeId) => {
+				const node = nodes.find((n) => n.id === nodeId);
+				const metrics = node?.metrics ?? [];
+				const previousMetric = previous[nodeId];
+				const hasPreviousMetric = metrics.some(
+					(metric) => metric.name === previousMetric,
+				);
+				next[nodeId] = hasPreviousMetric
+					? previousMetric
+					: (metrics[1]?.name ?? metrics[0]?.name ?? "");
+			});
+			return next;
+		});
+	}, [selectedNodeIds, nodes]);
 
-        const controller = new AbortController();
-        abortControllerRef.current = controller;
+	// Fetch multi-CI data. Each CI can use a different metric.
+	useEffect(() => {
+		const hasMultipleSelected = selectedNodeIds.length > 1;
 
-        debounceTimerRef.current = setTimeout(() => {
-            setIsSearching(true);
-            setSearchError(null);
+		if (!hasMultipleSelected) {
+			setMultiCiData([]);
+			setMultiCiLoading(false);
+			return;
+		}
 
-            fetchNodesSearch({ q: searchTerm, signal: controller.signal })
-                .then((results) => {
-                    setSearchResults(results);
-                    setIsSearching(false);
-                })
-                .catch((err) => {
-                    if (err.name !== 'AbortError') {
-                        console.error('Search failed:', err);
-                        setSearchError(err.message || `Error ${err.status}`);
-                        setSearchResults([]);
-                    }
-                    setIsSearching(false);
-                });
-        }, 300);
+		setMultiCiLoading(true);
+		const controller = new AbortController();
 
-        return () => {
-            controller.abort();
-            if (debounceTimerRef.current) {
-                clearTimeout(debounceTimerRef.current);
-            }
-        };
-    }, [searchTerm]);
+		const customRange =
+			startDate && endDate
+				? {
+						start: new Date(startDate).toISOString(),
+						end: new Date(endDate).toISOString(),
+					}
+				: null;
 
-    // Update available metrics when node changes
-    useEffect(() => {
-        if (selectedNode && selectedNode.metrics && selectedNode.metrics.length > 0) {
-            setSelectedMetric(selectedNode.metrics[0]);
-        } else {
-            setSelectedMetric(null);
-        }
-    }, [selectedNode]);
+		Promise.all(
+			selectedNodeIds.map(async (nodeId) => {
+				const node = nodes.find((n) => n.id === nodeId);
+				const metricId = selectedMetricByNodeId[nodeId];
+				const metric = node?.metrics?.find(
+					(candidate) => candidate.name === metricId,
+				);
 
-    // Fetch multi-CI data when selectedNodeIds or selectedMetric changes
-    useEffect(() => {
-        if (selectedNodeIds.length === 0 || !selectedMetric) return;
+				if (!node || !metricId) {
+					return {
+						node_id: nodeId,
+						label: node?.label ?? nodeId,
+						metricName: undefined,
+						unit: undefined,
+						data: [],
+					};
+				}
 
-        const hasMultipleSelected = selectedNodeIds.length > 1;
-        
-        if (!hasMultipleSelected) {
-            setMultiCiData([]);
-            return;
-        }
+				const data = await fetchNodeMetricHistory({
+					nodeId,
+					metricId,
+					hours: customRange ? undefined : 24,
+					startTime: customRange?.start,
+					endTime: customRange?.end,
+					signal: controller.signal,
+				});
 
-        setMultiCiLoading(true);
-        const controller = new AbortController();
+				return {
+					node_id: nodeId,
+					label: node.label,
+					metricName: metricId,
+					unit: metric?.unit,
+					data: data.map((point) => ({
+						time: point.time,
+						value:
+							typeof point.value === "string"
+								? parseFloat(point.value)
+								: point.value,
+					})),
+				};
+			}),
+		)
+			.then((nodeData) => {
+				setMultiCiData(nodeData);
+				setMultiCiLoading(false);
+			})
+			.catch((err) => {
+				if (err.name !== "AbortError") {
+					console.error("Failed to fetch multi-CI metric history", err);
+				}
+				setMultiCiLoading(false);
+			});
 
-        const customRange = startDate && endDate
-            ? { start: new Date(startDate).toISOString(), end: new Date(endDate).toISOString() }
-            : null;
+		return () => controller.abort();
+	}, [selectedNodeIds, selectedMetricByNodeId, nodes, startDate, endDate]);
 
-        fetchMetricsHistory({
-            nodeIds: selectedNodeIds,
-            metricId: selectedMetric.name,
-            hours: customRange ? undefined : 24,
-            startTime: customRange?.start,
-            endTime: customRange?.end,
-            signal: controller.signal,
-        })
-            .then((response) => {
-                setMultiCiData(response.nodes);
-                setMultiCiLoading(false);
-            })
-            .catch((err) => {
-                if (err.name !== 'AbortError') {
-                    console.error('Failed to fetch multi-CI metric history', err);
-                }
-                setMultiCiLoading(false);
-            });
+	// Fetch secondary metric data. Each CI can use a different secondary metric.
+	useEffect(() => {
+		if (!showSecondary || selectedNodeIds.length <= 1) {
+			setSecondaryMultiCiData([]);
+			setSecondaryMultiCiLoading(false);
+			return;
+		}
 
-        return () => controller.abort();
-    }, [selectedNodeIds, selectedMetric, startDate, endDate]);
+		setSecondaryMultiCiLoading(true);
+		setSecondaryMultiCiData([]);
+		const controller = new AbortController();
+		const customRange =
+			startDate && endDate
+				? {
+						start: new Date(startDate).toISOString(),
+						end: new Date(endDate).toISOString(),
+					}
+				: null;
 
-    // Fetch secondary metric data
-    useEffect(() => {
-        if (!showSecondary || secondaryMetricId.length === 0 || selectedNodeIds.length === 0) {
-            setSecondaryMultiCiData([]);
-            setSecondaryMultiCiLoading(false);
-            return;
-        }
+		Promise.all(
+			selectedNodeIds.map(async (nodeId) => {
+				const node = nodes.find((n) => n.id === nodeId);
+				const metricId = secondaryMetricByNodeId[nodeId];
+				const metric = node?.metrics?.find(
+					(candidate) => candidate.name === metricId,
+				);
 
-        setSecondaryMultiCiLoading(true);
-        setSecondaryMultiCiData([]);
-        const controller = new AbortController();
-        const customRange = startDate && endDate
-            ? { start: new Date(startDate).toISOString(), end: new Date(endDate).toISOString() }
-            : null;
+				if (!node || !metricId) {
+					return {
+						node_id: nodeId,
+						label: node?.label ?? nodeId,
+						metricName: undefined,
+						unit: undefined,
+						data: [],
+					};
+				}
 
-        fetchMetricsHistory({
-            nodeIds: selectedNodeIds,
-            metricId: secondaryMetricId,
-            hours: customRange ? undefined : 24,
-            startTime: customRange?.start,
-            endTime: customRange?.end,
-            signal: controller.signal,
-        })
-            .then((response) => {
-                setSecondaryMultiCiData(response.nodes);
-                setSecondaryMultiCiLoading(false);
-            })
-            .catch((err) => {
-                if (err.name !== 'AbortError') {
-                    console.error('Failed to fetch secondary metric history', err);
-                }
-                setSecondaryMultiCiLoading(false);
-            });
+				const data = await fetchNodeMetricHistory({
+					nodeId,
+					metricId,
+					hours: customRange ? undefined : 24,
+					startTime: customRange?.start,
+					endTime: customRange?.end,
+					signal: controller.signal,
+				});
 
-        return () => controller.abort();
-    }, [showSecondary, secondaryMetricId, selectedNodeIds, startDate, endDate]);
+				return {
+					node_id: nodeId,
+					label: node.label,
+					metricName: metricId,
+					unit: metric?.unit,
+					data: data.map((point) => ({
+						time: point.time,
+						value:
+							typeof point.value === "string"
+								? parseFloat(point.value)
+								: point.value,
+					})),
+				};
+			}),
+		)
+			.then((nodeData) => {
+				setSecondaryMultiCiData(nodeData);
+				setSecondaryMultiCiLoading(false);
+			})
+			.catch((err) => {
+				if (err.name !== "AbortError") {
+					console.error("Failed to fetch secondary metric history", err);
+				}
+				setSecondaryMultiCiLoading(false);
+			});
 
-    const handleResetDateRange = () => {
-        setStartDate('');
-        setEndDate('');
-    };
+		return () => controller.abort();
+	}, [
+		showSecondary,
+		selectedNodeIds,
+		secondaryMetricByNodeId,
+		nodes,
+		startDate,
+		endDate,
+	]);
 
-    const handleMultiCiChange = (ids: string[]) => {
-        setSelectedNodeIds(ids);
-        setBrushRange(null);
-    };
+	const handleResetDateRange = () => {
+		setStartDate("");
+		setEndDate("");
+	};
 
-    const handleBrushChange = (range: BrushRange | null) => {
-        setBrushRange(range);
-    };
+	const handleMultiCiChange = (ids: string[]) => {
+		setSelectedNodeIds(ids);
+		setBrushRange(null);
+	};
 
-    const hasMultipleSelected = selectedNodeIds.length > 1;
+	const handleBrushChange = (range: BrushRange | null) => {
+		setBrushRange(range);
+	};
 
-    return (
-        <div className="flex flex-col h-full bg-surface-950 text-white p-8 overflow-hidden">
-            <header className="mb-8 flex justify-between items-end">
-                <div>
-                    <h1 className="text-3xl font-black uppercase tracking-tighter">Metric Analytics</h1>
-                    <p className="text-neutral-500 font-mono text-sm mt-1">Historical Telemetry Visualization</p>
-                </div>
-            </header>
+	const hasMultipleSelected = selectedNodeIds.length > 1;
+	const selectedNodes = selectedNodeIds
+		.map((nodeId) => nodes.find((node) => node.id === nodeId))
+		.filter((node): node is GraphNode => Boolean(node));
 
-            <div className="grid grid-cols-12 gap-8 h-full">
-                {/* Controls Sidebar */}
-                <div className="col-span-12 lg:col-span-3 space-y-6 flex flex-col h-full overflow-hidden min-w-0">
-                    {/* Multi-CI Selector */}
-                    <div className="bg-surface-900 border border-white/5 rounded-xl p-5">
-                        <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">Compare Multiple CIs</label>
-                        <MultiSelectCIs
-                            selectedIds={selectedNodeIds}
-                            onChange={handleMultiCiChange}
-                            availableNodes={nodes}
-                            maxCIs={10}
-                        />
-                    </div>
+	return (
+		<div className="flex flex-col h-full bg-surface-950 text-white p-8 overflow-hidden">
+			<header className="mb-8 flex justify-between items-end">
+				<div>
+					<h1 className="text-3xl font-black uppercase tracking-tighter">
+						Metric Analytics
+					</h1>
+					<p className="text-neutral-500 font-mono text-sm mt-1">
+						Historical Telemetry Visualization
+					</p>
+				</div>
+			</header>
 
-                    {/* Date Range Selector */}
-                    <div className="bg-surface-900 border border-white/5 rounded-xl p-5">
-                        <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">Custom Time Range</label>
-                        <div className="space-y-3">
-                            <div>
-                                <label className="text-[10px] text-neutral-400 block mb-1">Start Date</label>
-                                <input
-                                    type="datetime-local"
-                                    className="w-full bg-black/40 border border-white/10 rounded-lg p-2 text-xs text-white outline-none focus:border-brand-500"
-                                    value={startDate}
-                                    onChange={(e) => setStartDate(e.target.value)}
-                                />
-                            </div>
-                            <div>
-                                <label className="text-[10px] text-neutral-400 block mb-1">End Date</label>
-                                <input
-                                    type="datetime-local"
-                                    className="w-full bg-black/40 border border-white/10 rounded-lg p-2 text-xs text-white outline-none focus:border-brand-500"
-                                    value={endDate}
-                                    onChange={(e) => setEndDate(e.target.value)}
-                                />
-                            </div>
-                            {startDate && endDate && (
-                                <button
-                                    onClick={handleResetDateRange}
-                                    className="w-full mt-2 bg-white/5 hover:bg-white/10 text-neutral-300 text-xs font-bold py-2 rounded-lg uppercase transition-colors"
-                                >
-                                    Reset to Live View
-                                </button>
-                            )}
-                        </div>
-                    </div>
+			<div className="grid grid-cols-12 gap-8 h-full">
+				{/* Controls Sidebar */}
+				<div className="col-span-12 lg:col-span-3 space-y-6 flex flex-col h-full overflow-hidden min-w-0">
+					{/* Multi-CI Selector */}
+					<div className="bg-surface-900 border border-white/5 rounded-xl p-5">
+						<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">
+							Compare Multiple CIs
+						</label>
+						<MultiSelectCIs
+							selectedIds={selectedNodeIds}
+							onChange={handleMultiCiChange}
+							availableNodes={nodes}
+							maxCIs={10}
+						/>
+					</div>
 
-                    {/* Metric Selector */}
-                    <div className="bg-surface-900 border border-white/5 rounded-xl p-5 flex-1 overflow-y-auto min-h-0">
-                        <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-3 block">Available Metrics</label>
-                        <div className="space-y-2">
-                            {selectedNode?.metrics?.map((m, idx) => (
-                                <button
-                                    key={idx}
-                                    onClick={() => {
-                                        setSelectedMetric(m);
-                                        setMultiCiData([]);
-                                        setBrushRange(null);
-                                    }}
-                                    className={`w-full text-left p-3 rounded-lg border transition-all flex items-center justify-between ${selectedMetric?.name === m.name
-                                        ? 'bg-brand-500/20 border-brand-500/50 text-white'
-                                        : 'bg-white/5 border-transparent text-neutral-400 hover:bg-white/10'
-                                        }`}
-                                >
-                                    <div>
-                                        <p className="text-xs font-bold uppercase">{m.name}</p>
-                                        <p className="text-[10px] opacity-60 font-mono mt-0.5">{m.protocol}</p>
-                                    </div>
-                                    <span className={`w-2 h-2 rounded-full ${m.status === 'OK' ? 'bg-emerald-500' : 'bg-red-500'}`}></span>
-                                </button>
-                            ))}
-                            {(!selectedNode?.metrics || selectedNode.metrics.length === 0) && (
-                                <p className="text-xs text-neutral-600 text-center py-4">No metrics available for this CI.</p>
-                            )}
-                        </div>
-                    </div>
+					{/* Date Range Selector */}
+					<div className="bg-surface-900 border border-white/5 rounded-xl p-5">
+						<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">
+							Custom Time Range
+						</label>
+						<div className="space-y-3">
+							<div>
+								<label className="text-[10px] text-neutral-400 block mb-1">
+									Start Date
+								</label>
+								<input
+									type="datetime-local"
+									className="w-full bg-black/40 border border-white/10 rounded-lg p-2 text-xs text-white outline-none focus:border-brand-500"
+									value={startDate}
+									onChange={(e) => setStartDate(e.target.value)}
+								/>
+							</div>
+							<div>
+								<label className="text-[10px] text-neutral-400 block mb-1">
+									End Date
+								</label>
+								<input
+									type="datetime-local"
+									className="w-full bg-black/40 border border-white/10 rounded-lg p-2 text-xs text-white outline-none focus:border-brand-500"
+									value={endDate}
+									onChange={(e) => setEndDate(e.target.value)}
+								/>
+							</div>
+							{startDate && endDate && (
+								<button
+									onClick={handleResetDateRange}
+									className="w-full mt-2 bg-white/5 hover:bg-white/10 text-neutral-300 text-xs font-bold py-2 rounded-lg uppercase transition-colors"
+								>
+									Reset to Live View
+								</button>
+							)}
+						</div>
+					</div>
 
-                    {/* Secondary Metric Toggle */}
-                    {hasMultipleSelected && (
-                        <div className="bg-surface-900 border border-white/5 rounded-xl p-5">
-                            <div className="flex items-center justify-between mb-3">
-                                <label className="text-xs font-bold text-neutral-500 uppercase tracking-wider">Secondary Metric</label>
-                                <button
-                                    onClick={() => setShowSecondary(!showSecondary)}
-                                    className={`w-10 h-5 rounded-full transition-colors ${showSecondary ? 'bg-brand-500' : 'bg-white/20'}`}
-                                >
-                                    <div className={`w-4 h-4 rounded-full bg-white transition-transform ${showSecondary ? 'translate-x-5' : 'translate-x-0.5'}`}></div>
-                                </button>
-                            </div>
-                            {showSecondary && (
-                                <select
-                                    value={secondaryMetricId}
-                                    onChange={(e) => setSecondaryMetricId(e.target.value)}
-                                    className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-3 text-sm text-white focus:border-brand-500 outline-none transition-colors appearance-none"
-                                >
-                                    <option value="" disabled>Select secondary metric...</option>
-                                    {selectedNode?.metrics?.map((m, idx) => (
-                                        <option key={idx} value={m.name}>{m.name}</option>
-                                    ))}
-                                </select>
-                            )}
-                        </div>
-                    )}
-                </div>
+					{/* Metric Selector */}
+					<div className="bg-surface-900 border border-white/5 rounded-xl p-5 flex-1 overflow-y-auto min-h-0">
+						<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-3 block">
+							{hasMultipleSelected ? "Metric per CI" : "Available Metrics"}
+						</label>
+						<div className="space-y-3">
+							{hasMultipleSelected ? (
+								selectedNodes.map((node) => {
+									const metrics = node.metrics ?? [];
+									return (
+										<div
+											key={node.id}
+											className="rounded-lg border border-white/10 bg-white/[0.03] p-3"
+										>
+											<p className="text-xs font-bold uppercase text-white truncate">
+												{node.label}
+											</p>
+											<p className="text-[10px] text-neutral-500 font-mono mb-2 truncate">
+												{node.brand || "Unknown brand"} {node.model || ""}
+											</p>
+											{metrics.length > 0 ? (
+												<select
+													value={
+														selectedMetricByNodeId[node.id] ?? metrics[0].name
+													}
+													onChange={(event) => {
+														setSelectedMetricByNodeId((previous) => ({
+															...previous,
+															[node.id]: event.target.value,
+														}));
+														setMultiCiData([]);
+														setBrushRange(null);
+													}}
+													className="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:border-brand-500 outline-none transition-colors"
+												>
+													{metrics.map((metric) => (
+														<option key={metric.name} value={metric.name}>
+															{metric.name}
+														</option>
+													))}
+												</select>
+											) : (
+												<p className="text-xs text-neutral-600 py-2">
+													No metrics available for this CI.
+												</p>
+											)}
+										</div>
+									);
+								})
+							) : (
+								<>
+									{selectedNode?.metrics?.map((m, idx) => (
+										<button
+											key={idx}
+											onClick={() => {
+												setSelectedMetric(m);
+												setMultiCiData([]);
+												setBrushRange(null);
+											}}
+											className={`w-full text-left p-3 rounded-lg border transition-all flex items-center justify-between ${
+												selectedMetric?.name === m.name
+													? "bg-brand-500/20 border-brand-500/50 text-white"
+													: "bg-white/5 border-transparent text-neutral-400 hover:bg-white/10"
+											}`}
+										>
+											<div>
+												<p className="text-xs font-bold uppercase">{m.name}</p>
+												<p className="text-[10px] opacity-60 font-mono mt-0.5">
+													{m.protocol}
+												</p>
+											</div>
+											<span
+												className={`w-2 h-2 rounded-full ${m.status === "OK" ? "bg-emerald-500" : "bg-red-500"}`}
+											></span>
+										</button>
+									))}
+									{(!selectedNode?.metrics ||
+										selectedNode.metrics.length === 0) && (
+										<p className="text-xs text-neutral-600 text-center py-4">
+											No metrics available for this CI.
+										</p>
+									)}
+								</>
+							)}
+						</div>
+					</div>
 
-                {/* Main Chart Area */}
-                <div className="col-span-12 lg:col-span-9 flex flex-col gap-6 h-full overflow-hidden pb-8 min-w-0">
-                    {hasMultipleSelected && selectedMetric ? (
-                        <>
-                            {/* Multi-CI Chart View */}
-                            <div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
-                                <div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
-                                    <span className="material-symbols-outlined text-9xl">monitoring</span>
-                                </div>
+					{/* Secondary Metric Toggle */}
+					{hasMultipleSelected && (
+						<div className="bg-surface-900 border border-white/5 rounded-xl p-5">
+							<div className="flex items-center justify-between mb-3">
+								<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider">
+									Secondary Metric
+								</label>
+								<button
+									onClick={() => setShowSecondary(!showSecondary)}
+									className={`w-10 h-5 rounded-full transition-colors ${showSecondary ? "bg-brand-500" : "bg-white/20"}`}
+								>
+									<div
+										className={`w-4 h-4 rounded-full bg-white transition-transform ${showSecondary ? "translate-x-5" : "translate-x-0.5"}`}
+									></div>
+								</button>
+							</div>
+							{showSecondary && (
+								<div className="space-y-3">
+									{selectedNodes.map((node) => {
+										const metrics = node.metrics ?? [];
+										return (
+											<div
+												key={node.id}
+												className="rounded-lg border border-white/10 bg-white/[0.03] p-3"
+											>
+												<p className="text-xs font-bold uppercase text-white truncate">
+													{node.label}
+												</p>
+												{metrics.length > 0 ? (
+													<select
+														value={
+															secondaryMetricByNodeId[node.id] ??
+															metrics[1]?.name ??
+															metrics[0].name
+														}
+														onChange={(event) => {
+															setSecondaryMetricByNodeId((previous) => ({
+																...previous,
+																[node.id]: event.target.value,
+															}));
+															setSecondaryMultiCiData([]);
+															setBrushRange(null);
+														}}
+														className="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:border-brand-500 outline-none transition-colors"
+													>
+														{metrics.map((metric) => (
+															<option key={metric.name} value={metric.name}>
+																{metric.name}
+															</option>
+														))}
+													</select>
+												) : (
+													<p className="text-xs text-neutral-600 py-2">
+														No metrics available for this CI.
+													</p>
+												)}
+											</div>
+										);
+									})}
+								</div>
+							)}
+						</div>
+					)}
+				</div>
 
-                                <div className="relative z-10 flex-1 flex flex-col min-h-0">
-                                    {multiCiLoading ? (
-                                        <div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
-                                            LOADING METRICS...
-                                        </div>
-                                    ) : (
-                                        <MultiMetricChart
-                                            nodeData={multiCiData}
-                                            brushRange={brushRange}
-                                            onBrushChange={handleBrushChange}
-                                            metricName={selectedMetric.name}
-                                            unit={selectedMetric.unit}
-                                        />
-                                    )}
-                                </div>
-                            </div>
+				{/* Main Chart Area */}
+				<div className="col-span-12 lg:col-span-9 flex flex-col gap-6 h-full overflow-hidden pb-8 min-w-0">
+					{hasMultipleSelected ? (
+						<>
+							{/* Multi-CI Chart View */}
+							<div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+								<div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
+									<span className="material-symbols-outlined text-9xl">
+										monitoring
+									</span>
+								</div>
 
-                            {/* Secondary Metric Section */}
-                            {showSecondary && secondaryMetricId && (
-                                <div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
-                                    <div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
-                                        <span className="material-symbols-outlined text-9xl">analytics</span>
-                                    </div>
-                                    <div className="relative z-10 flex-1 flex flex-col min-h-0">
-                                        <div className="mb-4">
-                                            <h3 className="text-white font-bold uppercase tracking-tight">{secondaryMetricId} Comparison</h3>
-                                            <p className="text-xs text-neutral-500">Secondary metric overlay</p>
-                                        </div>
-                                        {secondaryMultiCiLoading ? (
-                                            <div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
-                                                LOADING SECONDARY METRIC...
-                                            </div>
-                                        ) : (
-                                            <MultiMetricChart
-                                                nodeData={secondaryMultiCiData}
-                                                brushRange={brushRange}
-                                                onBrushChange={handleBrushChange}
-                                                metricName={secondaryMetricId}
-                                            />
-                                        )}
-                                    </div>
-                                </div>
-                            )}
-                        </>
-                    ) : selectedNode && selectedMetric ? (
-                        <div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
-                            {/* Background Pattern */}
-                            <div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
-                                <span className="material-symbols-outlined text-9xl">monitoring</span>
-                            </div>
+								<div className="relative z-10 flex-1 flex flex-col min-h-0">
+									{multiCiLoading ? (
+										<div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
+											LOADING METRICS...
+										</div>
+									) : (
+										<MultiMetricChart
+											nodeData={multiCiData}
+											brushRange={brushRange}
+											onBrushChange={handleBrushChange}
+											metricName="Selected metrics"
+										/>
+									)}
+								</div>
+							</div>
 
-                            <div className="relative z-10 flex-1 flex flex-col min-h-0">
-                                <MetricHistoryChart
-                                    nodeId={selectedNode.id}
-                                    metricId={selectedMetric.name}
-                                    metricName={selectedMetric.name}
-                                    unit={selectedMetric.unit}
-                                    customRange={startDate && endDate ? { start: new Date(startDate).toISOString(), end: new Date(endDate).toISOString() } : null}
-                                />
+							{/* Secondary Metric Section */}
+							{showSecondary && (
+								<div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+									<div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
+										<span className="material-symbols-outlined text-9xl">
+											analytics
+										</span>
+									</div>
+									<div className="relative z-10 flex-1 flex flex-col min-h-0">
+										<div className="mb-4">
+											<h3 className="text-white font-bold uppercase tracking-tight">
+												Secondary Metrics Comparison
+											</h3>
+											<p className="text-xs text-neutral-500">
+												Secondary metric per selected CI
+											</p>
+										</div>
+										{secondaryMultiCiLoading ? (
+											<div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
+												LOADING SECONDARY METRIC...
+											</div>
+										) : (
+											<MultiMetricChart
+												nodeData={secondaryMultiCiData}
+												brushRange={brushRange}
+												onBrushChange={handleBrushChange}
+												metricName="Secondary metrics"
+											/>
+										)}
+									</div>
+								</div>
+							)}
+						</>
+					) : selectedNode && selectedMetric ? (
+						<div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+							{/* Background Pattern */}
+							<div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
+								<span className="material-symbols-outlined text-9xl">
+									monitoring
+								</span>
+							</div>
 
-                                <div className="mt-8 grid grid-cols-3 gap-6 flex-shrink-0">
-                                    <StatCard label="Current Value" value={selectedMetric.value} unit={selectedMetric.unit} />
-                                    <StatCard label="Status" value={selectedMetric.status} isStatus />
-                                    <StatCard label="Last Updated" value={selectedMetric.last_updated} isDate />
-                                </div>
-                            </div>
-                        </div>
-                    ) : (
-                        <div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
-                            <span className="material-symbols-outlined text-6xl mb-4 opacity-20">analytics</span>
-                            <p className="font-bold uppercase tracking-widest">Select a CI and Metric</p>
-                        </div>
-                    )}
-                </div>
-            </div>
-        </div>
-    );
+							<div className="relative z-10 flex-1 flex flex-col min-h-0">
+								<MetricHistoryChart
+									nodeId={selectedNode.id}
+									metricId={selectedMetric.name}
+									metricName={selectedMetric.name}
+									unit={selectedMetric.unit}
+									customRange={
+										startDate && endDate
+											? {
+													start: new Date(startDate).toISOString(),
+													end: new Date(endDate).toISOString(),
+												}
+											: null
+									}
+								/>
+
+								<div className="mt-8 grid grid-cols-3 gap-6 flex-shrink-0">
+									<StatCard
+										label="Current Value"
+										value={selectedMetric.value}
+										unit={selectedMetric.unit}
+									/>
+									<StatCard
+										label="Status"
+										value={selectedMetric.status}
+										isStatus
+									/>
+									<StatCard
+										label="Last Updated"
+										value={selectedMetric.last_updated}
+										isDate
+									/>
+								</div>
+							</div>
+						</div>
+					) : (
+						<div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
+							<span className="material-symbols-outlined text-6xl mb-4 opacity-20">
+								analytics
+							</span>
+							<p className="font-bold uppercase tracking-widest">
+								Select a CI and Metric
+							</p>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
 };
 
-const StatCard: React.FC<{ label: string, value: string | number | null | undefined, unit?: string, isStatus?: boolean, isDate?: boolean }> = ({ label, value, unit, isStatus, isDate }) => {
-    let displayValue = value ?? '--';
-    let colorClass = 'text-white';
+const StatCard: React.FC<{
+	label: string;
+	value: string | number | null | undefined;
+	unit?: string;
+	isStatus?: boolean;
+	isDate?: boolean;
+}> = ({ label, value, unit, isStatus, isDate }) => {
+	let displayValue = value ?? "--";
+	let colorClass = "text-white";
 
-    if (isStatus) {
-        if (value === 'OK') colorClass = 'text-emerald-500';
-        else if (value === 'CRITICAL') colorClass = 'text-red-500';
-        else if (value === 'WARNING') colorClass = 'text-orange-500';
-    } else if (isDate && value) {
-        displayValue = new Date(value).toLocaleString();
-        colorClass = 'text-neutral-300 text-sm';
-    }
+	if (isStatus) {
+		if (value === "OK") colorClass = "text-emerald-500";
+		else if (value === "CRITICAL") colorClass = "text-red-500";
+		else if (value === "WARNING") colorClass = "text-orange-500";
+	} else if (isDate && value) {
+		displayValue = new Date(value).toLocaleString();
+		colorClass = "text-neutral-300 text-sm";
+	}
 
-    return (
-        <div className="bg-black/20 rounded-lg p-4 border border-white/5">
-            <p className="text-[10px] font-bold text-neutral-500 uppercase tracking-wider mb-1">{label}</p>
-            <p className={`text-2xl font-black tracking-tight ${colorClass}`}>
-                {displayValue} <span className="text-xs text-neutral-500 font-normal">{unit}</span>
-            </p>
-        </div>
-    );
+	return (
+		<div className="bg-black/20 rounded-lg p-4 border border-white/5">
+			<p className="text-[10px] font-bold text-neutral-500 uppercase tracking-wider mb-1">
+				{label}
+			</p>
+			<p className={`text-2xl font-black tracking-tight ${colorClass}`}>
+				{displayValue}{" "}
+				<span className="text-xs text-neutral-500 font-normal">{unit}</span>
+			</p>
+		</div>
+	);
 };
 
 export default MetricAnalytics;

--- a/frontend/components/MetricHistoryChart.tsx
+++ b/frontend/components/MetricHistoryChart.tsx
@@ -1,279 +1,355 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Brush, ReferenceArea } from 'recharts';
+import React, { useEffect, useState, useCallback } from "react";
+import {
+	AreaChart,
+	Area,
+	XAxis,
+	YAxis,
+	CartesianGrid,
+	Tooltip,
+	ResponsiveContainer,
+	Brush,
+	ReferenceArea,
+} from "recharts";
+import { fetchNodeMetricHistory } from "../services/queryResources";
 
 interface MetricHistoryChartProps {
-    nodeId: string;
-    metricId: string;
-    metricName: string;
-    unit?: string;
-    customRange?: { start: string, end: string } | null;
+	nodeId: string;
+	metricId: string;
+	metricName: string;
+	unit?: string;
+	customRange?: { start: string; end: string } | null;
 }
 
 interface DataPoint {
-    time: string;
-    value: number;
+	time: string;
+	value: number;
+	displayTime: string;
+	rawTime: string;
 }
 
-const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({ nodeId, metricId, metricName, unit, customRange }) => {
-    const [data, setData] = useState<DataPoint[]>([]);
-    const [loading, setLoading] = useState(false);
-    const [period, setPeriod] = useState(24); // hours
+const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
+	nodeId,
+	metricId,
+	metricName,
+	unit,
+	customRange,
+}) => {
+	const [data, setData] = useState<DataPoint[]>([]);
+	const [loading, setLoading] = useState(false);
+	const [period, setPeriod] = useState(24); // hours
 
-    // Brush/zoom state
-    const [brushRange, setBrushRange] = useState<{ startIndex?: number; endIndex?: number } | null>(null);
-    const [isSelecting, setIsSelecting] = useState(false);
-    const [selectionStart, setSelectionStart] = useState<number | null>(null);
-    const [selectionEnd, setSelectionEnd] = useState<number | null>(null);
-    const chartRef = useRef<HTMLDivElement>(null);
+	// Brush/zoom state
+	const [brushRange, setBrushRange] = useState<{
+		startIndex?: number;
+		endIndex?: number;
+	} | null>(null);
+	const [isSelecting, setIsSelecting] = useState(false);
+	const [selectionStart, setSelectionStart] = useState<string | null>(null);
+	const [selectionEnd, setSelectionEnd] = useState<string | null>(null);
 
-    useEffect(() => {
-        fetchData();
-    }, [nodeId, metricId, period, customRange]);
+	useEffect(() => {
+		fetchData();
+	}, [nodeId, metricId, period, customRange]);
 
-    // Reset brush when period or customRange changes
-    useEffect(() => {
-        setBrushRange(null);
-        setSelectionStart(null);
-        setSelectionEnd(null);
-    }, [period, customRange]);
+	// Reset brush when period or customRange changes
+	useEffect(() => {
+		setBrushRange(null);
+		setSelectionStart(null);
+		setSelectionEnd(null);
+	}, [period, customRange]);
 
-    const fetchData = () => {
-        setLoading(true);
+	const fetchData = () => {
+		setLoading(true);
 
-        let url = `/metrics/${nodeId}/${metricId}/history?limit=1000`;
-        if (customRange) {
-            url += `&start_time=${customRange.start}&end_time=${customRange.end}`;
-        } else {
-            url += `&hours=${period}`;
-        }
+		console.log(
+			`[MetricHistoryChart] Fetching history for ${nodeId}/${metricId}`,
+		);
 
-        console.log(`[MetricHistoryChart] Fetching: ${url}`);
+		fetchNodeMetricHistory({
+			nodeId,
+			metricId,
+			limit: 1000,
+			startTime: customRange?.start,
+			endTime: customRange?.end,
+			hours: customRange ? undefined : period,
+		})
+			.then((jsonData) => {
+				if (!Array.isArray(jsonData)) {
+					console.warn(
+						"[MetricHistoryChart] Received non-array data:",
+						jsonData,
+					);
+					setLoading(false);
+					return;
+				}
 
-        api.get<any[]>(url)
-            .then(jsonData => {
-                if (!Array.isArray(jsonData)) {
-                    console.warn("[MetricHistoryChart] Received non-array data:", jsonData);
-                    setLoading(false);
-                    return;
-                }
+				const sorted = jsonData.sort(
+					(a: any, b: any) =>
+						new Date(a.time).getTime() - new Date(b.time).getTime(),
+				);
+				const formatted = sorted.map((d: any) => ({
+					...d,
+					value: typeof d.value === "string" ? parseFloat(d.value) : d.value,
+					displayTime: new Date(d.time).toLocaleTimeString([], {
+						hour: "2-digit",
+						minute: "2-digit",
+						day: "numeric",
+						month: "short",
+					}),
+					rawTime: d.time,
+				}));
 
-                const sorted = jsonData.sort((a: any, b: any) => new Date(a.time).getTime() - new Date(b.time).getTime());
-                const formatted = sorted.map((d: any) => ({
-                    ...d,
-                    value: typeof d.value === 'string' ? parseFloat(d.value) : d.value,
-                    displayTime: new Date(d.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', day: 'numeric', month: 'short' }),
-                    rawTime: d.time
-                }));
+				console.log(`[MetricHistoryChart] Loaded ${formatted.length} points`);
+				setData(formatted);
+				setLoading(false);
+			})
+			.catch((err) => {
+				console.error("Failed to fetch metric history", err);
+				setLoading(false);
+			});
+	};
 
-                console.log(`[MetricHistoryChart] Loaded ${formatted.length} points`);
-                setData(formatted);
-                setLoading(false);
-            })
-            .catch(err => {
-                console.error("Failed to fetch metric history", err);
-                setLoading(false);
-            });
-    };
+	const handleResetView = () => {
+		setBrushRange(null);
+		setSelectionStart(null);
+		setSelectionEnd(null);
+		setIsSelecting(false);
+	};
 
-    const handleResetView = () => {
-        setBrushRange(null);
-        setSelectionStart(null);
-        setSelectionEnd(null);
-        setIsSelecting(false);
-    };
+	// Mouse handlers for drag-to-zoom
+	const handleMouseDown = useCallback((e: any) => {
+		if (!e || !e.activeLabel) return;
+		setIsSelecting(true);
+		setSelectionStart(e.activeLabel);
+		setSelectionEnd(e.activeLabel);
+	}, []);
 
-    // Mouse handlers for drag-to-zoom
-    const handleMouseDown = useCallback((e: any) => {
-        if (!e || !e.activeLabel) return;
-        setIsSelecting(true);
-        setSelectionStart(e.activeLabel);
-        setSelectionEnd(e.activeLabel);
-    }, []);
+	const handleMouseMove = useCallback(
+		(e: any) => {
+			if (!isSelecting || !e || !e.activeLabel) return;
+			setSelectionEnd(e.activeLabel);
+		},
+		[isSelecting],
+	);
 
-    const handleMouseMove = useCallback((e: any) => {
-        if (!isSelecting || !e || !e.activeLabel) return;
-        setSelectionEnd(e.activeLabel);
-    }, [isSelecting]);
+	const handleMouseUp = useCallback(() => {
+		if (!isSelecting || selectionStart === null || selectionEnd === null) {
+			setIsSelecting(false);
+			return;
+		}
 
-    const handleMouseUp = useCallback(() => {
-        if (!isSelecting || selectionStart === null || selectionEnd === null) {
-            setIsSelecting(false);
-            return;
-        }
+		// Find indices in data
+		const startIdx = data.findIndex((d) => d.displayTime === selectionStart);
+		const endIdx = data.findIndex((d) => d.displayTime === selectionEnd);
 
-        // Find indices in data
-        const startIdx = data.findIndex(d => d.displayTime === selectionStart);
-        const endIdx = data.findIndex(d => d.displayTime === selectionEnd);
+		if (startIdx !== -1 && endIdx !== -1) {
+			const [minIdx, maxIdx] =
+				startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
+			// Only apply if selection is meaningful (at least 2 points)
+			if (maxIdx - minIdx >= 2) {
+				setBrushRange({ startIndex: minIdx, endIndex: maxIdx });
+			}
+		}
 
-        if (startIdx !== -1 && endIdx !== -1) {
-            const [minIdx, maxIdx] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
-            // Only apply if selection is meaningful (at least 2 points)
-            if (maxIdx - minIdx >= 2) {
-                setBrushRange({ startIndex: minIdx, endIndex: maxIdx });
-            }
-        }
+		setIsSelecting(false);
+		setSelectionStart(null);
+		setSelectionEnd(null);
+	}, [isSelecting, selectionStart, selectionEnd, data]);
 
-        setIsSelecting(false);
-        setSelectionStart(null);
-        setSelectionEnd(null);
-    }, [isSelecting, selectionStart, selectionEnd, data]);
+	// Filter data based on brush selection
+	const displayData =
+		brushRange &&
+		brushRange.startIndex !== undefined &&
+		brushRange.endIndex !== undefined
+			? data.slice(brushRange.startIndex, brushRange.endIndex + 1)
+			: data;
 
-    // Filter data based on brush selection
-    const displayData = brushRange && brushRange.startIndex !== undefined && brushRange.endIndex !== undefined
-        ? data.slice(brushRange.startIndex, brushRange.endIndex + 1)
-        : data;
+	const hasBrushApplied = brushRange !== null;
 
-    const hasBrushApplied = brushRange !== null;
+	const renderContent = () => {
+		if (loading && data.length === 0) {
+			return (
+				<div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
+					LOADING METRICS...
+				</div>
+			);
+		}
 
-    const renderContent = () => {
-        if (loading && data.length === 0) {
-            return (
-                <div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
-                    LOADING METRICS...
-                </div>
-            );
-        }
+		if (!loading && data.length === 0) {
+			return (
+				<div className="flex-1 flex flex-col items-center justify-center text-neutral-500">
+					<span className="material-symbols-outlined text-4xl mb-2 opacity-50">
+						data_loss_prevention
+					</span>
+					<p className="text-sm font-mono uppercase">No telemetry data found</p>
+					<p className="text-xs opacity-50 mt-1">
+						Try adjusting the time range
+					</p>
+				</div>
+			);
+		}
 
-        if (!loading && data.length === 0) {
-            return (
-                <div className="flex-1 flex flex-col items-center justify-center text-neutral-500">
-                    <span className="material-symbols-outlined text-4xl mb-2 opacity-50">data_loss_prevention</span>
-                    <p className="text-sm font-mono uppercase">No telemetry data found</p>
-                    <p className="text-xs opacity-50 mt-1">Try adjusting the time range</p>
-                </div>
-            );
-        }
+		return (
+			<div
+				className="flex-1 w-full min-h-0 relative"
+				style={{ minWidth: 0, minHeight: 0 }}
+			>
+				<ResponsiveContainer width="99%" height="99%">
+					<AreaChart
+						data={displayData}
+						margin={{
+							top: 10,
+							right: 10,
+							left: -20,
+							bottom: hasBrushApplied ? 50 : 0,
+						}}
+						onMouseDown={handleMouseDown}
+						onMouseMove={handleMouseMove}
+						onMouseUp={handleMouseUp}
+						onMouseLeave={() => setIsSelecting(false)}
+					>
+						<defs>
+							<linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
+								<stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.3} />
+								<stop offset="95%" stopColor="#0ea5e9" stopOpacity={0} />
+							</linearGradient>
+						</defs>
+						<CartesianGrid
+							strokeDasharray="3 3"
+							stroke="#ffffff10"
+							vertical={false}
+						/>
+						<XAxis
+							dataKey="displayTime"
+							stroke="#525252"
+							tick={{ fill: "#525252", fontSize: 10 }}
+							tickLine={false}
+							axisLine={false}
+							minTickGap={30}
+						/>
+						<YAxis
+							stroke="#525252"
+							tick={{ fill: "#525252", fontSize: 10 }}
+							tickLine={false}
+							axisLine={false}
+							width={30}
+						/>
+						<Tooltip
+							contentStyle={{
+								backgroundColor: "#171717",
+								borderColor: "#333",
+								borderRadius: "8px",
+								fontSize: "12px",
+							}}
+							itemStyle={{ color: "#fff" }}
+							labelStyle={{ color: "#a3a3a3", marginBottom: "4px" }}
+							formatter={(value) => [
+								`${value}${unit ? ` ${unit}` : ""}`,
+								metricName,
+							]}
+						/>
+						<Area
+							type="monotone"
+							dataKey="value"
+							stroke="#0ea5e9"
+							strokeWidth={2}
+							fillOpacity={1}
+							fill="url(#colorValue)"
+						/>
+						{/* Selection rectangle overlay */}
+						{isSelecting && selectionStart && selectionEnd && (
+							<ReferenceArea
+								x1={selectionStart}
+								x2={selectionEnd}
+								strokeOpacity={0.3}
+								fill="#0ea5e9"
+								fillOpacity={0.2}
+							/>
+						)}
+						{/* Brush component at bottom for direct range selection */}
+						{data.length > 0 && (
+							<Brush
+								dataKey="displayTime"
+								height={30}
+								stroke="#525252"
+								fill="#171717"
+								tickFormatter={() => ""}
+								startIndex={brushRange?.startIndex}
+								endIndex={brushRange?.endIndex}
+								onChange={(range: any) => {
+									if (
+										range.startIndex !== undefined &&
+										range.endIndex !== undefined
+									) {
+										setBrushRange({
+											startIndex: range.startIndex,
+											endIndex: range.endIndex,
+										});
+									}
+								}}
+							/>
+						)}
+					</AreaChart>
+				</ResponsiveContainer>
+			</div>
+		);
+	};
 
-        return (
-            <div className="flex-1 w-full min-h-0 relative" style={{ minWidth: 0, minHeight: 0 }}>
-                <ResponsiveContainer width="99%" height="99%">
-                    <AreaChart
-                        data={displayData}
-                        margin={{ top: 10, right: 10, left: -20, bottom: hasBrushApplied ? 50 : 0 }}
-                        onMouseDown={handleMouseDown}
-                        onMouseMove={handleMouseMove}
-                        onMouseUp={handleMouseUp}
-                        onMouseLeave={() => setIsSelecting(false)}
-                    >
-                        <defs>
-                            <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
-                                <stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.3} />
-                                <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0} />
-                            </linearGradient>
-                        </defs>
-                        <CartesianGrid strokeDasharray="3 3" stroke="#ffffff10" vertical={false} />
-                        <XAxis
-                            dataKey="displayTime"
-                            stroke="#525252"
-                            tick={{ fill: '#525252', fontSize: 10 }}
-                            tickLine={false}
-                            axisLine={false}
-                            minTickGap={30}
-                        />
-                        <YAxis
-                            stroke="#525252"
-                            tick={{ fill: '#525252', fontSize: 10 }}
-                            tickLine={false}
-                            axisLine={false}
-                            width={30}
-                        />
-                        <Tooltip
-                            contentStyle={{ backgroundColor: '#171717', borderColor: '#333', borderRadius: '8px', fontSize: '12px' }}
-                            itemStyle={{ color: '#fff' }}
-                            labelStyle={{ color: '#a3a3a3', marginBottom: '4px' }}
-                        />
-                        <Area
-                            type="monotone"
-                            dataKey="value"
-                            stroke="#0ea5e9"
-                            strokeWidth={2}
-                            fillOpacity={1}
-                            fill="url(#colorValue)"
-                        />
-                        {/* Selection rectangle overlay */}
-                        {isSelecting && selectionStart && selectionEnd && (
-                            <ReferenceArea
-                                x1={selectionStart}
-                                x2={selectionEnd}
-                                strokeOpacity={0.3}
-                                fill="#0ea5e9"
-                                fillOpacity={0.2}
-                            />
-                        )}
-                        {/* Brush component at bottom for direct range selection */}
-                        {data.length > 0 && (
-                            <Brush
-                                dataKey="displayTime"
-                                height={30}
-                                stroke="#525252"
-                                fill="#171717"
-                                tickFormatter={() => ''}
-                                startIndex={brushRange?.startIndex}
-                                endIndex={brushRange?.endIndex}
-                                onChange={(range: any) => {
-                                    if (range.startIndex !== undefined && range.endIndex !== undefined) {
-                                        setBrushRange({ startIndex: range.startIndex, endIndex: range.endIndex });
-                                    }
-                                }}
-                            />
-                        )}
-                    </AreaChart>
-                </ResponsiveContainer>
-            </div>
-        );
-    };
+	return (
+		<div className="bg-surface-800 rounded-xl p-6 border border-white/5 shadow-inner flex flex-col h-full min-h-[300px]">
+			<div className="flex justify-between items-center mb-6 flex-shrink-0">
+				<div>
+					<h3 className="text-white font-bold uppercase tracking-tight">
+						{metricName} History
+					</h3>
+					<p className="text-xs text-neutral-500">
+						{hasBrushApplied
+							? `Zoomed: ${displayData.length} points selected`
+							: customRange
+								? `${new Date(customRange.start).toLocaleDateString()} - ${new Date(customRange.end).toLocaleDateString()}`
+								: `Past ${period} Hours`}
+					</p>
+				</div>
+				<div className="flex items-center gap-2">
+					{hasBrushApplied && (
+						<button
+							onClick={handleResetView}
+							className="flex items-center gap-1 px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-xs font-bold transition-all text-neutral-300"
+							title="Reset zoom (drag to select range, or use slider)"
+						>
+							<span className="material-symbols-outlined text-sm">
+								restart_alt
+							</span>
+							Reset View
+						</button>
+					)}
+					{!customRange && (
+						<div className="flex bg-black/20 rounded-lg p-1 gap-1">
+							{[1, 6, 24, 32, 72].map((h) => (
+								<button
+									key={h}
+									onClick={() => setPeriod(h)}
+									className={`px-3 py-1 rounded-md text-[10px] font-bold transition-all ${period === h && !hasBrushApplied ? "bg-brand-600 text-white shadow" : "text-neutral-500 hover:text-white hover:bg-white/5"}`}
+								>
+									{h}H
+								</button>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
 
-    return (
-        <div className="bg-surface-800 rounded-xl p-6 border border-white/5 shadow-inner flex flex-col h-full min-h-[300px]">
-            <div className="flex justify-between items-center mb-6 flex-shrink-0">
-                <div>
-                    <h3 className="text-white font-bold uppercase tracking-tight">{metricName} History</h3>
-                    <p className="text-xs text-neutral-500">
-                        {hasBrushApplied
-                            ? `Zoomed: ${displayData.length} points selected`
-                            : customRange
-                                ? `${new Date(customRange.start).toLocaleDateString()} - ${new Date(customRange.end).toLocaleDateString()}`
-                                : `Past ${period} Hours`
-                        }
-                    </p>
-                </div>
-                <div className="flex items-center gap-2">
-                    {hasBrushApplied && (
-                        <button
-                            onClick={handleResetView}
-                            className="flex items-center gap-1 px-3 py-1.5 bg-white/10 hover:bg-white/20 rounded-lg text-xs font-bold transition-all text-neutral-300"
-                            title="Reset zoom (drag to select range, or use slider)"
-                        >
-                            <span className="material-symbols-outlined text-sm">restart_alt</span>
-                            Reset View
-                        </button>
-                    )}
-                    {!customRange && (
-                        <div className="flex bg-black/20 rounded-lg p-1 gap-1">
-                            {[1, 6, 24, 32, 72].map(h => (
-                                <button
-                                    key={h}
-                                    onClick={() => setPeriod(h)}
-                                    className={`px-3 py-1 rounded-md text-[10px] font-bold transition-all ${period === h && !hasBrushApplied ? 'bg-brand-600 text-white shadow' : 'text-neutral-500 hover:text-white hover:bg-white/5'}`}
-                                >
-                                    {h}H
-                                </button>
-                            ))}
-                        </div>
-                    )}
-                </div>
-            </div>
+			{renderContent()}
 
-            {renderContent()}
-
-            {/* Instructions hint */}
-            {hasBrushApplied && (
-                <p className="text-[10px] text-neutral-600 text-center mt-2">
-                    Drag on chart or use slider below to zoom • Click "Reset View" to restore
-                </p>
-            )}
-        </div>
-    );
+			{/* Instructions hint */}
+			{hasBrushApplied && (
+				<p className="text-[10px] text-neutral-600 text-center mt-2">
+					Drag on chart or use slider below to zoom • Click "Reset View" to
+					restore
+				</p>
+			)}
+		</div>
+	);
 };
 
 export default MetricHistoryChart;

--- a/frontend/components/MultiMetricChart.tsx
+++ b/frontend/components/MultiMetricChart.tsx
@@ -1,52 +1,56 @@
-import React from 'react';
-import ChartPanel from './ChartPanel';
-import { NodeMetricData } from '../types';
+import React from "react";
+import ChartPanel from "./ChartPanel";
+import { NodeMetricData } from "../types";
 
 interface BrushRange {
-  startIndex?: number;
-  endIndex?: number;
+	startTime?: string;
+	endTime?: string;
 }
 
 interface MultiMetricChartProps {
-  nodeData: NodeMetricData[];
-  brushRange: BrushRange | null;
-  onBrushChange: (range: BrushRange | null) => void;
-  metricName?: string;
-  unit?: string;
+	nodeData: NodeMetricData[];
+	brushRange: BrushRange | null;
+	onBrushChange: (range: BrushRange | null) => void;
+	metricName?: string;
+	unit?: string;
 }
 
 const MultiMetricChart: React.FC<MultiMetricChartProps> = ({
-  nodeData,
-  brushRange,
-  onBrushChange,
-  metricName,
-  unit,
+	nodeData,
+	brushRange,
+	onBrushChange,
+	metricName,
+	unit,
 }) => {
-  if (nodeData.length === 0) {
-    return (
-      <div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
-        <span className="material-symbols-outlined text-6xl mb-4 opacity-20">analytics</span>
-        <p className="font-bold uppercase tracking-widest">Select CIs to Compare</p>
-      </div>
-    );
-  }
+	if (nodeData.length === 0) {
+		return (
+			<div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
+				<span className="material-symbols-outlined text-6xl mb-4 opacity-20">
+					analytics
+				</span>
+				<p className="font-bold uppercase tracking-widest">
+					Select CIs to Compare
+				</p>
+			</div>
+		);
+	}
 
-  return (
-    <div className="flex flex-col gap-4 h-full overflow-y-auto">
-      {nodeData.map((node) => (
-        <ChartPanel
-          key={node.node_id}
-          nodeId={node.node_id}
-          label={node.label}
-          data={node.data}
-          brushRange={brushRange}
-          onBrushChange={onBrushChange}
-          unit={unit}
-          metricName={metricName}
-        />
-      ))}
-    </div>
-  );
+	return (
+		<div className="flex flex-col gap-4 h-full overflow-y-auto">
+			{nodeData.map((node) => (
+				<ChartPanel
+					key={node.node_id}
+					nodeId={node.node_id}
+					label={node.label}
+					data={node.data}
+					brushRange={brushRange}
+					onBrushChange={onBrushChange}
+					unit={node.unit ?? unit}
+					metricName={node.metricName ?? metricName}
+				/>
+			))}
+		</div>
+	);
 };
 
 export default MultiMetricChart;

--- a/frontend/components/__tests__/ChartPanel.test.tsx
+++ b/frontend/components/__tests__/ChartPanel.test.tsx
@@ -75,7 +75,7 @@ describe('ChartPanel', () => {
         nodeId="ci-001"
         label="Router-01"
         data={SAMPLE_DATA}
-        brushRange={{ startIndex: 0, endIndex: 2 }}
+        brushRange={{ startTime: '2026-05-12T10:00:00Z', endTime: '2026-05-12T10:01:00Z' }}
         onBrushChange={vi.fn()}
       />
     );
@@ -89,7 +89,7 @@ describe('ChartPanel', () => {
         nodeId="ci-001"
         label="Router-01"
         data={SAMPLE_DATA}
-        brushRange={{ startIndex: 0, endIndex: 2 }}
+        brushRange={{ startTime: '2026-05-12T10:00:00Z', endTime: '2026-05-12T10:01:00Z' }}
         onBrushChange={vi.fn()}
       />
     );
@@ -104,7 +104,7 @@ describe('ChartPanel', () => {
         nodeId="ci-001"
         label="Router-01"
         data={SAMPLE_DATA}
-        brushRange={{ startIndex: 0, endIndex: 2 }}
+        brushRange={{ startTime: '2026-05-12T10:00:00Z', endTime: '2026-05-12T10:01:00Z' }}
         onBrushChange={onBrushChange}
       />
     );

--- a/frontend/components/__tests__/MultiMetricChart.test.tsx
+++ b/frontend/components/__tests__/MultiMetricChart.test.tsx
@@ -81,7 +81,7 @@ describe('MultiMetricChart', () => {
     render(
       <MultiMetricChart
         nodeData={SAMPLE_NODE_DATA}
-        brushRange={{ startIndex: 0, endIndex: 1 }}
+        brushRange={{ startTime: '2026-05-12T10:00:00Z', endTime: '2026-05-12T10:00:30Z' }}
         onBrushChange={onBrushChange}
       />
     );

--- a/frontend/services/queryResources.test.ts
+++ b/frontend/services/queryResources.test.ts
@@ -1,61 +1,104 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { fetchNodesSearch } from './queryResources';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fetchNodeMetricHistory, fetchNodesSearch } from "./queryResources";
 
 const { mockApiGet } = vi.hoisted(() => ({
-  mockApiGet: vi.fn(),
+	mockApiGet: vi.fn(),
 }));
 
-vi.mock('./api', () => ({
-  api: {
-    get: mockApiGet,
-  },
+vi.mock("./api", () => ({
+	api: {
+		get: mockApiGet,
+	},
 }));
 
-describe('fetchNodesSearch', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    mockApiGet.mockReset();
-  });
+describe("fetchNodesSearch", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mockApiGet.mockReset();
+	});
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+	afterEach(() => {
+		vi.useRealTimers();
+	});
 
-  it('calls /nodes/search with q query param', async () => {
-    mockApiGet.mockResolvedValue([
-      { id: 'CI-001', label: 'Router', status: 'OK', ip: '192.168.1.1' }
-    ]);
+	it("calls /nodes/search with q query param", async () => {
+		mockApiGet.mockResolvedValue([
+			{ id: "CI-001", label: "Router", status: "OK", ip: "192.168.1.1" },
+		]);
 
-    await fetchNodesSearch({ q: 'router' });
+		await fetchNodesSearch({ q: "router" });
 
-    expect(mockApiGet).toHaveBeenCalledWith('/nodes/search?q=router', { signal: undefined });
-  });
+		expect(mockApiGet).toHaveBeenCalledWith("/nodes/search?q=router", {
+			signal: undefined,
+		});
+	});
 
-  it('forwards abort signal', async () => {
-    mockApiGet.mockResolvedValue([]);
-    const signal = new AbortController().signal;
+	it("forwards abort signal", async () => {
+		mockApiGet.mockResolvedValue([]);
+		const signal = new AbortController().signal;
 
-    await fetchNodesSearch({ q: 'server', signal });
+		await fetchNodesSearch({ q: "server", signal });
 
-    expect(mockApiGet).toHaveBeenCalledWith('/nodes/search?q=server', { signal });
-  });
+		expect(mockApiGet).toHaveBeenCalledWith("/nodes/search?q=server", {
+			signal,
+		});
+	});
 
-  it('returns array of nodes on success', async () => {
-    const mockNodes = [
-      { id: 'CI-001', label: 'Core Router', ip: '192.168.1.1', status: 'OK', brand: 'Cisco', model: 'ASR-1000' },
-      { id: 'CI-002', label: 'Backup Router', ip: '192.168.1.2', status: 'ACTIVE', brand: 'Juniper', model: 'MX204' },
-    ];
-    mockApiGet.mockResolvedValue(mockNodes);
+	it("returns array of nodes on success", async () => {
+		const mockNodes = [
+			{
+				id: "CI-001",
+				label: "Core Router",
+				ip: "192.168.1.1",
+				status: "OK",
+				brand: "Cisco",
+				model: "ASR-1000",
+			},
+			{
+				id: "CI-002",
+				label: "Backup Router",
+				ip: "192.168.1.2",
+				status: "ACTIVE",
+				brand: "Juniper",
+				model: "MX204",
+			},
+		];
+		mockApiGet.mockResolvedValue(mockNodes);
 
-    const result = await fetchNodesSearch({ q: 'router' });
+		const result = await fetchNodesSearch({ q: "router" });
 
-    expect(result).toEqual(mockNodes);
-    expect(mockApiGet).toHaveBeenCalledTimes(1);
-  });
+		expect(result).toEqual(mockNodes);
+		expect(mockApiGet).toHaveBeenCalledTimes(1);
+	});
 
-  it('throws ApiError for non-2xx responses', async () => {
-    mockApiGet.mockRejectedValue(new Error('Query must be at least 2 characters'));
+	it("throws ApiError for non-2xx responses", async () => {
+		mockApiGet.mockRejectedValue(
+			new Error("Query must be at least 2 characters"),
+		);
 
-    await expect(fetchNodesSearch({ q: 'a' })).rejects.toThrow('Query must be at least 2 characters');
-  });
+		await expect(fetchNodesSearch({ q: "a" })).rejects.toThrow(
+			"Query must be at least 2 characters",
+		);
+	});
+});
+
+describe("fetchNodeMetricHistory", () => {
+	beforeEach(() => {
+		mockApiGet.mockReset();
+	});
+
+	it("calls single-node metric history endpoint with encoded params", async () => {
+		mockApiGet.mockResolvedValue([]);
+
+		await fetchNodeMetricHistory({
+			nodeId: "CI 001",
+			metricId: "cpu/load",
+			hours: 24,
+		});
+
+		expect(mockApiGet).toHaveBeenCalledWith(
+			"/metrics/CI%20001/cpu%2Fload/history?limit=1000&hours=24",
+			{ signal: undefined },
+		);
+	});
 });

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -59,8 +59,30 @@ export const fetchGraphTopology = ({ signal }: { signal?: AbortSignal } = {}) =>
 export const fetchOwners = ({ signal }: { signal?: AbortSignal } = {}) =>
   api.get<OwnerRecord[]>('/owners', { signal });
 
-export const fetchNodesSearch = ({ q, signal }: { q: string; signal?: AbortSignal } = {}) =>
+export const fetchNodesSearch = ({ q, signal }: { q: string; signal?: AbortSignal }) =>
   api.get<GraphNode[]>(`/nodes/search?q=${encodeURIComponent(q)}`, { signal });
+
+export interface FetchNodeMetricHistoryOptions {
+  nodeId: string;
+  metricId: string;
+  hours?: number;
+  startTime?: string;
+  endTime?: string;
+  limit?: number;
+  signal?: AbortSignal;
+}
+
+export const fetchNodeMetricHistory = async (options: FetchNodeMetricHistoryOptions): Promise<Array<{ time: string; value: number | string }>> => {
+  const { nodeId, metricId, hours, startTime, endTime, limit = 1000, signal } = options;
+  const params = new URLSearchParams();
+  params.set('limit', String(limit));
+  if (hours !== undefined) params.set('hours', String(hours));
+  if (startTime) params.set('start_time', startTime);
+  if (endTime) params.set('end_time', endTime);
+
+  const url = `/metrics/${encodeURIComponent(nodeId)}/${encodeURIComponent(metricId)}/history?${params.toString()}`;
+  return api.get<Array<{ time: string; value: number | string }>>(url, { signal });
+};
 
 export interface FetchMetricsHistoryOptions {
   nodeIds: string[];

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -188,6 +188,8 @@ export interface DataPoint {
 export interface NodeMetricData {
   node_id: string;
   label: string;
+  metricName?: string;
+  unit?: string;
   data: DataPoint[];
 }
 


### PR DESCRIPTION
Closes #166

Extends #165.

## Descripción del Cambio
Amplía Metric Analytics para soportar CIs heterogéneos antes de homologar métricas entre marcas/modelos.

- Corrige `MetricHistoryChart` para usar `fetchNodeMetricHistory()` en lugar de un `api` indefinido.
- Permite seleccionar métrica principal por cada CI seleccionado.
- Permite seleccionar métrica secundaria por cada CI seleccionado.
- Cambia el brush/zoom compartido a rango por timestamp (`startTime`/`endTime`) para evitar comparar ventanas desalineadas cuando cada CI tiene distinta cadencia o cantidad de muestras.
- Actualiza `CHANGELOG.md` bajo `Unreleased`; no se crea release nuevo.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Size Exception
- [x] Aceptamos `size:exception`: el diff supera el presupuesto de 400 líneas, pero el cambio fue limpiado, es cohesivo, y pasó Judgment Day dual review.

## ¿Cómo se probó?
- [x] `cd frontend && pnpm test:run components/MetricAnalytics.test.tsx services/queryResources.test.ts components/__tests__/ChartPanel.test.tsx components/__tests__/MultiMetricChart.test.tsx`
- [x] LSP diagnostics sin errores en archivos tocados
- [x] Judgment Day: Judge A PASS + Judge B PASS

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
