### PR TITLE
fix(analytics): prevent responsive overflow

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -107,7 +107,7 @@ const MainLayout: React.FC = () => {
   };
 
   return (
-    <div className="flex h-screen w-screen overflow-hidden bg-surface-950 font-sans text-neutral-200">
+    <div className="flex h-screen w-full max-w-full overflow-hidden bg-surface-950 font-sans text-neutral-200">
       {/* Sidebar Nav */}
       <nav className="w-20 lg:w-64 border-r border-white/5 flex flex-col glass z-50">
         <div className="p-6 flex items-center gap-3">
@@ -156,7 +156,7 @@ const MainLayout: React.FC = () => {
       </nav>
 
       {/* Main View Area */}
-      <div className="flex-1 flex flex-col relative overflow-hidden">
+      <div className="flex-1 min-w-0 flex flex-col relative overflow-hidden">
         <header className="h-20 border-b border-white/5 flex items-center justify-between px-8 glass z-40">
           <div className="flex items-center gap-4">
             <h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">Platform Engine v3.2</h1>
@@ -178,8 +178,8 @@ const MainLayout: React.FC = () => {
           </div>
         </header>
 
-        <main className="flex-1 flex overflow-hidden relative">
-          <div className="flex-1 h-full relative overflow-hidden">
+        <main className="flex-1 min-w-0 flex overflow-hidden relative">
+          <div className="flex-1 min-w-0 h-full relative overflow-hidden">
             <Routes>
               <Route index element={<SystemDashboard />} />
               <Route path="monitoring" element={<MonitoringConsole />} />

--- a/frontend/components/ChartPanel.tsx
+++ b/frontend/components/ChartPanel.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from "react";
+import type React from "react";
+import { useMemo } from "react";
 import {
 	AreaChart,
 	Area,
@@ -73,24 +74,24 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 	const hasData = data.length > 0;
 
 	return (
-		<div className="bg-surface-800 rounded-xl p-6 border border-white/5 shadow-inner flex flex-col h-full min-h-[250px]">
-			<div className="flex justify-between items-center mb-4 flex-shrink-0">
-				<div>
-					<h4 className="text-white font-bold uppercase tracking-tight">
+		<div className="flex h-full min-h-[250px] min-w-0 max-w-full flex-col rounded-xl border border-white/5 bg-surface-800 p-4 shadow-inner md:p-6">
+			<div className="mb-4 flex min-w-0 flex-shrink-0 items-center justify-between gap-3">
+				<div className="min-w-0">
+					<h4 className="truncate font-bold uppercase tracking-tight text-white">
 						{label}
 					</h4>
 					{metricName && (
-						<p className="text-[10px] text-brand-300 font-mono uppercase mt-0.5">
+						<p className="mt-0.5 truncate font-mono text-[10px] uppercase text-brand-300">
 							{metricName}
 						</p>
 					)}
-					<p className="text-xs text-neutral-500">
+					<p className="truncate text-xs text-neutral-500">
 						{hasBrushApplied
 							? `${displayData.length} points selected`
 							: `${data.length} data points`}
 					</p>
 				</div>
-				<div className="flex items-center gap-2">
+				<div className="flex shrink-0 items-center gap-2">
 					{hasBrushApplied && (
 						<button
 							onClick={handleResetView}
@@ -114,7 +115,7 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 				</div>
 			) : (
 				<div
-					className="flex-1 w-full min-h-0 relative"
+					className="relative min-h-0 w-full min-w-0 flex-1"
 					style={{ minWidth: 0, minHeight: 0 }}
 				>
 					<ResponsiveContainer width="99%" height="99%">

--- a/frontend/components/MetricAnalytics.test.tsx
+++ b/frontend/components/MetricAnalytics.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor, cleanup } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MetricAnalytics from "./MetricAnalytics";
-import { GraphNode } from "../types";
+import type { GraphNode } from "../types";
 
 const {
 	mockFetchNodes,
@@ -289,6 +289,127 @@ describe("MetricAnalytics", () => {
 					}),
 				);
 			});
+		});
+	});
+
+	describe("responsive layout guards", () => {
+		it("renders multi-CI controls with overflow guards for long labels", async () => {
+			vi.useRealTimers();
+			const longNodes: GraphNode[] = [
+				{
+					id: "CI-LONG-001",
+					label:
+						"Core Router With An Extremely Long Human Readable Name That Should Not Force Horizontal Overflow 001",
+					type: "INFRASTRUCTURE",
+					status: "OK",
+					metadata: {},
+					ip: "10.10.10.1",
+					brand: "VeryLongNetworkVendorName",
+					model: "VeryLongModelIdentifier-AAAAAAAAAAAAAAAAAAAAAAAA",
+					metrics: [
+						{
+							name: "primary-throughput-metric-with-a-very-long-name",
+							protocol: "snmp",
+							oid: "1.3.6.1.4.1.1",
+							value: "45",
+							status: "OK",
+							last_updated: "2026-05-11T10:00:00Z",
+						},
+						{
+							name: "secondary-latency-metric-with-a-very-long-name",
+							protocol: "snmp",
+							oid: "1.3.6.1.4.1.2",
+							value: "60",
+							status: "OK",
+							last_updated: "2026-05-11T10:00:00Z",
+						},
+					],
+				},
+				{
+					id: "CI-LONG-002",
+					label:
+						"Backup Router With Another Extremely Long Human Readable Name That Should Truncate 002",
+					type: "INFRASTRUCTURE",
+					status: "OK",
+					metadata: {},
+					ip: "10.10.10.2",
+					brand: "AnotherVeryLongNetworkVendorName",
+					model: "VeryLongModelIdentifier-BBBBBBBBBBBBBBBBBBBBBBBB",
+					metrics: [
+						{
+							name: "primary-packet-loss-metric-with-a-very-long-name",
+							protocol: "snmp",
+							oid: "1.3.6.1.4.1.3",
+							value: "12",
+							status: "OK",
+							last_updated: "2026-05-11T10:00:00Z",
+						},
+						{
+							name: "secondary-cpu-pressure-metric-with-a-very-long-name",
+							protocol: "snmp",
+							oid: "1.3.6.1.4.1.4",
+							value: "18",
+							status: "OK",
+							last_updated: "2026-05-11T10:00:00Z",
+						},
+					],
+				},
+			];
+			mockFetchNodes.mockResolvedValue(longNodes);
+			mockFetchNodeMetricHistory.mockResolvedValue([]);
+
+			const { container } = render(<MetricAnalytics />);
+
+			await waitFor(() =>
+				expect(screen.getByText(longNodes[0].label)).toBeInTheDocument(),
+			);
+
+			await act(async () => {
+				screen.getByText(longNodes[0].label).click();
+			});
+			await act(async () => {
+				screen.getByText(longNodes[1].label).click();
+			});
+
+			await waitFor(() =>
+				expect(screen.getByText("Metric per CI")).toBeInTheDocument(),
+			);
+
+			expect(container.firstElementChild).toHaveClass(
+				"min-w-0",
+				"max-w-full",
+				"overflow-x-hidden",
+				"overflow-y-auto",
+			);
+			expect(
+				screen.getByText("Metric per CI").closest(".col-span-12"),
+			).toHaveClass("min-w-0", "max-w-full", "overflow-x-hidden");
+
+			const selectedChipLabel = screen
+				.getAllByText(longNodes[0].label)
+				.find(
+					(element) =>
+						element.tagName.toLowerCase() === "span" &&
+						element.className.includes("truncate"),
+				);
+			expect(selectedChipLabel).toHaveClass("min-w-0", "truncate");
+
+			await act(async () => {
+				screen
+					.getByRole("button", {
+						name: /toggle secondary metric comparison/i,
+					})
+					.click();
+			});
+
+			expect(
+				screen.getByText("Secondary Metrics Comparison"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", {
+					name: /toggle secondary metric comparison/i,
+				}),
+			).toHaveClass("shrink-0");
 		});
 	});
 

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { GraphNode, MetricValue, NodeMetricData } from "../types";
+import type React from "react";
+import { useState, useEffect } from "react";
+import type { GraphNode, MetricValue, NodeMetricData } from "../types";
 import MetricHistoryChart from "./MetricHistoryChart";
 import MultiSelectCIs from "./MultiSelectCIs";
 import MultiMetricChart from "./MultiMetricChart";
@@ -299,24 +300,24 @@ const MetricAnalytics: React.FC = () => {
 		.filter((node): node is GraphNode => Boolean(node));
 
 	return (
-		<div className="flex flex-col h-full bg-surface-950 text-white p-8 overflow-hidden">
-			<header className="mb-8 flex justify-between items-end">
-				<div>
-					<h1 className="text-3xl font-black uppercase tracking-tighter">
+		<div className="flex h-full min-w-0 max-w-full flex-col overflow-x-hidden overflow-y-auto bg-surface-950 p-4 text-white md:p-8">
+			<header className="mb-8 flex min-w-0 items-end justify-between gap-4">
+				<div className="min-w-0">
+					<h1 className="truncate text-3xl font-black uppercase tracking-tighter">
 						Metric Analytics
 					</h1>
-					<p className="text-neutral-500 font-mono text-sm mt-1">
+					<p className="mt-1 truncate font-mono text-sm text-neutral-500">
 						Historical Telemetry Visualization
 					</p>
 				</div>
 			</header>
 
-			<div className="grid grid-cols-12 gap-8 h-full">
+			<div className="grid min-w-0 max-w-full flex-1 grid-cols-12 gap-4 md:gap-8 lg:min-h-0">
 				{/* Controls Sidebar */}
-				<div className="col-span-12 lg:col-span-3 space-y-6 flex flex-col h-full overflow-hidden min-w-0">
+				<div className="col-span-12 flex min-w-0 max-w-full flex-col space-y-6 overflow-x-hidden lg:col-span-3 lg:h-full lg:overflow-y-auto lg:pr-1">
 					{/* Multi-CI Selector */}
-					<div className="bg-surface-900 border border-white/5 rounded-xl p-5">
-						<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">
+					<div className="min-w-0 max-w-full rounded-xl border border-white/5 bg-surface-900 p-5">
+						<label className="mb-2 block text-xs font-bold uppercase tracking-wider text-neutral-500">
 							Compare Multiple CIs
 						</label>
 						<MultiSelectCIs
@@ -328,18 +329,18 @@ const MetricAnalytics: React.FC = () => {
 					</div>
 
 					{/* Date Range Selector */}
-					<div className="bg-surface-900 border border-white/5 rounded-xl p-5">
-						<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-2 block">
+					<div className="min-w-0 max-w-full rounded-xl border border-white/5 bg-surface-900 p-5">
+						<label className="mb-2 block text-xs font-bold uppercase tracking-wider text-neutral-500">
 							Custom Time Range
 						</label>
-						<div className="space-y-3">
+						<div className="min-w-0 space-y-3">
 							<div>
 								<label className="text-[10px] text-neutral-400 block mb-1">
 									Start Date
 								</label>
 								<input
 									type="datetime-local"
-									className="w-full bg-black/40 border border-white/10 rounded-lg p-2 text-xs text-white outline-none focus:border-brand-500"
+									className="w-full min-w-0 max-w-full rounded-lg border border-white/10 bg-black/40 p-2 text-xs text-white outline-none focus:border-brand-500"
 									value={startDate}
 									onChange={(e) => setStartDate(e.target.value)}
 								/>
@@ -350,7 +351,7 @@ const MetricAnalytics: React.FC = () => {
 								</label>
 								<input
 									type="datetime-local"
-									className="w-full bg-black/40 border border-white/10 rounded-lg p-2 text-xs text-white outline-none focus:border-brand-500"
+									className="w-full min-w-0 max-w-full rounded-lg border border-white/10 bg-black/40 p-2 text-xs text-white outline-none focus:border-brand-500"
 									value={endDate}
 									onChange={(e) => setEndDate(e.target.value)}
 								/>
@@ -367,23 +368,23 @@ const MetricAnalytics: React.FC = () => {
 					</div>
 
 					{/* Metric Selector */}
-					<div className="bg-surface-900 border border-white/5 rounded-xl p-5 flex-1 overflow-y-auto min-h-0">
-						<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider mb-3 block">
+					<div className="min-w-0 max-w-full flex-1 overflow-y-auto rounded-xl border border-white/5 bg-surface-900 p-5 lg:min-h-0">
+						<label className="mb-3 block text-xs font-bold uppercase tracking-wider text-neutral-500">
 							{hasMultipleSelected ? "Metric per CI" : "Available Metrics"}
 						</label>
-						<div className="space-y-3">
+						<div className="min-w-0 space-y-3">
 							{hasMultipleSelected ? (
 								selectedNodes.map((node) => {
 									const metrics = node.metrics ?? [];
 									return (
 										<div
 											key={node.id}
-											className="rounded-lg border border-white/10 bg-white/[0.03] p-3"
+											className="min-w-0 max-w-full rounded-lg border border-white/10 bg-white/[0.03] p-3"
 										>
-											<p className="text-xs font-bold uppercase text-white truncate">
+											<p className="truncate text-xs font-bold uppercase text-white">
 												{node.label}
 											</p>
-											<p className="text-[10px] text-neutral-500 font-mono mb-2 truncate">
+											<p className="mb-2 truncate font-mono text-[10px] text-neutral-500">
 												{node.brand || "Unknown brand"} {node.model || ""}
 											</p>
 											{metrics.length > 0 ? (
@@ -399,7 +400,7 @@ const MetricAnalytics: React.FC = () => {
 														setMultiCiData([]);
 														setBrushRange(null);
 													}}
-													className="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:border-brand-500 outline-none transition-colors"
+													className="w-full min-w-0 max-w-full truncate rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-xs text-white outline-none transition-colors focus:border-brand-500"
 												>
 													{metrics.map((metric) => (
 														<option key={metric.name} value={metric.name}>
@@ -425,20 +426,22 @@ const MetricAnalytics: React.FC = () => {
 												setMultiCiData([]);
 												setBrushRange(null);
 											}}
-											className={`w-full text-left p-3 rounded-lg border transition-all flex items-center justify-between ${
+											className={`flex w-full min-w-0 items-center justify-between rounded-lg border p-3 text-left transition-all ${
 												selectedMetric?.name === m.name
 													? "bg-brand-500/20 border-brand-500/50 text-white"
 													: "bg-white/5 border-transparent text-neutral-400 hover:bg-white/10"
 											}`}
 										>
-											<div>
-												<p className="text-xs font-bold uppercase">{m.name}</p>
-												<p className="text-[10px] opacity-60 font-mono mt-0.5">
+											<div className="min-w-0">
+												<p className="truncate text-xs font-bold uppercase">
+													{m.name}
+												</p>
+												<p className="mt-0.5 truncate font-mono text-[10px] opacity-60">
 													{m.protocol}
 												</p>
 											</div>
 											<span
-												className={`w-2 h-2 rounded-full ${m.status === "OK" ? "bg-emerald-500" : "bg-red-500"}`}
+												className={`h-2 w-2 shrink-0 rounded-full ${m.status === "OK" ? "bg-emerald-500" : "bg-red-500"}`}
 											></span>
 										</button>
 									))}
@@ -455,14 +458,15 @@ const MetricAnalytics: React.FC = () => {
 
 					{/* Secondary Metric Toggle */}
 					{hasMultipleSelected && (
-						<div className="bg-surface-900 border border-white/5 rounded-xl p-5">
-							<div className="flex items-center justify-between mb-3">
-								<label className="text-xs font-bold text-neutral-500 uppercase tracking-wider">
+						<div className="min-w-0 max-w-full rounded-xl border border-white/5 bg-surface-900 p-5">
+							<div className="mb-3 flex min-w-0 items-center justify-between gap-3">
+								<label className="truncate text-xs font-bold uppercase tracking-wider text-neutral-500">
 									Secondary Metric
 								</label>
 								<button
+									aria-label="Toggle secondary metric comparison"
 									onClick={() => setShowSecondary(!showSecondary)}
-									className={`w-10 h-5 rounded-full transition-colors ${showSecondary ? "bg-brand-500" : "bg-white/20"}`}
+									className={`h-5 w-10 shrink-0 rounded-full transition-colors ${showSecondary ? "bg-brand-500" : "bg-white/20"}`}
 								>
 									<div
 										className={`w-4 h-4 rounded-full bg-white transition-transform ${showSecondary ? "translate-x-5" : "translate-x-0.5"}`}
@@ -470,15 +474,15 @@ const MetricAnalytics: React.FC = () => {
 								</button>
 							</div>
 							{showSecondary && (
-								<div className="space-y-3">
+								<div className="min-w-0 space-y-3">
 									{selectedNodes.map((node) => {
 										const metrics = node.metrics ?? [];
 										return (
 											<div
 												key={node.id}
-												className="rounded-lg border border-white/10 bg-white/[0.03] p-3"
+												className="min-w-0 max-w-full rounded-lg border border-white/10 bg-white/[0.03] p-3"
 											>
-												<p className="text-xs font-bold uppercase text-white truncate">
+												<p className="truncate text-xs font-bold uppercase text-white">
 													{node.label}
 												</p>
 												{metrics.length > 0 ? (
@@ -496,7 +500,7 @@ const MetricAnalytics: React.FC = () => {
 															setSecondaryMultiCiData([]);
 															setBrushRange(null);
 														}}
-														className="w-full bg-black/40 border border-white/10 rounded-lg px-3 py-2 text-xs text-white focus:border-brand-500 outline-none transition-colors"
+														className="w-full min-w-0 max-w-full truncate rounded-lg border border-white/10 bg-black/40 px-3 py-2 text-xs text-white outline-none transition-colors focus:border-brand-500"
 													>
 														{metrics.map((metric) => (
 															<option key={metric.name} value={metric.name}>
@@ -519,18 +523,18 @@ const MetricAnalytics: React.FC = () => {
 				</div>
 
 				{/* Main Chart Area */}
-				<div className="col-span-12 lg:col-span-9 flex flex-col gap-6 h-full overflow-hidden pb-8 min-w-0">
+				<div className="col-span-12 flex min-h-[24rem] min-w-0 max-w-full flex-col gap-6 overflow-hidden pb-8 lg:col-span-9 lg:h-full lg:min-h-0">
 					{hasMultipleSelected ? (
 						<>
 							{/* Multi-CI Chart View */}
-							<div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+							<div className="relative flex min-w-0 max-w-full flex-1 flex-col overflow-hidden rounded-xl border border-white/5 bg-surface-900 p-4 md:p-8">
 								<div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
 									<span className="material-symbols-outlined text-9xl">
 										monitoring
 									</span>
 								</div>
 
-								<div className="relative z-10 flex-1 flex flex-col min-h-0">
+								<div className="relative z-10 flex min-h-0 min-w-0 flex-1 flex-col">
 									{multiCiLoading ? (
 										<div className="flex-1 flex items-center justify-center text-neutral-500 animate-pulse font-mono text-sm">
 											LOADING METRICS...
@@ -548,14 +552,14 @@ const MetricAnalytics: React.FC = () => {
 
 							{/* Secondary Metric Section */}
 							{showSecondary && (
-								<div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+								<div className="relative flex min-w-0 max-w-full flex-1 flex-col overflow-hidden rounded-xl border border-white/5 bg-surface-900 p-4 md:p-8">
 									<div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
 										<span className="material-symbols-outlined text-9xl">
 											analytics
 										</span>
 									</div>
-									<div className="relative z-10 flex-1 flex flex-col min-h-0">
-										<div className="mb-4">
+									<div className="relative z-10 flex min-h-0 min-w-0 flex-1 flex-col">
+										<div className="mb-4 min-w-0">
 											<h3 className="text-white font-bold uppercase tracking-tight">
 												Secondary Metrics Comparison
 											</h3>
@@ -580,7 +584,7 @@ const MetricAnalytics: React.FC = () => {
 							)}
 						</>
 					) : selectedNode && selectedMetric ? (
-						<div className="flex-1 bg-surface-900 border border-white/5 rounded-xl p-8 relative overflow-hidden flex flex-col">
+						<div className="relative flex min-w-0 max-w-full flex-1 flex-col overflow-hidden rounded-xl border border-white/5 bg-surface-900 p-4 md:p-8">
 							{/* Background Pattern */}
 							<div className="absolute top-0 right-0 p-12 opacity-5 pointer-events-none">
 								<span className="material-symbols-outlined text-9xl">
@@ -588,7 +592,7 @@ const MetricAnalytics: React.FC = () => {
 								</span>
 							</div>
 
-							<div className="relative z-10 flex-1 flex flex-col min-h-0">
+							<div className="relative z-10 flex min-h-0 min-w-0 flex-1 flex-col">
 								<MetricHistoryChart
 									nodeId={selectedNode.id}
 									metricId={selectedMetric.name}
@@ -604,7 +608,7 @@ const MetricAnalytics: React.FC = () => {
 									}
 								/>
 
-								<div className="mt-8 grid grid-cols-3 gap-6 flex-shrink-0">
+								<div className="mt-8 grid flex-shrink-0 grid-cols-1 gap-4 sm:grid-cols-3 md:gap-6">
 									<StatCard
 										label="Current Value"
 										value={selectedMetric.value}
@@ -624,7 +628,7 @@ const MetricAnalytics: React.FC = () => {
 							</div>
 						</div>
 					) : (
-						<div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
+						<div className="flex min-w-0 flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-white/10 bg-surface-900 text-neutral-600">
 							<span className="material-symbols-outlined text-6xl mb-4 opacity-20">
 								analytics
 							</span>
@@ -659,13 +663,15 @@ const StatCard: React.FC<{
 	}
 
 	return (
-		<div className="bg-black/20 rounded-lg p-4 border border-white/5">
-			<p className="text-[10px] font-bold text-neutral-500 uppercase tracking-wider mb-1">
+		<div className="min-w-0 rounded-lg border border-white/5 bg-black/20 p-4">
+			<p className="mb-1 truncate text-[10px] font-bold uppercase tracking-wider text-neutral-500">
 				{label}
 			</p>
-			<p className={`text-2xl font-black tracking-tight ${colorClass}`}>
+			<p
+				className={`truncate text-2xl font-black tracking-tight ${colorClass}`}
+			>
 				{displayValue}{" "}
-				<span className="text-xs text-neutral-500 font-normal">{unit}</span>
+				<span className="text-xs font-normal text-neutral-500">{unit}</span>
 			</p>
 		</div>
 	);

--- a/frontend/components/MultiMetricChart.tsx
+++ b/frontend/components/MultiMetricChart.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import type React from "react";
 import ChartPanel from "./ChartPanel";
-import { NodeMetricData } from "../types";
+import type { NodeMetricData } from "../types";
 
 interface BrushRange {
 	startTime?: string;
@@ -24,7 +24,7 @@ const MultiMetricChart: React.FC<MultiMetricChartProps> = ({
 }) => {
 	if (nodeData.length === 0) {
 		return (
-			<div className="flex-1 bg-surface-900 border border-dashed border-white/10 rounded-xl flex items-center justify-center flex-col text-neutral-600">
+			<div className="flex min-w-0 flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-white/10 bg-surface-900 text-neutral-600">
 				<span className="material-symbols-outlined text-6xl mb-4 opacity-20">
 					analytics
 				</span>
@@ -36,7 +36,7 @@ const MultiMetricChart: React.FC<MultiMetricChartProps> = ({
 	}
 
 	return (
-		<div className="flex flex-col gap-4 h-full overflow-y-auto">
+		<div className="flex h-full min-w-0 max-w-full flex-col gap-4 overflow-y-auto overflow-x-hidden">
 			{nodeData.map((node) => (
 				<ChartPanel
 					key={node.node_id}

--- a/frontend/components/MultiSelectCIs.tsx
+++ b/frontend/components/MultiSelectCIs.tsx
@@ -94,9 +94,9 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
   const selectedNodesMap = new Map(selectedIds.map(id => [id, availableNodes.find(n => n.id === id)]));
 
   return (
-    <div className="space-y-3">
+    <div className="min-w-0 max-w-full space-y-3">
       {/* Search Input */}
-      <div className="relative">
+      <div className="relative min-w-0 max-w-full">
         <input
           type="text"
           role="searchbox"
@@ -106,7 +106,7 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           maxLength={200}
-          className="w-full bg-black/40 border border-white/10 rounded-lg px-4 py-3 text-sm text-white focus:border-brand-500 outline-none transition-colors placeholder-neutral-500"
+          className="w-full min-w-0 max-w-full bg-black/40 border border-white/10 rounded-lg px-4 py-3 text-sm text-white focus:border-brand-500 outline-none transition-colors placeholder-neutral-500"
           disabled={selectedIds.length >= maxCIs}
         />
         {searchTerm && (
@@ -125,7 +125,7 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
         <p className="text-xs text-neutral-500">Loading...</p>
       )}
       {searchError && (
-        <p className="text-xs text-red-400">{searchError}</p>
+        <p className="text-xs text-red-400 break-words">{searchError}</p>
       )}
       {!isSearching && searchTerm.length >= 2 && searchResults.length === 0 && !searchError && (
         <p className="text-xs text-neutral-500">No results found</p>
@@ -133,17 +133,17 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
 
       {/* Search Results Dropdown */}
       {searchResults.length > 0 && (
-        <div className="max-h-48 overflow-y-auto bg-black/20 rounded-lg border border-white/5">
+        <div className="max-h-48 min-w-0 max-w-full overflow-y-auto bg-black/20 rounded-lg border border-white/5">
           {displayNodes.map(n => (
             <button
               key={n.id}
               onClick={() => handleAddNode(n.id)}
               disabled={selectedIds.length >= maxCIs}
-              className="w-full text-left p-3 hover:bg-white/5 border-b border-white/5 last:border-b-0 flex items-center gap-2 disabled:opacity-30 disabled:cursor-not-allowed"
+              className="w-full min-w-0 text-left p-3 hover:bg-white/5 border-b border-white/5 last:border-b-0 flex items-center gap-2 disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <span className={`w-2 h-2 rounded-full ${n.status === 'OK' ? 'bg-emerald-500' : 'bg-red-500'}`}></span>
-              <span className="text-sm text-white">{n.label || n.id}</span>
-              <span className="text-[10px] text-neutral-500 font-mono ml-auto">{n.ip || 'No IP'}</span>
+              <span className="min-w-0 truncate text-sm text-white">{n.label || n.id}</span>
+              <span className="text-[10px] text-neutral-500 font-mono ml-auto shrink-0">{n.ip || 'No IP'}</span>
             </button>
           ))}
         </div>
@@ -151,7 +151,7 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
 
       {/* Available Nodes (when not searching) */}
       {!isSearching && searchResults.length === 0 && availableNodes.length > 0 && (
-        <div className="max-h-48 overflow-y-auto bg-black/20 rounded-lg border border-white/5">
+        <div className="max-h-48 min-w-0 max-w-full overflow-y-auto bg-black/20 rounded-lg border border-white/5">
           {availableNodes
             .filter(n => !selectedIds.includes(n.id))
             .slice(0, 20)
@@ -159,12 +159,12 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
               <button
                 key={n.id}
                 onClick={() => handleAddNode(n.id)}
-                className="w-full text-left p-3 hover:bg-white/5 border-b border-white/5 last:border-b-0 flex items-center gap-2"
+                className="w-full min-w-0 text-left p-3 hover:bg-white/5 border-b border-white/5 last:border-b-0 flex items-center gap-2"
                 disabled={selectedIds.length >= maxCIs}
               >
                 <span className={`w-2 h-2 rounded-full ${n.status === 'OK' ? 'bg-emerald-500' : 'bg-red-500'}`}></span>
-                <span className="text-sm text-white">{n.label || n.id}</span>
-                <span className="text-[10px] text-neutral-500 font-mono ml-auto">{n.ip || 'No IP'}</span>
+                <span className="min-w-0 truncate text-sm text-white">{n.label || n.id}</span>
+                <span className="text-[10px] text-neutral-500 font-mono ml-auto shrink-0">{n.ip || 'No IP'}</span>
               </button>
             ))}
         </div>
@@ -172,16 +172,16 @@ const MultiSelectCIs: React.FC<MultiSelectCIsProps> = ({
 
       {/* Selected CIs Chips */}
       {selectedIds.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-3">
+        <div className="flex min-w-0 flex-wrap gap-2 mt-3">
           {selectedIds.map(id => {
             const node = selectedNodesMap.get(id);
             return (
               <div
                 key={id}
-                className="flex items-center gap-2 bg-brand-500/20 border border-brand-500/40 rounded-full px-3 py-1.5 text-sm"
+                className="flex min-w-0 max-w-full items-center gap-2 bg-brand-500/20 border border-brand-500/40 rounded-full px-3 py-1.5 text-sm"
               >
-                <span className="w-2 h-2 rounded-full bg-brand-500"></span>
-                <span className="text-white font-bold">{node?.label || id}</span>
+                <span className="w-2 h-2 rounded-full bg-brand-500 shrink-0"></span>
+                <span className="min-w-0 truncate text-white font-bold">{node?.label || id}</span>
                 <button
                   onClick={() => handleRemoveNode(id)}
                   className="text-neutral-400 hover:text-white transition-colors ml-1"


### PR DESCRIPTION
Closes #168

## Descripción del Cambio
- Endurece el layout de /analytics contra overflow horizontal en pantallas con escalado o viewport angosto.
- Agrega guards de flex/grid (`min-w-0`, `max-w-full`, `overflow-x-hidden`) en shell, controles, chips y contenedores de charts.
- Añade cobertura de regresión para etiquetas largas en Metric per CI y Secondary Metric.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios principales
| Archivo | Cambio |
|---|---|
| `frontend/App.tsx` | Reemplaza `w-screen` y agrega guards `min-w-0` para evitar overflow del shell. |
| `frontend/components/MetricAnalytics.tsx` | Ajusta grid, sidebar, tarjetas y stats para truncar/contener contenido y permitir scroll vertical. |
| `frontend/components/MultiSelectCIs.tsx` | Trunca labels largos en resultados y chips seleccionados. |
| `frontend/components/ChartPanel.tsx` | Agrega contención de ancho en headers y contenedor Recharts. |
| `frontend/components/MultiMetricChart.tsx` | Evita overflow horizontal en lista de charts. |
| `frontend/components/MetricAnalytics.test.tsx` | Cubre guards responsive con CI/metric labels largos. |

## ¿Cómo se probó?
- [x] `cd frontend && pnpm exec vitest run components/MetricAnalytics.test.tsx`
- [x] `cd frontend && pnpm build`
- [x] LSP diagnostics sin errores en archivos modificados
- [ ] Validación visual manual en navegador a 360px, 768px, 1024px y desktop con escalado

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Nota
jsdom no mide overflow visual real; el test cubre estructura/classes defensivas. La validación visual sigue siendo recomendada para cerrar el GAP de responsive/scaling.

---
*Generado por Alex*
