### PR TITLE
feat(analytics): add availability dashboard

### DIFF
--- a/frontend/components/AvailabilityDashboard.test.tsx
+++ b/frontend/components/AvailabilityDashboard.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AvailabilityDashboard from "./AvailabilityDashboard";
+import type { AvailabilityReportResponse } from "../types";
+
+const { mockUseAvailabilityReportQuery } = vi.hoisted(() => ({
+	mockUseAvailabilityReportQuery: vi.fn(),
+}));
+
+vi.mock("../hooks/queries/useAvailabilityReportQuery", () => ({
+	useAvailabilityReportQuery: mockUseAvailabilityReportQuery,
+}));
+
+const report: AvailabilityReportResponse = {
+	window_start: "2026-01-01T00:00:00Z",
+	window_end: "2026-01-31T00:00:00Z",
+	generated_at: "2026-01-31T00:05:00Z",
+	window_days: 30,
+	total_groups: 2,
+	rows: [
+		{
+			ci_id: "ci-1",
+			ci_name: "Core Router",
+			event_type: "AVAILABILITY",
+			recovered_incidents: 3,
+			mttr_seconds: 900,
+			mtbf_seconds: 7200,
+			downtime_seconds: 2700,
+			active_events: 1,
+			active_downtime_seconds: 600,
+			availability_percentage: 99.87,
+			first_failure_at: "2026-01-02T00:00:00Z",
+			last_failure_at: "2026-01-20T00:00:00Z",
+			ci: {
+				id: "ci-1",
+				label: "Core Router",
+				category: "Network",
+				type: "Router",
+				ip: "10.0.0.1",
+				owner: "NOC",
+				brand: "Cisco",
+				model: "ISR4331",
+				metadata: { rack: "R1", site: "Madrid" },
+			},
+		},
+		{
+			ci_id: "ci-2",
+			ci_name: "Billing Database",
+			event_type: "DATABASE",
+			recovered_incidents: 1,
+			mttr_seconds: 1800,
+			mtbf_seconds: null,
+			downtime_seconds: 1800,
+			active_events: 0,
+			active_downtime_seconds: 0,
+			availability_percentage: 99.95,
+			first_failure_at: "2026-01-10T00:00:00Z",
+			last_failure_at: "2026-01-10T00:00:00Z",
+			ci: {
+				id: "ci-2",
+				label: "Billing Database",
+				category: "Database",
+				type: "Postgres",
+				ip: "10.0.0.20",
+				owner: "DataOps",
+				brand: "PostgreSQL",
+				model: "15",
+				metadata: { tier: "gold" },
+			},
+		},
+	],
+};
+
+describe("AvailabilityDashboard", () => {
+	beforeEach(() => {
+		mockUseAvailabilityReportQuery.mockReturnValue({
+			data: report,
+			isLoading: false,
+			error: null,
+		});
+		URL.createObjectURL = vi.fn(() => "blob:availability");
+		URL.revokeObjectURL = vi.fn();
+	});
+
+	it("renders availability MTTR and MTBF rows from the report", () => {
+		render(<AvailabilityDashboard />);
+
+		expect(screen.getByText("Availability MTTR/MTBF")).toBeInTheDocument();
+		expect(screen.getByText("Core Router")).toBeInTheDocument();
+		expect(screen.getByText("Billing Database")).toBeInTheDocument();
+		expect(screen.getByText("15m")).toBeInTheDocument();
+		expect(screen.getAllByText("2h").length).toBeGreaterThan(0);
+	});
+
+	it("filters by enriched CI metadata and keeps the search after expanding a row", () => {
+		render(<AvailabilityDashboard />);
+
+		const search = screen.getByRole("searchbox", { name: /search availability/i });
+		fireEvent.change(search, { target: { value: "DataOps" } });
+
+		expect(screen.getByText("Billing Database")).toBeInTheDocument();
+		expect(screen.queryByText("Core Router")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /expand billing database/i }));
+
+		expect(search).toHaveValue("DataOps");
+		expect(screen.getByText("tier")).toBeInTheDocument();
+		expect(screen.getByText("gold")).toBeInTheDocument();
+	});
+
+	it("filters by represented metadata keys and formatted durations", () => {
+		render(<AvailabilityDashboard />);
+
+		const search = screen.getByRole("searchbox", { name: /search availability/i });
+		fireEvent.change(search, { target: { value: "rack" } });
+		expect(screen.getByText("Core Router")).toBeInTheDocument();
+		expect(screen.queryByText("Billing Database")).not.toBeInTheDocument();
+
+		fireEvent.change(search, { target: { value: "15m" } });
+		expect(screen.getByText("Core Router")).toBeInTheDocument();
+		expect(screen.queryByText("Billing Database")).not.toBeInTheDocument();
+	});
+
+	it("filters by category and resets back to all categories", () => {
+		render(<AvailabilityDashboard />);
+
+		fireEvent.change(screen.getByLabelText(/category/i), {
+			target: { value: "Network" },
+		});
+		expect(screen.getByText("Core Router")).toBeInTheDocument();
+		expect(screen.queryByText("Billing Database")).not.toBeInTheDocument();
+
+		fireEvent.change(screen.getByLabelText(/category/i), {
+			target: { value: "ALL" },
+		});
+		expect(screen.getByText("Billing Database")).toBeInTheDocument();
+	});
+
+	it("exports only currently filtered rows to CSV", async () => {
+		const click = vi.fn();
+		const originalCreateElement = document.createElement.bind(document);
+		vi.spyOn(document, "createElement").mockImplementation((tagName) => {
+			const element = originalCreateElement(tagName);
+			if (tagName === "a") {
+				element.click = click;
+			}
+			return element;
+		});
+
+		render(<AvailabilityDashboard />);
+		fireEvent.change(screen.getByRole("searchbox", { name: /search availability/i }), {
+			target: { value: "Cisco" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+
+		await waitFor(() => expect(click).toHaveBeenCalled());
+		const blob = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0] as Blob;
+		const csv = await blob.text();
+		expect(csv).toContain("Core Router");
+		expect(csv).toContain("Cisco");
+		expect(csv).not.toContain("Billing Database");
+	});
+
+	it("shows loading, error, and empty states", () => {
+		mockUseAvailabilityReportQuery.mockReturnValueOnce({ data: undefined, isLoading: true, error: null });
+		const { rerender } = render(<AvailabilityDashboard />);
+		expect(screen.getByText(/loading availability metrics/i)).toBeInTheDocument();
+
+		mockUseAvailabilityReportQuery.mockReturnValueOnce({ data: undefined, isLoading: false, error: new Error("boom") });
+		rerender(<AvailabilityDashboard />);
+		expect(screen.getByText(/could not load availability metrics/i)).toBeInTheDocument();
+
+		mockUseAvailabilityReportQuery.mockReturnValueOnce({ data: { ...report, rows: [] }, isLoading: false, error: null });
+		rerender(<AvailabilityDashboard />);
+		expect(screen.getByText(/no availability incidents/i)).toBeInTheDocument();
+	});
+});

--- a/frontend/components/AvailabilityDashboard.tsx
+++ b/frontend/components/AvailabilityDashboard.tsx
@@ -1,0 +1,202 @@
+import type React from "react";
+import { Fragment, useMemo, useState } from "react";
+import { useAvailabilityReportQuery } from "../hooks/queries/useAvailabilityReportQuery";
+import type { AvailabilityReportRow } from "../types";
+import {
+	averageSeconds,
+	availabilityRowsToCsv,
+	filterAvailabilityRows,
+	formatDurationSeconds,
+	getAvailabilityCategory,
+} from "../utils/availabilityReport";
+
+const formatPercent = (value?: number | null) =>
+	value == null ? "—" : `${value.toFixed(2)}%`;
+
+const metadataEntries = (row: AvailabilityReportRow) => {
+	const metadata = row.ci?.metadata ?? {};
+	return Object.entries(metadata).map(([key, value]) => [
+		key,
+		typeof value === "object" && value !== null
+			? JSON.stringify(value)
+			: String(value ?? ""),
+	]);
+};
+
+const downloadCsv = (csv: string) => {
+	const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = "availability-report.csv";
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	URL.revokeObjectURL(url);
+};
+
+const AvailabilityDashboard: React.FC = () => {
+	const { data, isLoading, error } = useAvailabilityReportQuery();
+	const rows = data?.rows ?? [];
+	const [searchTerm, setSearchTerm] = useState("");
+	const [category, setCategory] = useState("ALL");
+	const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+
+	const categories = useMemo(
+		() => Array.from(new Set(rows.map(getAvailabilityCategory))).sort(),
+		[rows],
+	);
+	const filteredRows = useMemo(
+		() => filterAvailabilityRows(rows, searchTerm, category),
+		[rows, searchTerm, category],
+	);
+	const averageMttr = averageSeconds(filteredRows.map((row) => row.mttr_seconds));
+	const averageMtbf = averageSeconds(filteredRows.map((row) => row.mtbf_seconds));
+	const activeEvents = filteredRows.reduce((sum, row) => sum + row.active_events, 0);
+	const worstAvailability = filteredRows.reduce<number | null>((worst, row) => {
+		if (row.availability_percentage == null) return worst;
+		return worst == null ? row.availability_percentage : Math.min(worst, row.availability_percentage);
+	}, null);
+
+	if (isLoading) {
+		return <div className="rounded-2xl border border-white/5 bg-surface-900 p-8 text-neutral-400">Loading availability metrics...</div>;
+	}
+
+	if (error) {
+		return <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-8 text-red-200">Could not load availability metrics. The metrics graph section remains available.</div>;
+	}
+
+	return (
+		<section className="space-y-6" aria-label="Availability analytics dashboard">
+			<div className="flex flex-col gap-4 rounded-2xl border border-white/5 bg-surface-900 p-6 md:flex-row md:items-end md:justify-between">
+				<div>
+					<p className="text-xs font-bold uppercase tracking-widest text-brand-400">Availability</p>
+					<h2 className="text-2xl font-black uppercase tracking-tight text-white">Availability MTTR/MTBF</h2>
+					<p className="mt-1 text-sm text-neutral-500">Report window {data?.window_start ? new Date(data.window_start).toLocaleDateString() : "—"} → {data?.window_end ? new Date(data.window_end).toLocaleDateString() : "—"}</p>
+				</div>
+				<button
+					type="button"
+					onClick={() => downloadCsv(availabilityRowsToCsv(filteredRows))}
+					className="rounded-lg bg-brand-600 px-4 py-2 text-xs font-bold uppercase tracking-widest text-white transition-colors hover:bg-brand-500 disabled:opacity-40"
+					disabled={filteredRows.length === 0}
+				>
+					Export CSV
+				</button>
+			</div>
+
+			<div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+				<SummaryCard label="Average MTTR" value={formatDurationSeconds(averageMttr)} />
+				<SummaryCard label="Average MTBF" value={formatDurationSeconds(averageMtbf)} />
+				<SummaryCard label="Active events" value={String(activeEvents)} />
+				<SummaryCard label="Worst availability" value={formatPercent(worstAvailability)} />
+			</div>
+
+			<div className="rounded-2xl border border-white/5 bg-surface-900 p-5">
+				<div className="mb-5 grid grid-cols-1 gap-4 md:grid-cols-[1fr_240px]">
+					<label className="block">
+						<span className="mb-2 block text-xs font-bold uppercase tracking-widest text-neutral-500">Search availability</span>
+						<input
+							role="searchbox"
+							aria-label="Search availability rows"
+							value={searchTerm}
+							onChange={(event) => setSearchTerm(event.target.value)}
+							placeholder="Search any represented CI field..."
+							className="w-full rounded-lg border border-white/10 bg-black/40 px-4 py-3 text-sm text-white outline-none transition-colors placeholder:text-neutral-600 focus:border-brand-500"
+						/>
+					</label>
+					<label className="block">
+						<span className="mb-2 block text-xs font-bold uppercase tracking-widest text-neutral-500">Category</span>
+						<select
+							aria-label="Category filter"
+							value={category}
+							onChange={(event) => setCategory(event.target.value)}
+							className="w-full rounded-lg border border-white/10 bg-black/40 px-4 py-3 text-sm text-white outline-none transition-colors focus:border-brand-500"
+						>
+							<option value="ALL">ALL</option>
+							{categories.map((option) => (
+								<option key={option} value={option}>{option}</option>
+							))}
+						</select>
+					</label>
+				</div>
+
+				{rows.length === 0 ? (
+					<div className="rounded-xl border border-dashed border-white/10 p-10 text-center text-neutral-500">No availability incidents are present for this report window.</div>
+				) : filteredRows.length === 0 ? (
+					<div className="rounded-xl border border-dashed border-white/10 p-10 text-center text-neutral-500">No rows match the current search and category filters.</div>
+				) : (
+					<div className="overflow-x-auto">
+						<table className="w-full min-w-[920px] text-left text-sm">
+							<thead className="text-xs uppercase tracking-widest text-neutral-500">
+								<tr className="border-b border-white/10">
+									<th className="p-3">CI</th>
+									<th className="p-3">Category</th>
+									<th className="p-3">Event Type</th>
+									<th className="p-3">Availability</th>
+									<th className="p-3">MTTR</th>
+									<th className="p-3">MTBF</th>
+									<th className="p-3">Recovered</th>
+									<th className="p-3">Active</th>
+									<th className="p-3">Details</th>
+								</tr>
+							</thead>
+							<tbody className="divide-y divide-white/5">
+								{filteredRows.map((row) => {
+									const rowId = `${row.ci_id}:${row.event_type}`;
+									const isExpanded = expandedRowId === rowId;
+									const name = row.ci?.label || row.ci_name || row.ci_id;
+									return (
+										<Fragment key={rowId}>
+											<tr key={rowId} className="text-neutral-300">
+												<td className="p-3"><p className="font-bold text-white">{name}</p><p className="font-mono text-xs text-neutral-500">{row.ci_id}</p></td>
+												<td className="p-3">{getAvailabilityCategory(row)}</td>
+												<td className="p-3">{row.event_type}</td>
+												<td className="p-3">{formatPercent(row.availability_percentage)}</td>
+												<td className="p-3">{formatDurationSeconds(row.mttr_seconds)}</td>
+												<td className="p-3">{formatDurationSeconds(row.mtbf_seconds)}</td>
+												<td className="p-3">{row.recovered_incidents}</td>
+												<td className="p-3">{row.active_events}</td>
+												<td className="p-3"><button type="button" aria-label={`Expand ${name}`} onClick={() => setExpandedRowId(isExpanded ? null : rowId)} className="rounded-lg border border-white/10 px-3 py-1 text-xs font-bold uppercase text-neutral-300 hover:border-brand-500 hover:text-white">{isExpanded ? "Hide" : "Expand"}</button></td>
+											</tr>
+											{isExpanded && (
+												<tr key={`${rowId}:details`} className="bg-black/20 text-xs text-neutral-400">
+													<td colSpan={9} className="p-4">
+														<div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+															<Detail label="IP" value={row.ci?.ip} />
+															<Detail label="Owner" value={row.ci?.owner} />
+															<Detail label="Brand" value={row.ci?.brand} />
+															<Detail label="Model" value={row.ci?.model} />
+															<Detail label="First Failure" value={row.first_failure_at} />
+															<Detail label="Last Failure" value={row.last_failure_at} />
+															{metadataEntries(row).map(([key, value]) => <Detail key={key} label={key} value={value} />)}
+														</div>
+													</td>
+												</tr>
+											)}
+										</Fragment>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				)}
+			</div>
+		</section>
+	);
+};
+
+const SummaryCard: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+	<div className="rounded-xl border border-white/5 bg-surface-900 p-5">
+		<p className="text-xs font-bold uppercase tracking-widest text-neutral-500">{label}</p>
+		<p className="mt-2 text-2xl font-black text-white">{value}</p>
+	</div>
+);
+
+const Detail: React.FC<{ label: string; value?: string | number | null }> = ({ label, value }) => (
+	<div className="rounded-lg border border-white/5 bg-white/[0.03] p-3">
+		<p className="font-bold uppercase tracking-widest text-neutral-500">{label}</p>
+		<p className="mt-1 break-words text-neutral-200">{value || "—"}</p>
+	</div>
+);
+
+export default AvailabilityDashboard;

--- a/frontend/components/MetricAnalytics.test.tsx
+++ b/frontend/components/MetricAnalytics.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor, cleanup } from "@testing-library/react";
+import { act, render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import MetricAnalytics from "./MetricAnalytics";
 import type { GraphNode } from "../types";
@@ -28,6 +28,10 @@ vi.stubGlobal("fetch", vi.fn());
 // Mock MetricHistoryChart
 vi.mock("./MetricHistoryChart", () => ({
 	default: () => <span data-testid="metric-history-chart">Mock Chart</span>,
+}));
+
+vi.mock("./AvailabilityDashboard", () => ({
+	default: () => <section aria-label="Availability MTTR/MTBF">Availability MTTR/MTBF Dashboard</section>,
 }));
 
 describe("MetricAnalytics", () => {
@@ -97,6 +101,31 @@ describe("MetricAnalytics", () => {
 	afterEach(() => {
 		vi.useRealTimers();
 		cleanup();
+	});
+
+	describe("analytics sections", () => {
+		it("renders METRICS and AVAILABILITY sections without admin-only gating", () => {
+			render(<MetricAnalytics />);
+
+			expect(screen.getByRole("button", { name: "METRICS" })).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "AVAILABILITY" })).toBeInTheDocument();
+			expect(screen.getByText("Historical Telemetry Visualization")).toBeInTheDocument();
+		});
+
+		it("keeps the existing metric graph experience under METRICS and opens Availability separately", () => {
+			mockFetchNodes.mockResolvedValue(mockNodes);
+			render(<MetricAnalytics />);
+
+			expect(screen.getByRole("searchbox")).toBeInTheDocument();
+			expect(screen.queryByText("Availability MTTR/MTBF Dashboard")).not.toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole("button", { name: "AVAILABILITY" }));
+			expect(screen.getByText("Availability MTTR/MTBF Dashboard")).toBeInTheDocument();
+			expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+
+			fireEvent.click(screen.getByRole("button", { name: "METRICS" }));
+			expect(screen.getByRole("searchbox")).toBeInTheDocument();
+		});
 	});
 
 	describe("search input", () => {

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -4,6 +4,7 @@ import type { GraphNode, MetricValue, NodeMetricData } from "../types";
 import MetricHistoryChart from "./MetricHistoryChart";
 import MultiSelectCIs from "./MultiSelectCIs";
 import MultiMetricChart from "./MultiMetricChart";
+import AvailabilityDashboard from "./AvailabilityDashboard";
 import { fetchNodes, fetchNodeMetricHistory } from "../services/queryResources";
 import { formatMetricValue } from "../utils/metricFormatting";
 
@@ -12,7 +13,11 @@ interface BrushRange {
 	endTime?: string;
 }
 
+type AnalyticsSection = "METRICS" | "AVAILABILITY";
+const ANALYTICS_SECTIONS: AnalyticsSection[] = ["METRICS", "AVAILABILITY"];
+
 const MetricAnalytics: React.FC = () => {
+	const [activeSection, setActiveSection] = useState<AnalyticsSection>("METRICS");
 	const [nodes, setNodes] = useState<GraphNode[]>([]);
 	const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
 	const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
@@ -302,7 +307,7 @@ const MetricAnalytics: React.FC = () => {
 
 	return (
 		<div className="flex h-full min-w-0 max-w-full flex-col overflow-x-hidden overflow-y-auto bg-surface-950 p-4 text-white md:p-8">
-			<header className="mb-8 flex min-w-0 items-end justify-between gap-4">
+			<header className="mb-8 flex min-w-0 flex-col gap-6 md:flex-row md:items-end md:justify-between">
 				<div className="min-w-0">
 					<h1 className="truncate text-3xl font-black uppercase tracking-tighter">
 						Metric Analytics
@@ -311,8 +316,23 @@ const MetricAnalytics: React.FC = () => {
 						Historical Telemetry Visualization
 					</p>
 				</div>
+				<nav className="flex gap-3 border-b border-white/5 pb-3 md:border-b-0 md:pb-0" aria-label="Analytics sections">
+					{ANALYTICS_SECTIONS.map((section) => (
+						<button
+							key={section}
+							type="button"
+							onClick={() => setActiveSection(section)}
+							className={`rounded-lg px-4 py-2 text-xs font-bold uppercase tracking-widest transition-all ${activeSection === section ? "bg-brand-600 text-white" : "text-neutral-500 hover:bg-white/5 hover:text-white"}`}
+						>
+							{section}
+						</button>
+					))}
+				</nav>
 			</header>
 
+			{activeSection === "AVAILABILITY" ? (
+				<AvailabilityDashboard />
+			) : (
 			<div className="grid min-w-0 max-w-full flex-1 grid-cols-12 gap-4 md:gap-8 lg:min-h-0">
 				{/* Controls Sidebar */}
 				<div className="col-span-12 flex min-w-0 max-w-full flex-col space-y-6 overflow-x-hidden lg:col-span-3 lg:h-full lg:overflow-y-auto lg:pr-1">
@@ -640,6 +660,7 @@ const MetricAnalytics: React.FC = () => {
 					)}
 				</div>
 			</div>
+			)}
 		</div>
 	);
 };

--- a/frontend/utils/availabilityReport.test.ts
+++ b/frontend/utils/availabilityReport.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	availabilityRowsToCsv,
+	buildAvailabilitySearchText,
+	filterAvailabilityRows,
+	getAvailabilityCategory,
+} from "./availabilityReport";
+import type { AvailabilityReportRow } from "../types";
+
+const baseRow: AvailabilityReportRow = {
+	ci_id: "ci-1",
+	ci_name: "Core Router",
+	event_type: "AVAILABILITY",
+	recovered_incidents: 1,
+	mttr_seconds: 900,
+	mtbf_seconds: 7200,
+	downtime_seconds: 900,
+	active_events: 0,
+	active_downtime_seconds: 0,
+	availability_percentage: 99.9,
+	first_failure_at: "2026-01-01T00:00:00Z",
+	last_failure_at: "2026-01-01T00:15:00Z",
+};
+
+describe("availabilityReport helpers", () => {
+	it("builds search text from represented keys, values, and formatted durations", () => {
+		const row: AvailabilityReportRow = {
+			...baseRow,
+			ci: {
+				id: "ci-1",
+				label: "Core Router",
+				type: "Router",
+				metadata: { rack: "R1", support_contact: { phone: "+34123456789" } },
+			},
+		};
+
+		const searchText = buildAvailabilitySearchText(row);
+
+		expect(searchText).toContain("rack");
+		expect(searchText).toContain("support_contact");
+		expect(searchText).toContain("+34123456789");
+		expect(searchText).toContain("15m");
+		expect(searchText).toContain("2h");
+	});
+
+	it("uses CI type as category fallback", () => {
+		const row: AvailabilityReportRow = {
+			...baseRow,
+			ci: { id: "ci-1", label: "Core Router", type: "Router" },
+		};
+
+		expect(getAvailabilityCategory(row)).toBe("Router");
+		expect(filterAvailabilityRows([row], "", "Router")).toEqual([row]);
+	});
+
+	it("escapes CSV values containing commas, quotes, LF, or CR", () => {
+		const row: AvailabilityReportRow = {
+			...baseRow,
+			ci: {
+				id: "ci-1",
+				label: "Core Router",
+				category: "Network",
+				brand: "ACME, Inc.",
+				model: "Quote \"Model\"\rLegacy",
+			},
+		};
+
+		const csv = availabilityRowsToCsv([row]);
+
+		expect(csv).toContain('"ACME, Inc."');
+		expect(csv).toContain('"Quote ""Model""\rLegacy"');
+	});
+});

--- a/frontend/utils/availabilityReport.ts
+++ b/frontend/utils/availabilityReport.ts
@@ -1,0 +1,118 @@
+import type { AvailabilityReportRow } from "../types";
+
+const CSV_COLUMNS = [
+	"CI Name",
+	"CI ID",
+	"Category",
+	"Type",
+	"IP",
+	"Owner",
+	"Brand",
+	"Model",
+	"Event Type",
+	"Availability %",
+	"MTTR Seconds",
+	"MTBF Seconds",
+	"Recovered Incidents",
+	"Active Events",
+	"Downtime Seconds",
+	"Active Downtime Seconds",
+	"First Failure",
+	"Last Failure",
+];
+
+export const formatDurationSeconds = (seconds?: number | null): string => {
+	if (seconds == null || Number.isNaN(seconds)) return "—";
+	if (seconds < 60) return `${Math.round(seconds)}s`;
+	const minutes = seconds / 60;
+	if (minutes < 60) return `${Math.round(minutes)}m`;
+	const hours = minutes / 60;
+	if (hours < 24) return `${Number.isInteger(hours) ? hours : hours.toFixed(1)}h`;
+	const days = hours / 24;
+	return `${Number.isInteger(days) ? days : days.toFixed(1)}d`;
+};
+
+export const getAvailabilityCategory = (row: AvailabilityReportRow): string =>
+	row.ci?.category || row.ci?.type || "Uncategorized";
+
+const flattenSearchValues = (value: unknown): string[] => {
+	if (value == null) return [];
+	if (["string", "number", "boolean"].includes(typeof value)) {
+		return [String(value)];
+	}
+	if (Array.isArray(value)) return value.flatMap(flattenSearchValues);
+	if (typeof value === "object") {
+		return Object.entries(value as Record<string, unknown>).flatMap(([key, nestedValue]) => [
+			key,
+			...flattenSearchValues(nestedValue),
+		]);
+	}
+	return [];
+};
+
+export const buildAvailabilitySearchText = (row: AvailabilityReportRow): string =>
+	[
+		...flattenSearchValues(row),
+		formatDurationSeconds(row.mttr_seconds),
+		formatDurationSeconds(row.mtbf_seconds),
+		getAvailabilityCategory(row),
+	]
+		.join(" ")
+		.toLowerCase();
+
+export const filterAvailabilityRows = (
+	rows: AvailabilityReportRow[],
+	searchTerm: string,
+	category: string,
+): AvailabilityReportRow[] => {
+	const query = searchTerm.trim().toLowerCase();
+	return rows.filter((row) => {
+		const categoryMatches =
+			category === "ALL" || getAvailabilityCategory(row) === category;
+		const searchMatches =
+			!query || buildAvailabilitySearchText(row).includes(query);
+		return categoryMatches && searchMatches;
+	});
+};
+
+const csvValue = (value: unknown): string => {
+	if (value == null) return "";
+	const text = String(value);
+	if (/[",\n\r]/.test(text)) return `"${text.replaceAll('"', '""')}"`;
+	return text;
+};
+
+export const availabilityRowsToCsv = (rows: AvailabilityReportRow[]): string => {
+	const lines = [CSV_COLUMNS.join(",")];
+	rows.forEach((row) => {
+		lines.push(
+			[
+				row.ci?.label || row.ci_name || row.ci_id,
+				row.ci_id,
+				getAvailabilityCategory(row),
+				row.ci?.type,
+				row.ci?.ip,
+				row.ci?.owner,
+				row.ci?.brand,
+				row.ci?.model,
+				row.event_type,
+				row.availability_percentage,
+				row.mttr_seconds,
+				row.mtbf_seconds,
+				row.recovered_incidents,
+				row.active_events,
+				row.downtime_seconds,
+				row.active_downtime_seconds,
+				row.first_failure_at,
+				row.last_failure_at,
+			].map(csvValue).join(","),
+		);
+	});
+	return lines.join("\n");
+};
+
+export const averageSeconds = (values: Array<number | null | undefined>): number | null => {
+	const valid = values.filter((value): value is number => typeof value === "number");
+	if (valid.length === 0) return null;
+	return valid.reduce((sum, value) => sum + value, 0) / valid.length;
+};


### PR DESCRIPTION
## Descripción del Cambio
Continúa #185
Closes #180

PR 2 de la cadena para mover Availability MTTR/MTBF fuera de Monitoring y completar la experiencia en Analytics.

- Agrega secciones `METRICS` / `AVAILABILITY` dentro de Analytics, usando el patrón visual de secciones sin acoplarlo a permisos Admin.
- Mantiene intacta la visualización de gráficas existente bajo `METRICS`.
- Agrega mini-dashboard de disponibilidad con MTTR/MTBF, búsqueda global, filtro por categoría, detalles expandibles y export CSV filtrado.
- Usa el contrato enriquecido de availability report agregado en #185.

| File | Change |
|------|--------|
| `frontend/components/MetricAnalytics.tsx` | Agrega shell de secciones `METRICS` / `AVAILABILITY` y conserva gráficas actuales. |
| `frontend/components/MetricAnalytics.test.tsx` | Cubre navegación de secciones y preservación del área de métricas. |
| `frontend/components/AvailabilityDashboard.tsx` | Nuevo dashboard MTTR/MTBF con búsqueda, filtros, detalles y export. |
| `frontend/components/AvailabilityDashboard.test.tsx` | Cubre render, búsqueda persistente, filtros, export y estados. |
| `frontend/utils/availabilityReport.ts` | Helpers de duración, búsqueda, filtros, CSV y promedios. |
| `frontend/utils/availabilityReport.test.ts` | Cubre búsqueda por keys/values/duraciones, fallback categoría y CSV escaping. |

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/AvailabilityDashboard.test.tsx components/MetricAnalytics.test.tsx utils/availabilityReport.test.ts` — 20 passed
- [x] `git diff --check`

Notas de suite completa heredadas:
- Frontend full suite sigue fallando por baseline no relacionado: `localStorage.clear/removeItem is not a function` en tests fuera del scope.
- `tsc --noEmit` reportó errores baseline no relacionados; no en archivos de PR2 según revisión.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Issue aprobado (`status:approved`).
- [x] PR tendrá exactamente un label `type:feature`.
- [x] Commit convencional: `feat(analytics): add availability dashboard`.
- [x] No hay acoplamiento Admin-only; el acceso sigue dependiendo del modelo de perfil/permisos existente.

---
*Generado por Alex*