### PR TITLE
fix(dashboard): stabilize monitored CI counter

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -197,6 +197,17 @@ def _log_observe_only_cycle(settings, metrics_count, collected_count, failed_cou
     )
 
 
+def _count_monitored_cis(session) -> int:
+    """Return the stable count of distinct CIs with active metric assignments."""
+    record = session.run("""
+        MATCH (n:CI)-[:HAS_METRIC]->(:MetricDef)
+        RETURN count(DISTINCT n) AS cis_monitored
+    """).single()
+    if not record:
+        return 0
+    return int(record.get("cis_monitored") or 0)
+
+
 def _base_severity_from_criticality(criticality) -> str:
     try:
         normalized = int(criticality or 1)
@@ -540,16 +551,18 @@ def poll_snmp():
             # Update collector status in Neo4j
             duration_current = time.time() - start_time
             jobs_per_min = round((len(metrics_to_save) / duration_current) * 60, 1) if duration_current > 0 else 0.0
+            monitored_ci_count = _count_monitored_cis(session)
             session.run("""
                 MERGE (c:CollectorStatus {id: 'main'})
                 SET c.last_run = datetime(),
                     c.status = 'RUNNING',
-                    c.cis_monitored = $cis,
+                    c.cis_monitored = $cis_monitored,
+                    c.last_cycle_metrics_processed = $last_cycle_metrics_processed,
                     c.metrics_collected = $collected,
                     c.metrics_failed = $failed,
                     c.cycle_duration = $duration,
                     c.jobs_per_min = $jobs_per_min
-            """, cis=metrics_count, collected=len(metrics_to_save), failed=failed_count, duration=round(duration_current, 2), jobs_per_min=jobs_per_min)
+            """, cis_monitored=monitored_ci_count, last_cycle_metrics_processed=metrics_count, collected=len(metrics_to_save), failed=failed_count, duration=round(duration_current, 2), jobs_per_min=jobs_per_min)
             _log_observe_only_cycle(
                 polling_settings,
                 metrics_count,

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -45,11 +45,23 @@ LAST_COLLECTION_TIME = None
 COLLECTOR_STATUS = "STOPPED"
 GLOBAL_STATS = {
     "cis_monitored": 0,
+    "last_cycle_metrics_processed": 0,
     "metrics_collected": 0,
     "metrics_failed": 0,
     "cycle_duration": 0.0,
     "jobs_per_min": 0.0,
 }
+
+
+def _count_monitored_cis(session) -> int:
+    """Return the stable count of distinct CIs with active metric assignments."""
+    record = session.run("""
+        MATCH (n:CI)-[:HAS_METRIC]->(:MetricDef)
+        RETURN count(DISTINCT n) AS cis_monitored
+    """).single()
+    if not record:
+        return 0
+    return int(record.get("cis_monitored") or 0)
 
 
 def get_collector_status():
@@ -61,6 +73,7 @@ def get_collector_status():
                 RETURN c.last_run AS last_run,
                        c.status AS status,
                        c.cis_monitored AS cis_monitored,
+                       c.last_cycle_metrics_processed AS last_cycle_metrics_processed,
                        c.metrics_collected AS metrics_collected,
                        c.metrics_failed AS metrics_failed,
                        c.cycle_duration AS cycle_duration,
@@ -74,6 +87,7 @@ def get_collector_status():
                     "status": record.get("status") or "UNKNOWN",
                     "stats": {
                         "cis_monitored": record.get("cis_monitored") or 0,
+                        "last_cycle_metrics_processed": record.get("last_cycle_metrics_processed") or 0,
                         "metrics_collected": record.get("metrics_collected") or 0,
                         "metrics_failed": record.get("metrics_failed") or 0,
                         "cycle_duration": record.get("cycle_duration") or 0.0,
@@ -165,6 +179,7 @@ async def snmp_collector_loop():
 
             GLOBAL_STATS["cycle_duration"] = round(elapsed, 2)
             GLOBAL_STATS["cis_monitored"] = stats.get("cis", 0)
+            GLOBAL_STATS["last_cycle_metrics_processed"] = stats.get("total", 0)
             GLOBAL_STATS["metrics_collected"] = stats.get("total", 0)
             GLOBAL_STATS["metrics_failed"] = stats.get("errors", 0)
             if elapsed > 0:
@@ -227,7 +242,10 @@ def run_snmp_cycle_sync(driver):
         total_metrics += executed
         total_errors += errors
 
-    return {"cis": len(cis), "total": total_metrics, "errors": total_errors}
+    with driver.session() as session:
+        monitored_cis = _count_monitored_cis(session)
+
+    return {"cis": monitored_cis, "total": total_metrics, "errors": total_errors}
 
 
 def process_ci_metrics(ci, metrics, driver):

--- a/backend/tests/test_snmp_service_snapshots.py
+++ b/backend/tests/test_snmp_service_snapshots.py
@@ -8,6 +8,63 @@ def _load_snmp_service_module():
     return importlib.import_module("services.snmp_service")
 
 
+def test_get_collector_status_exposes_last_cycle_metrics_processed(mock_neo4j_session):
+    snmp_service = _load_snmp_service_module()
+    mock_neo4j_session.set_response(
+        "MATCH (c:CollectorStatus",
+        [
+            {
+                "last_run": "2026-05-28T01:00:00Z",
+                "status": "RUNNING",
+                "cis_monitored": 2,
+                "last_cycle_metrics_processed": 5,
+                "metrics_collected": 4,
+                "metrics_failed": 1,
+                "cycle_duration": 1.25,
+                "jobs_per_min": 192.0,
+            }
+        ],
+    )
+
+    status = snmp_service.get_collector_status()
+
+    assert status["stats"]["cis_monitored"] == 2
+    assert status["stats"]["last_cycle_metrics_processed"] == 5
+    assert status["stats"]["metrics_collected"] == 4
+
+
+def test_get_collector_status_tolerates_missing_last_cycle_metrics_processed(mock_neo4j_session):
+    snmp_service = _load_snmp_service_module()
+    mock_neo4j_session.set_response(
+        "MATCH (c:CollectorStatus",
+        [
+            {
+                "last_run": "2026-05-28T01:00:00Z",
+                "status": "RUNNING",
+                "cis_monitored": 2,
+                "metrics_collected": 4,
+                "metrics_failed": 1,
+                "cycle_duration": 1.25,
+                "jobs_per_min": 192.0,
+            }
+        ],
+    )
+
+    status = snmp_service.get_collector_status()
+
+    assert status["stats"]["cis_monitored"] == 2
+    assert status["stats"]["last_cycle_metrics_processed"] == 0
+
+
+def test_get_collector_status_fallback_stats_include_last_cycle_metrics_processed(mock_neo4j_session):
+    snmp_service = _load_snmp_service_module()
+    mock_neo4j_session.set_response("MATCH (c:CollectorStatus", [])
+
+    status = snmp_service.get_collector_status()
+
+    assert status["stats"]["last_cycle_metrics_processed"] == 0
+
+
 def test_resolve_event_snapshot_flattens_business_context(mock_neo4j_session):
     snmp_service = _load_snmp_service_module()
     mock_neo4j_session.set_response(

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -268,6 +268,92 @@ class TestSNMPWorkerObservability:
         db.close.assert_called_once()
 
 
+class TestMonitoredCIStatus:
+    """Regression tests for stable monitored CI status semantics."""
+
+    def test_count_monitored_cis_uses_distinct_has_metric_assignments(self):
+        mock_session = MockNeo4jSession()
+        mock_session.set_response("count(distinct n) as cis_monitored", [{"cis_monitored": 2}])
+
+        from engines.snmp_worker import _count_monitored_cis
+
+        assert _count_monitored_cis(mock_session) == 2
+        count_query = mock_session.queries[0]["query"]
+        assert "HAS_METRIC" in count_query
+        assert "count(DISTINCT n)" in count_query
+
+    def test_count_monitored_cis_returns_zero_when_no_record(self):
+        mock_session = MockNeo4jSession()
+        mock_session.set_default_response([])
+
+        from engines.snmp_worker import _count_monitored_cis
+
+        assert _count_monitored_cis(mock_session) == 0
+
+    @patch("engines.snmp_worker.get_polling_pipeline_settings")
+    @patch("engines.snmp_worker.fetch_snmp_value")
+    @patch("engines.snmp_worker.bulk_insert_metrics")
+    @patch("engines.snmp_worker.SessionLocal")
+    def test_poll_snmp_persists_stable_ci_count_and_last_cycle_processed_count(
+        self, mock_session_local, mock_bulk_insert, mock_fetch_snmp, mock_get_settings
+    ):
+        from config import PollingPipelineSettings
+
+        mock_get_settings.return_value = PollingPipelineSettings()
+        mock_fetch_snmp.return_value = 42.0
+        mock_session_local.return_value = MagicMock()
+
+        mock_session = MockNeo4jSession()
+        mock_session.set_response("count(distinct n) as cis_monitored", [{"cis_monitored": 2}])
+        mock_session.set_response("match (n:ci)-[r:has_metric]->(m:metricdef)", [
+            {
+                "node_id": "ci-001",
+                "metric_id": "cpu",
+                "protocol": "SNMP",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                "port": 161,
+            },
+            {
+                "node_id": "ci-001",
+                "metric_id": "memory",
+                "protocol": "SNMP",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": "1.3.6.1.2.1.25.2.3.1.6",
+                "port": 161,
+            },
+            {
+                "node_id": "ci-002",
+                "metric_id": "cpu",
+                "protocol": "SNMP",
+                "ip": "192.168.1.2",
+                "community": "public",
+                "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                "port": 161,
+            },
+        ])
+        mock_session.set_default_response([])
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+        with patch("engines.snmp_worker.driver", mock_driver):
+            from engines.snmp_worker import poll_snmp
+            poll_snmp()
+
+        status_update = next(
+            q for q in mock_session.queries
+            if "MERGE (c:CollectorStatus" in q["query"]
+        )
+        assert status_update["params"]["cis_monitored"] == 2
+        assert status_update["params"]["last_cycle_metrics_processed"] == 3
+        assert "c.last_cycle_metrics_processed" in status_update["query"]
+        assert mock_bulk_insert.call_args.args[1][0]["node_id"] == "ci-001"
+
+
 class TestSNMPCollectionFailures:
     """Regression tests for SNMP no-response collection-failure lifecycle."""
 

--- a/frontend/components/SystemDashboard.test.tsx
+++ b/frontend/components/SystemDashboard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import SystemDashboard from './SystemDashboard';
@@ -30,6 +29,7 @@ describe('SystemDashboard', () => {
           last_run: '2026-04-04T10:00:00.000Z',
           stats: {
             cis_monitored: 8,
+            last_cycle_metrics_processed: 173,
             metrics_collected: 120,
             metrics_failed: 1,
             cycle_duration: 3,
@@ -47,5 +47,8 @@ describe('SystemDashboard', () => {
     expect(screen.getByText('40%')).toBeInTheDocument();
     expect(screen.getByText('CONNECTED')).toBeInTheDocument();
     expect(screen.getByText('RUNNING')).toBeInTheDocument();
+    expect(screen.getByText('Active Monitored CIs')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.queryByText('173')).not.toBeInTheDocument();
   });
 });

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -18,6 +18,7 @@ export interface SystemStatus {
 		last_run: string | null;
 		stats: {
 			cis_monitored: number;
+			last_cycle_metrics_processed?: number;
 			metrics_collected: number;
 			metrics_failed: number;
 			cycle_duration: number;


### PR DESCRIPTION
Closes #163

## Descripción del Cambio
Corrige la semántica de `Active Monitored CIs` para que muestre el conteo estable de CIs monitoreados, no la cantidad de métricas procesadas en el último ciclo.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- `cis_monitored` ahora se calcula con conteo estable de CIs distintos con `HAS_METRIC`.
- Se agrega `last_cycle_metrics_processed` como campo API opcional para preservar la métrica del último ciclo.
- El dashboard sigue mostrando `Active Monitored CIs` desde `cis_monitored`, sin nueva UI visible.

## Cambios
| File | Change |
|------|--------|
| `backend/engines/snmp_worker.py` | Calcula CIs monitoreados estables y persiste el conteo del último ciclo por separado. |
| `backend/services/snmp_service.py` | Expone `last_cycle_metrics_processed` y alinea fallback async/status. |
| `backend/tests/test_snmp_worker.py` | Agrega regresión para conteo estable vs último ciclo. |
| `backend/tests/test_snmp_service_snapshots.py` | Cubre el campo opcional en status/snapshots. |
| `frontend/services/queryResources.ts` | Agrega type opcional `last_cycle_metrics_processed`. |
| `frontend/components/SystemDashboard.test.tsx` | Verifica que la card usa `cis_monitored` y no el conteo del último ciclo. |

## ¿Cómo se probó?
- [x] `cd backend && uv run pytest tests/test_snmp_worker.py -q`
- [x] `cd backend && uv run pytest tests/test_snmp_service_snapshots.py -q`
- [x] `cd backend && uv run pytest tests/test_snmp_worker.py tests/test_snmp_service_snapshots.py tests/test_snmp_service_collection_failures.py -q`
- [x] `cd frontend && pnpm test:run SystemDashboard`
- [x] `git diff --check`

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Issue aprobado enlazado.
- [x] Exactamente un tipo de cambio seleccionado / label `type:bug`.
- [x] Shellcheck no aplica: no se modificaron scripts shell.
- [x] Commit convencional: `fix(dashboard): stabilize monitored CI counter`.
- [x] Sin trailers `Co-Authored-By`.

---
*Generado por Alex*
