### PR TITLE
feat(availability): enrich report and decouple monitoring

### DIFF
--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -183,6 +183,23 @@ class EventDetailResponse(BaseModel):
     itsm_context: ItsmContext
 
 
+class AvailabilityReportCI(BaseModel):
+    id: Optional[str] = None
+    label: Optional[str] = None
+    category: Optional[str] = None
+    type: Optional[str] = None
+    status: Optional[str] = None
+    ip: Optional[str] = None
+    location_name: Optional[str] = None
+    owner: Optional[str] = None
+    brand: Optional[str] = None
+    model: Optional[str] = None
+    serialNumber: Optional[str] = None
+    firmwareVersion: Optional[str] = None
+    pollingInterval: Optional[int] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
 class AvailabilityReportRow(BaseModel):
     ci_id: str
     ci_name: Optional[str] = None
@@ -196,6 +213,7 @@ class AvailabilityReportRow(BaseModel):
     availability_percentage: Optional[float] = None
     first_failure_at: Optional[str] = None
     last_failure_at: Optional[str] = None
+    ci: Optional[AvailabilityReportCI] = None
 
 
 class AvailabilityReportResponse(BaseModel):

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -420,12 +420,130 @@ def _resolve_availability_window(
     return window_start, window_end, generated_at
 
 
+_CI_CANONICAL_FIELDS = {
+    "id",
+    "name",
+    "label",
+    "category",
+    "layer",
+    "type",
+    "status",
+    "ip",
+    "location_name",
+    "owner",
+    "brand",
+    "model",
+    "serialNumber",
+    "firmwareVersion",
+    "pollingInterval",
+}
+
+_SENSITIVE_CI_KEY_PARTS = (
+    "credential",
+    "password",
+    "passphrase",
+    "passwd",
+    "pwd",
+    "secret",
+    "token",
+    "snmp",
+    "community",
+    "auth",
+    "priv",
+    "username",
+    "user_name",
+    "login",
+    "user",
+)
+
+
 def _availability_group_key(event_data: Dict[str, Any]) -> Optional[tuple[str, str]]:
     ci_id = event_data.get("ci_id")
     event_type = event_data.get("event_type")
     if not ci_id or not event_type:
         return None
     return str(ci_id), str(event_type)
+
+
+def _is_sensitive_ci_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(part in normalized for part in _SENSITIVE_CI_KEY_PARTS)
+
+
+def _json_safe_ci_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, list):
+        safe_items = [_json_safe_ci_value(item) for item in value]
+        return [item for item in safe_items if item is not None]
+    if isinstance(value, dict):
+        sanitized = _sanitize_ci_metadata(value)
+        return sanitized or None
+    return None
+
+
+def _sanitize_ci_metadata(ci_data: Dict[str, Any]) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    for key, value in ci_data.items():
+        if key in _CI_CANONICAL_FIELDS or _is_sensitive_ci_key(key):
+            continue
+        safe_value = _json_safe_ci_value(value)
+        if safe_value is not None:
+            metadata[key] = safe_value
+    return metadata
+
+
+def _build_availability_ci_metadata(
+    ci_data: Dict[str, Any], category: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    if not ci_data:
+        return None
+    ci_type = category or ci_data.get("type") or ci_data.get("layer")
+    metadata = _sanitize_ci_metadata(ci_data)
+    payload = _clean_dict(
+        {
+            "id": ci_data.get("id"),
+            "label": ci_data.get("name") or ci_data.get("label"),
+            "category": category,
+            "type": ci_type,
+            "status": ci_data.get("status"),
+            "ip": ci_data.get("ip"),
+            "location_name": ci_data.get("location_name"),
+            "owner": ci_data.get("owner"),
+            "brand": ci_data.get("brand"),
+            "model": ci_data.get("model"),
+            "serialNumber": ci_data.get("serialNumber"),
+            "firmwareVersion": ci_data.get("firmwareVersion"),
+            "pollingInterval": ci_data.get("pollingInterval"),
+            "metadata": metadata or None,
+        }
+    )
+    return payload or None
+
+
+def _merge_availability_ci_metadata(
+    existing: Optional[Dict[str, Any]], incoming: Optional[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    if not existing:
+        return incoming
+    if not incoming:
+        return existing
+    incoming_values = {
+        key: value for key, value in incoming.items() if value is not None
+    }
+    merged = {**existing, **incoming_values}
+    existing_metadata = (
+        existing.get("metadata") if isinstance(existing.get("metadata"), dict) else {}
+    )
+    incoming_metadata = (
+        incoming.get("metadata") if isinstance(incoming.get("metadata"), dict) else {}
+    )
+    metadata = {**existing_metadata, **incoming_metadata}
+    if metadata:
+        merged["metadata"] = metadata
+    return merged
 
 
 def get_availability_report(
@@ -450,7 +568,9 @@ def get_availability_report(
     groups: Dict[tuple[str, str], Dict[str, Any]] = {}
 
     def ensure_group(
-        key: tuple[str, str], ci_name: Optional[str] = None
+        key: tuple[str, str],
+        ci_name: Optional[str] = None,
+        ci_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         row = groups.setdefault(
             key,
@@ -463,10 +583,12 @@ def get_availability_report(
                 "downtime_seconds": 0.0,
                 "active_events": 0,
                 "active_downtime_seconds": 0.0,
+                "ci": ci_metadata,
             },
         )
         if ci_name and not row.get("ci_name"):
             row["ci_name"] = ci_name
+        row["ci"] = _merge_availability_ci_metadata(row.get("ci"), ci_metadata)
         return row
 
     driver = get_db()
@@ -480,7 +602,9 @@ def get_availability_report(
               AND e.created_at >= $window_start
               AND e.created_at <= $window_end
               AND e.recovered_at <= $window_end
-            RETURN e, ci
+            OPTIONAL MATCH (ci)-[:CATEGORIZED_AS]->(cat:Category)
+            WITH e, ci, head(collect(DISTINCT cat.name)) AS category
+            RETURN e, ci, category
             ORDER BY e.created_at ASC
             """,
             window_start=window_start,
@@ -501,7 +625,10 @@ def get_availability_report(
             if recovered_at < created_at or recovered_at > window_end:
                 continue
 
-            row = ensure_group(key, ci_data.get("name"))
+            ci_metadata = _build_availability_ci_metadata(
+                ci_data, _record_value(record, "category")
+            )
+            row = ensure_group(key, ci_data.get("name"), ci_metadata)
             repair_seconds = (recovered_at - created_at).total_seconds()
             row["failure_starts"].append(created_at)
             row["repair_seconds"].append(repair_seconds)
@@ -517,7 +644,9 @@ def get_availability_report(
             WHERE e.status IN ['OPEN', 'ACK']
               AND e.created_at IS NOT NULL
               AND e.created_at <= $window_end
-            RETURN e, ci
+            OPTIONAL MATCH (ci)-[:CATEGORIZED_AS]->(cat:Category)
+            WITH e, ci, head(collect(DISTINCT cat.name)) AS category
+            RETURN e, ci, category
             ORDER BY e.created_at ASC
             """,
             window_end=window_end,
@@ -531,7 +660,10 @@ def get_availability_report(
             created_at = _parse_datetime(event_data.get("created_at"))
             if created_at is None or created_at > window_end:
                 continue
-            row = ensure_group(key, ci_data.get("name"))
+            ci_metadata = _build_availability_ci_metadata(
+                ci_data, _record_value(record, "category")
+            )
+            row = ensure_group(key, ci_data.get("name"), ci_metadata)
             row["active_events"] += 1
             if window_start <= created_at <= window_end:
                 row["failure_starts"].append(created_at)
@@ -577,6 +709,7 @@ def get_availability_report(
                 "last_failure_at": failure_starts[-1].isoformat()
                 if failure_starts
                 else None,
+                "ci": row.get("ci"),
             }
         )
 

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -213,6 +213,119 @@ class TestEventServiceSmoke:
         assert row["mtbf_seconds"] == 10800
         assert row["active_events"] == 1
 
+    def test_get_availability_report_enriches_rows_with_sanitized_ci_metadata(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response(
+            "not e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-1",
+                        "ci_id": "ci-1",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc),
+                    },
+                    "ci": {
+                        "id": "ci-1",
+                        "name": "Router-01",
+                        "layer": "NETWORK",
+                        "status": "ONLINE",
+                        "ip": "10.0.0.1",
+                        "location_name": "Madrid HQ",
+                        "owner": "NOC",
+                        "brand": "Cisco",
+                        "model": "ISR4331",
+                        "serialNumber": "FTX1234",
+                        "firmwareVersion": "17.9",
+                        "pollingInterval": 60,
+                        "rack": "R1",
+                        "username": "admin",
+                        "login": "router-admin",
+                        "user": "operator",
+                        "passwd": "legacy-password",
+                        "pwd": "short-password",
+                        "passphrase": "phrase-value",
+                        "support_contact": {"username": "support", "phone": "+34123456789"},
+                        "snmp_community": "public",
+                        "credentials": {"username": "admin", "password": "secret"},
+                        "api_token": "token-value",
+                        "installed_at": datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc),
+                        "location": object(),
+                    },
+                    "category": "Routers",
+                }
+            ],
+        )
+        mock_neo4j_session.set_response("e.status in ['open', 'ack']", [])
+
+        report = get_availability_report(start=start, end=end, now=end)
+
+        row = report["rows"][0]
+        assert row["mttr_seconds"] == 900
+        assert row["downtime_seconds"] == 900
+        assert row["ci"] == {
+            "id": "ci-1",
+            "label": "Router-01",
+            "category": "Routers",
+            "type": "Routers",
+            "status": "ONLINE",
+            "ip": "10.0.0.1",
+            "location_name": "Madrid HQ",
+            "owner": "NOC",
+            "brand": "Cisco",
+            "model": "ISR4331",
+            "serialNumber": "FTX1234",
+            "firmwareVersion": "17.9",
+            "pollingInterval": 60,
+            "metadata": {
+                "rack": "R1",
+                "support_contact": {"phone": "+34123456789"},
+                "installed_at": "2025-12-01T10:00:00+00:00",
+            },
+        }
+        assert "credentials" not in row["ci"]["metadata"]
+        assert "username" not in row["ci"]["metadata"]
+        assert "login" not in row["ci"]["metadata"]
+        assert "user" not in row["ci"]["metadata"]
+        assert "passwd" not in row["ci"]["metadata"]
+        assert "pwd" not in row["ci"]["metadata"]
+        assert "passphrase" not in row["ci"]["metadata"]
+        assert "username" not in row["ci"]["metadata"]["support_contact"]
+        assert "snmp_community" not in row["ci"]["metadata"]
+        assert "api_token" not in row["ci"]["metadata"]
+        assert "location" not in row["ci"]["metadata"]
+
+    def test_get_availability_report_aggregates_categories_before_metric_rows(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+
+        get_availability_report(start=start, end=end, now=end)
+
+        recovered_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "NOT e.status IN ['OPEN', 'ACK']" in query["query"]
+        )["query"]
+        active_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "WHERE e.status IN ['OPEN', 'ACK']" in query["query"]
+        )["query"]
+
+        assert "head(collect(DISTINCT cat.name)) AS category" in recovered_query
+        assert "head(collect(DISTINCT cat.name)) AS category" in active_query
+        assert "RETURN e, ci, category" in recovered_query
+        assert "RETURN e, ci, category" in active_query
+
     def test_get_availability_report_queries_filter_window_in_cypher(
         self, mock_neo4j_session
     ):

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -1223,6 +1223,15 @@ class TestEventsList:
                     "availability_percentage": 99.9306,
                     "first_failure_at": start.isoformat(),
                     "last_failure_at": end.isoformat(),
+                    "ci": {
+                        "id": "ci-001",
+                        "label": "Router-01",
+                        "category": "Routers",
+                        "type": "Routers",
+                        "ip": "10.0.0.1",
+                        "owner": "NOC",
+                        "metadata": {"rack": "R1"},
+                    },
                 }
             ],
         }
@@ -1236,10 +1245,63 @@ class TestEventsList:
             )
 
         assert response.status_code == 200
-        assert response.json() == payload
+        body = response.json()
+        assert body["window_start"] == payload["window_start"]
+        assert body["window_end"] == payload["window_end"]
+        assert body["generated_at"] == payload["generated_at"]
+        assert body["window_days"] == 30.0
+        assert body["total_groups"] == 1
+        row = body["rows"][0]
+        assert row["ci_id"] == "ci-001"
+        assert row["ci_name"] == "Router-01"
+        assert row["mttr_seconds"] == 900
+        assert row["mtbf_seconds"] == 7200
+        assert row["ci"]["id"] == "ci-001"
+        assert row["ci"]["label"] == "Router-01"
+        assert row["ci"]["category"] == "Routers"
+        assert row["ci"]["type"] == "Routers"
+        assert row["ci"]["ip"] == "10.0.0.1"
+        assert row["ci"]["owner"] == "NOC"
+        assert row["ci"]["metadata"] == {"rack": "R1"}
         get_report.assert_called_once()
         assert get_report.call_args.kwargs["start"] == start
         assert get_report.call_args.kwargs["end"] == end
+
+    def test_availability_report_endpoint_keeps_old_rows_valid(self):
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        payload = {
+            "window_start": start.isoformat(),
+            "window_end": start.isoformat(),
+            "generated_at": start.isoformat(),
+            "window_days": 0,
+            "total_groups": 1,
+            "rows": [
+                {
+                    "ci_id": "ci-001",
+                    "ci_name": "Router-01",
+                    "event_type": "AVAILABILITY",
+                    "recovered_incidents": 0,
+                    "mttr_seconds": None,
+                    "mtbf_seconds": None,
+                    "downtime_seconds": 0,
+                    "active_events": 0,
+                    "active_downtime_seconds": 0,
+                    "availability_percentage": None,
+                    "first_failure_at": None,
+                    "last_failure_at": None,
+                }
+            ],
+        }
+
+        with patch(
+            "routers.events.event_service.get_availability_report", return_value=payload
+        ):
+            response = client.get("/api/events/availability-report")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["rows"][0]["ci_id"] == "ci-001"
+        assert body["rows"][0].get("ci") in (None, {})
 
 
 class TestEventsDetail:

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -15,7 +15,7 @@ import {
 } from "react-leaflet";
 import { createPortal } from "react-dom";
 import "leaflet/dist/leaflet.css";
-import type { GraphNode, Event, AvailabilityReportRow } from "../types";
+import type { GraphNode, Event } from "../types";
 import { STATUS_COLORS } from "../utils/status";
 import DependencyMiniMap from "./DependencyMiniMap";
 import { useEventCorrelation } from "../hooks/useEventCorrelation";
@@ -73,26 +73,6 @@ function formatOpenAge(event: Event): string {
 	if (days > 0) return `${days}d ${hours}h`;
 	if (hours > 0) return `${hours}h ${minutes}m`;
 	return `${minutes}m`;
-}
-
-function formatDurationSeconds(value?: number | null): string {
-	if (value === null || value === undefined || !Number.isFinite(value))
-		return "—";
-	const totalSeconds = Math.max(0, Math.round(value));
-	const days = Math.floor(totalSeconds / 86400);
-	const hours = Math.floor((totalSeconds % 86400) / 3600);
-	const minutes = Math.floor((totalSeconds % 3600) / 60);
-
-	if (days > 0) return `${days}d ${hours}h`;
-	if (hours > 0) return `${hours}h ${minutes}m`;
-	if (minutes > 0) return `${minutes}m`;
-	return `${totalSeconds}s`;
-}
-
-function formatAvailability(value?: number | null): string {
-	if (value === null || value === undefined || !Number.isFinite(value))
-		return "—";
-	return `${value.toFixed(2)}%`;
 }
 
 function getOpenAgeTone(event: Event): string {
@@ -921,15 +901,7 @@ const MonitoringConsole: React.FC = () => {
 	const [streamFilter, setStreamFilter] = useState<
 		"ALL" | "CRITICAL" | "WARNING" | "ACK"
 	>("ALL");
-	const {
-		nodes,
-		links,
-		events,
-		categories,
-		availabilityReport,
-		availabilityReportIsLoading,
-		availabilityReportError,
-	} = useMonitoringConsoleData();
+	const { nodes, links, events, categories } = useMonitoringConsoleData();
 	const eventMutations = useEventMutations();
 
 	// --- Actions ---
@@ -1148,39 +1120,6 @@ const MonitoringConsole: React.FC = () => {
 	).length;
 	const kpiWarning = openEvents.filter((e) => e.severity === "WARNING").length;
 	const kpiAck = ackEvents.length;
-	const allAvailabilityRows: AvailabilityReportRow[] = useMemo(() => {
-		const rows =
-			availabilityReport && Array.isArray(availabilityReport.rows)
-				? availabilityReport.rows
-				: [];
-		return [...rows].sort((a, b) => {
-			const aAvailability = a.availability_percentage ?? 101;
-			const bAvailability = b.availability_percentage ?? 101;
-			if (aAvailability !== bAvailability) return aAvailability - bAvailability;
-			return (
-				b.active_events +
-				b.recovered_incidents -
-				(a.active_events + a.recovered_incidents)
-			);
-		});
-	}, [availabilityReport]);
-	const availabilityRows = allAvailabilityRows.slice(0, 5);
-	const reportWindowLabel = availabilityReport?.window_days
-		? `${Math.round(availabilityReport.window_days)}d window`
-		: "Last 30d";
-	const mttrRows = allAvailabilityRows.filter(
-		(row) => row.mttr_seconds !== null && row.mttr_seconds !== undefined,
-	);
-	const averageMttrSeconds =
-		mttrRows.length > 0
-			? mttrRows.reduce((sum, row) => sum + (row.mttr_seconds ?? 0), 0) /
-				mttrRows.length
-			: null;
-	const activeAvailabilityEvents = allAvailabilityRows.reduce(
-		(sum, row) => sum + row.active_events,
-		0,
-	);
-
 	// Helper for Cleanup Button Logic
 	// Note: summary feed doesn't include comments, so count is best-effort.
 	// Backend may skip events with comments during prune.
@@ -1412,111 +1351,6 @@ const MonitoringConsole: React.FC = () => {
 								active={streamFilter === "ALL"}
 								onClick={() => setStreamFilter("ALL")}
 							/>
-						</div>
-
-						{/* Availability Metrics */}
-						<div className="glass p-6 rounded-2xl border border-white/5">
-							<div className="flex items-center justify-between gap-4 mb-5">
-								<div>
-									<h3 className="text-sm font-bold text-neutral-300 uppercase flex items-center gap-2">
-										<span className="material-symbols-outlined text-emerald-400">
-											monitoring
-										</span>
-										Availability Metrics
-									</h3>
-									<p className="text-xs text-neutral-500 mt-1">
-										MTTR/MTBF by CI + event type · {reportWindowLabel}
-									</p>
-								</div>
-								<div className="flex gap-6 text-right">
-									<div>
-										<div className="text-[10px] text-neutral-500 font-bold uppercase">
-											Avg MTTR
-										</div>
-										<div className="text-lg font-black text-white">
-											{formatDurationSeconds(averageMttrSeconds)}
-										</div>
-									</div>
-									<div>
-										<div className="text-[10px] text-neutral-500 font-bold uppercase">
-											Active Down
-										</div>
-										<div className="text-lg font-black text-red-300">
-											{activeAvailabilityEvents}
-										</div>
-									</div>
-								</div>
-							</div>
-							{availabilityReportIsLoading ? (
-								<div className="text-sm text-neutral-500 italic py-3">
-									Loading availability metrics…
-								</div>
-							) : availabilityReportError ? (
-								<div className="text-sm text-red-300 italic py-3">
-									Availability metrics unavailable.
-								</div>
-							) : availabilityRows.length === 0 ? (
-								<div className="text-sm text-neutral-600 italic py-3">
-									No recovered availability incidents in the report window.
-								</div>
-							) : (
-								<div className="grid grid-cols-1 lg:grid-cols-5 gap-3">
-									{availabilityRows.map((row) => (
-										<div
-											key={`${row.ci_id}-${row.event_type}`}
-											className="rounded-xl bg-black/20 border border-white/5 p-4"
-										>
-											<div className="flex items-start justify-between gap-3 mb-3">
-												<div className="min-w-0">
-													<div className="text-sm font-black text-white truncate">
-														{row.ci_name || row.ci_id}
-													</div>
-													<div className="text-[10px] text-neutral-500 font-bold uppercase truncate">
-														{row.event_type}
-													</div>
-												</div>
-												<span className="text-[10px] font-black text-emerald-300 bg-emerald-500/10 px-2 py-1 rounded">
-													{formatAvailability(row.availability_percentage)}
-												</span>
-											</div>
-											<div className="grid grid-cols-2 gap-3 text-xs">
-												<div>
-													<div className="text-neutral-500 uppercase font-bold">
-														MTTR
-													</div>
-													<div className="text-neutral-100 font-black">
-														{formatDurationSeconds(row.mttr_seconds)}
-													</div>
-												</div>
-												<div>
-													<div className="text-neutral-500 uppercase font-bold">
-														MTBF
-													</div>
-													<div className="text-neutral-100 font-black">
-														{formatDurationSeconds(row.mtbf_seconds)}
-													</div>
-												</div>
-												<div>
-													<div className="text-neutral-500 uppercase font-bold">
-														Recovered
-													</div>
-													<div className="text-neutral-100 font-black">
-														{row.recovered_incidents}
-													</div>
-												</div>
-												<div>
-													<div className="text-neutral-500 uppercase font-bold">
-														Active
-													</div>
-													<div className="text-red-300 font-black">
-														{row.active_events}
-													</div>
-												</div>
-											</div>
-										</div>
-									))}
-								</div>
-							)}
 						</div>
 
 						{/* Event Stream Table */}

--- a/frontend/components/__tests__/MonitoringConsole.smoke.test.tsx
+++ b/frontend/components/__tests__/MonitoringConsole.smoke.test.tsx
@@ -15,7 +15,6 @@ import {
 	render,
 	screen,
 	waitFor,
-	within,
 } from "@testing-library/react";
 import type React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -232,12 +231,10 @@ describe("MonitoringConsole smoke tests", () => {
 		expect(endpointCalls["/links"]).toBe(1);
 		expect(endpointCalls["/categories"]).toBe(1);
 		expect(endpointCalls["/events?status=CONSOLE"]).toBe(2);
-		expect(endpointCalls["/events/availability-report"]).toBeGreaterThanOrEqual(
-			1,
-		);
+		expect(endpointCalls["/events/availability-report"]).toBeUndefined();
 	});
 
-	it("GIVEN availability report data WHEN dashboard renders THEN concise MTTR and MTBF metrics are visible", async () => {
+	it("GIVEN monitoring dashboard renders THEN it does not fetch or show the full availability report", async () => {
 		const { default: MonitoringConsole } = await import("../MonitoringConsole");
 
 		mockApiGet.mockImplementation((url: string) => {
@@ -246,71 +243,22 @@ describe("MonitoringConsole smoke tests", () => {
 			if (url === "/categories") return Promise.resolve([]);
 			if (url === "/events?status=CONSOLE") return Promise.resolve([]);
 			if (url === "/events/availability-report") {
-				return Promise.resolve({
-					window_start: "2026-01-01T00:00:00.000Z",
-					window_end: "2026-01-31T00:00:00.000Z",
-					generated_at: "2026-01-31T00:00:00.000Z",
-					window_days: 30,
-					total_groups: 1,
-					rows: [
-						{
-							ci_id: "ci-1",
-							ci_name: "Router-01",
-							event_type: "AVAILABILITY",
-							recovered_incidents: 2,
-							mttr_seconds: 900,
-							mtbf_seconds: 7200,
-							downtime_seconds: 1800,
-							active_events: 1,
-							active_downtime_seconds: 300,
-							availability_percentage: 99.75,
-						},
-						...Array.from({ length: 4 }, (_, index) => ({
-							ci_id: `ci-extra-${index}`,
-							ci_name: `Router-extra-${index}`,
-							event_type: "AVAILABILITY",
-							recovered_incidents: 1,
-							mttr_seconds: 600,
-							mtbf_seconds: null,
-							downtime_seconds: 600,
-							active_events: 0,
-							active_downtime_seconds: 0,
-							availability_percentage: 99.8 + index / 100,
-						})),
-						{
-							ci_id: "ci-hidden",
-							ci_name: "Hidden-Router",
-							event_type: "AVAILABILITY",
-							recovered_incidents: 1,
-							mttr_seconds: 600,
-							mtbf_seconds: null,
-							downtime_seconds: 600,
-							active_events: 9,
-							active_downtime_seconds: 900,
-							availability_percentage: 99.99,
-						},
-					],
-				});
+				throw new Error("Monitoring must not fetch availability analytics");
 			}
 			return Promise.resolve([]);
 		});
 
 		renderWithQueryClient(<MonitoringConsole />);
 
-		expect(await screen.findByText("Availability Metrics")).toBeInTheDocument();
-		expect(await screen.findByText("Router-01")).toBeInTheDocument();
-		expect(screen.getAllByText("AVAILABILITY").length).toBeGreaterThanOrEqual(
-			1,
-		);
-		expect(screen.getAllByText("15m").length).toBeGreaterThanOrEqual(1);
-		expect(screen.getByText("2h 0m")).toBeInTheDocument();
-		expect(screen.getByText("99.75%")).toBeInTheDocument();
-		expect(screen.queryByText("Hidden-Router")).not.toBeInTheDocument();
-		const activeDownCard = screen.getByText("Active Down").parentElement;
-		expect(activeDownCard).not.toBeNull();
+		await waitFor(() => {
+			expect(mockApiGet.mock.calls.some(([url]) => url === "/events?status=CONSOLE")).toBe(true);
+		});
+		expect(screen.queryByText("Availability Metrics")).not.toBeInTheDocument();
+		expect(screen.queryByText("MTTR/MTBF by CI + event type")).not.toBeInTheDocument();
+		expect(screen.queryByText("Active Down")).not.toBeInTheDocument();
 		expect(
-			within(activeDownCard as HTMLElement).getByText("10"),
-		).toBeInTheDocument();
+			mockApiGet.mock.calls.some(([url]) => url === "/events/availability-report"),
+		).toBe(false);
 	});
 
 	it("GIVEN recovered events WHEN console feed loads THEN they stay visible without ACK action and are cleanable", async () => {

--- a/frontend/hooks/queries/useMonitoringConsoleData.test.tsx
+++ b/frontend/hooks/queries/useMonitoringConsoleData.test.tsx
@@ -32,6 +32,7 @@ function Probe() {
 
 describe("useMonitoringConsoleData", () => {
 	beforeEach(() => {
+		vi.clearAllMocks();
 		mockUseNodesQuery.mockReturnValue({
 			data: [{ id: "node-1", type: "INFRASTRUCTURE" }],
 			isLoading: false,
@@ -71,39 +72,26 @@ describe("useMonitoringConsoleData", () => {
 		expect(screen.getByTestId("payload")).toHaveTextContent(
 			'"events":[{"id":"evt-1","ci_id":"node-1"}]',
 		);
-		expect(screen.getByTestId("payload")).toHaveTextContent(
-			'"availabilityReport":{"rows":[{"ci_id":"node-1","event_type":"AVAILABILITY"}]}',
-		);
-		expect(screen.getByTestId("payload")).toHaveTextContent(
-			'"availabilityReportIsLoading":false',
-		);
-		expect(screen.getByTestId("payload")).toHaveTextContent(
-			'"availabilityReportError":null',
+		expect(mockUseAvailabilityReportQuery).not.toHaveBeenCalled();
+		expect(screen.getByTestId("payload")).not.toHaveTextContent(
+			"availabilityReport",
 		);
 		expect(screen.getByTestId("payload")).toHaveTextContent(
 			'"categories":["Network"]',
 		);
 	});
 
-	it("surfaces availability report loading and error state separately", () => {
-		mockUseAvailabilityReportQuery.mockReturnValue({
-			data: undefined,
-			isLoading: true,
-			error: "report failed",
+	it("does not let availability report failures affect monitoring", () => {
+		mockUseAvailabilityReportQuery.mockImplementation(() => {
+			throw new Error("availability report should not be queried by monitoring");
 		});
 
 		render(<Probe />);
 
-		expect(screen.getByTestId("payload")).toHaveTextContent(
-			'"availabilityReport":null',
-		);
-		expect(screen.getByTestId("payload")).toHaveTextContent(
-			'"availabilityReportIsLoading":true',
-		);
-		expect(screen.getByTestId("payload")).toHaveTextContent(
-			'"availabilityReportError":"report failed"',
-		);
 		expect(screen.getByTestId("payload")).toHaveTextContent('"error":null');
+		expect(screen.getByTestId("payload")).not.toHaveTextContent(
+			"availabilityReport",
+		);
 	});
 
 	it("surfaces node types when category names are missing", () => {

--- a/frontend/hooks/queries/useMonitoringConsoleData.ts
+++ b/frontend/hooks/queries/useMonitoringConsoleData.ts
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import { useActiveEventsQuery } from "./useActiveEventsQuery";
-import { useAvailabilityReportQuery } from "./useAvailabilityReportQuery";
 import { useCategoriesQuery } from "./useCategoriesQuery";
 import { useLinksQuery } from "./useLinksQuery";
 import { useNodesQuery } from "./useNodesQuery";
@@ -9,7 +8,6 @@ export const useMonitoringConsoleData = () => {
 	const nodesQuery = useNodesQuery();
 	const linksQuery = useLinksQuery();
 	const eventsQuery = useActiveEventsQuery();
-	const availabilityReportQuery = useAvailabilityReportQuery();
 	const categoriesQuery = useCategoriesQuery();
 
 	const nodes = nodesQuery.data ?? [];
@@ -39,9 +37,6 @@ export const useMonitoringConsoleData = () => {
 		nodes,
 		links: linksQuery.data ?? [],
 		events: eventsQuery.data ?? [],
-		availabilityReport: availabilityReportQuery.data ?? null,
-		availabilityReportIsLoading: availabilityReportQuery.isLoading,
-		availabilityReportError: availabilityReportQuery.error ?? null,
 		categories,
 		isLoading:
 			nodesQuery.isLoading ||

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -64,6 +64,23 @@ export interface GraphLink {
 	relationship: "DEPENDS_ON" | "RUNS_ON" | "PART_OF" | "MANAGED_BY";
 }
 
+export interface AvailabilityReportCI {
+	id?: string | null;
+	label?: string | null;
+	category?: string | null;
+	type?: string | null;
+	status?: string | null;
+	ip?: string | null;
+	location_name?: string | null;
+	owner?: string | null;
+	brand?: string | null;
+	model?: string | null;
+	serialNumber?: string | null;
+	firmwareVersion?: string | null;
+	pollingInterval?: number | null;
+	metadata?: Record<string, unknown> | null;
+}
+
 export interface AvailabilityReportRow {
 	ci_id: string;
 	ci_name?: string | null;
@@ -77,6 +94,7 @@ export interface AvailabilityReportRow {
 	availability_percentage?: number | null;
 	first_failure_at?: string | null;
 	last_failure_at?: string | null;
+	ci?: AvailabilityReportCI | null;
 }
 
 export interface AvailabilityReportResponse {


### PR DESCRIPTION
## Descripción del Cambio
Closes #180

PR 1 de la cadena para mover Availability MTTR/MTBF fuera de Monitoring.

- Enriquece `GET /api/events/availability-report` con metadata CI sanitizada y aditiva para futura búsqueda/filtros en Analytics.
- Desacopla Monitoring del availability report: ya no fetchea ni renderiza el panel MTTR/MTBF.
- Mantiene intacta la semántica actual de MTTR, MTBF, downtime, active downtime y `/api/events?status=CONSOLE`.

| File | Change |
|------|--------|
| `backend/models/core.py` | Agrega `AvailabilityReportCI` y `ci` opcional en rows del reporte. |
| `backend/services/event_service.py` | Enriquece rows con CI metadata sanitizada y agrega categorías sin duplicar eventos. |
| `backend/tests/test_event_service_smoke.py` | Cubre metadata CI, sanitización y agregación de categorías. |
| `backend/tests/test_routers_metrics_events.py` | Cubre contrato aditivo del endpoint y compatibilidad con rows antiguas. |
| `frontend/hooks/queries/useMonitoringConsoleData.ts` | Quita dependencia de availability report desde Monitoring. |
| `frontend/components/MonitoringConsole.tsx` | Remueve el panel completo de Availability Metrics. |
| `frontend/types.ts` | Refleja el contrato CI enriquecido para PR 2. |
| Frontend tests | Actualiza cobertura de Monitoring sin availability report. |

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && python -m pytest tests/test_event_service_smoke.py -k availability_report -q` — 7 passed
- [x] `cd backend && python -m pytest tests/test_routers_metrics_events.py -k availability_report -q` — 2 passed
- [x] `pnpm --dir frontend exec vitest run components/__tests__/MonitoringConsole.smoke.test.tsx hooks/queries/useMonitoringConsoleData.test.tsx` — 11 passed
- [x] `git diff --check`
- [x] `python -m py_compile backend/services/event_service.py backend/models/core.py backend/routers/events.py`

Notas de suite completa:
- Backend full suite: 825 passed, 108 failed, 1 skipped. Fallos baseline/no relacionados observados en auth expectations, RTU routes/repo mocks y graph links.
- Frontend full suite: 252 passed, 59 failed. Fallos baseline/no relacionados por `localStorage.clear/removeItem is not a function` en tests fuera del scope.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Issue aprobado (`status:approved`).
- [x] PR tendrá exactamente un label `type:*`.
- [x] Commit convencional: `feat(availability): enrich report and decouple monitoring`.

---
*Generado por Alex*