### PR TITLE
fix(users): normalize permission strings

### DIFF
--- a/backend/repositories/user_repo.py
+++ b/backend/repositories/user_repo.py
@@ -1,8 +1,14 @@
+from typing import Any, Iterable
+
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
 from models.sql_models import User
 from models.user import UserCreate, UserUpdate
 from utils.security import get_password_hash
+
+
+def _normalize_permissions(permissions: Iterable[Any]) -> list[str]:
+    return [str(getattr(permission, "value", permission)) for permission in permissions]
 
 
 def get_user_by_username(db: Session, username: str):
@@ -19,8 +25,8 @@ def get_users(db: Session, skip: int = 0, limit: int = 100):
 
 def create_user(db: Session, user: UserCreate):
     hashed_password = get_password_hash(user.password)
-    # Convert Pydantic Enums to strings for DB storage if needed
-    permissions_str = [p.value for p in user.permissions]
+    # Convert Pydantic Enums or enum-like values to strings for DB storage if needed.
+    permissions_str = _normalize_permissions(user.permissions)
 
     db_user = User(
         username=user.username,
@@ -47,17 +53,17 @@ def update_user(db: Session, username: str, user_update: UserUpdate):
         return None
 
     if user_update.password:
-        db_user.hashed_password = get_password_hash(user_update.password)
+        setattr(db_user, "hashed_password", get_password_hash(user_update.password))
     if user_update.role:
-        db_user.role = user_update.role
+        setattr(db_user, "role", user_update.role)
     if user_update.tier is not None:
-        db_user.tier = user_update.tier
+        setattr(db_user, "tier", user_update.tier)
     if user_update.permissions is not None:
-        db_user.permissions = [p.value for p in user_update.permissions]
+        setattr(db_user, "permissions", _normalize_permissions(user_update.permissions))
     if user_update.allowed_locations is not None:
-        db_user.allowed_locations = user_update.allowed_locations
+        setattr(db_user, "allowed_locations", user_update.allowed_locations)
     if user_update.allowed_ci_types is not None:
-        db_user.allowed_ci_types = user_update.allowed_ci_types
+        setattr(db_user, "allowed_ci_types", user_update.allowed_ci_types)
 
     db.commit()
     db.refresh(db_user)

--- a/backend/tests/test_user_repo_create.py
+++ b/backend/tests/test_user_repo_create.py
@@ -10,14 +10,13 @@ Fix: Hardcode is_active=True and force_password_change=False in
 create_user, since UserCreate has no fields for these concepts.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
-from pydantic import ValidationError
 
 # Patch Neo4j before importing main
 _mock_neo4j_driver = MagicMock()
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
-    from models.user import UserCreate, UserPermission
+    from models.refresh_token import RefreshToken  # noqa: F401 - register SQLAlchemy relationship
+    from models.user import UserCreate, UserPermission, UserUpdate
     from repositories import user_repo
 
 
@@ -147,6 +146,21 @@ class TestUserRepoCreateUser:
         assert db_user.phone == "+1234567890"
         assert db_user.email == "user@example.com"
 
+    def test_create_user_accepts_raw_string_permissions(self):
+        """create_user should persist raw string permissions from API/UI payloads."""
+        db = self._make_mock_db()
+        user_in = UserCreate(
+            username="stringperms",
+            password="SecureP@ss123",
+            role="OPERATOR",
+            permissions=["EVENT_VIEW", "CI_EDIT"],
+        )
+
+        user_repo.create_user(db, user_in)
+
+        db_user = db.add.call_args[0][0]
+        assert db_user.permissions == ["EVENT_VIEW", "CI_EDIT"]
+
     def test_create_user_commits_and_refreshes(self):
         """create_user should commit and refresh the new user."""
         db = self._make_mock_db()
@@ -176,3 +190,84 @@ class TestUserRepoCreateUser:
 
         db_user = db.add.call_args[0][0]
         assert db_user.tier == "T3"
+
+    def test_create_user_accepts_enum_like_permissions(self):
+        """create_user should remain compatible with enum-like permission values."""
+        db = self._make_mock_db()
+        permission = MagicMock(value="EVENT_VIEW")
+        user_in = UserCreate.model_construct(
+            username="enumlike",
+            password="SecureP@ss123",
+            role="OPERATOR",
+            tier="T1",
+            permissions=[permission],
+            allowed_locations=[],
+            allowed_ci_types=None,
+            phone=None,
+            email=None,
+        )
+
+        user_repo.create_user(db, user_in)
+
+        db_user = db.add.call_args[0][0]
+        assert db_user.permissions == ["EVENT_VIEW"]
+
+
+class TestUserRepoUpdateUser:
+    """Test user_repo.update_user permission normalization behavior."""
+
+    def _make_mock_db_with_user(self, existing_permissions=None):
+        db = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+        db_user = MagicMock()
+        db_user.permissions = list(existing_permissions or [])
+        db.query.return_value.filter.return_value.first.return_value = db_user
+        return db, db_user
+
+    def test_update_user_accepts_raw_string_permissions(self):
+        """update_user should persist raw string permissions from API/UI payloads."""
+        db, db_user = self._make_mock_db_with_user(["USER_MANAGE"])
+        update = UserUpdate(permissions=["EVENT_VIEW", "CI_EDIT"])
+
+        result = user_repo.update_user(db, "stringperms", update)
+
+        assert result is db_user
+        assert db_user.permissions == ["EVENT_VIEW", "CI_EDIT"]
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once_with(db_user)
+
+    def test_update_user_accepts_enum_like_permissions(self):
+        """update_user should remain compatible with enum-like permission values."""
+        db, db_user = self._make_mock_db_with_user(["USER_MANAGE"])
+        permission = MagicMock(value="EVENT_VIEW")
+        update = UserUpdate.model_construct(
+            password=None,
+            role=None,
+            tier=None,
+            permissions=[permission],
+            allowed_locations=None,
+            allowed_ci_types=None,
+        )
+
+        user_repo.update_user(db, "enumlike", update)
+
+        assert db_user.permissions == ["EVENT_VIEW"]
+
+    def test_update_user_preserves_permissions_when_omitted(self):
+        """permissions=None should leave existing permissions unchanged."""
+        db, db_user = self._make_mock_db_with_user(["EVENT_VIEW", "CI_EDIT"])
+        update = UserUpdate(permissions=None)
+
+        user_repo.update_user(db, "noperms", update)
+
+        assert db_user.permissions == ["EVENT_VIEW", "CI_EDIT"]
+
+    def test_update_user_clears_permissions_with_empty_list(self):
+        """permissions=[] should explicitly clear existing permissions."""
+        db, db_user = self._make_mock_db_with_user(["EVENT_VIEW", "CI_EDIT"])
+        update = UserUpdate(permissions=[])
+
+        user_repo.update_user(db, "clearperms", update)
+
+        assert db_user.permissions == []


### PR DESCRIPTION
## Descripción del Cambio
Closes #172

Normaliza la persistencia de permisos de usuarios para aceptar permisos como strings crudos desde la UI/API sin romper compatibilidad con valores enum-like.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Agrega helper de normalización para permisos en `user_repo`.
- Cubre create/update con permisos string, enum-like, permisos omitidos y lista vacía.
- Mantiene roles/frontend fuera de alcance.

## Cambios
| File | Change |
|------|--------|
| `backend/repositories/user_repo.py` | Normaliza permisos antes de persistir create/update. |
| `backend/tests/test_user_repo_create.py` | Agrega regresiones repository-level para permisos string y compatibilidad. |

## ¿Cómo se probó?
- [x] `cd backend && .venv/bin/python -m pytest tests/test_user_repo_create.py` — 17 passed
- [x] `cd backend && .venv/bin/python -m pytest tests/test_models.py tests/test_auth_extended.py` — 74 passed
- [x] `cd backend && .venv/bin/python -m pytest tests/test_user_repo_create.py tests/test_models.py tests/test_auth_extended.py` — 91 passed
- [x] `git diff --check -- backend/repositories/user_repo.py backend/tests/test_user_repo_create.py`

Nota: suite backend completa sigue roja con fallas ajenas al scope (`813 passed, 1 skipped, 108 failed`).

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] ShellCheck no aplica: no se modificaron scripts shell.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
