### PR TITLE
feat(metrics): add ICMP latency and jitter telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **ICMP latency and jitter telemetry** (PR #TBD, issue #175):
+- **ICMP latency and jitter telemetry** (PR #177, issue #175):
   - Preserves existing binary ICMP availability metrics for event lifecycle compatibility while adding `icmp_latency_ms` and `icmp_jitter_ms` sidecar telemetry streams.
   - Parses successful ping latency, stores latency only on successful probes, and calculates jitter as the absolute delta between consecutive successful latency samples.
   - Guards legacy and leased polling paths so latency/jitter metrics are never polled or evaluated as availability events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ICMP latency and jitter telemetry** (PR #TBD, issue #175):
+  - Preserves existing binary ICMP availability metrics for event lifecycle compatibility while adding `icmp_latency_ms` and `icmp_jitter_ms` sidecar telemetry streams.
+  - Parses successful ping latency, stores latency only on successful probes, and calculates jitter as the absolute delta between consecutive successful latency samples.
+  - Guards legacy and leased polling paths so latency/jitter metrics are never polled or evaluated as availability events.
+  - Adds an idempotent migration script for existing CIs with ping metrics: `backend/scripts/migrate_icmp_sidecar_metrics.py`.
+  - Adds focused backend regression coverage for parser semantics, event safety, scheduler/executor guards, writer sidecar persistence, and migration idempotency.
+
 ## [1.12.6] — 2026-05-26
 
 ### Fixed

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -17,9 +17,19 @@ import logging
 from neo4j import GraphDatabase
 
 logger = logging.getLogger(__name__)
+from sqlalchemy import text
+
 from repositories.metric_repo import insert_metric_value, bulk_insert_metrics
 from postgres_db import SessionLocal
 from config import get_icmp_settings, get_polling_pipeline_settings
+from polling.icmp_measurements import (
+    ICMP_LATENCY_METRIC_ID,
+    build_icmp_sidecar_samples,
+    coerce_ping_measurement,
+    is_icmp_availability_metric,
+    PingMeasurement,
+    parse_ping_latency_ms,
+)
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
@@ -70,7 +80,7 @@ def verify_connection():
 _consecutive_failures: Dict[str, int] = {}
 
 
-def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2) -> float:
+def fetch_icmp_ping_measurement(ip: str, timeout_ms: int = 3000, retries: int = 2) -> PingMeasurement:
     """Perform ICMP ping with configurable timeout and retry.
 
     Args:
@@ -79,7 +89,7 @@ def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2) -> float:
         retries: Number of additional attempts after initial failure.
 
     Returns:
-        1.0 if any ping attempt succeeds, 0.0 if all attempts fail.
+        Structured ping availability and latency when parsed.
     """
     attempts = retries + 1
     system = platform.system().lower()
@@ -97,15 +107,22 @@ def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2) -> float:
                 stderr=subprocess.PIPE,
                 text=True
             )
+            output = f"{result.stdout or ''}\n{result.stderr or ''}"
             if result.returncode == 0:
-                return 1.0
+                return PingMeasurement(True, parse_ping_latency_ms(output), raw=output)
         except OSError as e:
             logger.warning(f"Ping attempt {attempt + 1}/{attempts} failed for {ip}: {e}")
             continue
         except subprocess.TimeoutExpired as e:
             logger.warning(f"Ping attempt {attempt + 1}/{attempts} timed out for {ip}: {e}")
             continue
-    return 0.0
+    return PingMeasurement(False, None, raw=None, error="ICMP ping failed")
+
+
+def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2, include_measurement: bool = False):
+    """Perform ICMP ping and preserve the legacy binary availability contract by default."""
+    measurement = fetch_icmp_ping_measurement(ip, timeout_ms=timeout_ms, retries=retries)
+    return measurement if include_measurement else measurement.availability_value
 
 def fetch_snmp_value(ip, community, oid, port=161, include_status=False):
     """Perform a real SNMP GET.
@@ -186,6 +203,22 @@ def _base_severity_from_criticality(criticality) -> str:
     except (TypeError, ValueError):
         normalized = 1
     return {2: "WARNING", 3: "CRITICAL"}.get(normalized, "INFO")
+
+
+def _previous_latency_ms(db, node_id: str, before: datetime) -> float | None:
+    result = db.execute(
+        text("""
+            SELECT value FROM metric_values
+            WHERE node_id = :node_id AND metric_id = :metric_id AND time < :before
+            ORDER BY time DESC LIMIT 1
+        """),
+        {"node_id": node_id, "metric_id": ICMP_LATENCY_METRIC_ID, "before": before},
+    )
+    row = result.first() if hasattr(result, "first") else None
+    if not row:
+        return None
+    value = row[0] if not isinstance(row, dict) else row.get("value")
+    return None if value is None else float(value)
 
 
 def _dedupe_snmp_collection_failures(failures):
@@ -365,11 +398,16 @@ def poll_snmp():
                      coalesce(m.polling_interval, 60) as interval,
                      coalesce(r.last_polled, datetime({year:1970})) as last_p
                 WHERE duration.between(last_p, datetime()).seconds >= interval
+                  AND NOT (
+                    toUpper(coalesce(m.protocol, '')) = 'ICMP'
+                    AND (m.id IN ['icmp_latency_ms', 'icmp_jitter_ms'] OR coalesce(m.metric_kind, '') = 'telemetry')
+                  )
                 RETURN n.id as node_id, n.ip as ip, 
                        coalesce(n.snmp_community, 'public') as community,
                        coalesce(n.snmp_port, 161) as port,
                        m.id as metric_id, m.name as metric_name, m.protocol as protocol,
                        m.oid as oid, m.criticality as criticality,
+                       m.metric_kind as metric_kind,
                        interval
             """)
             
@@ -386,9 +424,28 @@ def poll_snmp():
                     continue
 
                 val = None
+                sidecar_samples = []
+                metric_metadata = {"metric_kind": record.get("metric_kind")}
                 icmp_settings = get_icmp_settings()
+                if protocol == "ICMP" and not is_icmp_availability_metric(mid, metric_metadata):
+                    continue
                 if protocol == "ICMP":
-                    val = fetch_icmp_ping(ip, timeout_ms=icmp_settings.timeout_ms, retries=icmp_settings.retries)
+                    measurement = coerce_ping_measurement(fetch_icmp_ping(
+                        ip,
+                        timeout_ms=icmp_settings.timeout_ms,
+                        retries=icmp_settings.retries,
+                        include_measurement=True,
+                    ))
+                    val = measurement.availability_value
+                    sample_time = datetime.utcnow()
+                    if measurement.available:
+                        previous_latency = _previous_latency_ms(db, node_id, sample_time)
+                        sidecar_samples = build_icmp_sidecar_samples(
+                            node_id,
+                            measurement,
+                            previous_latency_ms=previous_latency,
+                            observed_at=sample_time,
+                        )
                     # Debounce logic: track consecutive failures per node
                     if val == 0:
                         _consecutive_failures[node_id] = _consecutive_failures.get(node_id, 0) + 1
@@ -401,6 +458,7 @@ def poll_snmp():
                         else:
                             # Below threshold: suppress metric recording until threshold
                             val = None
+                            sidecar_samples = []
                     else:
                         # Success: reset counter and proceed normally
                         _consecutive_failures[node_id] = 0
@@ -418,12 +476,14 @@ def poll_snmp():
                     )
                 
                 if val is not None:
+                    primary_time = datetime.utcnow()
                     metrics_to_save.append({
                         "node_id": node_id,
                         "metric_id": mid,
                         "value": val,
-                        "time": datetime.utcnow()
+                        "time": primary_time
                     })
+                    metrics_to_save.extend(sidecar_samples)
 
                     metric_name = record["metric_name"] or mid
                     severity = _base_severity_from_criticality(record["criticality"])
@@ -443,7 +503,23 @@ def poll_snmp():
                         "event_type": EVENT_TYPE_AVAILABILITY if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else None,
                         "source_protocol": SOURCE_PROTOCOL_ICMP if protocol == SOURCE_PROTOCOL_ICMP else protocol,
                         "severity": severity,
+                        "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP else "telemetry",
                     })
+                    for sample in sidecar_samples:
+                        latest_updates.append({
+                            "node_id": node_id,
+                            "metric_id": sample["metric_id"],
+                            "value": sample["value"],
+                            "protocol": protocol,
+                            "metric_name": sample["metric_id"],
+                            "criticality": record["criticality"],
+                            "status": "OK",
+                            "message": "Latest ICMP telemetry sample collected by legacy SNMP worker",
+                            "event_type": None,
+                            "source_protocol": SOURCE_PROTOCOL_ICMP,
+                            "severity": "INFO",
+                            "metric_kind": "telemetry",
+                        })
                 else:
                     failed_count += 1
                     if is_snmp_no_response_failure(
@@ -490,7 +566,7 @@ def poll_snmp():
             if metrics_to_save:
                 bulk_insert_metrics(db, metrics_to_save)
                 for update in latest_updates:
-                    if update["protocol"].upper() == "ICMP" and update["value"] in (0.0, 1.0):
+                    if update["protocol"].upper() == "ICMP" and update.get("metric_kind") == "availability" and update["value"] in (0.0, 1.0):
                         session.run(
                             "MATCH (n:CI {id: $id}) SET n.status = $status, n.last_seen = datetime()",
                             id=update["node_id"],
@@ -505,8 +581,9 @@ def poll_snmp():
                             r.status = $status,
                             r.last_message = $msg
                     """, nid=update["node_id"], mid=update["metric_id"], val=update["value"], status=update["status"], msg=update["message"])
-                _refresh_icmp_availability_events(session, latest_updates)
-                _recover_icmp_availability_events(session, latest_updates)
+                availability_updates = [u for u in latest_updates if u.get("metric_kind") == "availability"]
+                _refresh_icmp_availability_events(session, availability_updates)
+                _recover_icmp_availability_events(session, availability_updates)
                 _recover_snmp_collection_failures(session, latest_updates)
                 print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")
 

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Any, Iterable, Mapping
 from uuid import UUID
 
+from polling.icmp_measurements import is_icmp_availability_metric
 from services.polling_event_lifecycle import (
     COLLECTION_FAILURE_PREFIX,
     EVENT_TYPE_AVAILABILITY,
@@ -97,7 +98,7 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
             event_type = EVENT_TYPE_COLLECTION_FAILURE
             message = collection_failure_message(envelope.get("error") or {}, result_status)
         elif numeric is not None:
-            availability = protocol == "ICMP" or metric_name == "mariadb-GS"
+            availability = (protocol == "ICMP" and is_icmp_availability_metric(metric_id, metadata)) or metric_name == "mariadb-GS"
             if availability and numeric == 0:
                 severity = _base_severity(metadata)
                 is_breach = True

--- a/backend/polling/icmp_measurements.py
+++ b/backend/polling/icmp_measurements.py
@@ -1,0 +1,110 @@
+"""Shared ICMP ping measurement helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+ICMP_AVAILABILITY_METRIC_ID = "icmp_availability"
+ICMP_LATENCY_METRIC_ID = "icmp_latency_ms"
+ICMP_JITTER_METRIC_ID = "icmp_jitter_ms"
+ICMP_SIDECAR_METRIC_IDS = [ICMP_LATENCY_METRIC_ID, ICMP_JITTER_METRIC_ID]
+
+
+@dataclass(frozen=True)
+class PingMeasurement:
+    available: bool
+    latency_ms: float | None = None
+    raw: str | None = None
+    error: str | None = None
+
+    @property
+    def availability_value(self) -> float:
+        return 1.0 if self.available else 0.0
+
+
+_TIME_RE = re.compile(r"time\s*[=<]\s*(?P<value>\d+(?:\.\d+)?)\s*ms", re.IGNORECASE)
+_AVERAGE_RE = re.compile(r"Average\s*=\s*(?P<value>\d+(?:\.\d+)?)\s*ms", re.IGNORECASE)
+_RTT_RE = re.compile(r"(?:round-trip|rtt)[^=]*=\s*\d+(?:\.\d+)?/(?P<avg>\d+(?:\.\d+)?)/", re.IGNORECASE)
+
+
+def parse_ping_latency_ms(output: str | None) -> float | None:
+    """Parse a round-trip latency in milliseconds from common ping outputs."""
+    if not output:
+        return None
+    text = str(output)
+    for regex, group in ((_TIME_RE, "value"), (_AVERAGE_RE, "value"), (_RTT_RE, "avg")):
+        match = regex.search(text)
+        if match:
+            value = float(match.group(group))
+            if "time<" in match.group(0).lower():
+                return 0.5 if value <= 1 else value / 2
+            return value
+    return None
+
+
+def coerce_ping_measurement(raw: Any) -> PingMeasurement:
+    """Normalize legacy float/bool or structured ping fetcher output."""
+    if isinstance(raw, PingMeasurement):
+        return raw
+    if isinstance(raw, tuple) and len(raw) >= 2:
+        available = bool(raw[0])
+        latency = None if raw[1] is None else float(raw[1])
+        return PingMeasurement(available=available, latency_ms=latency)
+    numeric = float(raw or 0.0)
+    return PingMeasurement(available=numeric > 0)
+
+
+def build_icmp_sidecar_samples(
+    node_id: str,
+    measurement: PingMeasurement,
+    *,
+    previous_latency_ms: float | None = None,
+    observed_at: Any | None = None,
+) -> list[dict[str, Any]]:
+    """Build latency and optional jitter sidecar samples for a successful ping."""
+    if not measurement.available or measurement.latency_ms is None:
+        return []
+    samples: list[dict[str, Any]] = [{
+        "node_id": node_id,
+        "metric_id": ICMP_LATENCY_METRIC_ID,
+        "value": float(measurement.latency_ms),
+    }]
+    if previous_latency_ms is not None:
+        samples.append({
+            "node_id": node_id,
+            "metric_id": ICMP_JITTER_METRIC_ID,
+            "value": abs(float(measurement.latency_ms) - float(previous_latency_ms)),
+        })
+    if observed_at is not None:
+        for sample in samples:
+            sample["time"] = observed_at
+    return samples
+
+
+def icmp_metadata(measurement: PingMeasurement) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"sidecar_metric_ids": list(ICMP_SIDECAR_METRIC_IDS)}
+    if measurement.available and measurement.latency_ms is not None:
+        metadata["latency_ms"] = float(measurement.latency_ms)
+    return metadata
+
+
+def is_icmp_telemetry_metric(metric_id: str, metadata: dict[str, Any] | None = None) -> bool:
+    """Return true for ICMP sidecar telemetry metrics that are derived, not polled."""
+    value = str(metric_id or "")
+    return value in ICMP_SIDECAR_METRIC_IDS or bool(metadata and metadata.get("metric_kind") == "telemetry")
+
+
+def is_icmp_availability_metric(metric_id: str, metadata: dict[str, Any] | None = None) -> bool:
+    """Return true only for ICMP binary availability metrics.
+
+    Sidecar telemetry IDs are denied first so bad upstream metadata cannot turn
+    latency or jitter samples into availability events.
+    """
+    if is_icmp_telemetry_metric(metric_id, metadata):
+        return False
+    if metadata and metadata.get("metric_kind") == "availability":
+        return True
+    value = str(metric_id or "")
+    return value == ICMP_AVAILABILITY_METRIC_ID or value == "PING-CHECK" or value.startswith("PING-")

--- a/backend/polling/scheduler.py
+++ b/backend/polling/scheduler.py
@@ -10,6 +10,7 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 
 from polling.contracts import PollingPriority, PollingProtocol
 from polling.pg_queue import create_cycle, enqueue_tasks
+from polling.icmp_measurements import is_icmp_telemetry_metric
 from polling.protocol_contracts import build_protocol_payload
 
 
@@ -97,6 +98,8 @@ def build_tasks_from_records(records: Iterable[Mapping[str, Any]], cycle: PollCy
         metric_id = str(record.get("metric_id") or record.get("id") or "")
         if not ci_id or not metric_id:
             raise ValueError("Scheduler records require node_id/ci_id and metric_id/id")
+        if protocol == PollingProtocol.ICMP and is_icmp_telemetry_metric(metric_id, dict(record)):
+            continue
         source = _source(record, protocol)
         payload = build_protocol_payload({**dict(record), "protocol": protocol.value, "source": source})
         priority = _priority(record, protocol)
@@ -118,6 +121,7 @@ def build_tasks_from_records(records: Iterable[Mapping[str, Any]], cycle: PollCy
             "source": source,
             "payload": payload,
             "metadata_version": record.get("metadata_version") or cycle.config_version,
+            "metric_kind": record.get("metric_kind"),
         })
     return sorted(tasks, key=lambda task: (int(task["priority"]), task["protocol"].value, task["metric_id"]))
 

--- a/backend/polling/snmp_executor.py
+++ b/backend/polling/snmp_executor.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Mapping
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 from polling.contracts import PollResultEnvelope, PollingProtocol, PollingResultStatus
+from polling.icmp_measurements import coerce_ping_measurement, icmp_metadata, is_icmp_availability_metric, is_icmp_telemetry_metric
 from polling.idempotency import generate_idempotency_key
 from services.polling_event_lifecycle import is_snmp_no_response_failure
 
@@ -43,10 +44,10 @@ def _protocol(task: Mapping[str, Any] | Any) -> PollingProtocol:
     return value if isinstance(value, PollingProtocol) else PollingProtocol(str(value).strip().upper())
 
 
-def _default_icmp_fetcher(**kwargs) -> float:
-    from engines.snmp_worker import fetch_icmp_ping
+def _default_icmp_fetcher(**kwargs) -> Any:
+    from engines.snmp_worker import fetch_icmp_ping_measurement
 
-    return fetch_icmp_ping(kwargs["ip"], timeout_ms=kwargs.get("timeout_ms", 3000), retries=kwargs.get("retries", 2))
+    return fetch_icmp_ping_measurement(kwargs["ip"], timeout_ms=kwargs.get("timeout_ms", 3000), retries=kwargs.get("retries", 2))
 
 
 def _default_snmp_fetcher(**kwargs) -> Any:
@@ -84,18 +85,34 @@ def execute_poll_task(
     status = PollingResultStatus.ERROR
     value: dict[str, Any] = {"numeric": None, "text": None, "raw": None}
     error: dict[str, Any] = {"code": "unsupported_protocol", "message": protocol.value, "retryable": False}
+    measurement = None
+    task_metadata = _get(task, "metadata", {}) or {}
+    if not isinstance(task_metadata, Mapping):
+        task_metadata = {}
+    metric_id = str(_get(task, "metric_id"))
 
     try:
         if protocol == PollingProtocol.ICMP:
-            fetcher = icmp_fetcher or _default_icmp_fetcher
-            numeric = float(fetcher(
-                ip=payload.get("target") or _get(task, "source"),
-                timeout_ms=int(payload.get("timeout_ms") or 3000),
-                retries=int(payload.get("retries") or 2),
-            ) or 0.0)
-            status = PollingResultStatus.OK if numeric > 0 else PollingResultStatus.CRITICAL
-            value = {"numeric": numeric, "text": None, "raw": numeric}
-            error = {"code": None, "message": None, "retryable": False}
+            metric_metadata = {**dict(task_metadata), **({"metric_kind": _get(task, "metric_kind")} if _get(task, "metric_kind") else {})}
+            if not is_icmp_availability_metric(metric_id, metric_metadata):
+                status = PollingResultStatus.OK
+                value = {"numeric": None, "text": None, "raw": None}
+                error = {
+                    "code": "skipped_icmp_telemetry" if is_icmp_telemetry_metric(metric_id, metric_metadata) else "unsupported_icmp_metric",
+                    "message": "ICMP telemetry sidecars are derived from availability polls",
+                    "retryable": False,
+                }
+            else:
+                fetcher = icmp_fetcher or _default_icmp_fetcher
+                measurement = coerce_ping_measurement(fetcher(
+                    ip=payload.get("target") or _get(task, "source"),
+                    timeout_ms=int(payload.get("timeout_ms") or 3000),
+                    retries=int(payload.get("retries") or 2),
+                ))
+                numeric = measurement.availability_value
+                status = PollingResultStatus.OK if numeric > 0 else PollingResultStatus.CRITICAL
+                value = {"numeric": numeric, "text": None, "raw": numeric}
+                error = {"code": None, "message": None, "retryable": False}
         elif protocol == PollingProtocol.SNMP:
             fetcher = snmp_fetcher or _default_snmp_fetcher
             raw = fetcher(
@@ -149,8 +166,13 @@ def execute_poll_task(
     task_id = _get(task, "task_id")
     cycle_id = _get(task, "cycle_id")
     ci_id = str(_get(task, "ci_id"))
-    metric_id = str(_get(task, "metric_id"))
     source = str(_get(task, "source") or payload.get("target") or "")
+    icmp_result_metadata: dict[str, Any] = {}
+    if protocol == PollingProtocol.ICMP:
+        if measurement is not None:
+            icmp_result_metadata = {"metric_kind": "availability", "icmp": icmp_metadata(measurement)}
+        elif is_icmp_telemetry_metric(metric_id, task_metadata):
+            icmp_result_metadata = {"metric_kind": "telemetry"}
     return PollResultEnvelope(
         result_id=_result_id(task_id, observed, status),
         task_id=task_id,
@@ -175,6 +197,7 @@ def execute_poll_task(
         value=value,
         error=error,
         metadata={
+            **icmp_result_metadata,
             "site_id": _get(task, "site_id"),
             "subnet": _get(task, "subnet"),
             "ip_address": _get(task, "ip_address"),

--- a/backend/polling/writer_pool.py
+++ b/backend/polling/writer_pool.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 
 from models.timescale_models import MetricValue
 from polling import event_writer, pg_queue
+from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
 
 
 def _utc_now() -> datetime:
@@ -67,6 +68,35 @@ def _sample(envelope: Mapping[str, Any]) -> dict[str, Any] | None:
         "value": numeric,
         "time": _timestamp(envelope["observed_at"]),
     }
+
+
+def previous_metric_value(db, node_id: str, metric_id: str, before: datetime) -> float | None:
+    result = db.execute(
+        text("""
+            SELECT value FROM metric_values
+            WHERE node_id = :node_id AND metric_id = :metric_id AND time < :before
+            ORDER BY time DESC LIMIT 1
+        """),
+        {"node_id": node_id, "metric_id": metric_id, "before": before},
+    )
+    row = result.first() if hasattr(result, "first") else None
+    if not row:
+        return None
+    value = row[0] if not isinstance(row, Mapping) else row.get("value")
+    return None if value is None else float(value)
+
+
+def _sidecar_samples(db, envelope: Mapping[str, Any]) -> list[dict[str, Any]]:
+    icmp = ((envelope.get("metadata") or {}).get("icmp") or {})
+    if "latency_ms" not in icmp:
+        return []
+    observed = _timestamp(envelope["observed_at"])
+    latency = float(icmp["latency_ms"])
+    samples = [{"node_id": envelope["ci_id"], "metric_id": ICMP_LATENCY_METRIC_ID, "value": latency, "time": observed}]
+    previous = previous_metric_value(db, envelope["ci_id"], ICMP_LATENCY_METRIC_ID, observed)
+    if previous is not None:
+        samples.append({"node_id": envelope["ci_id"], "metric_id": ICMP_JITTER_METRIC_ID, "value": abs(latency - previous), "time": observed})
+    return samples
 
 
 def receipt_exists(db, idempotency_key: str) -> bool:
@@ -184,7 +214,11 @@ def run_writer_once(
         stats["written"] += 1
 
     try:
-        samples = [item["sample"] for item in new_payloads if item["sample"] is not None]
+        samples = []
+        for item in new_payloads:
+            if item["sample"] is not None:
+                samples.append(item["sample"])
+            samples.extend(_sidecar_samples(timescale_db, item["envelope"]))
         persist_samples_and_receipts(timescale_db, new_payloads, samples)
         stats["inserted"] += len(samples)
     except Exception as exc:

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Any, Optional, Set
 import json
+from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
 import re
 from neo4j import Driver
 from database import get_db
@@ -403,6 +404,45 @@ def find_open_parent_event(ci_id: str, max_depth: int = 3) -> Optional[Dict[str,
         }
 
 
+def ensure_icmp_sidecar_metric_defs(session) -> None:
+    session.run("""
+        MERGE (latency:MetricDef {id: $latency_id})
+        SET latency.name = 'ICMP Latency',
+            latency.protocol = 'ICMP',
+            latency.description = 'ICMP ping round-trip latency in milliseconds',
+            latency.dataType = 'FLOAT',
+            latency.unit = 'ms',
+            latency.operator = '>=',
+            latency.criticality = coalesce(latency.criticality, 1),
+            latency.metric_kind = 'telemetry'
+        MERGE (jitter:MetricDef {id: $jitter_id})
+        SET jitter.name = 'ICMP Jitter',
+            jitter.protocol = 'ICMP',
+            jitter.description = 'Absolute delta between consecutive successful ICMP latency samples',
+            jitter.dataType = 'FLOAT',
+            jitter.unit = 'ms',
+            jitter.operator = '>=',
+            jitter.criticality = coalesce(jitter.criticality, 1),
+            jitter.metric_kind = 'telemetry'
+    """, latency_id=ICMP_LATENCY_METRIC_ID, jitter_id=ICMP_JITTER_METRIC_ID)
+
+
+def migrate_icmp_sidecar_metrics() -> None:
+    """Idempotently link ICMP latency/jitter MetricDefs to CIs with ping availability metrics."""
+    driver = get_db()
+    with driver.session() as session:
+        ensure_icmp_sidecar_metric_defs(session)
+        session.run("""
+            MATCH (n:CI)-[:HAS_METRIC]->(availability:MetricDef)
+            WHERE toUpper(coalesce(availability.protocol, '')) = 'ICMP'
+              AND (availability.id = 'PING-CHECK' OR availability.id STARTS WITH 'PING-' OR coalesce(availability.metric_kind, '') = 'availability')
+            MATCH (latency:MetricDef {id: $latency_id})
+            MATCH (jitter:MetricDef {id: $jitter_id})
+            MERGE (n)-[:HAS_METRIC]->(latency)
+            MERGE (n)-[:HAS_METRIC]->(jitter)
+        """, latency_id=ICMP_LATENCY_METRIC_ID, jitter_id=ICMP_JITTER_METRIC_ID)
+
+
 def create_default_ping_metric(node_id: str, node_label: str) -> None:
     """
     Create a default ICMP PING metric for a CI node when it has an IP address.
@@ -415,15 +455,25 @@ def create_default_ping_metric(node_id: str, node_label: str) -> None:
         session.run("""
             MERGE (m:MetricDef {id: $metric_id})
             SET m.protocol = 'ICMP',
+                m.name = coalesce(m.name, 'ICMP Availability'),
                 m.description = 'ICMP Ping Monitoring',
                 m.applicable_to = $applicable_to,
                 m.operator = '>=',
-                m.criticality = 1
+                m.criticality = 1,
+                m.metric_kind = 'availability'
             WITH m
             MATCH (n:CI {id: $node_id})
             MERGE (n)-[:HAS_METRIC]->(m)
         """, metric_id=metric_id, node_id=node_id,
            applicable_to=json.dumps({"names": [node_label]}))
+        ensure_icmp_sidecar_metric_defs(session)
+        session.run("""
+            MATCH (n:CI {id: $node_id})
+            MATCH (latency:MetricDef {id: $latency_id})
+            MATCH (jitter:MetricDef {id: $jitter_id})
+            MERGE (n)-[:HAS_METRIC]->(latency)
+            MERGE (n)-[:HAS_METRIC]->(jitter)
+        """, node_id=node_id, latency_id=ICMP_LATENCY_METRIC_ID, jitter_id=ICMP_JITTER_METRIC_ID)
 
 
 def update_node_metadata(node_id: str, metadata: dict) -> bool:

--- a/backend/scripts/migrate_icmp_sidecar_metrics.py
+++ b/backend/scripts/migrate_icmp_sidecar_metrics.py
@@ -1,0 +1,29 @@
+"""Idempotently link ICMP latency/jitter sidecar metrics to existing CIs.
+
+Run from the repository root with:
+    python backend/scripts/migrate_icmp_sidecar_metrics.py
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+# Add backend to path for direct script execution.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from repositories import topology_repo
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    logger.info("Starting ICMP sidecar metric migration...")
+    topology_repo.migrate_icmp_sidecar_metrics()
+    logger.info("ICMP sidecar metric migration complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_icmp_measurements.py
+++ b/backend/tests/test_icmp_measurements.py
@@ -1,0 +1,47 @@
+from polling.icmp_measurements import (
+    ICMP_JITTER_METRIC_ID,
+    ICMP_LATENCY_METRIC_ID,
+    PingMeasurement,
+    build_icmp_sidecar_samples,
+    is_icmp_availability_metric,
+    is_icmp_telemetry_metric,
+    parse_ping_latency_ms,
+)
+
+
+def test_parse_ping_latency_ms_common_platform_outputs():
+    assert parse_ping_latency_ms("64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=12.3 ms") == 12.3
+    assert parse_ping_latency_ms("round-trip min/avg/max/stddev = 10.1/12.4/20.0/1.0 ms") == 12.4
+    assert parse_ping_latency_ms("Reply from 10.0.0.1: bytes=32 time=12ms TTL=64\nAverage = 12ms") == 12.0
+    assert parse_ping_latency_ms("Reply from 10.0.0.1: bytes=32 time<1ms TTL=64") == 0.5
+
+
+def test_parse_ping_latency_ms_returns_none_for_failures():
+    assert parse_ping_latency_ms("Request timed out.") is None
+    assert parse_ping_latency_ms("100% packet loss") is None
+    assert parse_ping_latency_ms("") is None
+
+
+def test_build_icmp_sidecar_samples_success_failure_and_jitter():
+    success = PingMeasurement(available=True, latency_ms=15.5, raw="ok")
+    samples = build_icmp_sidecar_samples("ci-1", success, previous_latency_ms=None)
+    assert samples == [{"node_id": "ci-1", "metric_id": ICMP_LATENCY_METRIC_ID, "value": 15.5}]
+
+    with_jitter = build_icmp_sidecar_samples("ci-1", success, previous_latency_ms=10.0)
+    assert with_jitter == [
+        {"node_id": "ci-1", "metric_id": ICMP_LATENCY_METRIC_ID, "value": 15.5},
+        {"node_id": "ci-1", "metric_id": ICMP_JITTER_METRIC_ID, "value": 5.5},
+    ]
+
+    failure = PingMeasurement(available=False, latency_ms=None, raw="timeout")
+    assert build_icmp_sidecar_samples("ci-1", failure, previous_latency_ms=10.0) == []
+
+
+def test_icmp_metric_kind_helpers_deny_sidecars_even_with_bad_availability_metadata():
+    assert is_icmp_availability_metric("PING-CHECK", {"metric_kind": "availability"}) is True
+    assert is_icmp_availability_metric("PING-router-a", {}) is True
+    assert is_icmp_availability_metric("icmp_latency_ms", {"metric_kind": "availability"}) is False
+    assert is_icmp_availability_metric("icmp_jitter_ms", {"metric_kind": "availability"}) is False
+    assert is_icmp_telemetry_metric("icmp_latency_ms", {}) is True
+    assert is_icmp_telemetry_metric("icmp_jitter_ms", {"metric_kind": "availability"}) is True
+    assert is_icmp_telemetry_metric("PING-CHECK", {"metric_kind": "availability"}) is False

--- a/backend/tests/test_icmp_metric_migration.py
+++ b/backend/tests/test_icmp_metric_migration.py
@@ -1,0 +1,49 @@
+from tests.conftest import MockNeo4jDriver
+
+
+def test_create_default_ping_metric_links_latency_and_jitter_sidecars(monkeypatch):
+    from repositories import topology_repo
+
+    driver = MockNeo4jDriver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.create_default_ping_metric("ci-1", "router-a")
+
+    queries = "\n".join(q["query"] for q in driver.mock_session.queries)
+    params = [q["params"] for q in driver.mock_session.queries]
+    assert "PING-router-a" in str(params)
+    assert "icmp_latency_ms" in str(params)
+    assert "icmp_jitter_ms" in str(params)
+    assert "metric_kind = 'availability'" in queries
+    assert "metric_kind = 'telemetry'" in queries
+    assert "MERGE (n)-[:HAS_METRIC]->(latency)" in queries
+    assert "MERGE (n)-[:HAS_METRIC]->(jitter)" in queries
+
+
+def test_migrate_icmp_sidecar_metrics_is_idempotent_for_existing_ping_cis(monkeypatch):
+    from repositories import topology_repo
+
+    driver = MockNeo4jDriver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.migrate_icmp_sidecar_metrics()
+
+    queries = "\n".join(q["query"] for q in driver.mock_session.queries)
+    params = [q["params"] for q in driver.mock_session.queries]
+    assert "MERGE (latency:MetricDef {id: $latency_id})" in queries
+    assert "MERGE (jitter:MetricDef {id: $jitter_id})" in queries
+    assert "availability.id = 'PING-CHECK'" in queries
+    assert "availability.id STARTS WITH 'PING-'" in queries
+    assert "MERGE (n)-[:HAS_METRIC]->(latency)" in queries
+    assert "MERGE (n)-[:HAS_METRIC]->(jitter)" in queries
+    assert {"latency_id": "icmp_latency_ms", "jitter_id": "icmp_jitter_ms"} in params
+
+
+def test_migrate_icmp_sidecar_metrics_script_entrypoint_invokes_repository(monkeypatch):
+    from scripts import migrate_icmp_sidecar_metrics as script
+
+    calls = []
+    monkeypatch.setattr(script.topology_repo, "migrate_icmp_sidecar_metrics", lambda: calls.append("migrated"))
+
+    assert script.main() == 0
+    assert calls == ["migrated"]

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -18,6 +18,25 @@ def _event_row(value: float | None = 97.0, status="OK", metadata=None):
     }
 
 
+def test_event_writer_ignores_icmp_latency_and_jitter_as_availability_events():
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-router", "metadata": {"name": "PING-router", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_latency_ms", "metadata": {"name": "ICMP Latency", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_jitter_ms", "metadata": {"name": "ICMP Jitter", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_latency_ms", "metadata": {"name": "ICMP Latency", "criticality": 3, "metric_kind": "availability"}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_jitter_ms", "metadata": {"name": "ICMP Jitter", "criticality": 3, "metric_kind": "availability"}},
+    ])
+
+    assert rows[0]["event_type"] == "AVAILABILITY"
+    assert rows[1]["event_type"] == "AVAILABILITY"
+    for row in rows[2:]:
+        assert row["event_type"] is None
+        assert row["is_breach"] is False
+
+
 def test_event_writer_derives_threshold_breach_and_availability_recovery_rows():
     from polling.event_writer import build_event_rows
 

--- a/backend/tests/test_polling_scheduler.py
+++ b/backend/tests/test_polling_scheduler.py
@@ -36,6 +36,35 @@ def _records():
     ]
 
 
+def test_scheduler_skips_icmp_latency_and_jitter_sidecar_records():
+    from polling.scheduler import build_cycle, build_tasks_from_records
+
+    cycle = build_cycle(scheduled_for=datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc), config_version="v1")
+    records = _records() + [
+        {
+            "node_id": "ci-icmp",
+            "ip": "10.0.0.1",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "metadata_version": "v1",
+        },
+        {
+            "node_id": "ci-icmp",
+            "ip": "10.0.0.1",
+            "metric_id": "icmp_jitter_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "metadata_version": "v1",
+        },
+    ]
+
+    tasks = build_tasks_from_records(records, cycle)
+
+    assert {task["metric_id"] for task in tasks} == {"PING-CHECK", "CPU", "CLI-CPU"}
+    assert all(task["metric_id"] not in {"icmp_latency_ms", "icmp_jitter_ms"} for task in tasks)
+
+
 def test_scheduler_builds_15_minute_cycle_and_priority_ordered_tasks():
     from polling.contracts import PollingPriority, PollingProtocol
     from polling.scheduler import build_cycle, build_tasks_from_records, group_tasks_by_protocol

--- a/backend/tests/test_polling_snmp_executor.py
+++ b/backend/tests/test_polling_snmp_executor.py
@@ -83,13 +83,53 @@ def test_snmp_executor_maps_no_data_and_errors_to_retryable_results():
 
 def test_icmp_executor_maps_ping_success_and_failure_statuses():
     from polling.contracts import PollingResultStatus
+    from polling.icmp_measurements import PingMeasurement
     from polling.snmp_executor import execute_poll_task
 
     payload = {"kind": "icmp_ping", "target": "10.0.0.1", "timeout_ms": 500, "retries": 1}
-    success = execute_poll_task(_task("ICMP", payload), icmp_fetcher=lambda **kwargs: 1.0)
-    failure = execute_poll_task(_task("ICMP", payload), icmp_fetcher=lambda **kwargs: 0.0)
+    success = execute_poll_task(_task("ICMP", payload), icmp_fetcher=lambda **kwargs: PingMeasurement(True, 18.25, raw="ok"))
+    failure = execute_poll_task(_task("ICMP", payload), icmp_fetcher=lambda **kwargs: PingMeasurement(False, None, raw="timeout"))
 
     assert success.status == PollingResultStatus.OK
     assert success.value["numeric"] == 1.0
+    assert success.metric_id == "PING-CHECK"
+    assert success.metadata["metric_kind"] == "availability"
+    assert success.metadata["icmp"]["latency_ms"] == 18.25
+    assert success.metadata["icmp"]["sidecar_metric_ids"] == ["icmp_latency_ms", "icmp_jitter_ms"]
     assert failure.status == PollingResultStatus.CRITICAL
     assert failure.value["numeric"] == 0.0
+    assert "latency_ms" not in failure.metadata["icmp"]
+
+
+def test_icmp_executor_fetcher_exception_returns_error_envelope_without_unbound_measurement():
+    from polling.contracts import PollingResultStatus
+    from polling.snmp_executor import execute_poll_task
+
+    def boom(**kwargs):
+        raise RuntimeError("icmp exploded")
+
+    payload = {"kind": "icmp_ping", "target": "10.0.0.1", "timeout_ms": 500, "retries": 1}
+    result = execute_poll_task(_task("ICMP", payload), icmp_fetcher=boom)
+
+    assert result.status == PollingResultStatus.ERROR
+    assert result.error == {"code": "executor_error", "message": "icmp exploded", "retryable": True}
+    assert result.value == {"numeric": None, "text": None, "raw": None}
+    assert "icmp" not in result.metadata
+    assert result.metadata.get("metric_kind") != "availability"
+
+
+def test_icmp_executor_skips_sidecar_metric_tasks_as_telemetry_not_availability():
+    from polling.contracts import PollingResultStatus
+    from polling.snmp_executor import execute_poll_task
+
+    payload = {"kind": "icmp_ping", "target": "10.0.0.1", "timeout_ms": 500, "retries": 1}
+    result = execute_poll_task(
+        _task("ICMP", payload, metric_id="icmp_latency_ms", metadata={"metric_kind": "telemetry"}),
+        icmp_fetcher=lambda **kwargs: 1.0,
+    )
+
+    assert result.status == PollingResultStatus.OK
+    assert result.value == {"numeric": None, "text": None, "raw": None}
+    assert result.error == {"code": "skipped_icmp_telemetry", "message": "ICMP telemetry sidecars are derived from availability polls", "retryable": False}
+    assert result.metadata["metric_kind"] == "telemetry"
+    assert "icmp" not in result.metadata

--- a/backend/tests/test_polling_writer_pool.py
+++ b/backend/tests/test_polling_writer_pool.py
@@ -54,6 +54,37 @@ def test_writer_skips_duplicate_receipts_and_marks_result_written(monkeypatch):
     assert len(completed) == 1
 
 
+def test_writer_expands_icmp_sidecar_samples_and_keeps_events_primary_only(monkeypatch):
+    from polling import writer_pool
+
+    persisted = []
+    event_rows = []
+    row = _row(key="icmp-1", numeric=1.0)
+    row.protocol = "ICMP"
+    row.metric_id = "PING-CHECK"
+    row.envelope.update({
+        "protocol": "ICMP",
+        "metric_id": "PING-CHECK",
+        "metadata": {"metric_kind": "availability", "icmp": {"latency_ms": 20.0, "sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms"]}},
+    })
+    monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
+    monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
+    monkeypatch.setattr(writer_pool, "previous_metric_value", lambda db, node_id, metric_id, before: 12.5)
+    monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: None)
+
+    stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
+
+    assert stats["inserted"] == 3
+    assert persisted[0][1] == [
+        {"node_id": "ci-1", "metric_id": "PING-CHECK", "value": 1.0, "time": row.observed_at},
+        {"node_id": "ci-1", "metric_id": "icmp_latency_ms", "value": 20.0, "time": row.observed_at},
+        {"node_id": "ci-1", "metric_id": "icmp_jitter_ms", "value": 7.5, "time": row.observed_at},
+    ]
+    assert [event["metric_id"] for event in event_rows] == ["PING-CHECK"]
+
+
 def test_writer_batches_timescale_inserts_receipts_and_neo4j_updates(monkeypatch):
     from polling import writer_pool
 

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -65,6 +65,17 @@ class TestFetchICMPPing:
         assert mock_run.call_count == 1
 
     @patch("engines.snmp_worker.subprocess.run")
+    def test_fetch_icmp_ping_measurement_extracts_latency_while_binary_wrapper_stays_compatible(self, mock_run):
+        """Structured ICMP returns latency but legacy wrapper still returns 1.0."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="64 bytes from 192.168.1.1: time=9.75 ms", stderr="")
+        from engines.snmp_worker import fetch_icmp_ping, fetch_icmp_ping_measurement
+
+        measurement = fetch_icmp_ping_measurement("192.168.1.1", timeout_ms=3000, retries=0)
+        assert measurement.available is True
+        assert measurement.latency_ms == 9.75
+        assert fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=0) == 1.0
+
+    @patch("engines.snmp_worker.subprocess.run")
     def test_fetch_icmp_ping_success_on_retry(self, mock_run):
         """Returns 1.0 when retry succeeds after first failure."""
         mock_run.side_effect = [
@@ -675,3 +686,71 @@ class TestICMPDebounce:
         ]
         assert availability_queries == []
         assert _consecutive_failures.get("ci-001", 0) >= 3
+
+
+def test_poll_snmp_skips_icmp_sidecar_metrics_as_primary_poll_targets():
+    from engines.snmp_worker import _consecutive_failures
+    from polling.icmp_measurements import PingMeasurement
+
+    _consecutive_failures.clear()
+    mock_db = MagicMock()
+    mock_db.execute.return_value.first.return_value = None
+    mock_session = MockNeo4jSession()
+    mock_session.set_response("match", [
+        {
+            "node_id": "ci-001",
+            "metric_id": "PING-CHECK",
+            "protocol": "ICMP",
+            "metric_kind": "availability",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": None,
+            "port": 161,
+            "metric_name": "Ping availability",
+            "criticality": 3,
+        },
+        {
+            "node_id": "ci-001",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": None,
+            "port": 161,
+            "metric_name": "ICMP Latency",
+            "criticality": 1,
+        },
+        {
+            "node_id": "ci-001",
+            "metric_id": "icmp_jitter_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": None,
+            "port": 161,
+            "metric_name": "ICMP Jitter",
+            "criticality": 1,
+        },
+    ])
+    mock_session.set_default_response([])
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=mock_db), \
+         patch("engines.snmp_worker.bulk_insert_metrics") as mock_bulk_insert, \
+         patch("engines.snmp_worker.fetch_icmp_ping", return_value=PingMeasurement(True, 12.0)) as mock_fetch_icmp:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()
+
+    mock_fetch_icmp.assert_called_once()
+    mock_bulk_insert.assert_called_once()
+    rows = mock_bulk_insert.call_args.args[1]
+    assert any(row["metric_id"] == "PING-CHECK" and row["value"] == 1.0 for row in rows)
+    assert any(row["metric_id"] == "icmp_latency_ms" and row["value"] == 12.0 for row in rows)
+    assert not any(row["metric_id"] == "icmp_latency_ms" and row["value"] == 1.0 for row in rows)
+    assert not any(row["metric_id"] == "icmp_jitter_ms" and row["value"] in (0.0, 1.0) for row in rows)


### PR DESCRIPTION
Closes #175

## Descripción del Cambio
Agrega telemetría ICMP de latencia y jitter preservando la métrica binaria de disponibilidad existente para no romper eventos ni estados de CI.

### Resumen
- Mantiene disponibilidad ICMP como `1.0/0.0` y agrega sidecars `icmp_latency_ms` e `icmp_jitter_ms`.
- Evita que latencia/jitter sean tratados como objetivos de polling de disponibilidad o como eventos de disponibilidad.
- Agrega migración idempotente para vincular sidecars a CIs existentes con métricas ping.
- Documenta la mejora en `CHANGELOG.md` como entrada Unreleased.

| File | Change |
|------|--------|
| `backend/polling/icmp_measurements.py` | Helper compartido para parseo de ping, constantes ICMP, sidecars y guardas de disponibilidad. |
| `backend/engines/snmp_worker.py` | Emisión legacy de disponibilidad + latencia/jitter, excluyendo sidecars como poll targets. |
| `backend/polling/scheduler.py` | Evita encolar sidecars ICMP como tareas de disponibilidad. |
| `backend/polling/snmp_executor.py` | Mantiene envelope primario binario y agrega metadata de latencia; maneja errores del fetcher. |
| `backend/polling/writer_pool.py` | Persiste sidecars de latencia/jitter en Timescale bajo idempotencia del resultado primario. |
| `backend/polling/event_writer.py` | Endurece guardas para que sidecars nunca abran eventos de disponibilidad. |
| `backend/repositories/topology_repo.py` | Crea/vincula MetricDefs sidecar de forma idempotente. |
| `backend/scripts/migrate_icmp_sidecar_metrics.py` | Entry point de migración para CIs existentes. |
| `backend/tests/*` | Cobertura de parser, migración, scheduler, executor, writer, eventos y legacy worker. |
| `CHANGELOG.md` | Entrada Unreleased para release notes. |

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] Targeted backend suite:
  ```bash
  cd backend && uv run --with pytest --with pytest-asyncio --with httpx --with sqlalchemy --with pydantic --with fastapi --with neo4j --with passlib --with bcrypt --with python-jose --with pandas --with openpyxl --with python-multipart --with apscheduler --with schedule --with paramiko python -m pytest tests/test_icmp_measurements.py tests/test_icmp_metric_migration.py tests/test_polling_event_writer.py tests/test_polling_scheduler.py tests/test_polling_snmp_executor.py tests/test_polling_writer_pool.py tests/test_snmp_worker.py -q
  ```
  Resultado: `60 passed, 18 warnings`.
- [x] `git diff --check`
- [x] AST parse de archivos backend modificados/relevantes.
- [x] Fresh adversarial review posterior a fixes: sin blockers/majors/minors.

Caveat: no se ejecutaron tests frontend porque el entorno no tiene `corepack`. El frontend ya soporta series numéricas arbitrarias y muestra `metric.unit`; no hubo cambios frontend.

## Release notes
- Nueva telemetría ICMP: `icmp_latency_ms` y `icmp_jitter_ms`.
- La disponibilidad ICMP existente sigue siendo binaria para compatibilidad de eventos.
- Ejecutar migración idempotente para CIs existentes cuando se despliegue:
  ```bash
  cd backend && python scripts/migrate_icmp_sidecar_metrics.py
  ```

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
