### PR TITLE
perf(events): optimize availability report queries

### DIFF
--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -477,9 +477,14 @@ def get_availability_report(
             WHERE e.created_at IS NOT NULL
               AND e.recovered_at IS NOT NULL
               AND NOT e.status IN ['OPEN', 'ACK']
+              AND e.created_at >= $window_start
+              AND e.created_at <= $window_end
+              AND e.recovered_at <= $window_end
             RETURN e, ci
             ORDER BY e.created_at ASC
             """,
+            window_start=window_start,
+            window_end=window_end,
         )
         for record in recovered_result:
             event_data = _node_to_dict(_record_value(record, "e"))
@@ -511,9 +516,11 @@ def get_availability_report(
             MATCH (e:Event)<-[:HAS_EVENT]-(ci:CI)
             WHERE e.status IN ['OPEN', 'ACK']
               AND e.created_at IS NOT NULL
+              AND e.created_at <= $window_end
             RETURN e, ci
             ORDER BY e.created_at ASC
             """,
+            window_end=window_end,
         )
         for record in active_result:
             event_data = _node_to_dict(_record_value(record, "e"))

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -213,6 +213,71 @@ class TestEventServiceSmoke:
         assert row["mtbf_seconds"] == 10800
         assert row["active_events"] == 1
 
+    def test_get_availability_report_queries_filter_window_in_cypher(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+
+        get_availability_report(start=start, end=end, now=end)
+
+        recovered_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "NOT e.status IN ['OPEN', 'ACK']" in query["query"]
+        )
+        active_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "WHERE e.status IN ['OPEN', 'ACK']" in query["query"]
+        )
+
+        assert recovered_query["params"] == {
+            "window_start": start,
+            "window_end": end,
+        }
+        assert "e.created_at >= $window_start" in recovered_query["query"]
+        assert "e.created_at <= $window_end" in recovered_query["query"]
+        assert "e.recovered_at <= $window_end" in recovered_query["query"]
+
+        assert active_query["params"] == {"window_end": end}
+        assert "e.created_at <= $window_end" in active_query["query"]
+        assert "e.created_at >= $window_start" not in active_query["query"]
+
+    def test_get_availability_report_active_before_window_counts_downtime_not_mtbf(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response("not e.status in ['open', 'ack']", [])
+        mock_neo4j_session.set_response(
+            "e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-active-before-window",
+                        "ci_id": "ci-1",
+                        "status": "OPEN",
+                        "event_type": "AVAILABILITY",
+                        "created_at": datetime(2025, 12, 31, 23, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-1", "name": "Router-01"},
+                }
+            ],
+        )
+
+        report = get_availability_report(start=start, end=end, now=end)
+
+        row = report["rows"][0]
+        assert row["active_events"] == 1
+        assert row["active_downtime_seconds"] == 7200
+        assert row["mtbf_seconds"] is None
+        assert row["first_failure_at"] is None
+        assert row["last_failure_at"] is None
+        assert row["availability_percentage"] == 0.0
+
     def test_get_availability_report_defaults_to_last_30_days(self, mock_neo4j_session):
         get_availability_report = _load_event_service_module().get_availability_report
         now = datetime(2026, 2, 1, 12, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Descripción del Cambio
Closes #176

- Optimiza `GET /api/events/availability-report` moviendo filtros de ventana al query Cypher.
- Mantiene la semántica actual de MTTR/MTBF y downtime activo.
- Agrega regresiones para contrato de query y eventos activos iniciados antes de la ventana.

| File | Change |
|------|--------|
| `backend/services/event_service.py` | Agrega predicados `window_start`/`window_end` a consultas Neo4j de eventos recuperados y activos. |
| `backend/tests/test_event_service_smoke.py` | Cubre filtros Cypher esperados y downtime activo pre-ventana sin contaminar MTBF. |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [x] Performance (Optimización)

## ¿Cómo se probó?
- [x] `/home/alex/dev/next-gen/next-gen/backend/.venv/bin/python -m pytest tests/test_event_service_smoke.py -k availability_report` — 5 passed
- [x] `/home/alex/dev/next-gen/next-gen/backend/.venv/bin/python -m pytest tests/test_event_service_smoke.py tests/test_routers_metrics_events.py -k "availability_report or availability-report"` — 6 passed
- [x] Fresh-context review fanout completado sin blockers

Nota: no se modificaron scripts shell. No se agregó migración/index Neo4j en este PR; conviene validar planner/performance con Neo4j real antes de rollout productivo.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
