### PR TITLE
feat(cmdb): guard read-only relationship links

### DIFF
--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -6,6 +6,7 @@ import { api } from '../services/api';
 import RelationshipBadge from './RelationshipBadge';
 import RelationshipTooltip from './RelationshipTooltip';
 import VisualRelationshipEditor from './VisualRelationshipEditor';
+import { canDeleteRelationship, isReadOnlyRelationship } from './relationshipCapabilities';
 
 // ============================================================================
 // Relationship Indicators — Types & Utilities
@@ -251,6 +252,8 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
     };
 
     const handleDelete = async (link: any) => {
+        if (!canDeleteRelationship(link.relationship)) return;
+
         if (confirm(`Delete link: ${link.source} -[${link.relationship}]-> ${link.target}?`)) {
             try {
                 await api.delete('/links', link);
@@ -489,38 +492,47 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                                 </tr>
                             </thead>
                             <tbody className="text-sm">
-                                {filteredCiLinks.map((link, i) => (
-                                    <tr key={i} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
-                                        <td className="p-3 font-mono text-brand-400" title={link.source}>{link.source_label || link.source}</td>
-                                        <td className="p-3 text-center">
-                                            <span className="text-[10px] font-bold bg-white/10 px-2 py-1 rounded text-neutral-300 uppercase">{link.relationship}</span>
-                                        </td>
-                                        <td className="p-3 font-mono text-accent-cyan" title={link.target}>{link.target_label || link.target}</td>
-                                        <td className="p-3 text-right flex items-center justify-end gap-2">
-                                            <button
-                                                onClick={() => {
-                                                    // Smart Root Selection: Select the "Superior" node as Root
-                                                    // For dependencies, the Target is the Provider (Superior)
-                                                    if (['DEPENDS_ON', 'HOSTED_ON'].includes(link.relationship)) {
-                                                        setVisualizationTarget(link.target);
-                                                    } else {
-                                                        setVisualizationTarget(link.source);
-                                                    }
-                                                }}
-                                                className="text-neutral-500 hover:text-brand-400 transition-colors"
-                                                title="Visualize Correlation"
-                                            >
-                                                <span className="material-symbols-outlined text-lg">hub</span>
-                                            </button>
-                                            <button
-                                                onClick={() => handleDelete(link)}
-                                                className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
-                                            >
-                                                <span className="material-symbols-outlined text-lg">delete</span>
-                                            </button>
-                                        </td>
-                                    </tr>
-                                ))}
+                                {filteredCiLinks.map((link, i) => {
+                                    const readOnly = isReadOnlyRelationship(link.relationship);
+
+                                    return (
+                                        <tr key={i} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
+                                            <td className="p-3 font-mono text-brand-400" title={link.source}>{link.source_label || link.source}</td>
+                                            <td className="p-3 text-center">
+                                                <span className="text-[10px] font-bold bg-white/10 px-2 py-1 rounded text-neutral-300 uppercase">{link.relationship}</span>
+                                                {readOnly && (
+                                                    <span className="ml-2 text-[10px] font-bold bg-amber-400/10 px-2 py-1 rounded text-amber-200 uppercase">Read-only</span>
+                                                )}
+                                            </td>
+                                            <td className="p-3 font-mono text-accent-cyan" title={link.target}>{link.target_label || link.target}</td>
+                                            <td className="p-3 text-right flex items-center justify-end gap-2">
+                                                <button
+                                                    onClick={() => {
+                                                        // Smart Root Selection: Select the "Superior" node as Root
+                                                        // For dependencies, the Target is the Provider (Superior)
+                                                        if (['DEPENDS_ON', 'HOSTED_ON'].includes(link.relationship)) {
+                                                            setVisualizationTarget(link.target);
+                                                        } else {
+                                                            setVisualizationTarget(link.source);
+                                                        }
+                                                    }}
+                                                    className="text-neutral-500 hover:text-brand-400 transition-colors"
+                                                    title="Visualize Correlation"
+                                                >
+                                                    <span className="material-symbols-outlined text-lg">hub</span>
+                                                </button>
+                                                {canDeleteRelationship(link.relationship) && (
+                                                    <button
+                                                        onClick={() => handleDelete(link)}
+                                                        className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                                                    >
+                                                        <span className="material-symbols-outlined text-lg">delete</span>
+                                                    </button>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
                                 {filteredCiLinks.length === 0 && (
                                     <tr>
                                         <td colSpan={4} className="p-8 text-center text-neutral-500 text-xs">

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -45,6 +45,16 @@ const links: LinkData[] = [
 	},
 ];
 
+const readOnlyLinks: LinkData[] = [
+	{
+		source: "ci-a",
+		source_label: "Router A",
+		target: "ci-b",
+		target_label: "Switch B",
+		relationship: "RUNS_ON",
+	},
+];
+
 describe("VisualRelationshipEditor", () => {
 	const onMutated = vi.fn();
 
@@ -125,6 +135,37 @@ describe("VisualRelationshipEditor", () => {
 			});
 		});
 		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps RUNS_ON visible and labeled read-only", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={readOnlyLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
+		expect(screen.getAllByText("RUNS_ON").length).toBeGreaterThan(0);
+		expect(screen.getByText("Read-only")).toBeInTheDocument();
+	});
+
+	it("does not offer delete for RUNS_ON links", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={readOnlyLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "Delete" }),
+		).not.toBeInTheDocument();
+		expect(mockApiDelete).not.toHaveBeenCalled();
 	});
 
 	it("deletes an existing visual link and refreshes", async () => {

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -3,6 +3,10 @@ import { useMemo, useState } from "react";
 import type { GraphNode } from "../types";
 import { api } from "../services/api";
 import type { LinkData } from "./RelationshipManager";
+import {
+	canDeleteRelationship,
+	isReadOnlyRelationship,
+} from "./relationshipCapabilities";
 
 const SUPPORTED_RELATIONSHIP_TYPES = [
 	"CONNECTS_TO",
@@ -106,6 +110,8 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	};
 
 	const handleDelete = async (link: LinkData) => {
+		if (!canDeleteRelationship(link.relationship)) return;
+
 		setSaving(true);
 		setError("");
 		try {
@@ -249,29 +255,42 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 							<div className="sticky top-0 bg-neutral-950/90 p-3 text-[10px] font-black uppercase tracking-widest text-neutral-500">
 								Existing links
 							</div>
-							{ciLinks.map((link) => (
-								<div
-									key={`${link.source}-${link.target}-${link.relationship}`}
-									className="border-t border-white/5 p-3 text-xs text-neutral-300"
-								>
-									<div className="font-bold text-white">
-										{link.source_label || link.source} →{" "}
-										{link.target_label || link.target}
+							{ciLinks.map((link) => {
+								const readOnly = isReadOnlyRelationship(link.relationship);
+
+								return (
+									<div
+										key={`${link.source}-${link.target}-${link.relationship}`}
+										className="border-t border-white/5 p-3 text-xs text-neutral-300"
+									>
+										<div className="font-bold text-white">
+											{link.source_label || link.source} →{" "}
+											{link.target_label || link.target}
+										</div>
+										<div className="mt-1 flex items-center justify-between gap-2">
+											<span className="flex items-center gap-2">
+												<span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
+													{link.relationship}
+												</span>
+												{readOnly && (
+													<span className="rounded border border-amber-400/30 bg-amber-400/10 px-2 py-1 text-[10px] font-black uppercase text-amber-200">
+														Read-only
+													</span>
+												)}
+											</span>
+											{canDeleteRelationship(link.relationship) && (
+												<button
+													onClick={() => handleDelete(link)}
+													className="text-red-300 hover:text-red-200"
+													disabled={saving}
+												>
+													Delete
+												</button>
+											)}
+										</div>
 									</div>
-									<div className="mt-1 flex items-center justify-between gap-2">
-										<span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
-											{link.relationship}
-										</span>
-										<button
-											onClick={() => handleDelete(link)}
-											className="text-red-300 hover:text-red-200"
-											disabled={saving}
-										>
-											Delete
-										</button>
-									</div>
-								</div>
-							))}
+								);
+							})}
 							{ciLinks.length === 0 && (
 								<div className="p-6 text-center text-xs text-neutral-500">
 									No CI links yet.

--- a/frontend/components/relationshipCapabilities.test.ts
+++ b/frontend/components/relationshipCapabilities.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+	canDeleteRelationship,
+	isReadOnlyRelationship,
+} from "./relationshipCapabilities";
+
+describe("relationshipCapabilities", () => {
+	it("marks RUNS_ON as read-only", () => {
+		expect(isReadOnlyRelationship("RUNS_ON")).toBe(true);
+	});
+
+	it("blocks deleting RUNS_ON relationships", () => {
+		expect(canDeleteRelationship("RUNS_ON")).toBe(false);
+	});
+
+	it("allows deleting mutable and unknown relationships by default", () => {
+		expect(canDeleteRelationship("CONNECTS_TO")).toBe(true);
+		expect(canDeleteRelationship("USES_CUSTOM_TYPE")).toBe(true);
+	});
+});

--- a/frontend/components/relationshipCapabilities.ts
+++ b/frontend/components/relationshipCapabilities.ts
@@ -1,0 +1,7 @@
+export const READ_ONLY_RELATIONSHIP_TYPES = new Set(["RUNS_ON"]);
+
+export const isReadOnlyRelationship = (relationship: string) =>
+	READ_ONLY_RELATIONSHIP_TYPES.has(relationship);
+
+export const canDeleteRelationship = (relationship: string) =>
+	!isReadOnlyRelationship(relationship);


### PR DESCRIPTION
Closes #199

## Descripción del Cambio
- Adds a frontend relationship capability helper for read-only relationship types.
- Keeps `RUNS_ON` links visible while labeling them `Read-only` and suppressing delete actions in the visual relationship editor and RelationshipManager table.
- Preserves delete behavior for mutable links like `CONNECTS_TO` and keeps legacy `CONNECTED_TO` out of creation options.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/VisualRelationshipEditor.test.tsx components/relationshipCapabilities.test.ts`
- [x] LSP diagnostics on touched TS/TSX files: no errors
- [x] Fresh review found behavior correct after removing generated cache noise

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Chain Context

```text
main
 └─ PR1 relationship type homologation ✅ merged
     └─ PR2 inventory correlation indicators ✅ merged
         └─ PR3 visual relationship editor ✅ merged
             └─ PR4 read-only relationship UI guardrails 📍
```

## Notes
- Frontend-only change.
- Does not touch `/api/nodes`, backend routes, Neo4j write behavior, inventory APIs, relationship definitions, changelog, canvas layout, pan/zoom, filtering, or stashed work.
