### PR TITLE
fix(admin): include unlocated CIs in inventory

### DIFF
--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -8,12 +8,15 @@ from models.core import Node, Link
 
 def get_nodes(allowed_locations: Optional[List[str]] = None, is_admin: bool = False) -> List[Dict[str, Any]]:
     driver = get_db()
-    query = "MATCH (n:CI) WHERE n.location IS NOT NULL AND n.location.latitude IS NOT NULL AND n.location.longitude IS NOT NULL"
+    query = "MATCH (n:CI)"
     params = {}
+    where = []
     if not is_admin:
         if not allowed_locations: return []
-        query += " AND n.location_name IN $allowed_locations "
+        where.append("n.location_name IN $allowed_locations")
         params["allowed_locations"] = allowed_locations
+    if where:
+        query += " WHERE " + " AND ".join(where)
     query += """
         OPTIONAL MATCH (n)-[:CATEGORIZED_AS]->(c:Category)
         OPTIONAL MATCH (n)-[r:HAS_METRIC]->(m:MetricDef)

--- a/backend/tests/test_node_service.py
+++ b/backend/tests/test_node_service.py
@@ -309,6 +309,36 @@ class TestGetNodes:
 
             assert result[0]["location"] is None
 
+    def test_get_nodes_returns_located_and_unlocated_nodes(self):
+        """Inventory serialization should preserve located and unlocated rows."""
+        admin = _make_user(username="admin", role="ADMIN")
+
+        class FakeLocation:
+            def __init__(self):
+                self.latitude = 19.4326
+                self.longitude = -99.1332
+
+        located_props = _make_node_record(node_id="ci-located", name="Located CI")
+        located_props["location"] = FakeLocation()
+        unlocated_props = _make_node_record(
+            node_id="ci-unlocated",
+            name="Unlocated CI",
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [
+                _make_full_record(node_props=located_props),
+                _make_full_record(node_props=unlocated_props),
+            ]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert [node["id"] for node in result] == ["ci-located", "ci-unlocated"]
+            assert result[0]["location"] == {"lat": 19.4326, "long": -99.1332}
+            assert result[1]["location"] is None
+
     def test_metadata_excludes_standard_fields(self):
         """Metadata dict should exclude standard fields (id, name, status, etc.)."""
         admin = _make_user(username="admin", role="ADMIN")

--- a/backend/tests/test_routers_nodes.py
+++ b/backend/tests/test_routers_nodes.py
@@ -193,6 +193,38 @@ class TestGetNodes:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
+    def test_list_nodes_admin_includes_unlocated_ci(self):
+        """Admin inventory should include CIs that have no point location."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        node_record = _make_neo4j_node_record(
+            node_id="ci-unlocated",
+            name="Unlocated CI",
+        )
+        node_record["location"] = None
+        full_record = _make_full_record(node_props=node_record, category="router")
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 1
+            assert data[0]["id"] == "ci-unlocated"
+            assert data[0]["location"] is None
+            mock_repo.get_nodes.assert_called_once_with([], True)
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
     def test_list_nodes_operator_scoped_by_location(self, mock_neo4j_driver):
         """Non-admin should have results scoped to allowed_locations."""
         fake_user = _make_pydantic_user(
@@ -233,6 +265,44 @@ class TestGetNodes:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
+    def test_list_nodes_operator_includes_allowed_unlocated_ci(self):
+        """Operator inventory should include unlocated CIs in allowed locations."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            allowed_locations=["Site A"],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        node_record = _make_neo4j_node_record(
+            node_id="ci-site-a",
+            name="Site A CI",
+            location_name="Site A",
+        )
+        node_record["location"] = None
+        full_record = _make_full_record(node_props=node_record, category="switch")
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 1
+            assert data[0]["id"] == "ci-site-a"
+            assert data[0]["location_name"] == "Site A"
+            assert data[0]["location"] is None
+            mock_repo.get_nodes.assert_called_once_with(["Site A"], False)
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
     def test_list_nodes_operator_no_locations_returns_empty(self):
         """Operator with no allowed_locations should get empty list."""
         fake_user = _make_pydantic_user(
@@ -257,6 +327,7 @@ class TestGetNodes:
             assert response.status_code == 200
             data = response.json()
             assert data == []
+            mock_repo.get_nodes.assert_called_once_with([], False)
 
         app.dependency_overrides.pop(get_current_active_user, None)
 

--- a/backend/tests/test_topology_repo_get_nodes.py
+++ b/backend/tests/test_topology_repo_get_nodes.py
@@ -1,0 +1,74 @@
+"""Repository query contract tests for topology_repo.get_nodes."""
+
+from repositories import topology_repo
+
+
+_COORDINATE_PREDICATES = (
+    "n.location IS NOT NULL",
+    "n.location.latitude IS NOT NULL",
+    "n.location.longitude IS NOT NULL",
+)
+
+
+def _assert_no_coordinate_predicates(query: str) -> None:
+    for predicate in _COORDINATE_PREDICATES:
+        assert predicate not in query
+
+
+def test_get_nodes_admin_does_not_require_point_location(mock_neo4j_driver):
+    """Admin inventory listing should not filter out CIs without coordinates."""
+    mock_neo4j_driver.mock_session.set_default_response(
+        [{"n": {"id": "ci-unlocated"}, "category": "router", "metrics": []}]
+    )
+
+    rows = topology_repo.get_nodes(allowed_locations=[], is_admin=True)
+
+    assert rows == [
+        {"node": {"id": "ci-unlocated"}, "category": "router", "metrics": []}
+    ]
+    query_call = mock_neo4j_driver.mock_session.queries[-1]
+    query = query_call["query"]
+    assert "MATCH (n:CI)" in query
+    assert "n.location_name IN $allowed_locations" not in query
+    _assert_no_coordinate_predicates(query)
+
+
+def test_get_nodes_non_admin_scopes_by_location_name_without_point_filter(
+    mock_neo4j_driver,
+):
+    """Scoped inventory should use location_name without requiring coordinates."""
+    mock_neo4j_driver.mock_session.set_default_response(
+        [{"n": {"id": "ci-site-a"}, "category": "switch", "metrics": []}]
+    )
+
+    rows = topology_repo.get_nodes(["Site A"], is_admin=False)
+
+    assert rows == [
+        {"node": {"id": "ci-site-a"}, "category": "switch", "metrics": []}
+    ]
+    query_call = mock_neo4j_driver.mock_session.queries[-1]
+    query = query_call["query"]
+    assert "n.location_name IN $allowed_locations" in query
+    assert query_call["params"] == {"allowed_locations": ["Site A"]}
+    _assert_no_coordinate_predicates(query)
+
+
+def test_get_nodes_non_admin_no_allowed_locations_returns_empty_without_query(
+    mock_neo4j_driver,
+):
+    """Non-admin users without allowed locations should not query inventory."""
+    rows = topology_repo.get_nodes([], is_admin=False)
+
+    assert rows == []
+    assert mock_neo4j_driver.mock_session.queries == []
+
+
+def test_get_filtered_graph_data_keeps_point_location_filter(mock_neo4j_driver):
+    """Map/topology graph data should remain restricted to geolocated CIs."""
+    mock_neo4j_driver.mock_session.set_default_response([])
+
+    topology_repo.get_filtered_graph_data(is_admin=True)
+
+    node_query = mock_neo4j_driver.mock_session.queries[0]["query"]
+    for predicate in _COORDINATE_PREDICATES:
+        assert predicate in node_query


### PR DESCRIPTION
## Descripción del Cambio
Closes #189

- Ajusta `GET /api/nodes` para que el inventario incluya todos los CIs scopiados, aunque no tengan coordenadas.
- Mantiene el scoping non-admin por `location_name`.
- Agrega cobertura de regresión para inventario, serialización de `location: null` y preservación del filtro geográfico en graph/topology.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && /home/alex/dev/next-gen/next-gen/backend/.venv/bin/python -m pytest tests/test_topology_repo_get_nodes.py tests/test_node_service.py::TestGetNodes tests/test_routers_nodes.py::TestGetNodes -q`
- Resultado: `28 passed, 5 warnings`

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notas
- El cambio es backend-only.
- `get_filtered_graph_data()` conserva el filtro por coordenadas para mapa/topología.
- Full backend suite tiene fallas preexistentes/no relacionadas documentadas durante SDD verify.

---
*Generado por Alex*
