### PR TITLE
feat(cmdb): show Admin Inventory correlation indicators

### DIFF
--- a/frontend/components/AdminPage.test.tsx
+++ b/frontend/components/AdminPage.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AdminPage from './AdminPage';
+
+const { mockApiGet, mockApiPost } = vi.hoisted(() => ({
+    mockApiGet: vi.fn(),
+    mockApiPost: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+    api: {
+        get: mockApiGet,
+        post: mockApiPost,
+        delete: vi.fn(),
+        download: vi.fn(),
+        request: vi.fn(),
+    },
+}));
+
+vi.mock('../context/AuthContext', () => ({
+    useAuth: () => ({ hasPermission: () => true }),
+}));
+
+vi.mock('./MetricsManager', () => ({ default: () => <div>Metrics Manager</div> }));
+vi.mock('./DictionaryManager', () => ({ default: () => <div>Dictionary Manager</div> }));
+vi.mock('./CIEditor', () => ({ default: () => <div>CI Editor</div> }));
+vi.mock('./RelationshipManager', () => ({ default: () => <div>Relationship Manager</div> }));
+vi.mock('./MassLinkEditor', () => ({ default: () => <div>Mass Link Editor</div> }));
+vi.mock('./CatalogManager', () => ({ default: () => <div>Catalog Manager</div> }));
+
+const nodes = [
+    { id: 'ci-a', label: 'Router A', type: 'Network', status: 'ACTIVE', ip: '10.0.0.1' },
+    { id: 'ci-b', label: 'Switch B', type: 'Network', status: 'ACTIVE', ip: '10.0.0.2' },
+    { id: 'ci-c', label: 'Server C', type: 'Server', status: 'MAINTENANCE', ip: '10.0.0.3' },
+    { id: 'ci-d', label: 'Camera D', type: 'Camera', status: 'ACTIVE', ip: '10.0.0.4' },
+];
+
+const relationships = {
+    'ci-a': {
+        asSource: [{ otherId: 'ci-b', otherLabel: 'Switch B', type: 'CONNECTS_TO' }],
+        asTarget: [],
+    },
+    'ci-b': {
+        asSource: [],
+        asTarget: [{ otherId: 'ci-a', otherLabel: 'Router A', type: 'CONNECTS_TO' }],
+    },
+    'ci-c': {
+        asSource: [{ otherId: 'ci-d', otherLabel: 'Camera D', type: 'HOSTED_ON' }],
+        asTarget: [{ otherId: 'ci-a', otherLabel: 'Router A', type: 'DEPENDS_ON' }],
+    },
+    'ci-d': { asSource: [], asTarget: [] },
+};
+
+describe('AdminPage inventory relationships', () => {
+    beforeEach(() => {
+        mockApiGet.mockReset();
+        mockApiPost.mockReset();
+        mockApiGet.mockImplementation((endpoint: string) => {
+            if (endpoint === '/nodes') return Promise.resolve(nodes);
+            return Promise.resolve([]);
+        });
+        mockApiPost.mockImplementation((endpoint: string) => {
+            if (endpoint === '/cis/relationships') return Promise.resolve(relationships);
+            return Promise.resolve({});
+        });
+    });
+
+    it('fetches visible inventory relationships and renders none/incoming/outgoing/both indicators', async () => {
+        render(<AdminPage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'INVENTORY' }));
+
+        expect(await screen.findByText('Router A')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledWith('/cis/relationships', {
+                ci_ids: ['ci-a', 'ci-b', 'ci-c', 'ci-d'],
+            });
+        });
+
+        expect(await screen.findByText('Outgoing')).toBeInTheDocument();
+        expect(screen.getByText('Incoming')).toBeInTheDocument();
+        expect(screen.getByText('Incoming + outgoing')).toBeInTheDocument();
+        expect(screen.getByText('No correlations')).toBeInTheDocument();
+    });
+
+    it('shows selected CI relationship details with direction, type, related label, and id', async () => {
+        render(<AdminPage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'INVENTORY' }));
+        fireEvent.click(await screen.findByText('Router A'));
+
+        expect(await screen.findByText('CI Correlation Details')).toBeInTheDocument();
+        expect(screen.getByText('OUTGOING')).toBeInTheDocument();
+        expect(screen.getByText('CONNECTS_TO')).toBeInTheDocument();
+        expect(screen.getAllByText('Switch B').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('ci-b').length).toBeGreaterThan(0);
+    });
+});

--- a/frontend/components/AdminPage.tsx
+++ b/frontend/components/AdminPage.tsx
@@ -6,9 +6,16 @@ import CIEditor from './CIEditor';
 import RelationshipManager from './RelationshipManager';
 import MassLinkEditor from './MassLinkEditor';
 import CatalogManager from './CatalogManager';
-import { GraphNode } from '../types';
+import type { GraphNode } from '../types';
 import { useAuth } from '../context/AuthContext';
 import { api } from '../services/api';
+import {
+    type CiRelationshipSummary,
+    formatCiRelationshipDetails,
+    getCiRelationshipDetails,
+    getCiRelationshipState,
+    getCiRelationshipStateLabel,
+} from '../utils/ciRelationships';
 
 /**
  * AdminPage Component
@@ -32,6 +39,8 @@ const AdminPage: React.FC = () => {
     const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
     const [refreshKey, setRefreshKey] = useState(0);
     const [inventorySearch, setInventorySearch] = useState('');
+    const [relationshipSummaries, setRelationshipSummaries] = useState<Record<string, CiRelationshipSummary>>({});
+    const [relationshipsLoading, setRelationshipsLoading] = useState(false);
 
     useEffect(() => {
         fetchData();
@@ -143,6 +152,38 @@ const AdminPage: React.FC = () => {
 
         return data.filter((item) => searchableText(item).toLowerCase().includes(query));
     }, [data, inventorySearch]);
+
+    const filteredInventoryIds = useMemo(
+        () => filteredInventory.map((item) => item.id).filter(Boolean),
+        [filteredInventory],
+    );
+    const filteredInventoryIdsKey = filteredInventoryIds.join('|');
+
+    useEffect(() => {
+        if (activeTab !== 'INVENTORY' || filteredInventoryIds.length === 0) {
+            setRelationshipSummaries({});
+            setRelationshipsLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        setRelationshipsLoading(true);
+        api.post<Record<string, CiRelationshipSummary>>('/cis/relationships', { ci_ids: filteredInventoryIds })
+            .then((summary) => {
+                if (!cancelled) setRelationshipSummaries(summary || {});
+            })
+            .catch((error) => {
+                console.error(error);
+                if (!cancelled) setRelationshipSummaries({});
+            })
+            .finally(() => {
+                if (!cancelled) setRelationshipsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [activeTab, filteredInventoryIdsKey]);
 
     return (
         <div className="p-8 h-full overflow-y-auto custom-scrollbar space-y-8">
@@ -278,51 +319,95 @@ const AdminPage: React.FC = () => {
                                             <th className="p-3 uppercase tracking-wider font-bold">Category</th>
                                             <th className="p-3 uppercase tracking-wider font-bold">IP Address</th>
                                             <th className="p-3 uppercase tracking-wider font-bold">Status</th>
+                                            <th className="p-3 uppercase tracking-wider font-bold">Correlations</th>
                                             <th className="p-3 text-right uppercase tracking-wider font-bold">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody className="text-sm divide-y divide-white/5">
-                                        {filteredInventory.map((item: any) => (
-                                            <tr
-                                                key={item.id}
-                                                className={`hover:bg-brand-500/5 transition-colors cursor-pointer ${selectedNode?.id === item.id ? 'bg-brand-500/10' : ''}`}
-                                                onClick={() => setSelectedNode(item)}
-                                            >
-                                                <td className="p-3">
-                                                    <div className="font-bold text-white">{item.label}</div>
-                                                    <div className="text-[10px] text-neutral-500 font-mono">{item.id}</div>
-                                                </td>
-                                                <td className="p-3 text-neutral-300">
-                                                    <span className="px-2 py-1 rounded bg-white/5 text-xs border border-white/5">
-                                                        {item.type || 'Uncategorized'}
-                                                    </span>
-                                                </td>
-                                                <td className="p-3 font-mono text-neutral-400 text-xs">
-                                                    {item.ip || '-'}
-                                                </td>
-                                                <td className="p-3">
-                                                    <span className={`px-2 py-0.5 rounded text-[10px] font-black uppercase ${item.status === 'ACTIVE' ? 'bg-green-500/20 text-green-400' :
-                                                        item.status === 'MAINTENANCE' ? 'bg-yellow-500/20 text-yellow-400' :
-                                                            'bg-neutral-500/20 text-neutral-400'
-                                                        }`}>
-                                                        {item.status}
-                                                    </span>
-                                                </td>
-                                                <td className="p-3 text-right">
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.stopPropagation();
-                                                            if (confirm('Delete CI?')) {
-                                                                api.delete(`/nodes/${item.id}`).then(() => fetchData());
-                                                            }
-                                                        }}
-                                                        className="text-neutral-500 hover:text-red-500 p-2 transition-colors"
+                                        {filteredInventory.map((item: any) => {
+                                            const relationshipSummary = relationshipSummaries[item.id];
+                                            const relationshipState = getCiRelationshipState(relationshipSummary);
+                                            const relationshipDetails = getCiRelationshipDetails(relationshipSummary);
+                                            const relationshipTitle = formatCiRelationshipDetails(relationshipSummary);
+                                            return (
+                                                <React.Fragment key={item.id}>
+                                                    <tr
+                                                        className={`hover:bg-brand-500/5 transition-colors cursor-pointer ${selectedNode?.id === item.id ? 'bg-brand-500/10' : ''}`}
+                                                        onClick={() => setSelectedNode(item)}
                                                     >
-                                                        <span className="material-symbols-outlined text-sm">delete</span>
-                                                    </button>
-                                                </td>
-                                            </tr>
-                                        ))}
+                                                        <td className="p-3">
+                                                            <div className="font-bold text-white">{item.label}</div>
+                                                            <div className="text-[10px] text-neutral-500 font-mono">{item.id}</div>
+                                                        </td>
+                                                        <td className="p-3 text-neutral-300">
+                                                            <span className="px-2 py-1 rounded bg-white/5 text-xs border border-white/5">
+                                                                {item.type || 'Uncategorized'}
+                                                            </span>
+                                                        </td>
+                                                        <td className="p-3 font-mono text-neutral-400 text-xs">
+                                                            {item.ip || '-'}
+                                                        </td>
+                                                        <td className="p-3">
+                                                            <span className={`px-2 py-0.5 rounded text-[10px] font-black uppercase ${item.status === 'ACTIVE' ? 'bg-green-500/20 text-green-400' :
+                                                                item.status === 'MAINTENANCE' ? 'bg-yellow-500/20 text-yellow-400' :
+                                                                    'bg-neutral-500/20 text-neutral-400'
+                                                                }`}>
+                                                                {item.status}
+                                                            </span>
+                                                        </td>
+                                                        <td className="p-3">
+                                                            <span
+                                                                title={relationshipTitle}
+                                                                className={`inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[10px] font-black uppercase ${relationshipState === 'both' ? 'border-purple-400/30 bg-purple-500/10 text-purple-300' :
+                                                                    relationshipState === 'incoming' ? 'border-cyan-400/30 bg-cyan-500/10 text-cyan-300' :
+                                                                        relationshipState === 'outgoing' ? 'border-brand-400/30 bg-brand-500/10 text-brand-300' :
+                                                                            'border-white/10 bg-white/5 text-neutral-500'
+                                                                    }`}
+                                                            >
+                                                                <span className="material-symbols-outlined text-xs">
+                                                                    {relationshipState === 'none' ? 'link_off' : 'account_tree'}
+                                                                </span>
+                                                                {relationshipsLoading ? 'Loading' : getCiRelationshipStateLabel(relationshipState)}
+                                                            </span>
+                                                        </td>
+                                                        <td className="p-3 text-right">
+                                                            <button
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    if (confirm('Delete CI?')) {
+                                                                        api.delete(`/nodes/${item.id}`).then(() => fetchData());
+                                                                    }
+                                                                }}
+                                                                className="text-neutral-500 hover:text-red-500 p-2 transition-colors"
+                                                            >
+                                                                <span className="material-symbols-outlined text-sm">delete</span>
+                                                            </button>
+                                                        </td>
+                                                    </tr>
+                                                    {selectedNode?.id === item.id && relationshipDetails.length > 0 && (
+                                                        <tr className="bg-neutral-950/40">
+                                                            <td colSpan={6} className="px-3 py-3">
+                                                                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+                                                                    <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-neutral-500">CI Correlation Details</p>
+                                                                    <div className="grid gap-2 md:grid-cols-2">
+                                                                        {relationshipDetails.map((detail) => (
+                                                                            <div key={`${detail.direction}-${detail.type}-${detail.otherId}`} className="rounded-lg border border-white/5 bg-white/[0.03] px-3 py-2">
+                                                                                <div className="flex items-center justify-between gap-2">
+                                                                                    <span className="text-[10px] font-black uppercase text-brand-300">{detail.direction}</span>
+                                                                                    <span className="rounded bg-white/10 px-1.5 py-0.5 text-[9px] font-black text-neutral-300">{detail.type}</span>
+                                                                                </div>
+                                                                                <div className="mt-1 text-xs font-bold text-white">{detail.otherLabel}</div>
+                                                                                <div className="font-mono text-[10px] text-neutral-500">{detail.otherId}</div>
+                                                                            </div>
+                                                                        ))}
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                        </tr>
+                                                    )}
+                                                </React.Fragment>
+                                            );
+                                        })}
                                     </tbody>
                                 </table>
                             </div>

--- a/frontend/utils/ciRelationships.test.ts
+++ b/frontend/utils/ciRelationships.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatCiRelationshipDetails,
+	getCiRelationshipDetails,
+	getCiRelationshipState,
+} from "./ciRelationships";
+
+describe("ciRelationships", () => {
+	it("derives none, incoming, outgoing, and both states", () => {
+		expect(getCiRelationshipState()).toBe("none");
+		expect(getCiRelationshipState({ asSource: [], asTarget: [] })).toBe("none");
+		expect(
+			getCiRelationshipState({
+				asSource: [{ otherId: "ci-b", otherLabel: "Switch B", type: "CONNECTS_TO" }],
+				asTarget: [],
+			}),
+		).toBe("outgoing");
+		expect(
+			getCiRelationshipState({
+				asSource: [],
+				asTarget: [{ otherId: "ci-a", otherLabel: "Router A", type: "DEPENDS_ON" }],
+			}),
+		).toBe("incoming");
+		expect(
+			getCiRelationshipState({
+				asSource: [{ otherId: "ci-c", otherLabel: "Server C", type: "HOSTED_ON" }],
+				asTarget: [{ otherId: "ci-a", otherLabel: "Router A", type: "CONNECTS_TO" }],
+			}),
+		).toBe("both");
+	});
+
+	it("formats relationship details with direction, type, label, and id", () => {
+		const summary = {
+			asSource: [{ otherId: "ci-b", otherLabel: "Switch B", type: "CONNECTS_TO" }],
+			asTarget: [{ otherId: "ci-a", otherLabel: "Router A", type: "DEPENDS_ON" }],
+		};
+
+		expect(getCiRelationshipDetails(summary)).toEqual([
+			{ direction: "OUTGOING", type: "CONNECTS_TO", otherId: "ci-b", otherLabel: "Switch B" },
+			{ direction: "INCOMING", type: "DEPENDS_ON", otherId: "ci-a", otherLabel: "Router A" },
+		]);
+		expect(formatCiRelationshipDetails(summary)).toContain("OUTGOING: CONNECTS_TO Switch B (ci-b)");
+		expect(formatCiRelationshipDetails(summary)).toContain("INCOMING: DEPENDS_ON Router A (ci-a)");
+	});
+});

--- a/frontend/utils/ciRelationships.ts
+++ b/frontend/utils/ciRelationships.ts
@@ -1,0 +1,69 @@
+export interface CiRelationshipEntry {
+	otherId: string;
+	otherLabel: string;
+	type: string;
+}
+
+export interface CiRelationshipSummary {
+	asSource: CiRelationshipEntry[];
+	asTarget: CiRelationshipEntry[];
+}
+
+export type CiRelationshipState = "none" | "incoming" | "outgoing" | "both";
+
+export interface CiRelationshipDetail {
+	direction: "OUTGOING" | "INCOMING";
+	type: string;
+	otherId: string;
+	otherLabel: string;
+}
+
+export const getCiRelationshipState = (
+	summary?: CiRelationshipSummary,
+): CiRelationshipState => {
+	const hasOutgoing = Boolean(summary?.asSource?.length);
+	const hasIncoming = Boolean(summary?.asTarget?.length);
+	if (hasIncoming && hasOutgoing) return "both";
+	if (hasIncoming) return "incoming";
+	if (hasOutgoing) return "outgoing";
+	return "none";
+};
+
+export const getCiRelationshipStateLabel = (
+	state: CiRelationshipState,
+): string => {
+	if (state === "both") return "Incoming + outgoing";
+	if (state === "incoming") return "Incoming";
+	if (state === "outgoing") return "Outgoing";
+	return "No correlations";
+};
+
+export const getCiRelationshipDetails = (
+	summary?: CiRelationshipSummary,
+): CiRelationshipDetail[] => [
+	...(summary?.asSource ?? []).map((entry) => ({
+		direction: "OUTGOING" as const,
+		type: entry.type,
+		otherId: entry.otherId,
+		otherLabel: entry.otherLabel,
+	})),
+	...(summary?.asTarget ?? []).map((entry) => ({
+		direction: "INCOMING" as const,
+		type: entry.type,
+		otherId: entry.otherId,
+		otherLabel: entry.otherLabel,
+	})),
+];
+
+export const formatCiRelationshipDetails = (
+	summary?: CiRelationshipSummary,
+): string => {
+	const details = getCiRelationshipDetails(summary);
+	if (!details.length) return "No CI correlations";
+	return details
+		.map(
+			(detail) =>
+				`${detail.direction}: ${detail.type} ${detail.otherLabel} (${detail.otherId})`,
+		)
+		.join("\n");
+};


### PR DESCRIPTION
Closes #194
Part of #191

## Descripción del Cambio
PR2 de la cadena `visual-ci-correlations`.

Agrega indicadores de correlación en Admin Inventory para que se vea si cada CI tiene relaciones entrantes, salientes, ambas o ninguna, y muestra el detalle de correlaciones del CI seleccionado.

## Chain Context
Tracker: #191

```text
#191 Tracker — Visual CI correlation workflow
├── ✅ PR1: Homologate relationship types/API + migration tooling (#193)
├── 📍 PR2: Admin Inventory relationship indicators
└── PR3: Static visual correlation modal/create flow
```

**Start state:** PR1 homologó tipos/API y dejó disponible `/cis/relationships` scoped.

**End state:** Admin Inventory muestra estado y detalle de correlaciones por CI.

**Out of scope:** creación visual de relaciones, modal/topología, aplicar migración productiva.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Adds four-state CI correlation helpers: none, incoming, outgoing, both.
- Fetches Admin Inventory relationship summaries from `/cis/relationships`.
- Renders row indicators and selected-CI details with direction, type, related label, and related id.
- Adds focused tests for helper behavior and Admin Inventory rendering.

## Changes
| File | Change |
|------|--------|
| `frontend/components/AdminPage.tsx` | Fetches relationship summaries and renders Inventory correlation indicators/details. |
| `frontend/components/AdminPage.test.tsx` | Covers endpoint call, four states, and selected CI detail fields. |
| `frontend/utils/ciRelationships.ts` | Adds shared relationship summary state/detail helpers. |
| `frontend/utils/ciRelationships.test.ts` | Covers state derivation and detail formatting. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run utils/ciRelationships.test.ts components/AdminPage.test.tsx` — 2 files / 4 tests passed
- [x] LSP diagnostics on changed files — 0 errors
- [x] Fresh reviewer audit — no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Review Workload
PR2 footprint: 4 files, 338 insertions, 41 deletions. Under the 400-line review budget.
