### PR TITLE
feat(cmdb): complete visual CI correlation workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.12] — 2026-05-29
+
+### Added
+- **Visual CI relationship editor completion** (PRs #198, #200, #202, and #204; tracker #191):
+  - Adds a dedicated visual relationship editor for creating and deleting supported CI relationships from the map context.
+  - Keeps read-only graph relationships such as `RUNS_ON` visible while labeling them read-only and suppressing unsupported delete actions.
+  - Adds visual CI create, edit, and delete controls backed by the existing `/api/nodes` create/update/delete APIs.
+  - Adds layer/technology checkbox filters derived from `node.category ?? node.type`, with all layers visible by default, All/None controls, filtered visible links, and guarded hidden endpoint selection.
+  - Preserves relationship CRUD behavior, CI CRUD behavior, legacy `CONNECTED_TO` creation exclusion, and existing backend contracts.
+
 ## [1.12.11] — 2026-05-28
 
 ### Added

--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -174,7 +174,7 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
     };
 
     const refreshRelationshipViews = async () => {
-        await fetchLinks();
+        await Promise.all([fetchData(), fetchLinks()]);
         onRefresh();
     };
 

--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -6,6 +6,7 @@ import { api } from '../services/api';
 import RelationshipBadge from './RelationshipBadge';
 import RelationshipTooltip from './RelationshipTooltip';
 import VisualRelationshipEditor from './VisualRelationshipEditor';
+import { canDeleteRelationship, isReadOnlyRelationship } from './relationshipCapabilities';
 
 // ============================================================================
 // Relationship Indicators — Types & Utilities
@@ -251,6 +252,8 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
     };
 
     const handleDelete = async (link: any) => {
+        if (!canDeleteRelationship(link.relationship)) return;
+
         if (confirm(`Delete link: ${link.source} -[${link.relationship}]-> ${link.target}?`)) {
             try {
                 await api.delete('/links', link);
@@ -489,38 +492,47 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                                 </tr>
                             </thead>
                             <tbody className="text-sm">
-                                {filteredCiLinks.map((link, i) => (
-                                    <tr key={i} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
-                                        <td className="p-3 font-mono text-brand-400" title={link.source}>{link.source_label || link.source}</td>
-                                        <td className="p-3 text-center">
-                                            <span className="text-[10px] font-bold bg-white/10 px-2 py-1 rounded text-neutral-300 uppercase">{link.relationship}</span>
-                                        </td>
-                                        <td className="p-3 font-mono text-accent-cyan" title={link.target}>{link.target_label || link.target}</td>
-                                        <td className="p-3 text-right flex items-center justify-end gap-2">
-                                            <button
-                                                onClick={() => {
-                                                    // Smart Root Selection: Select the "Superior" node as Root
-                                                    // For dependencies, the Target is the Provider (Superior)
-                                                    if (['DEPENDS_ON', 'HOSTED_ON'].includes(link.relationship)) {
-                                                        setVisualizationTarget(link.target);
-                                                    } else {
-                                                        setVisualizationTarget(link.source);
-                                                    }
-                                                }}
-                                                className="text-neutral-500 hover:text-brand-400 transition-colors"
-                                                title="Visualize Correlation"
-                                            >
-                                                <span className="material-symbols-outlined text-lg">hub</span>
-                                            </button>
-                                            <button
-                                                onClick={() => handleDelete(link)}
-                                                className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
-                                            >
-                                                <span className="material-symbols-outlined text-lg">delete</span>
-                                            </button>
-                                        </td>
-                                    </tr>
-                                ))}
+                                {filteredCiLinks.map((link, i) => {
+                                    const readOnly = isReadOnlyRelationship(link.relationship);
+
+                                    return (
+                                        <tr key={i} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
+                                            <td className="p-3 font-mono text-brand-400" title={link.source}>{link.source_label || link.source}</td>
+                                            <td className="p-3 text-center">
+                                                <span className="text-[10px] font-bold bg-white/10 px-2 py-1 rounded text-neutral-300 uppercase">{link.relationship}</span>
+                                                {readOnly && (
+                                                    <span className="ml-2 text-[10px] font-bold bg-amber-400/10 px-2 py-1 rounded text-amber-200 uppercase">Read-only</span>
+                                                )}
+                                            </td>
+                                            <td className="p-3 font-mono text-accent-cyan" title={link.target}>{link.target_label || link.target}</td>
+                                            <td className="p-3 text-right flex items-center justify-end gap-2">
+                                                <button
+                                                    onClick={() => {
+                                                        // Smart Root Selection: Select the "Superior" node as Root
+                                                        // For dependencies, the Target is the Provider (Superior)
+                                                        if (['DEPENDS_ON', 'HOSTED_ON'].includes(link.relationship)) {
+                                                            setVisualizationTarget(link.target);
+                                                        } else {
+                                                            setVisualizationTarget(link.source);
+                                                        }
+                                                    }}
+                                                    className="text-neutral-500 hover:text-brand-400 transition-colors"
+                                                    title="Visualize Correlation"
+                                                >
+                                                    <span className="material-symbols-outlined text-lg">hub</span>
+                                                </button>
+                                                {canDeleteRelationship(link.relationship) && (
+                                                    <button
+                                                        onClick={() => handleDelete(link)}
+                                                        className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                                                    >
+                                                        <span className="material-symbols-outlined text-lg">delete</span>
+                                                    </button>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    );
+                                })}
                                 {filteredCiLinks.length === 0 && (
                                     <tr>
                                         <td colSpan={4} className="p-8 text-center text-neutral-500 text-xs">

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -55,6 +55,47 @@ const readOnlyLinks: LinkData[] = [
 	},
 ];
 
+const appNode: GraphNode = {
+	id: "app-1",
+	label: "App",
+	type: "APPLICATION",
+	category: "Application",
+	status: "ACTIVE",
+	metadata: {},
+};
+const dbNode: GraphNode = {
+	id: "db-1",
+	label: "DB",
+	type: "INFRASTRUCTURE",
+	category: "Database",
+	status: "ACTIVE",
+	metadata: {},
+};
+const infraNode: GraphNode = {
+	id: "infra-1",
+	label: "Infra",
+	type: "INFRASTRUCTURE",
+	status: "ACTIVE",
+	metadata: {},
+};
+const layeredNodes: GraphNode[] = [appNode, dbNode, infraNode];
+const layeredLinks: LinkData[] = [
+	{
+		source: "app-1",
+		source_label: "App",
+		target: "db-1",
+		target_label: "DB",
+		relationship: "CONNECTS_TO",
+	},
+	{
+		source: "app-1",
+		source_label: "App",
+		target: "infra-1",
+		target_label: "Infra",
+		relationship: "USES",
+	},
+];
+
 describe("VisualRelationshipEditor", () => {
 	const onMutated = vi.fn();
 
@@ -254,6 +295,202 @@ describe("VisualRelationshipEditor", () => {
 		);
 
 		expect(screen.getByRole("button", { name: "Delete CI" })).toBeDisabled();
+	});
+
+	it("renders layer filters from category/type and selects all by default", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={layeredNodes}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		const appLayer = screen.getByRole("checkbox", {
+			name: /Application layer \(1 CIs\)/,
+		});
+		const databaseLayer = screen.getByRole("checkbox", {
+			name: /Database layer \(1 CIs\)/,
+		});
+		expect(
+			screen.getByRole("checkbox", {
+				name: /INFRASTRUCTURE layer \(1 CIs\)/,
+			}),
+		).toBeChecked();
+
+		expect(appLayer).toBeChecked();
+		expect(databaseLayer).toBeChecked();
+		expect(
+			screen.getByRole("button", { name: "CI node App" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "CI node DB" }),
+		).toBeInTheDocument();
+	});
+
+	it("filters nodes and shows an empty state when all layers are hidden", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={layeredNodes}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+
+		expect(
+			screen.queryByRole("button", { name: "CI node DB" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "CI node App" }),
+		).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "None" }));
+
+		expect(
+			screen.queryByRole("button", { name: "CI node App" }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText("No CIs match selected layers"),
+		).toBeInTheDocument();
+	});
+
+	it("filters links whose endpoints are hidden", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={layeredNodes}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(screen.getByText("App → DB")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+
+		expect(screen.queryByText("App → DB")).not.toBeInTheDocument();
+		expect(screen.getByText("App → Infra")).toBeInTheDocument();
+	});
+
+	it("clears hidden selected endpoints and preserves visible relationship creation", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={layeredNodes}
+				links={[]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node App" }));
+		fireEvent.click(screen.getByRole("button", { name: "CI node DB" }));
+		expect(screen.getByText(/Target:/).parentElement).toHaveTextContent("DB");
+
+		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+
+		expect(screen.getByText(/Target:/).parentElement).toHaveTextContent(
+			"Select target",
+		);
+		expect(
+			screen.getByRole("button", { name: "Create relationship" }),
+		).toBeDisabled();
+		expect(mockApiPost).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+		fireEvent.click(screen.getByRole("button", { name: "CI node App" }));
+		fireEvent.click(screen.getByRole("button", { name: "CI node DB" }));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Create relationship" }),
+		);
+
+		await waitFor(() => {
+			expect(mockApiPost).toHaveBeenCalledWith("/links", {
+				source: "app-1",
+				target: "db-1",
+				relationship: "CONNECTS_TO",
+			});
+		});
+	});
+
+	it("preserves deselected and none layer choices across node refreshes", () => {
+		const { rerender } = render(
+			<VisualRelationshipEditor
+				nodes={layeredNodes}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+		rerender(
+			<VisualRelationshipEditor
+				nodes={[...layeredNodes]}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("checkbox", { name: /Database layer/ }),
+		).not.toBeChecked();
+		expect(
+			screen.queryByRole("button", { name: "CI node DB" }),
+		).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "None" }));
+		rerender(
+			<VisualRelationshipEditor
+				nodes={[...layeredNodes]}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(
+			screen.getByText("No CIs match selected layers"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("checkbox", { name: /Application layer/ }),
+		).not.toBeChecked();
+		expect(
+			screen.getByRole("checkbox", { name: /Database layer/ }),
+		).not.toBeChecked();
+		expect(
+			screen.getByRole("checkbox", { name: /INFRASTRUCTURE layer/ }),
+		).not.toBeChecked();
+	});
+
+	it("auto-selects newly discovered layers after node refresh", () => {
+		const { rerender } = render(
+			<VisualRelationshipEditor
+				nodes={[layeredNodes[0]]}
+				links={[]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		rerender(
+			<VisualRelationshipEditor
+				nodes={[layeredNodes[0], layeredNodes[1]]}
+				links={[]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(
+			screen.getByRole("checkbox", { name: /Database layer \(1 CIs\)/ }),
+		).toBeChecked();
+		expect(
+			screen.getByRole("button", { name: "CI node DB" }),
+		).toBeInTheDocument();
 	});
 
 	it("prevents self-links", () => {

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -87,6 +87,175 @@ describe("VisualRelationshipEditor", () => {
 		);
 	});
 
+	it("populates CI form from clicked visual node", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+
+		expect(screen.getByLabelText("CI ID")).toHaveValue("ci-a");
+		expect(screen.getByLabelText("CI label")).toHaveValue("Router A");
+		expect(screen.getByLabelText("CI type")).toHaveValue("INFRASTRUCTURE");
+		expect(screen.getByLabelText("CI status")).toHaveValue("ACTIVE");
+		expect(screen.getByRole("button", { name: "Save CI" })).toBeInTheDocument();
+	});
+
+	it("prevents create without required CI fields", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+		expect(screen.getByText("CI ID is required.")).toBeInTheDocument();
+		expect(mockApiPost).not.toHaveBeenCalled();
+	});
+
+	it("creates CI via existing node upsert API", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+		fireEvent.change(screen.getByLabelText("CI ID"), {
+			target: { value: "ci-c" },
+		});
+		fireEvent.change(screen.getByLabelText("CI label"), {
+			target: { value: "Firewall C" },
+		});
+		fireEvent.change(screen.getByLabelText("CI type"), {
+			target: { value: "INFRASTRUCTURE" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+		await waitFor(() => {
+			expect(mockApiPost).toHaveBeenCalledWith(
+				"/nodes",
+				expect.objectContaining({
+					id: "ci-c",
+					label: "Firewall C",
+					type: "INFRASTRUCTURE",
+					status: "OK",
+					metadata: {},
+				}),
+			);
+		});
+		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("updates selected CI via node upsert and preserves metadata", async () => {
+		const nodesWithMetadata: GraphNode[] = [
+			{ ...nodes[0], metadata: { rack: "R1" }, owner: "ops" },
+			nodes[1],
+		];
+		render(
+			<VisualRelationshipEditor
+				nodes={nodesWithMetadata}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.change(screen.getByLabelText("CI label"), {
+			target: { value: "Router A Updated" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Save CI" }));
+
+		await waitFor(() => {
+			expect(mockApiPost).toHaveBeenCalledWith(
+				"/nodes",
+				expect.objectContaining({
+					id: "ci-a",
+					label: "Router A Updated",
+					metadata: { rack: "R1" },
+					owner: "ops",
+				}),
+			);
+		});
+	});
+
+	it("preserves CI form state after save failure", async () => {
+		mockApiPost.mockRejectedValueOnce(new Error("boom"));
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+		fireEvent.change(screen.getByLabelText("CI ID"), {
+			target: { value: "ci-c" },
+		});
+		fireEvent.change(screen.getByLabelText("CI label"), {
+			target: { value: "Firewall C" },
+		});
+		fireEvent.change(screen.getByLabelText("CI type"), {
+			target: { value: "INFRASTRUCTURE" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+		expect(await screen.findByText("Could not save CI.")).toBeInTheDocument();
+		expect(screen.getByLabelText("CI ID")).toHaveValue("ci-c");
+		expect(screen.getByLabelText("CI label")).toHaveValue("Firewall C");
+		expect(onMutated).not.toHaveBeenCalled();
+	});
+
+	it("deletes selected CI using existing node delete API", async () => {
+		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.click(screen.getByRole("button", { name: "Delete CI" }));
+
+		await waitFor(() =>
+			expect(mockApiDelete).toHaveBeenCalledWith("/nodes/ci-a"),
+		);
+		expect(onMutated).toHaveBeenCalledTimes(1);
+		confirmSpy.mockRestore();
+	});
+
+	it("does not allow delete without selected CI", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(screen.getByRole("button", { name: "Delete CI" })).toBeDisabled();
+	});
+
 	it("prevents self-links", () => {
 		render(
 			<VisualRelationshipEditor

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -45,6 +45,16 @@ const links: LinkData[] = [
 	},
 ];
 
+const readOnlyLinks: LinkData[] = [
+	{
+		source: "ci-a",
+		source_label: "Router A",
+		target: "ci-b",
+		target_label: "Switch B",
+		relationship: "RUNS_ON",
+	},
+];
+
 describe("VisualRelationshipEditor", () => {
 	const onMutated = vi.fn();
 
@@ -125,6 +135,37 @@ describe("VisualRelationshipEditor", () => {
 			});
 		});
 		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps RUNS_ON visible and labeled read-only", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={readOnlyLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
+		expect(screen.getAllByText("RUNS_ON").length).toBeGreaterThan(0);
+		expect(screen.getByText("Read-only")).toBeInTheDocument();
+	});
+
+	it("does not offer delete for RUNS_ON links", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={readOnlyLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: "Delete" }),
+		).not.toBeInTheDocument();
+		expect(mockApiDelete).not.toHaveBeenCalled();
 	});
 
 	it("deletes an existing visual link and refreshes", async () => {

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -17,6 +17,41 @@ const SUPPORTED_RELATIONSHIP_TYPES = [
 	"PROVIDES",
 ] as const;
 
+const CI_TYPES: GraphNode["type"][] = [
+	"SERVICE",
+	"INFRASTRUCTURE",
+	"APPLICATION",
+	"USER",
+	"CLOUD_RESOURCE",
+];
+
+const CI_STATUSES: GraphNode["status"][] = [
+	"OK",
+	"ACTIVE",
+	"EXCEPTION",
+	"MAINTENANCE",
+];
+
+type CiFormState = {
+	id: string;
+	label: string;
+	type: GraphNode["type"] | "";
+	status: GraphNode["status"];
+	ip: string;
+	owner: string;
+	location_name: string;
+};
+
+const EMPTY_CI_FORM: CiFormState = {
+	id: "",
+	label: "",
+	type: "",
+	status: "OK",
+	ip: "",
+	owner: "",
+	location_name: "",
+};
+
 interface VisualRelationshipEditorProps {
 	nodes: GraphNode[];
 	links: LinkData[];
@@ -25,6 +60,16 @@ interface VisualRelationshipEditorProps {
 }
 
 const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
+
+const toCiForm = (node: GraphNode): CiFormState => ({
+	id: node.id,
+	label: node.label,
+	type: node.type,
+	status: node.status || "OK",
+	ip: node.ip || "",
+	owner: node.owner || "",
+	location_name: node.location_name || "",
+});
 
 const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	nodes,
@@ -38,6 +83,10 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		useState<(typeof SUPPORTED_RELATIONSHIP_TYPES)[number]>("CONNECTS_TO");
 	const [error, setError] = useState("");
 	const [saving, setSaving] = useState(false);
+	const [selectedCiId, setSelectedCiId] = useState("");
+	const [ciForm, setCiForm] = useState<CiFormState>(EMPTY_CI_FORM);
+	const [ciError, setCiError] = useState("");
+	const [ciSaving, setCiSaving] = useState(false);
 
 	const ciLinks = useMemo(
 		() => links.filter((link) => link.relationship !== "HAS_METRIC"),
@@ -68,8 +117,83 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		[positionedNodes],
 	);
 
+	const selectedCi = selectedCiId ? nodeMap.get(selectedCiId) : undefined;
+	const isEditingCi = Boolean(selectedCi);
+
+	const updateCiForm = (field: keyof CiFormState, value: string) => {
+		setCiForm((current) => ({ ...current, [field]: value }));
+	};
+
+	const startNewCi = () => {
+		setSelectedCiId("");
+		setCiForm(EMPTY_CI_FORM);
+		setCiError("");
+	};
+
+	const validateCiForm = () => {
+		if (!ciForm.id.trim()) return "CI ID is required.";
+		if (!ciForm.label.trim()) return "Label is required.";
+		if (!ciForm.type) return "Type is required.";
+		return "";
+	};
+
+	const buildCiPayload = (): GraphNode => ({
+		...(selectedCi ?? {}),
+		id: ciForm.id.trim(),
+		label: ciForm.label.trim(),
+		type: ciForm.type as GraphNode["type"],
+		status: ciForm.status || "OK",
+		metadata: selectedCi?.metadata ?? {},
+		ip: ciForm.ip.trim() || undefined,
+		owner: ciForm.owner.trim() || undefined,
+		location_name: ciForm.location_name.trim() || undefined,
+	});
+
+	const handleSaveCi = async () => {
+		const validationError = validateCiForm();
+		if (validationError) {
+			setCiError(validationError);
+			return;
+		}
+		setCiSaving(true);
+		setCiError("");
+		try {
+			await api.post("/nodes", buildCiPayload());
+			await onMutated();
+		} catch (err) {
+			console.error(err);
+			setCiError("Could not save CI.");
+		} finally {
+			setCiSaving(false);
+		}
+	};
+
+	const handleDeleteCi = async () => {
+		if (!selectedCi) return;
+		if (!confirm(`Delete CI ${selectedCi.id}?`)) return;
+		setCiSaving(true);
+		setCiError("");
+		try {
+			await api.delete(`/nodes/${encodeURIComponent(selectedCi.id)}`);
+			setSelectedCiId("");
+			setCiForm(EMPTY_CI_FORM);
+			await onMutated();
+		} catch (err) {
+			console.error(err);
+			setCiError("Could not delete CI.");
+		} finally {
+			setCiSaving(false);
+		}
+	};
+
 	const selectNode = (id: string) => {
 		setError("");
+		setCiError("");
+		const node = nodeMap.get(id);
+		if (node) {
+			setSelectedCiId(id);
+			setCiForm(toCiForm(node));
+		}
 		if (!sourceId || (sourceId && targetId)) {
 			setSourceId(id);
 			setTargetId("");
@@ -205,6 +329,107 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 					</div>
 
 					<aside className="flex min-h-0 flex-col gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+						<div className="rounded-xl border border-white/10 bg-black/20 p-3">
+							<div className="flex items-center justify-between gap-2">
+								<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
+									CI details — {isEditingCi ? "editing" : "new"}
+								</p>
+								<button
+									type="button"
+									onClick={startNewCi}
+									className="text-[10px] font-black uppercase text-brand-300 hover:text-brand-200"
+								>
+									New CI
+								</button>
+							</div>
+							<div className="mt-3 grid grid-cols-2 gap-2 text-xs text-neutral-300">
+								<label className="col-span-2 space-y-1">
+									<span className="text-neutral-500">CI ID</span>
+									<input
+										aria-label="CI ID"
+										value={ciForm.id}
+										disabled={isEditingCi || ciSaving}
+										onChange={(event) => updateCiForm("id", event.target.value)}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white disabled:opacity-60"
+									/>
+								</label>
+								<label className="col-span-2 space-y-1">
+									<span className="text-neutral-500">Label</span>
+									<input
+										aria-label="CI label"
+										value={ciForm.label}
+										disabled={ciSaving}
+										onChange={(event) =>
+											updateCiForm("label", event.target.value)
+										}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 text-white"
+									/>
+								</label>
+								<label className="space-y-1">
+									<span className="text-neutral-500">Type</span>
+									<select
+										aria-label="CI type"
+										value={ciForm.type}
+										disabled={ciSaving}
+										onChange={(event) =>
+											updateCiForm("type", event.target.value)
+										}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+									>
+										<option value="">Select type</option>
+										{CI_TYPES.map((type) => (
+											<option key={type} value={type}>
+												{type}
+											</option>
+										))}
+									</select>
+								</label>
+								<label className="space-y-1">
+									<span className="text-neutral-500">Status</span>
+									<select
+										aria-label="CI status"
+										value={ciForm.status}
+										disabled={ciSaving}
+										onChange={(event) =>
+											updateCiForm("status", event.target.value)
+										}
+										className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+									>
+										{CI_STATUSES.map((status) => (
+											<option key={status} value={status}>
+												{status}
+											</option>
+										))}
+									</select>
+								</label>
+								{ciError && (
+									<div className="col-span-2 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
+										{ciError}
+									</div>
+								)}
+								<button
+									type="button"
+									onClick={handleSaveCi}
+									disabled={ciSaving}
+									className="col-span-2 rounded-xl bg-cyan-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
+								>
+									{ciSaving
+										? "Saving CI..."
+										: isEditingCi
+											? "Save CI"
+											: "Create CI"}
+								</button>
+								<button
+									type="button"
+									onClick={handleDeleteCi}
+									disabled={!isEditingCi || ciSaving}
+									className="col-span-2 rounded-xl border border-red-500/30 py-2 text-xs font-black uppercase text-red-300 disabled:cursor-not-allowed disabled:opacity-40"
+								>
+									Delete CI
+								</button>
+							</div>
+						</div>
+
 						<div className="rounded-xl border border-white/10 bg-black/20 p-3">
 							<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
 								New relationship

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { GraphNode } from "../types";
 import { api } from "../services/api";
 import type { LinkData } from "./RelationshipManager";
@@ -60,6 +60,9 @@ interface VisualRelationshipEditorProps {
 }
 
 const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
+const nodeLayer = (node: GraphNode) => node.category ?? node.type;
+const sameLayers = (a: string[], b: string[]) =>
+	a.length === b.length && a.every((layer, index) => layer === b[index]);
 
 const toCiForm = (node: GraphNode): CiFormState => ({
 	id: node.id,
@@ -87,10 +90,56 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	const [ciForm, setCiForm] = useState<CiFormState>(EMPTY_CI_FORM);
 	const [ciError, setCiError] = useState("");
 	const [ciSaving, setCiSaving] = useState(false);
+	const [selectedLayers, setSelectedLayers] = useState<string[]>([]);
+	const knownLayerLabelsRef = useRef<string[]>([]);
 
 	const ciLinks = useMemo(
 		() => links.filter((link) => link.relationship !== "HAS_METRIC"),
 		[links],
+	);
+	const layerOptions = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const node of nodes) {
+			const layer = nodeLayer(node);
+			counts.set(layer, (counts.get(layer) ?? 0) + 1);
+		}
+		return Array.from(counts.entries())
+			.map(([label, count]) => ({ label, count }))
+			.sort((a, b) => a.label.localeCompare(b.label));
+	}, [nodes]);
+
+	useEffect(() => {
+		const available = layerOptions.map((option) => option.label);
+		const previousAvailable = knownLayerLabelsRef.current;
+		knownLayerLabelsRef.current = available;
+
+		setSelectedLayers((current) => {
+			const availableSet = new Set(available);
+			const previousAvailableSet = new Set(previousAvailable);
+			const preserved = current.filter((layer) => availableSet.has(layer));
+			const newlyDiscovered = available.filter(
+				(layer) => !previousAvailableSet.has(layer),
+			);
+			const next = [...preserved, ...newlyDiscovered];
+			return sameLayers(current, next) ? current : next;
+		});
+	}, [layerOptions]);
+
+	const visibleNodes = useMemo(
+		() => nodes.filter((node) => selectedLayers.includes(nodeLayer(node))),
+		[nodes, selectedLayers],
+	);
+	const visibleNodeIds = useMemo(
+		() => new Set(visibleNodes.map((node) => node.id)),
+		[visibleNodes],
+	);
+	const visibleCiLinks = useMemo(
+		() =>
+			ciLinks.filter(
+				(link) =>
+					visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target),
+			),
+		[ciLinks, visibleNodeIds],
 	);
 	const nodeMap = useMemo(
 		() => new Map(nodes.map((node) => [node.id, node])),
@@ -99,19 +148,25 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	const positionedNodes = useMemo(() => {
 		const centerX = 500;
 		const centerY = 300;
-		const radius = nodes.length > 10 ? 250 : 210;
-		return nodes.map((node, index) => {
+		const radius = visibleNodes.length > 10 ? 250 : 210;
+		return visibleNodes.map((node, index) => {
 			const angle =
-				nodes.length <= 1
+				visibleNodes.length <= 1
 					? 0
-					: (index / nodes.length) * Math.PI * 2 - Math.PI / 2;
+					: (index / visibleNodes.length) * Math.PI * 2 - Math.PI / 2;
 			return {
 				node,
-				x: nodes.length <= 1 ? centerX : centerX + Math.cos(angle) * radius,
-				y: nodes.length <= 1 ? centerY : centerY + Math.sin(angle) * radius,
+				x:
+					visibleNodes.length <= 1
+						? centerX
+						: centerX + Math.cos(angle) * radius,
+				y:
+					visibleNodes.length <= 1
+						? centerY
+						: centerY + Math.sin(angle) * radius,
 			};
 		});
-	}, [nodes]);
+	}, [visibleNodes]);
 	const positionMap = useMemo(
 		() => new Map(positionedNodes.map((item) => [item.node.id, item])),
 		[positionedNodes],
@@ -119,6 +174,29 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 
 	const selectedCi = selectedCiId ? nodeMap.get(selectedCiId) : undefined;
 	const isEditingCi = Boolean(selectedCi);
+
+	useEffect(() => {
+		setSourceId((current) =>
+			current && !visibleNodeIds.has(current) ? "" : current,
+		);
+		setTargetId((current) =>
+			current && !visibleNodeIds.has(current) ? "" : current,
+		);
+	}, [visibleNodeIds]);
+
+	const toggleLayer = (layer: string) => {
+		setSelectedLayers((current) =>
+			current.includes(layer)
+				? current.filter((item) => item !== layer)
+				: [...current, layer],
+		);
+	};
+	const selectAllLayers = () => {
+		setSelectedLayers(layerOptions.map((option) => option.label));
+	};
+	const clearAllLayers = () => {
+		setSelectedLayers([]);
+	};
 
 	const updateCiForm = (field: keyof CiFormState, value: string) => {
 		setCiForm((current) => ({ ...current, [field]: value }));
@@ -187,6 +265,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	};
 
 	const selectNode = (id: string) => {
+		if (!visibleNodeIds.has(id)) return;
 		setError("");
 		setCiError("");
 		const node = nodeMap.get(id);
@@ -213,6 +292,10 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		}
 		if (sourceId === targetId) {
 			setError("Source and target must be different CIs.");
+			return;
+		}
+		if (!visibleNodeIds.has(sourceId) || !visibleNodeIds.has(targetId)) {
+			setError("Selected CIs must be visible.");
 			return;
 		}
 		setSaving(true);
@@ -272,12 +355,61 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 
 				<div className="grid flex-1 min-h-0 grid-cols-[1fr_360px] gap-4 p-4">
 					<div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.16),rgba(0,0,0,0.15)_45%,rgba(0,0,0,0.55))]">
+						<div className="absolute left-4 top-4 z-10 w-56 rounded-xl border border-white/10 bg-neutral-950/85 p-3 shadow-xl backdrop-blur">
+							<div className="flex items-center justify-between gap-2">
+								<div>
+									<p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
+										Layers
+									</p>
+									<p className="text-[10px] text-neutral-500">
+										{visibleNodes.length}/{nodes.length} CIs
+									</p>
+								</div>
+								<div className="flex gap-2 text-[10px] font-black uppercase">
+									<button
+										type="button"
+										onClick={selectAllLayers}
+										className="text-brand-300 hover:text-brand-200"
+									>
+										All
+									</button>
+									<button
+										type="button"
+										onClick={clearAllLayers}
+										className="text-neutral-400 hover:text-white"
+									>
+										None
+									</button>
+								</div>
+							</div>
+							<div className="mt-3 space-y-2">
+								{layerOptions.map((option) => (
+									<label
+										key={option.label}
+										className="flex items-center justify-between gap-2 text-xs text-neutral-300"
+									>
+										<span className="flex items-center gap-2 truncate">
+											<input
+												type="checkbox"
+												checked={selectedLayers.includes(option.label)}
+												onChange={() => toggleLayer(option.label)}
+												aria-label={`${option.label} layer (${option.count} CIs)`}
+											/>
+											<span className="truncate">{option.label}</span>
+										</span>
+										<span className="rounded bg-white/10 px-2 py-0.5 font-mono text-[10px] text-neutral-400">
+											{option.count}
+										</span>
+									</label>
+								))}
+							</div>
+						</div>
 						<svg
 							className="absolute inset-0 h-full w-full"
 							viewBox="0 0 1000 620"
 							aria-label="Existing CI relationship links"
 						>
-							{ciLinks.map((link) => {
+							{visibleCiLinks.map((link) => {
 								const source = positionMap.get(link.source);
 								const target = positionMap.get(link.target);
 								if (!source || !target) return null;
@@ -302,6 +434,11 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 								);
 							})}
 						</svg>
+						{visibleNodes.length === 0 && (
+							<div className="absolute inset-0 flex items-center justify-center text-xs font-bold uppercase tracking-widest text-neutral-500">
+								No CIs match selected layers
+							</div>
+						)}
 						{positionedNodes.map(({ node, x, y }) => {
 							const selectedAsSource = sourceId === node.id;
 							const selectedAsTarget = targetId === node.id;
@@ -480,7 +617,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 							<div className="sticky top-0 bg-neutral-950/90 p-3 text-[10px] font-black uppercase tracking-widest text-neutral-500">
 								Existing links
 							</div>
-							{ciLinks.map((link) => {
+							{visibleCiLinks.map((link) => {
 								const readOnly = isReadOnlyRelationship(link.relationship);
 
 								return (
@@ -516,9 +653,11 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 									</div>
 								);
 							})}
-							{ciLinks.length === 0 && (
+							{visibleCiLinks.length === 0 && (
 								<div className="p-6 text-center text-xs text-neutral-500">
-									No CI links yet.
+									{ciLinks.length === 0
+										? "No CI links yet."
+										: "No visible CI links for selected layers."}
 								</div>
 							)}
 						</div>

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -3,6 +3,10 @@ import { useMemo, useState } from "react";
 import type { GraphNode } from "../types";
 import { api } from "../services/api";
 import type { LinkData } from "./RelationshipManager";
+import {
+	canDeleteRelationship,
+	isReadOnlyRelationship,
+} from "./relationshipCapabilities";
 
 const SUPPORTED_RELATIONSHIP_TYPES = [
 	"CONNECTS_TO",
@@ -106,6 +110,8 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	};
 
 	const handleDelete = async (link: LinkData) => {
+		if (!canDeleteRelationship(link.relationship)) return;
+
 		setSaving(true);
 		setError("");
 		try {
@@ -249,29 +255,42 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 							<div className="sticky top-0 bg-neutral-950/90 p-3 text-[10px] font-black uppercase tracking-widest text-neutral-500">
 								Existing links
 							</div>
-							{ciLinks.map((link) => (
-								<div
-									key={`${link.source}-${link.target}-${link.relationship}`}
-									className="border-t border-white/5 p-3 text-xs text-neutral-300"
-								>
-									<div className="font-bold text-white">
-										{link.source_label || link.source} →{" "}
-										{link.target_label || link.target}
+							{ciLinks.map((link) => {
+								const readOnly = isReadOnlyRelationship(link.relationship);
+
+								return (
+									<div
+										key={`${link.source}-${link.target}-${link.relationship}`}
+										className="border-t border-white/5 p-3 text-xs text-neutral-300"
+									>
+										<div className="font-bold text-white">
+											{link.source_label || link.source} →{" "}
+											{link.target_label || link.target}
+										</div>
+										<div className="mt-1 flex items-center justify-between gap-2">
+											<span className="flex items-center gap-2">
+												<span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
+													{link.relationship}
+												</span>
+												{readOnly && (
+													<span className="rounded border border-amber-400/30 bg-amber-400/10 px-2 py-1 text-[10px] font-black uppercase text-amber-200">
+														Read-only
+													</span>
+												)}
+											</span>
+											{canDeleteRelationship(link.relationship) && (
+												<button
+													onClick={() => handleDelete(link)}
+													className="text-red-300 hover:text-red-200"
+													disabled={saving}
+												>
+													Delete
+												</button>
+											)}
+										</div>
 									</div>
-									<div className="mt-1 flex items-center justify-between gap-2">
-										<span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
-											{link.relationship}
-										</span>
-										<button
-											onClick={() => handleDelete(link)}
-											className="text-red-300 hover:text-red-200"
-											disabled={saving}
-										>
-											Delete
-										</button>
-									</div>
-								</div>
-							))}
+								);
+							})}
 							{ciLinks.length === 0 && (
 								<div className="p-6 text-center text-xs text-neutral-500">
 									No CI links yet.

--- a/frontend/components/relationshipCapabilities.test.ts
+++ b/frontend/components/relationshipCapabilities.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+	canDeleteRelationship,
+	isReadOnlyRelationship,
+} from "./relationshipCapabilities";
+
+describe("relationshipCapabilities", () => {
+	it("marks RUNS_ON as read-only", () => {
+		expect(isReadOnlyRelationship("RUNS_ON")).toBe(true);
+	});
+
+	it("blocks deleting RUNS_ON relationships", () => {
+		expect(canDeleteRelationship("RUNS_ON")).toBe(false);
+	});
+
+	it("allows deleting mutable and unknown relationships by default", () => {
+		expect(canDeleteRelationship("CONNECTS_TO")).toBe(true);
+		expect(canDeleteRelationship("USES_CUSTOM_TYPE")).toBe(true);
+	});
+});

--- a/frontend/components/relationshipCapabilities.ts
+++ b/frontend/components/relationshipCapabilities.ts
@@ -1,0 +1,7 @@
+export const READ_ONLY_RELATIONSHIP_TYPES = new Set(["RUNS_ON"]);
+
+export const isReadOnlyRelationship = (relationship: string) =>
+	READ_ONLY_RELATIONSHIP_TYPES.has(relationship);
+
+export const canDeleteRelationship = (relationship: string) =>
+	!isReadOnlyRelationship(relationship);


### PR DESCRIPTION
Closes #191
Closes #199
Closes #201
Closes #203

## Descripción del Cambio
- Completes the visual CI correlation chain with the visual relationship editor follow-ups.
- Adds read-only relationship guardrails for listable-but-non-mutable graph links such as `RUNS_ON`.
- Adds visual CI create/edit/delete controls backed by existing node APIs.
- Adds layer/technology checkbox filters in the visual editor.
- Documents the patch release as `1.12.12`.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/VisualRelationshipEditor.test.tsx components/relationshipCapabilities.test.ts`
- [x] LSP diagnostics on touched TS/TSX files: no errors
- [x] `git diff --check`
- [x] Fresh final review: no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Chain Summary

```text
main
 └─ PR3 #198 visual relationship editor ✅ merged
     └─ PR4 #200 read-only relationship UI guardrails ✅ merged to chain
         └─ PR5 #202 visual CI CRUD controls ✅ merged to chain
             └─ PR6 #204 layer/technology filters ✅ merged to chain
```

## Notes
- No backend routes, schemas, permissions, migrations, or inventory API behavior changes are included.
- `/api/nodes` usage is through existing contracts only.
- Changelog release line: `1.12.12`.
