### PR TITLE
feat(cmdb): add visual relationship editor

### DIFF
--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { GraphNode } from '../types';
+import type React from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import type { GraphNode } from '../types';
 import TopologyViewer from './TopologyViewer';
 import { api } from '../services/api';
 import RelationshipBadge from './RelationshipBadge';
 import RelationshipTooltip from './RelationshipTooltip';
+import VisualRelationshipEditor from './VisualRelationshipEditor';
 
 // ============================================================================
 // Relationship Indicators — Types & Utilities
@@ -119,6 +121,7 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
 
     // --- State: Visualization Modal ---
     const [visualizationTarget, setVisualizationTarget] = useState<string | null>(null);
+    const [showVisualEditor, setShowVisualEditor] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
 
     // --- Effects ---
@@ -167,6 +170,11 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
             console.error("Failed to fetch links", error);
             setLinks([]);
         }
+    };
+
+    const refreshRelationshipViews = async () => {
+        await fetchLinks();
+        onRefresh();
     };
 
     const fetchNodeMetrics = async (nodeId: string) => {
@@ -444,6 +452,13 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                             <span className="material-symbols-outlined text-brand-500">hub</span>
                             CI Relationships ({filteredCiLinks.length})
                         </h3>
+                        <button
+                            onClick={() => setShowVisualEditor(true)}
+                            className="btn-primary text-xs"
+                        >
+                            <span className="material-symbols-outlined text-sm">account_tree</span>
+                            Visual editor
+                        </button>
                         <div className="relative">
                             <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-neutral-500 text-sm">search</span>
                             <input
@@ -586,6 +601,15 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                         </div>
                     </div>
                 </div>
+            )}
+
+            {showVisualEditor && (
+                <VisualRelationshipEditor
+                    nodes={nodes}
+                    links={ciLinks}
+                    onClose={() => setShowVisualEditor(false)}
+                    onMutated={refreshRelationshipViews}
+                />
             )}
         </div>
     );

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -1,0 +1,165 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphNode } from "../types";
+import VisualRelationshipEditor from "./VisualRelationshipEditor";
+import type { LinkData } from "./RelationshipManager";
+
+const { mockApiPost, mockApiDelete } = vi.hoisted(() => ({
+	mockApiPost: vi.fn(),
+	mockApiDelete: vi.fn(),
+}));
+
+vi.mock("../services/api", () => ({
+	api: {
+		post: mockApiPost,
+		delete: mockApiDelete,
+	},
+}));
+
+const nodes: GraphNode[] = [
+	{
+		id: "ci-a",
+		label: "Router A",
+		type: "INFRASTRUCTURE",
+		status: "ACTIVE",
+		metadata: {},
+		ip: "10.0.0.1",
+	},
+	{
+		id: "ci-b",
+		label: "Switch B",
+		type: "INFRASTRUCTURE",
+		status: "ACTIVE",
+		metadata: {},
+		ip: "10.0.0.2",
+	},
+];
+
+const links: LinkData[] = [
+	{
+		source: "ci-a",
+		source_label: "Router A",
+		target: "ci-b",
+		target_label: "Switch B",
+		relationship: "CONNECTS_TO",
+	},
+];
+
+describe("VisualRelationshipEditor", () => {
+	const onMutated = vi.fn();
+
+	beforeEach(() => {
+		mockApiPost.mockReset();
+		mockApiDelete.mockReset();
+		onMutated.mockReset();
+		mockApiPost.mockResolvedValue({});
+		mockApiDelete.mockResolvedValue({});
+	});
+
+	it("selects source then target by clicking static CI nodes", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		expect(screen.getByText(/Source:/).parentElement).toHaveTextContent(
+			"Router A",
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+		expect(screen.getByText(/Target:/).parentElement).toHaveTextContent(
+			"Switch B",
+		);
+	});
+
+	it("prevents self-links", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={[]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+
+		expect(
+			screen.getByText("Source and target must be different CIs."),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "Create relationship" }),
+		).toBeDisabled();
+	});
+
+	it("creates a link with a supported relationship type and refreshes", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={[]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+		fireEvent.change(screen.getByLabelText("Relationship type"), {
+			target: { value: "DEPENDS_ON" },
+		});
+		fireEvent.click(
+			screen.getByRole("button", { name: "Create relationship" }),
+		);
+
+		await waitFor(() => {
+			expect(mockApiPost).toHaveBeenCalledWith("/links", {
+				source: "ci-a",
+				target: "ci-b",
+				relationship: "DEPENDS_ON",
+			});
+		});
+		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("deletes an existing visual link and refreshes", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+		await waitFor(() =>
+			expect(mockApiDelete).toHaveBeenCalledWith("/links", links[0]),
+		);
+		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not offer legacy CONNECTED_TO relationship type", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={[]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("option", { name: "CONNECTED_TO" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("option", { name: "CONNECTS_TO" }),
+		).toBeInTheDocument();
+	});
+});

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -1,0 +1,288 @@
+import type React from "react";
+import { useMemo, useState } from "react";
+import type { GraphNode } from "../types";
+import { api } from "../services/api";
+import type { LinkData } from "./RelationshipManager";
+
+const SUPPORTED_RELATIONSHIP_TYPES = [
+	"CONNECTS_TO",
+	"DEPENDS_ON",
+	"HOSTED_ON",
+	"MANAGES",
+	"USES",
+	"PROVIDES",
+] as const;
+
+interface VisualRelationshipEditorProps {
+	nodes: GraphNode[];
+	links: LinkData[];
+	onClose: () => void;
+	onMutated: () => void | Promise<void>;
+}
+
+const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
+
+const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
+	nodes,
+	links,
+	onClose,
+	onMutated,
+}) => {
+	const [sourceId, setSourceId] = useState("");
+	const [targetId, setTargetId] = useState("");
+	const [relationship, setRelationship] =
+		useState<(typeof SUPPORTED_RELATIONSHIP_TYPES)[number]>("CONNECTS_TO");
+	const [error, setError] = useState("");
+	const [saving, setSaving] = useState(false);
+
+	const ciLinks = useMemo(
+		() => links.filter((link) => link.relationship !== "HAS_METRIC"),
+		[links],
+	);
+	const nodeMap = useMemo(
+		() => new Map(nodes.map((node) => [node.id, node])),
+		[nodes],
+	);
+	const positionedNodes = useMemo(() => {
+		const centerX = 500;
+		const centerY = 300;
+		const radius = nodes.length > 10 ? 250 : 210;
+		return nodes.map((node, index) => {
+			const angle =
+				nodes.length <= 1
+					? 0
+					: (index / nodes.length) * Math.PI * 2 - Math.PI / 2;
+			return {
+				node,
+				x: nodes.length <= 1 ? centerX : centerX + Math.cos(angle) * radius,
+				y: nodes.length <= 1 ? centerY : centerY + Math.sin(angle) * radius,
+			};
+		});
+	}, [nodes]);
+	const positionMap = useMemo(
+		() => new Map(positionedNodes.map((item) => [item.node.id, item])),
+		[positionedNodes],
+	);
+
+	const selectNode = (id: string) => {
+		setError("");
+		if (!sourceId || (sourceId && targetId)) {
+			setSourceId(id);
+			setTargetId("");
+			return;
+		}
+		if (id === sourceId) {
+			setError("Source and target must be different CIs.");
+			return;
+		}
+		setTargetId(id);
+	};
+
+	const handleCreate = async () => {
+		if (!sourceId || !targetId) {
+			setError("Select a source CI and a target CI.");
+			return;
+		}
+		if (sourceId === targetId) {
+			setError("Source and target must be different CIs.");
+			return;
+		}
+		setSaving(true);
+		setError("");
+		try {
+			await api.post("/links", {
+				source: sourceId,
+				target: targetId,
+				relationship,
+			});
+			setTargetId("");
+			await onMutated();
+		} catch (err) {
+			console.error(err);
+			setError("Could not create relationship.");
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	const handleDelete = async (link: LinkData) => {
+		setSaving(true);
+		setError("");
+		try {
+			await api.delete("/links", link);
+			await onMutated();
+		} catch (err) {
+			console.error(err);
+			setError("Could not delete relationship.");
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-6 backdrop-blur-xl">
+			<div className="flex h-full w-full max-w-7xl flex-col rounded-2xl border border-white/10 bg-neutral-950 shadow-2xl">
+				<div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+					<div>
+						<h2 className="text-xl font-black uppercase text-white">
+							Visual Relationship Editor
+						</h2>
+						<p className="text-xs font-bold uppercase tracking-widest text-neutral-500">
+							Click source CI, click target CI, choose type, then create link
+						</p>
+					</div>
+					<button
+						onClick={onClose}
+						className="text-neutral-400 hover:text-white"
+						aria-label="Close visual relationship editor"
+					>
+						<span className="material-symbols-outlined text-3xl">close</span>
+					</button>
+				</div>
+
+				<div className="grid flex-1 min-h-0 grid-cols-[1fr_360px] gap-4 p-4">
+					<div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),rgba(0,0,0,0.15)_45%,rgba(0,0,0,0.55))]">
+						<svg
+							className="absolute inset-0 h-full w-full"
+							viewBox="0 0 1000 620"
+							aria-label="Existing CI relationship links"
+						>
+							{ciLinks.map((link) => {
+								const source = positionMap.get(link.source);
+								const target = positionMap.get(link.target);
+								if (!source || !target) return null;
+								return (
+									<g key={`${link.source}-${link.target}-${link.relationship}`}>
+										<line
+											x1={source.x}
+											y1={source.y}
+											x2={target.x}
+											y2={target.y}
+											className="stroke-brand-400/40"
+											strokeWidth={2}
+										/>
+										<text
+											x={(source.x + target.x) / 2}
+											y={(source.y + target.y) / 2}
+											className="fill-neutral-300 text-[10px] font-bold"
+										>
+											{link.relationship}
+										</text>
+									</g>
+								);
+							})}
+						</svg>
+						{positionedNodes.map(({ node, x, y }) => {
+							const selectedAsSource = sourceId === node.id;
+							const selectedAsTarget = targetId === node.id;
+							return (
+								<button
+									key={node.id}
+									type="button"
+									onClick={() => selectNode(node.id)}
+									className={`absolute w-36 -translate-x-1/2 -translate-y-1/2 rounded-2xl border px-3 py-2 text-left shadow-xl transition-all ${selectedAsSource ? "border-brand-400 bg-brand-500/25 text-white" : selectedAsTarget ? "border-accent-cyan bg-cyan-500/20 text-white" : "border-white/10 bg-neutral-900/90 text-neutral-300 hover:border-white/30"}`}
+									style={{
+										left: `${(x / 1000) * 100}%`,
+										top: `${(y / 620) * 100}%`,
+									}}
+									aria-label={`CI node ${nodeLabel(node)}`}
+								>
+									<span className="block truncate text-xs font-black uppercase">
+										{nodeLabel(node)}
+									</span>
+									<span className="block truncate font-mono text-[10px] opacity-60">
+										{node.id}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+
+					<aside className="flex min-h-0 flex-col gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+						<div className="rounded-xl border border-white/10 bg-black/20 p-3">
+							<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
+								New relationship
+							</p>
+							<div className="mt-3 space-y-2 text-xs text-neutral-300">
+								<div>
+									<span className="text-neutral-500">Source:</span>{" "}
+									{nodeLabel(nodeMap.get(sourceId))}
+								</div>
+								<div>
+									<span className="text-neutral-500">Target:</span>{" "}
+									{targetId
+										? nodeLabel(nodeMap.get(targetId))
+										: "Select target"}
+								</div>
+								<select
+									value={relationship}
+									onChange={(event) =>
+										setRelationship(event.target.value as typeof relationship)
+									}
+									className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+									aria-label="Relationship type"
+								>
+									{SUPPORTED_RELATIONSHIP_TYPES.map((type) => (
+										<option key={type} value={type}>
+											{type}
+										</option>
+									))}
+								</select>
+								{error && (
+									<div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
+										{error}
+									</div>
+								)}
+								<button
+									onClick={handleCreate}
+									disabled={
+										saving || !sourceId || !targetId || sourceId === targetId
+									}
+									className="w-full rounded-xl bg-brand-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
+								>
+									{saving ? "Saving..." : "Create relationship"}
+								</button>
+							</div>
+						</div>
+
+						<div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-white/10 bg-black/20">
+							<div className="sticky top-0 bg-neutral-950/90 p-3 text-[10px] font-black uppercase tracking-widest text-neutral-500">
+								Existing links
+							</div>
+							{ciLinks.map((link) => (
+								<div
+									key={`${link.source}-${link.target}-${link.relationship}`}
+									className="border-t border-white/5 p-3 text-xs text-neutral-300"
+								>
+									<div className="font-bold text-white">
+										{link.source_label || link.source} →{" "}
+										{link.target_label || link.target}
+									</div>
+									<div className="mt-1 flex items-center justify-between gap-2">
+										<span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
+											{link.relationship}
+										</span>
+										<button
+											onClick={() => handleDelete(link)}
+											className="text-red-300 hover:text-red-200"
+											disabled={saving}
+										>
+											Delete
+										</button>
+									</div>
+								</div>
+							))}
+							{ciLinks.length === 0 && (
+								<div className="p-6 text-center text-xs text-neutral-500">
+									No CI links yet.
+								</div>
+							)}
+						</div>
+					</aside>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default VisualRelationshipEditor;


### PR DESCRIPTION
Closes #197
Part of #191

## Descripción del Cambio
PR3 de la cadena `visual-ci-correlations`.

Agrega una ventana visual para crear y eliminar relaciones entre CIs desde Administración → Links, usando una presentación de nodos/edges similar a CMDB pero con nodos estáticos y sin persistencia de layout.

## Chain Context
Tracker: #191

```text
#191 Tracker — Visual CI correlation workflow
├── ✅ PR1: Homologate relationship types/API + migration tooling (#193)
├── ✅ PR2: Admin Inventory relationship indicators (#195)
├── 📍 PR3: Visual relationship editor
└── PR4: CI CRUD inside the visual map
```

**Start state:** Admin had normalized relationship APIs and Inventory indicators, but link creation/editing was still form/list-based.

**End state:** Admin Links includes a visual editor to see CIs as nodes, see existing links, create links via source/target click selection, and delete existing links.

**Out of scope:** CI CRUD in the map, persisted node layout, draggable nodes, and link type update.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Adds `VisualRelationshipEditor` with static CMDB-like node/edge rendering.
- Supports click source → click target → select relationship type → create link.
- Supports deleting existing links from the visual editor.
- Wires the editor into `RelationshipManager` under Admin Links.

## Changes
| File | Change |
|------|--------|
| `frontend/components/VisualRelationshipEditor.tsx` | New static visual link editor modal. |
| `frontend/components/VisualRelationshipEditor.test.tsx` | Covers selection, self-link prevention, create/delete payloads, refresh callback, and no `CONNECTED_TO`. |
| `frontend/components/RelationshipManager.tsx` | Adds Admin Links launch button and refresh wiring. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/VisualRelationshipEditor.test.tsx components/__tests__/computeRelationshipMap.unit.test.ts --reporter=dot` — 2 files / 11 tests passed
- [x] LSP diagnostics on changed files — 0 errors
- [x] Fresh reviewer audit — no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Review Workload
PR3 footprint: 3 files, 479 insertions, 2 deletions. Slightly over the 400-line preference because this introduces a new component plus focused tests, but scope is limited to visual link CRUD and excludes CI CRUD.

