### PR TITLE
feat(cmdb): add visual CI CRUD controls

### DIFF
--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -174,7 +174,7 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
     };
 
     const refreshRelationshipViews = async () => {
-        await fetchLinks();
+        await Promise.all([fetchData(), fetchLinks()]);
         onRefresh();
     };
 

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -87,6 +87,175 @@ describe("VisualRelationshipEditor", () => {
 		);
 	});
 
+	it("populates CI form from clicked visual node", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+
+		expect(screen.getByLabelText("CI ID")).toHaveValue("ci-a");
+		expect(screen.getByLabelText("CI label")).toHaveValue("Router A");
+		expect(screen.getByLabelText("CI type")).toHaveValue("INFRASTRUCTURE");
+		expect(screen.getByLabelText("CI status")).toHaveValue("ACTIVE");
+		expect(screen.getByRole("button", { name: "Save CI" })).toBeInTheDocument();
+	});
+
+	it("prevents create without required CI fields", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+		expect(screen.getByText("CI ID is required.")).toBeInTheDocument();
+		expect(mockApiPost).not.toHaveBeenCalled();
+	});
+
+	it("creates CI via existing node upsert API", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+		fireEvent.change(screen.getByLabelText("CI ID"), {
+			target: { value: "ci-c" },
+		});
+		fireEvent.change(screen.getByLabelText("CI label"), {
+			target: { value: "Firewall C" },
+		});
+		fireEvent.change(screen.getByLabelText("CI type"), {
+			target: { value: "INFRASTRUCTURE" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+		await waitFor(() => {
+			expect(mockApiPost).toHaveBeenCalledWith(
+				"/nodes",
+				expect.objectContaining({
+					id: "ci-c",
+					label: "Firewall C",
+					type: "INFRASTRUCTURE",
+					status: "OK",
+					metadata: {},
+				}),
+			);
+		});
+		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("updates selected CI via node upsert and preserves metadata", async () => {
+		const nodesWithMetadata: GraphNode[] = [
+			{ ...nodes[0], metadata: { rack: "R1" }, owner: "ops" },
+			nodes[1],
+		];
+		render(
+			<VisualRelationshipEditor
+				nodes={nodesWithMetadata}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.change(screen.getByLabelText("CI label"), {
+			target: { value: "Router A Updated" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Save CI" }));
+
+		await waitFor(() => {
+			expect(mockApiPost).toHaveBeenCalledWith(
+				"/nodes",
+				expect.objectContaining({
+					id: "ci-a",
+					label: "Router A Updated",
+					metadata: { rack: "R1" },
+					owner: "ops",
+				}),
+			);
+		});
+	});
+
+	it("preserves CI form state after save failure", async () => {
+		mockApiPost.mockRejectedValueOnce(new Error("boom"));
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+		fireEvent.change(screen.getByLabelText("CI ID"), {
+			target: { value: "ci-c" },
+		});
+		fireEvent.change(screen.getByLabelText("CI label"), {
+			target: { value: "Firewall C" },
+		});
+		fireEvent.change(screen.getByLabelText("CI type"), {
+			target: { value: "INFRASTRUCTURE" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+		expect(await screen.findByText("Could not save CI.")).toBeInTheDocument();
+		expect(screen.getByLabelText("CI ID")).toHaveValue("ci-c");
+		expect(screen.getByLabelText("CI label")).toHaveValue("Firewall C");
+		expect(onMutated).not.toHaveBeenCalled();
+	});
+
+	it("deletes selected CI using existing node delete API", async () => {
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete CI" }));
+
+		await waitFor(() =>
+			expect(mockApiDelete).toHaveBeenCalledWith("/nodes/ci-a"),
+		);
+		expect(onMutated).toHaveBeenCalledTimes(1);
+		confirmSpy.mockRestore();
+	});
+
+	it("does not allow delete without selected CI", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(screen.getByRole("button", { name: "Delete CI" })).toBeDisabled();
+	});
+
 	it("prevents self-links", () => {
 		render(
 			<VisualRelationshipEditor

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -17,6 +17,41 @@ const SUPPORTED_RELATIONSHIP_TYPES = [
 	"PROVIDES",
 ] as const;
 
+const CI_TYPES: GraphNode["type"][] = [
+	"SERVICE",
+	"INFRASTRUCTURE",
+	"APPLICATION",
+	"USER",
+	"CLOUD_RESOURCE",
+];
+
+const CI_STATUSES: GraphNode["status"][] = [
+	"OK",
+	"ACTIVE",
+	"EXCEPTION",
+	"MAINTENANCE",
+];
+
+type CiFormState = {
+	id: string;
+	label: string;
+	type: GraphNode["type"] | "";
+	status: GraphNode["status"];
+	ip: string;
+	owner: string;
+	location_name: string;
+};
+
+const EMPTY_CI_FORM: CiFormState = {
+	id: "",
+	label: "",
+	type: "",
+	status: "OK",
+	ip: "",
+	owner: "",
+	location_name: "",
+};
+
 interface VisualRelationshipEditorProps {
 	nodes: GraphNode[];
 	links: LinkData[];
@@ -25,6 +60,16 @@ interface VisualRelationshipEditorProps {
 }
 
 const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
+
+const toCiForm = (node: GraphNode): CiFormState => ({
+	id: node.id,
+	label: node.label,
+	type: node.type,
+	status: node.status || "OK",
+	ip: node.ip || "",
+	owner: node.owner || "",
+	location_name: node.location_name || "",
+});
 
 const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	nodes,
@@ -38,6 +83,10 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		useState<(typeof SUPPORTED_RELATIONSHIP_TYPES)[number]>("CONNECTS_TO");
 	const [error, setError] = useState("");
 	const [saving, setSaving] = useState(false);
+	const [selectedCiId, setSelectedCiId] = useState("");
+	const [ciForm, setCiForm] = useState<CiFormState>(EMPTY_CI_FORM);
+	const [ciError, setCiError] = useState("");
+	const [ciSaving, setCiSaving] = useState(false);
 
 	const ciLinks = useMemo(
 		() => links.filter((link) => link.relationship !== "HAS_METRIC"),
@@ -68,8 +117,83 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		[positionedNodes],
 	);
 
+	const selectedCi = selectedCiId ? nodeMap.get(selectedCiId) : undefined;
+	const isEditingCi = Boolean(selectedCi);
+
+	const updateCiForm = (field: keyof CiFormState, value: string) => {
+		setCiForm((current) => ({ ...current, [field]: value }));
+	};
+
+	const startNewCi = () => {
+		setSelectedCiId("");
+		setCiForm(EMPTY_CI_FORM);
+		setCiError("");
+	};
+
+	const validateCiForm = () => {
+		if (!ciForm.id.trim()) return "CI ID is required.";
+		if (!ciForm.label.trim()) return "Label is required.";
+		if (!ciForm.type) return "Type is required.";
+		return "";
+	};
+
+	const buildCiPayload = (): GraphNode => ({
+		...(selectedCi ?? {}),
+		id: ciForm.id.trim(),
+		label: ciForm.label.trim(),
+		type: ciForm.type as GraphNode["type"],
+		status: ciForm.status || "OK",
+		metadata: selectedCi?.metadata ?? {},
+		ip: ciForm.ip.trim() || undefined,
+		owner: ciForm.owner.trim() || undefined,
+		location_name: ciForm.location_name.trim() || undefined,
+	});
+
+	const handleSaveCi = async () => {
+		const validationError = validateCiForm();
+		if (validationError) {
+			setCiError(validationError);
+			return;
+		}
+		setCiSaving(true);
+		setCiError("");
+		try {
+			await api.post("/nodes", buildCiPayload());
+			await onMutated();
+		} catch (err) {
+			console.error(err);
+			setCiError("Could not save CI.");
+		} finally {
+			setCiSaving(false);
+		}
+	};
+
+	const handleDeleteCi = async () => {
+		if (!selectedCi) return;
+		if (!confirm(`Delete CI ${selectedCi.id}?`)) return;
+		setCiSaving(true);
+		setCiError("");
+		try {
+			await api.delete(`/nodes/${encodeURIComponent(selectedCi.id)}`);
+			setSelectedCiId("");
+			setCiForm(EMPTY_CI_FORM);
+			await onMutated();
+		} catch (err) {
+			console.error(err);
+			setCiError("Could not delete CI.");
+		} finally {
+			setCiSaving(false);
+		}
+	};
+
 	const selectNode = (id: string) => {
 		setError("");
+		setCiError("");
+		const node = nodeMap.get(id);
+		if (node) {
+			setSelectedCiId(id);
+			setCiForm(toCiForm(node));
+		}
 		if (!sourceId || (sourceId && targetId)) {
 			setSourceId(id);
 			setTargetId("");
@@ -205,6 +329,107 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 					</div>
 
 					<aside className="flex min-h-0 flex-col gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+						<div className="rounded-xl border border-white/10 bg-black/20 p-3">
+							<div className="flex items-center justify-between gap-2">
+								<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
+									CI details — {isEditingCi ? "editing" : "new"}
+								</p>
+								<button
+									type="button"
+									onClick={startNewCi}
+									className="text-[10px] font-black uppercase text-brand-300 hover:text-brand-200"
+								>
+									New CI
+								</button>
+							</div>
+							<div className="mt-3 grid grid-cols-2 gap-2 text-xs text-neutral-300">
+								<label className="col-span-2 space-y-1">
+									<span className="text-neutral-500">CI ID</span>
+									<input
+										aria-label="CI ID"
+										value={ciForm.id}
+										disabled={isEditingCi || ciSaving}
+										onChange={(event) => updateCiForm("id", event.target.value)}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white disabled:opacity-60"
+									/>
+								</label>
+								<label className="col-span-2 space-y-1">
+									<span className="text-neutral-500">Label</span>
+									<input
+										aria-label="CI label"
+										value={ciForm.label}
+										disabled={ciSaving}
+										onChange={(event) =>
+											updateCiForm("label", event.target.value)
+										}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 text-white"
+									/>
+								</label>
+								<label className="space-y-1">
+									<span className="text-neutral-500">Type</span>
+									<select
+										aria-label="CI type"
+										value={ciForm.type}
+										disabled={ciSaving}
+										onChange={(event) =>
+											updateCiForm("type", event.target.value)
+										}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+									>
+										<option value="">Select type</option>
+										{CI_TYPES.map((type) => (
+											<option key={type} value={type}>
+												{type}
+											</option>
+										))}
+									</select>
+								</label>
+								<label className="space-y-1">
+									<span className="text-neutral-500">Status</span>
+									<select
+										aria-label="CI status"
+										value={ciForm.status}
+										disabled={ciSaving}
+										onChange={(event) =>
+											updateCiForm("status", event.target.value)
+										}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+									>
+										{CI_STATUSES.map((status) => (
+											<option key={status} value={status}>
+												{status}
+											</option>
+										))}
+									</select>
+								</label>
+								{ciError && (
+									<div className="col-span-2 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
+										{ciError}
+									</div>
+								)}
+								<button
+									type="button"
+									onClick={handleSaveCi}
+									disabled={ciSaving}
+									className="col-span-2 rounded-xl bg-cyan-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
+								>
+									{ciSaving
+										? "Saving CI..."
+										: isEditingCi
+											? "Save CI"
+											: "Create CI"}
+								</button>
+								<button
+									type="button"
+									onClick={handleDeleteCi}
+									disabled={!isEditingCi || ciSaving}
+									className="col-span-2 rounded-xl border border-red-500/30 py-2 text-xs font-black uppercase text-red-300 disabled:cursor-not-allowed disabled:opacity-40"
+								>
+									Delete CI
+								</button>
+							</div>
+						</div>
+
 						<div className="rounded-xl border border-white/10 bg-black/20 p-3">
 							<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
 								New relationship


### PR DESCRIPTION
Closes #201

## Descripción del Cambio
- Adds a compact CI details panel inside the visual relationship editor.
- Supports CI create/update through the existing `POST /nodes` API and CI delete through the existing `DELETE /nodes/{id}` API.
- Preserves relationship creation/deletion behavior and PR4 read-only relationship guardrails.
- Refreshes both nodes and links after visual editor mutations.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/VisualRelationshipEditor.test.tsx components/relationshipCapabilities.test.ts`
- [x] LSP diagnostics on touched TS/TSX files: no errors
- [x] Fresh review found no blockers
- [x] `git diff --check`

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Chain Context

```text
main
 └─ PR3 #198 visual relationship editor ✅ merged
     └─ feat/visual-ci-correlations-chain
         └─ PR4 #200 read-only relationship UI guardrails ✅ merged
             └─ PR5 visual CI CRUD controls 📍
```

## Notes
- Frontend-only change.
- Uses existing node APIs only; no backend routes, schemas, permissions, or repository changes.
- Does not add filtering/search, pan/zoom, layout redesign, changelog, or stash/off-scope changes.
- Diff is 396 changed lines, within the 400-line review budget.
