### PR TITLE
feat(cmdb): homologate CI relationship types

### DIFF
--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -1,10 +1,16 @@
 from typing import List, Dict, Any, Optional, Set
+import importlib
 import json
 from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
 import re
 from neo4j import Driver
 from database import get_db
 from models.core import Node, Link
+_relationship_types = importlib.import_module("services.relationship_types")
+LISTABLE_RELATIONSHIP_TYPES = _relationship_types.LISTABLE_RELATIONSHIP_TYPES
+SUPPORTED_CI_RELATIONSHIP_TYPES = _relationship_types.SUPPORTED_CI_RELATIONSHIP_TYPES
+cypher_relationship_union = _relationship_types.cypher_relationship_union
+validate_ci_relationship_type = _relationship_types.validate_ci_relationship_type
 
 def get_nodes(allowed_locations: Optional[List[str]] = None, is_admin: bool = False) -> List[Dict[str, Any]]:
     driver = get_db()
@@ -59,7 +65,7 @@ def get_node_usage(node_id: str) -> int:
         res = session.run("MATCH (n:CI {id: $id})-[r]-() RETURN count(r) as count", id=node_id).single()
         return res["count"] if res else 0
 
-def get_valid_owners_and_layers() -> (Set[str], Set[str]):
+def get_valid_owners_and_layers() -> tuple[Set[str], Set[str]]:
     driver = get_db()
     with driver.session() as session:
         res_o = session.run("MATCH (o:OwnerGroup) RETURN o.name as name")
@@ -81,14 +87,11 @@ def bulk_insert_node(nid, label, ntype, status, ip, brand, model, serial, firmwa
         lat=lat, long=long, loc_name=metadata.get('location_name'), polling=polling, snmp=snmp_str, metadata=metadata, owner=owner)
 
 # Valid relationship types for injection prevention
-_VALID_RELATIONSHIPS = frozenset({"CONNECTS_TO", "HOSTED_ON", "DEPENDS_ON", "MANAGES", "USES", "PROVIDES"})
+_VALID_RELATIONSHIPS = SUPPORTED_CI_RELATIONSHIP_TYPES
 
 def _validate_relationship(rel: str) -> str:
     """Validate and sanitize relationship type. Raises ValueError if invalid."""
-    clean = rel.upper().replace(" ", "_")
-    if clean not in _VALID_RELATIONSHIPS:
-        raise ValueError(f"Invalid relationship type: {rel}")
-    return clean
+    return validate_ci_relationship_type(rel)
 
 # Valid node labels for injection prevention
 _VALID_NODE_LABELS = frozenset({"CI", "MetricDef", "Category", "OwnerGroup", "HardwareModel", "User"})
@@ -108,8 +111,9 @@ def get_template_data():
 
 def get_links(allowed_locations=None, is_admin=False):
     driver = get_db()
-    query = """
-        MATCH (a)-[r:CONNECTS_TO|DEPENDS_ON|RUNS_ON|HAS_METRIC]->(b)
+    rel_union = cypher_relationship_union(LISTABLE_RELATIONSHIP_TYPES)
+    query = f"""
+        MATCH (a)-[r:{rel_union}]->(b)
         WHERE (a:CI OR a:MetricDef) AND (b:CI OR b:MetricDef)
           AND a.id IS NOT NULL AND b.id IS NOT NULL
     """
@@ -327,40 +331,52 @@ def get_filtered_graph_data(layer=None, location=None, owner=None, allowed_locat
         return nodes, links
 
 
-def get_cis_relationship_summary(ci_ids: list[str]) -> dict:
+def get_cis_relationship_summary(ci_ids: list[str], allowed_locations=None, is_admin=False) -> dict:
     """
-    Batch-fetch relationship summary for a set of CI ids.
+    Batch-fetch CI relationship summary for a set of CI ids.
     Returns {ci_id: {asSource: [{otherId, otherLabel, type}], asTarget: [...]}}.
-    Filters out system relationships (CATEGORIZED_AS, OWNED_BY, IS_MODEL).
-    Caps at 1000 ids.
+    Applies the same location scoping pattern used by /links and caps at 1000 ids.
     """
     if not ci_ids:
         return {}
     ci_ids = list(ci_ids)[:1000]
+    summary: dict[str, dict] = {cid: {"asSource": [], "asTarget": []} for cid in ci_ids}
+    if not is_admin and not allowed_locations:
+        return summary
 
     driver = get_db()
-    query = """
-        MATCH (a)-[r]->(b)
-        WHERE (a.id IN $ci_ids OR b.id IN $ci_ids)
-          AND (a:CI OR a:MetricDef) AND (b:CI OR b:MetricDef)
-          AND NOT type(r) IN ['CATEGORIZED_AS', 'OWNED_BY', 'IS_MODEL']
-        RETURN a.id AS source_id, COALESCE(a.name, a.id) AS source_label,
-               b.id AS target_id, COALESCE(b.name, b.id) AS target_label,
+    rel_union = cypher_relationship_union(SUPPORTED_CI_RELATIONSHIP_TYPES)
+    query = f"""
+        MATCH (a:CI)-[r:{rel_union}]->(b:CI)
+    """
+    params: dict[str, Any] = {"ci_ids": ci_ids}
+    if is_admin:
+        query += " WHERE (a.id IN $ci_ids OR b.id IN $ci_ids)"
+    else:
+        query += """
+        WHERE ((a.id IN $ci_ids AND a.location_name IN $allowed_locations)
+            OR (b.id IN $ci_ids AND b.location_name IN $allowed_locations))
+        """
+        params["allowed_locations"] = allowed_locations
+    query += """
+        RETURN a.id AS source_id, COALESCE(a.name, a.id) AS source_label, a.location_name AS source_location,
+               b.id AS target_id, COALESCE(b.name, b.id) AS target_label, b.location_name AS target_location,
                type(r) AS rel_type
     """
     with driver.session() as session:
-        results = session.run(query, ci_ids=ci_ids)
+        results = session.run(query, **params)
         records = list(results)  # Consume all records inside the session block
-
-    summary: dict[str, dict] = {cid: {"asSource": [], "asTarget": []} for cid in ci_ids}
+    allowed_set = set(allowed_locations or [])
     for row in records:
         src, tgt, rel = row["source_id"], row["target_id"], row["rel_type"]
         src_label, tgt_label = row["source_label"], row["target_label"]
+        source_visible = is_admin or row.get("source_location") in allowed_set
+        target_visible = is_admin or row.get("target_location") in allowed_set
         # If ci_ids contains source, it appears as "source" in the rel
-        if src in summary:
+        if src in summary and source_visible:
             summary[src]["asSource"].append({"otherId": tgt, "otherLabel": tgt_label, "type": rel})
         # If ci_ids contains target, it appears as "target" in the rel
-        if tgt in summary:
+        if tgt in summary and target_visible:
             summary[tgt]["asTarget"].append({"otherId": src, "otherLabel": src_label, "type": rel})
 
     return summary

--- a/backend/routers/links.py
+++ b/backend/routers/links.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 from models.core import Link
 from models.user import User
@@ -69,9 +69,7 @@ async def get_cis_relationships(payload: CiIdsPayload, current_user: User = Depe
     Batch-fetch relationship summary for a list of CI ids.
     Returns {ci_id: {asSource: [...], asTarget: [...]}}.
     """
-    from repositories import topology_repo
-    result = topology_repo.get_cis_relationship_summary(payload.ci_ids)
-    return result
+    return link_service.get_cis_relationships(payload.ci_ids, current_user)
 
 
 @router.post("/links/mass/simulate")
@@ -132,9 +130,9 @@ async def update_mass_links(payload: MassUpdatePayload, current_user: User = Dep
 
 @router.get("/graph/full")
 async def get_full_graph(
-    layer: str = None,
-    location: str = None,
-    owner: str = None,
+    layer: Optional[str] = None,
+    location: Optional[str] = None,
+    owner: Optional[str] = None,
     current_user: User = Depends(get_current_active_user)
 ):
     """

--- a/backend/scripts/audit_relationship_types.py
+++ b/backend/scripts/audit_relationship_types.py
@@ -1,0 +1,21 @@
+"""Print Neo4j relationship type counts without mutating data."""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+get_db = importlib.import_module("database").get_db
+audit_relationship_type_counts = importlib.import_module("services.relationship_migration").audit_relationship_type_counts
+
+
+def main() -> int:
+    with get_db().session() as session:
+        print(json.dumps(audit_relationship_type_counts(session), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/migrate_relationship_types.py
+++ b/backend/scripts/migrate_relationship_types.py
@@ -1,0 +1,46 @@
+"""Dry-run/apply migration for legacy CI relationship types."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from pathlib import Path
+
+CONFIRMATION_PHRASE = "MIGRATE RELATIONSHIP TYPES"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+get_db = importlib.import_module("database").get_db
+migration_module = importlib.import_module("services.relationship_migration")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Migrate legacy Neo4j relationship types")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Plan changes without mutation (default)")
+    mode.add_argument("--apply", action="store_true", help="Apply the migration")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help=f"Required with --apply to skip interactive confirmation. Dry-run first and type '{CONFIRMATION_PHRASE}' if not using --yes.",
+    )
+    args = parser.parse_args()
+    if args.apply and not args.yes:
+        print("WARNING: --apply will mutate Neo4j relationships.", file=sys.stderr)
+        print("Run --dry-run first and keep a DB backup/snapshot before applying.", file=sys.stderr)
+        confirmation = input(f"Type '{CONFIRMATION_PHRASE}' to continue: ")
+        if confirmation != CONFIRMATION_PHRASE:
+            print("Migration cancelled.", file=sys.stderr)
+            return 2
+    with get_db().session() as session:
+        report = migration_module.migrate_relationship_types(
+            session,
+            migration_module.LEGACY_RELATIONSHIP_TYPE_MAP,
+            apply=args.apply,
+        )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/link_service.py
+++ b/backend/services/link_service.py
@@ -3,7 +3,7 @@ from models.core import Link
 from models.user import User
 from repositories import topology_repo
 
-def get_links(current_user: User = None) -> List[Dict[str, Any]]:
+def get_links(current_user: Optional[User] = None) -> List[Dict[str, Any]]:
     """
     Fetch all active relationship links.
     Enforces data scoping based on user allowed locations.
@@ -28,7 +28,18 @@ def delete_link(link: Link) -> Dict[str, str]:
     topology_repo.delete_link(link.source, link.target, link.relationship)
     return {"message": "Link deleted"}
 
-def get_full_graph(current_user: User = None, layer: str = None, location: str = None, owner: str = None) -> Dict[str, List[Dict[str, Any]]]:
+def get_cis_relationships(ci_ids: list[str], current_user: User) -> dict:
+    """
+    Batch-fetch scoped CI relationship summaries for Admin relationship UI.
+    """
+    is_admin = current_user.role == "ADMIN"
+    return topology_repo.get_cis_relationship_summary(
+        ci_ids,
+        allowed_locations=current_user.allowed_locations,
+        is_admin=is_admin,
+    )
+
+def get_full_graph(current_user: Optional[User] = None, layer: Optional[str] = None, location: Optional[str] = None, owner: Optional[str] = None) -> Dict[str, List[Dict[str, Any]]]:
     """
     Fetch the COMPLETE graph topology for visualization.
     Supports filtering by metadata and data scoping.
@@ -107,7 +118,11 @@ def simulate_bulk_links(current_user: User, source_filter: dict, target_filter: 
     # T8: Enrich with existing relationship info for the simulate response
     src_ids, tgt_ids = _get_filtered_node_ids(source_filter, target_filter, is_admin, current_user.allowed_locations)
     all_ids = list(set(src_ids + tgt_ids))
-    existing_rels = topology_repo.get_cis_relationship_summary(all_ids)
+    existing_rels = topology_repo.get_cis_relationship_summary(
+        all_ids,
+        allowed_locations=current_user.allowed_locations,
+        is_admin=is_admin,
+    )
 
     sources_with_rels = [sid for sid in src_ids if existing_rels.get(sid, {}).get("asSource")]
     targets_with_rels = [tid for tid in tgt_ids if existing_rels.get(tid, {}).get("asTarget")]
@@ -155,7 +170,11 @@ def execute_bulk_links(current_user: User, source_filter: dict, target_filter: d
 
     src_ids, tgt_ids = _get_filtered_node_ids(source_filter, target_filter, is_admin, allowed_locations)
     all_ids = list(set(src_ids + tgt_ids))
-    existing_rels = topology_repo.get_cis_relationship_summary(all_ids)
+    existing_rels = topology_repo.get_cis_relationship_summary(
+        all_ids,
+        allowed_locations=allowed_locations,
+        is_admin=is_admin,
+    )
 
     affected_sources = [
         sid for sid in src_ids

--- a/backend/services/relationship_migration.py
+++ b/backend/services/relationship_migration.py
@@ -1,0 +1,72 @@
+"""Audit and migrate legacy CI relationship types."""
+from __future__ import annotations
+
+from typing import Any
+
+from .relationship_types import LEGACY_RELATIONSHIP_TYPE_MAP, validate_ci_relationship_type, validate_legacy_relationship_type
+
+
+def audit_relationship_type_counts(session) -> dict[str, int]:
+    rows = session.run("""
+        MATCH ()-[r]->()
+        RETURN type(r) AS type, count(r) AS count
+        ORDER BY type
+    """)
+    return {row["type"]: row["count"] for row in rows}
+
+
+def _estimate_after_counts(before: dict[str, int], mappings: list[dict[str, Any]]) -> dict[str, int]:
+    after = dict(before)
+    for entry in mappings:
+        legacy_count = int(entry["legacy_count"])
+        target_count = int(after.get(entry["to"], 0))
+        after[entry["from"]] = max(0, int(after.get(entry["from"], 0)) - legacy_count)
+        after[entry["to"]] = target_count + int(entry["planned_creates"])
+    return after
+
+
+def migrate_relationship_types(session, mapping: dict[str, str] | None = None, *, apply: bool = False) -> dict[str, Any]:
+    report: dict[str, Any] = {"mode": "apply" if apply else "dry-run", "before": audit_relationship_type_counts(session), "mappings": []}
+    for legacy_raw, target_raw in (mapping or LEGACY_RELATIONSHIP_TYPE_MAP).items():
+        legacy = validate_legacy_relationship_type(legacy_raw)
+        target = validate_ci_relationship_type(target_raw)
+        if legacy == target:
+            raise ValueError("Legacy and target relationship types must differ")
+
+        plan = session.run(f"""
+            MATCH (a)-[old_rel:{legacy}]->(b)
+            OPTIONAL MATCH (a)-[replacement:{target}]->(b)
+            RETURN count(old_rel) AS legacy_count,
+                   count(replacement) AS duplicate_count,
+                   count(old_rel) - count(replacement) AS create_count
+        """).single() or {}
+        entry = {
+            "from": legacy,
+            "to": target,
+            "legacy_count": plan.get("legacy_count", 0),
+            "planned_creates": plan.get("create_count", 0),
+            "skipped_duplicates": plan.get("duplicate_count", 0),
+            "deleted_legacy": 0,
+        }
+        if apply and entry["legacy_count"]:
+            applied = session.run(f"""
+                MATCH (a)-[old_rel:{legacy}]->(b)
+                OPTIONAL MATCH (a)-[existing:{target}]->(b)
+                WITH a, b, old_rel, existing, properties(old_rel) AS props
+                FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                    CREATE (a)-[new_rel:{target}]->(b)
+                    SET new_rel = props
+                )
+                WITH a, b, old_rel
+                MATCH (a)-[replacement:{target}]->(b)
+                DELETE old_rel
+                RETURN count(old_rel) AS deleted_count
+            """).single() or {}
+            entry["deleted_legacy"] = applied.get("deleted_count", 0)
+        report["mappings"].append(entry)
+    if apply:
+        report["after"] = audit_relationship_type_counts(session)
+    else:
+        report["after"] = dict(report["before"])
+        report["after_if_applied"] = _estimate_after_counts(report["before"], report["mappings"])
+    return report

--- a/backend/services/relationship_types.py
+++ b/backend/services/relationship_types.py
@@ -1,0 +1,53 @@
+"""Shared relationship type definitions for CI correlation APIs."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+import re
+
+SUPPORTED_CI_RELATIONSHIP_TYPES = frozenset({
+    "CONNECTS_TO",
+    "DEPENDS_ON",
+    "HOSTED_ON",
+    "MANAGES",
+    "USES",
+    "PROVIDES",
+})
+
+SYSTEM_RELATIONSHIP_TYPES = frozenset({"HAS_METRIC"})
+READ_ONLY_GRAPH_RELATIONSHIP_TYPES = frozenset({"RUNS_ON"})
+LISTABLE_RELATIONSHIP_TYPES = (
+    SUPPORTED_CI_RELATIONSHIP_TYPES | SYSTEM_RELATIONSHIP_TYPES | READ_ONLY_GRAPH_RELATIONSHIP_TYPES
+)
+
+LEGACY_RELATIONSHIP_TYPE_MAP = {"CONNECTED_TO": "CONNECTS_TO"}
+_SAFE_RELATIONSHIP_TYPE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def normalize_relationship_type(relationship: str) -> str:
+    return relationship.upper().replace(" ", "_")
+
+
+def validate_legacy_relationship_type(relationship: str) -> str:
+    clean = normalize_relationship_type(relationship)
+    if clean in SUPPORTED_CI_RELATIONSHIP_TYPES or not _SAFE_RELATIONSHIP_TYPE.fullmatch(clean):
+        raise ValueError(f"Invalid legacy relationship type: {relationship}")
+    return clean
+
+
+def validate_ci_relationship_type(relationship: str) -> str:
+    clean = normalize_relationship_type(relationship)
+    if clean not in SUPPORTED_CI_RELATIONSHIP_TYPES:
+        raise ValueError(f"Invalid relationship type: {relationship}")
+    return clean
+
+
+def cypher_relationship_union(relationship_types: Iterable[str]) -> str:
+    """Build a Cypher relationship union after validating known safe type names."""
+    allowed = LISTABLE_RELATIONSHIP_TYPES | SUPPORTED_CI_RELATIONSHIP_TYPES
+    clean_types = []
+    for rel_type in relationship_types:
+        clean = normalize_relationship_type(rel_type)
+        if clean not in allowed:
+            raise ValueError(f"Invalid relationship type for Cypher union: {rel_type}")
+        clean_types.append(clean)
+    return "|".join(sorted(set(clean_types)))

--- a/backend/tests/test_relationship_migration.py
+++ b/backend/tests/test_relationship_migration.py
@@ -1,0 +1,67 @@
+from services.relationship_migration import LEGACY_RELATIONSHIP_TYPE_MAP, audit_relationship_type_counts, migrate_relationship_types
+
+
+class FakeResult:
+    def __init__(self, records=None, single_record=None):
+        self.records = records or []
+        self.single_record = single_record
+
+    def __iter__(self):
+        return iter(self.records)
+
+    def single(self):
+        return self.single_record
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        if "RETURN type(r) AS type" in query:
+            return FakeResult([{"type": "CONNECTED_TO", "count": 2}, {"type": "CONNECTS_TO", "count": 1}])
+        if "legacy_count" in query:
+            return FakeResult(single_record={"legacy_count": 2, "duplicate_count": 1, "create_count": 1})
+        if "deleted_count" in query:
+            return FakeResult(single_record={"deleted_count": 2})
+        return FakeResult()
+
+
+def test_audit_relationship_type_counts_is_read_only():
+    session = FakeSession()
+    assert audit_relationship_type_counts(session) == {"CONNECTED_TO": 2, "CONNECTS_TO": 1}
+    assert "DELETE" not in session.calls[0][0]
+    assert "CREATE" not in session.calls[0][0]
+
+
+def test_migrate_relationship_types_dry_run_does_not_mutate():
+    session = FakeSession()
+    report = migrate_relationship_types(session, LEGACY_RELATIONSHIP_TYPE_MAP, apply=False)
+    entry = report["mappings"][0]
+    assert report["mode"] == "dry-run"
+    assert (entry["from"], entry["to"], entry["planned_creates"], entry["skipped_duplicates"]) == ("CONNECTED_TO", "CONNECTS_TO", 1, 1)
+    assert report["after"] == report["before"]
+    assert report["after_if_applied"] == {"CONNECTED_TO": 0, "CONNECTS_TO": 2}
+    assert all("DELETE" not in query and "CREATE" not in query for query, _ in session.calls)
+
+
+def test_migrate_relationship_types_rejects_unsafe_legacy_type():
+    session = FakeSession()
+    try:
+        migrate_relationship_types(session, {"CONNECTED_TO`) DELETE r //": "CONNECTS_TO"}, apply=False)
+    except ValueError:
+        return
+    raise AssertionError("unsafe legacy relationship type was accepted")
+
+
+def test_migrate_relationship_types_apply_copies_properties_and_deletes_after_replacement():
+    session = FakeSession()
+    report = migrate_relationship_types(session, LEGACY_RELATIONSHIP_TYPE_MAP, apply=True)
+    apply_query = session.calls[-2][0]
+    assert report["mode"] == "apply"
+    assert report["mappings"][0]["deleted_legacy"] == 2
+    assert "CREATE (a)-[new_rel:CONNECTS_TO]->(b)" in apply_query
+    assert "SET new_rel = props" in apply_query
+    assert "MATCH (a)-[replacement:CONNECTS_TO]->(b)" in apply_query
+    assert "DELETE old_rel" in apply_query

--- a/backend/tests/test_relationship_types.py
+++ b/backend/tests/test_relationship_types.py
@@ -1,0 +1,31 @@
+import pytest
+
+from services.relationship_types import (
+    LISTABLE_RELATIONSHIP_TYPES,
+    SUPPORTED_CI_RELATIONSHIP_TYPES,
+    cypher_relationship_union,
+    validate_ci_relationship_type,
+)
+
+
+def test_supported_ci_relationship_types_include_homologated_types():
+    assert {"CONNECTS_TO", "DEPENDS_ON", "HOSTED_ON"}.issubset(SUPPORTED_CI_RELATIONSHIP_TYPES)
+    assert "CONNECTED_TO" not in SUPPORTED_CI_RELATIONSHIP_TYPES
+
+
+def test_validate_ci_relationship_type_rejects_legacy_connected_to():
+    with pytest.raises(ValueError):
+        validate_ci_relationship_type("CONNECTED_TO")
+
+
+def test_validate_ci_relationship_type_accepts_normalized_supported_type():
+    assert validate_ci_relationship_type("connects to") == "CONNECTS_TO"
+
+
+def test_listable_relationship_union_includes_created_supported_types():
+    rel_union = cypher_relationship_union(LISTABLE_RELATIONSHIP_TYPES)
+
+    assert "CONNECTS_TO" in rel_union
+    assert "DEPENDS_ON" in rel_union
+    assert "HOSTED_ON" in rel_union
+    assert "CONNECTED_TO" not in rel_union

--- a/backend/tests/test_topology_relationships.py
+++ b/backend/tests/test_topology_relationships.py
@@ -1,0 +1,111 @@
+import asyncio
+from unittest.mock import patch
+
+from repositories import topology_repo
+from models.user import User
+from routers.links import CiIdsPayload, get_cis_relationships
+from services import link_service
+
+
+def test_create_link_rejects_legacy_connected_to(mock_neo4j_driver):
+    try:
+        topology_repo.create_link("ci-a", "ci-b", "CONNECTED_TO")
+    except ValueError:
+        return
+    raise AssertionError("legacy CONNECTED_TO relationship was accepted")
+
+
+def test_create_link_accepts_connects_to(mock_neo4j_driver):
+    topology_repo.create_link("ci-a", "ci-b", "CONNECTS_TO")
+
+    query = mock_neo4j_driver.mock_session.queries[-1]["query"]
+    assert "MERGE (a)-[r:CONNECTS_TO]->(b)" in query
+
+
+def test_get_links_query_includes_hosted_on(mock_neo4j_driver):
+    mock_neo4j_driver.mock_session.set_default_response([])
+
+    topology_repo.get_links(allowed_locations=[], is_admin=True)
+
+    query = mock_neo4j_driver.mock_session.queries[-1]["query"]
+    assert "HOSTED_ON" in query
+    assert "CONNECTS_TO" in query
+    assert "DEPENDS_ON" in query
+    assert "CONNECTED_TO" not in query
+
+
+def test_cis_relationships_route_uses_scoped_service_path():
+    async def run_route():
+        user = User(
+            username="operator",
+            role="OPERATOR",
+            permissions=["CI_VIEW"],
+            allowed_locations=["HQ-Madrid"],
+        )
+        with patch("routers.links.link_service.get_cis_relationships", return_value={"ci-a": {}}) as mock_service:
+            result = await get_cis_relationships(CiIdsPayload(ci_ids=["ci-a"]), user)
+        return result, mock_service
+
+    result, mock_service = asyncio.run(run_route())
+    assert result == {"ci-a": {}}
+    mock_service.assert_called_once()
+    assert mock_service.call_args.args[0] == ["ci-a"]
+    assert mock_service.call_args.args[1].allowed_locations == ["HQ-Madrid"]
+
+
+def test_cis_relationship_summary_applies_non_admin_location_scope(mock_neo4j_driver):
+    mock_neo4j_driver.mock_session.set_default_response([])
+    user = User(
+        username="operator",
+        role="OPERATOR",
+        permissions=["CI_VIEW"],
+        allowed_locations=["HQ-Madrid"],
+    )
+
+    link_service.get_cis_relationships(["ci-a", "ci-b"], user)
+
+    query_call = mock_neo4j_driver.mock_session.queries[-1]
+    assert "a.id IN $ci_ids AND a.location_name IN $allowed_locations" in query_call["query"]
+    assert "b.id IN $ci_ids AND b.location_name IN $allowed_locations" in query_call["query"]
+    assert query_call["params"]["allowed_locations"] == ["HQ-Madrid"]
+
+
+def test_cis_relationship_summary_does_not_populate_disallowed_requested_ci(mock_neo4j_driver):
+    mock_neo4j_driver.mock_session.set_default_response([
+        {
+            "source_id": "allowed-ci",
+            "source_label": "Allowed CI",
+            "source_location": "HQ-Madrid",
+            "target_id": "blocked-ci",
+            "target_label": "Blocked CI",
+            "target_location": "Secret",
+            "rel_type": "CONNECTS_TO",
+        }
+    ])
+    user = User(
+        username="operator",
+        role="OPERATOR",
+        permissions=["CI_VIEW"],
+        allowed_locations=["HQ-Madrid"],
+    )
+
+    summary = link_service.get_cis_relationships(["allowed-ci", "blocked-ci"], user)
+
+    assert summary["allowed-ci"]["asSource"] == [
+        {"otherId": "blocked-ci", "otherLabel": "Blocked CI", "type": "CONNECTS_TO"}
+    ]
+    assert summary["blocked-ci"] == {"asSource": [], "asTarget": []}
+
+
+def test_cis_relationship_summary_returns_empty_scoped_summary_without_locations(mock_neo4j_driver):
+    user = User(
+        username="operator",
+        role="OPERATOR",
+        permissions=["CI_VIEW"],
+        allowed_locations=[],
+    )
+
+    summary = link_service.get_cis_relationships(["ci-a"], user)
+
+    assert summary == {"ci-a": {"asSource": [], "asTarget": []}}
+    assert mock_neo4j_driver.mock_session.queries == []

--- a/frontend/components/RelationshipBadge.tsx
+++ b/frontend/components/RelationshipBadge.tsx
@@ -13,7 +13,7 @@ interface RelationshipBadgeProps {
 /**
  * RelationshipBadge — renders colored dot badges for a CI's relationship types.
  * - Green dot: CI is a source of DEPENDS_ON relationships
- * - Blue dot: CI is a source of CONNECTED_TO relationships
+ * - Blue dot: CI is a source of CONNECTS_TO relationships
  * Only renders when the CI has relevant outgoing relationships.
  */
 const RelationshipBadge: React.FC<RelationshipBadgeProps> = ({ ciId, relationships }) => {
@@ -21,7 +21,7 @@ const RelationshipBadge: React.FC<RelationshipBadgeProps> = ({ ciId, relationshi
   if (!rels || (rels.asSource.length === 0 && rels.asTarget.length === 0)) return null;
 
   const hasDepends = rels.asSource.some(r => r.type === 'DEPENDS_ON');
-  const hasConnected = rels.asSource.some(r => r.type === 'CONNECTED_TO');
+  const hasConnected = rels.asSource.some(r => r.type === 'CONNECTS_TO');
 
   return (
     <span className="flex items-center gap-1 ml-2" aria-label="Has relationships">
@@ -35,8 +35,8 @@ const RelationshipBadge: React.FC<RelationshipBadgeProps> = ({ ciId, relationshi
       {hasConnected && (
         <span
           className="inline-block w-2 h-2 rounded-full bg-blue-500"
-          title="CONNECTED_TO"
-          aria-label="Has CONNECTED_TO relationships"
+          title="CONNECTS_TO"
+          aria-label="Has CONNECTS_TO relationships"
         />
       )}
     </span>

--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -353,7 +353,7 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                             >
                                 <option value="DEPENDS_ON">DEPENDS_ON (Impact Flow)</option>
                                 <option value="HOSTED_ON">HOSTED_ON (Containment)</option>
-                                <option value="CONNECTED_TO">CONNECTED_TO (Network)</option>
+                                <option value="CONNECTS_TO">CONNECTS_TO (Network)</option>
                             </select>
                         </div>
 
@@ -486,7 +486,7 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                                                 onClick={() => {
                                                     // Smart Root Selection: Select the "Superior" node as Root
                                                     // For dependencies, the Target is the Provider (Superior)
-                                                    if (['DEPENDS_ON', 'HOSTED_ON', 'BELONGS_TO', 'MANAGED_BY'].includes(link.relationship)) {
+                                                    if (['DEPENDS_ON', 'HOSTED_ON'].includes(link.relationship)) {
                                                         setVisualizationTarget(link.target);
                                                     } else {
                                                         setVisualizationTarget(link.source);

--- a/frontend/components/RelationshipTooltip.tsx
+++ b/frontend/components/RelationshipTooltip.tsx
@@ -71,7 +71,7 @@ const RelationshipTooltip: React.FC<RelationshipTooltipProps> = ({ ciId, relatio
               className={`inline-block text-[9px] font-bold px-1.5 py-0.5 rounded uppercase shrink-0 mt-0.5 ${
                 item.type === 'DEPENDS_ON'
                   ? 'bg-green-500/20 text-green-400'
-                  : item.type === 'CONNECTED_TO'
+                  : item.type === 'CONNECTS_TO'
                   ? 'bg-blue-500/20 text-blue-400'
                   : 'bg-white/10 text-neutral-400'
               }`}

--- a/frontend/components/__tests__/RelationshipBadge.unit.test.tsx
+++ b/frontend/components/__tests__/RelationshipBadge.unit.test.tsx
@@ -2,7 +2,7 @@
  * RelationshipBadge.unit.test.tsx
  *
  * BDD unit tests for RelationshipBadge component.
- * Tests badge rendering for DEPENDS_ON (green) and CONNECTED_TO (blue) relationship types.
+ * Tests badge rendering for DEPENDS_ON (green) and CONNECTS_TO (blue) relationship types.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -17,14 +17,14 @@ const singleDependSourceMap = new Map([
 ]);
 
 const singleConnectedSourceMap = new Map([
-  ['CI-A', { asSource: [{ otherId: 'CI-C', otherLabel: 'CI-C', type: 'CONNECTED_TO' }], asTarget: [] }],
+  ['CI-A', { asSource: [{ otherId: 'CI-C', otherLabel: 'CI-C', type: 'CONNECTS_TO' }], asTarget: [] }],
 ]);
 
 const multiTypeMap = new Map([
   ['CI-A', {
     asSource: [
       { otherId: 'CI-B', otherLabel: 'CI-B', type: 'DEPENDS_ON' },
-      { otherId: 'CI-C', otherLabel: 'CI-C', type: 'CONNECTED_TO' },
+      { otherId: 'CI-C', otherLabel: 'CI-C', type: 'CONNECTS_TO' },
     ],
     asTarget: [
       { otherId: 'CI-D', otherLabel: 'CI-D', type: 'DEPENDS_ON' },
@@ -55,7 +55,7 @@ describe('RelationshipBadge', () => {
     });
   });
 
-  describe('GIVEN a CI with CONNECTED_TO relationships', () => {
+  describe('GIVEN a CI with CONNECTS_TO relationships', () => {
     it('WHEN rendered THEN a blue badge dot is displayed', () => {
       render(<RelationshipBadge ciId="CI-A" relationships={singleConnectedSourceMap} />);
       const dots = document.querySelectorAll('.bg-blue-500');
@@ -64,7 +64,7 @@ describe('RelationshipBadge', () => {
 
     it('WHEN rendered THEN badge has correct title attribute', () => {
       render(<RelationshipBadge ciId="CI-A" relationships={singleConnectedSourceMap} />);
-      const dot = document.querySelector('[title="CONNECTED_TO"]');
+      const dot = document.querySelector('[title="CONNECTS_TO"]');
       expect(dot).not.toBeNull();
     });
   });
@@ -90,7 +90,7 @@ describe('RelationshipBadge', () => {
   describe('GIVEN a CI with no entry in relationship map', () => {
     it('WHEN rendered THEN no badge is rendered', () => {
       render(<RelationshipBadge ciId="NONEXISTENT" relationships={emptyMap} />);
-      const dots = document.querySelectorAll('[title="DEPENDS_ON"], [title="CONNECTED_TO"]');
+      const dots = document.querySelectorAll('[title="DEPENDS_ON"], [title="CONNECTS_TO"]');
       expect(dots.length).toBe(0);
     });
   });

--- a/frontend/components/__tests__/computeRelationshipMap.unit.test.ts
+++ b/frontend/components/__tests__/computeRelationshipMap.unit.test.ts
@@ -50,19 +50,19 @@ describe('computeRelationshipMap', () => {
     });
   });
 
-  describe('GIVEN a single CONNECTED_TO link', () => {
-    it('WHEN called THEN correctly partitions asSource/asTarget with CONNECTED_TO type', () => {
-      const links = [link('X', 'Y', 'CONNECTED_TO')];
+  describe('GIVEN a single CONNECTS_TO link', () => {
+    it('WHEN called THEN correctly partitions asSource/asTarget with CONNECTS_TO type', () => {
+      const links = [link('X', 'Y', 'CONNECTS_TO')];
       const map = computeRelationshipMap(links);
 
       const xRels = map.get('X');
       const yRels = map.get('Y');
 
       expect(xRels!.asSource).toHaveLength(1);
-      expect(xRels!.asSource[0].type).toBe('CONNECTED_TO');
+      expect(xRels!.asSource[0].type).toBe('CONNECTS_TO');
       expect(xRels!.asSource[0].otherId).toBe('Y');
       expect(yRels!.asTarget).toHaveLength(1);
-      expect(yRels!.asTarget[0].type).toBe('CONNECTED_TO');
+      expect(yRels!.asTarget[0].type).toBe('CONNECTS_TO');
     });
   });
 
@@ -70,7 +70,7 @@ describe('computeRelationshipMap', () => {
     it('WHEN called THEN CI has multiple asSource entries', () => {
       const links = [
         link('CI1', 'CI2', 'DEPENDS_ON'),
-        link('CI1', 'CI3', 'CONNECTED_TO'),
+        link('CI1', 'CI3', 'CONNECTS_TO'),
         link('CI4', 'CI1', 'DEPENDS_ON'),  // CI1 as target
       ];
       const map = computeRelationshipMap(links);

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -61,7 +61,16 @@ export interface GraphLink {
 	id: string;
 	source: string;
 	target: string;
-	relationship: "DEPENDS_ON" | "RUNS_ON" | "PART_OF" | "MANAGED_BY";
+	relationship:
+		| "CONNECTS_TO"
+		| "DEPENDS_ON"
+		| "HOSTED_ON"
+		| "MANAGES"
+		| "USES"
+		| "PROVIDES"
+		| "RUNS_ON"
+		| "HAS_METRIC"
+		| "CATEGORIZED_AS";
 }
 
 export interface AvailabilityReportRow {


### PR DESCRIPTION
Closes #192
Part of #191

## Descripción del Cambio
PR1 de la cadena `visual-ci-correlations`.

Homologa los tipos de relaciones/correlaciones de CIs para que la UI y el backend usen `CONNECTS_TO` como tipo soportado, dejando `CONNECTED_TO` sólo como legacy migrable.

## Chain Context
Tracker: #191

```text
#191 Tracker — Visual CI correlation workflow
├── 📍 PR1: Homologate relationship types/API + migration tooling
├── PR2: Admin Inventory relationship indicators
└── PR3: Static visual correlation modal/create flow
```

**Start state:** Admin relationship flows had inconsistent relationship names (`CONNECTED_TO` vs `CONNECTS_TO`) and incomplete/scoping-risky relationship summary behavior.

**End state:** Supported relationship types are centralized, legacy writes are rejected, `/links` and `/cis/relationships` are aligned/scoped, and production audit/migration tooling exists.

**Out of scope:** Admin Inventory indicators, visual modal, applying the production migration, and unrelated dirty `GlobalInventory` / metric formatting changes.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Centralizes backend CI relationship type validation and rejects legacy `CONNECTED_TO` for new writes.
- Aligns `/links` and `/cis/relationships` with supported CI relationship types and user scoping.
- Adds read-only audit and guarded dry-run/apply migration scripts for production data.
- Updates small frontend relationship displays/tests to use `CONNECTS_TO`.

## Changes
| File | Change |
|------|--------|
| `backend/services/relationship_types.py` | Shared supported/listable/legacy relationship type definitions and validation. |
| `backend/services/relationship_migration.py` | Audit/migration helpers with dry-run/apply reporting. |
| `backend/scripts/audit_relationship_types.py` | Read-only relationship type count script. |
| `backend/scripts/migrate_relationship_types.py` | Dry-run/apply migration entry point with apply confirmation guard. |
| `backend/repositories/topology_repo.py` | Uses shared types for validation/listing and scoped CI relationship summary. |
| `backend/services/link_service.py` / `backend/routers/links.py` | Routes `/cis/relationships` through scoped service logic. |
| `frontend/components/Relationship*.tsx`, `frontend/types.ts` | Replaces stale `CONNECTED_TO` UI references with `CONNECTS_TO`. |
| tests | Adds backend migration/type/scoping tests and updates frontend relationship tests. |

## ¿Cómo se probó?
- [x] `cd backend && .venv/bin/python -m py_compile services/relationship_types.py services/relationship_migration.py scripts/audit_relationship_types.py scripts/migrate_relationship_types.py`
- [x] `cd backend && .venv/bin/python -m pytest tests/test_relationship_types.py tests/test_topology_relationships.py tests/test_relationship_migration.py` — 15 passed
- [x] `pnpm --dir frontend exec vitest run components/__tests__/RelationshipBadge.unit.test.tsx components/__tests__/computeRelationshipMap.unit.test.ts` — 2 files / 13 tests passed
- [x] Fresh reviewer audit: no blockers before commit

## Production Migration Notes
DB was unavailable locally, so production should run:

```bash
cd backend
python scripts/audit_relationship_types.py
python scripts/migrate_relationship_types.py --dry-run
python scripts/migrate_relationship_types.py --apply
```

`--apply` warns and requires the confirmation phrase unless `--yes` is provided. Take/confirm a DB backup before applying.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Review Workload
Approximate staged PR1 footprint: 16 files, 498 insertions, 55 deletions. This exceeds the 400-line preference but remains one coherent PR1 unit because backend validation, scoping, migration tooling, and focused tests are tightly coupled. Follow-up UI work stays out of this PR.
