### PR TITLE
feat(cmdb): add full-page visual editor route

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import type React from 'react';
+import { useState } from 'react';
 import { HashRouter as Router, Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import LoginPage from './components/LoginPage';
-import { GraphNode } from './types';
+import type { GraphNode } from './types';
 import { api } from './services/api';
 import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from './services/queryKeys';
@@ -22,6 +23,7 @@ import UserManager from './components/UserManager';
 import RoleManager from './components/RoleManager';
 import CIDetailModal from './components/CIDetailModal';
 import MetricAnalytics from './components/MetricAnalytics';
+import VisualRelationshipEditorPage from './components/VisualRelationshipEditorPage';
 
 // --- Protected Route Helper ---
 const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
@@ -184,6 +186,7 @@ const MainLayout: React.FC = () => {
               <Route index element={<SystemDashboard />} />
               <Route path="monitoring" element={<MonitoringConsole />} />
               <Route path="admin" element={<AdminPage />} />
+              <Route path="admin/relationships/visual-editor" element={<VisualRelationshipEditorPage />} />
               <Route path="users" element={<UserManager />} />
               <Route path="cmdb" element={<GraphCMDB onNodeClick={(n) => { setSelectedNode(n); setShowDetailModal(true); }} />} />
               {/* <Route path="network" element={<NetworkVisualizer />} /> */}

--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -1,11 +1,11 @@
 import type React from 'react';
 import { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import type { GraphNode } from '../types';
 import TopologyViewer from './TopologyViewer';
 import { api } from '../services/api';
 import RelationshipBadge from './RelationshipBadge';
 import RelationshipTooltip from './RelationshipTooltip';
-import VisualRelationshipEditor from './VisualRelationshipEditor';
 import { canDeleteRelationship, isReadOnlyRelationship } from './relationshipCapabilities';
 
 // ============================================================================
@@ -82,7 +82,7 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
     const [sourceNodeId, setSourceNodeId] = useState<string>('');
 
     // --- State: Target Selection ---
-    const [targetCategory, setTargetCategory] = useState<string>('');
+    const [targetCategory] = useState<string>('');
     const [targetNodeIds, setTargetNodeIds] = useState<string[]>([]);
 
     // --- State: Relationship Settings ---
@@ -122,7 +122,6 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
 
     // --- State: Visualization Modal ---
     const [visualizationTarget, setVisualizationTarget] = useState<string | null>(null);
-    const [showVisualEditor, setShowVisualEditor] = useState(false);
     const [showHelp, setShowHelp] = useState(false);
 
     // --- Effects ---
@@ -171,11 +170,6 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
             console.error("Failed to fetch links", error);
             setLinks([]);
         }
-    };
-
-    const refreshRelationshipViews = async () => {
-        await Promise.all([fetchData(), fetchLinks()]);
-        onRefresh();
     };
 
     const fetchNodeMetrics = async (nodeId: string) => {
@@ -455,13 +449,15 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                             <span className="material-symbols-outlined text-brand-500">hub</span>
                             CI Relationships ({filteredCiLinks.length})
                         </h3>
-                        <button
-                            onClick={() => setShowVisualEditor(true)}
+                        <Link
+                            to="/admin/relationships/visual-editor"
+                            target="_blank"
+                            rel="noopener noreferrer"
                             className="btn-primary text-xs"
                         >
                             <span className="material-symbols-outlined text-sm">account_tree</span>
                             Visual editor
-                        </button>
+                        </Link>
                         <div className="relative">
                             <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-neutral-500 text-sm">search</span>
                             <input
@@ -615,14 +611,6 @@ const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) 
                 </div>
             )}
 
-            {showVisualEditor && (
-                <VisualRelationshipEditor
-                    nodes={nodes}
-                    links={ciLinks}
-                    onClose={() => setShowVisualEditor(false)}
-                    onMutated={refreshRelationshipViews}
-                />
-            )}
         </div>
     );
 };

--- a/frontend/components/RelationshipManager.visualEditor.test.tsx
+++ b/frontend/components/RelationshipManager.visualEditor.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import RelationshipManager from './RelationshipManager';
+
+const { mockApiGet } = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  api: {
+    get: mockApiGet,
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('./TopologyViewer', () => ({ default: () => <div>Topology viewer</div> }));
+
+describe('RelationshipManager visual editor entry point', () => {
+  beforeEach(() => {
+    mockApiGet.mockReset();
+    mockApiGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/nodes') return Promise.resolve([]);
+      if (endpoint === '/categories') return Promise.resolve([]);
+      if (endpoint === '/links') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+  });
+
+  it('opens the visual editor as a dedicated new-tab route', async () => {
+    render(
+      <MemoryRouter>
+        <RelationshipManager onRefresh={vi.fn()} />
+      </MemoryRouter>,
+    );
+
+    const visualEditorLink = await screen.findByRole('link', { name: /Visual editor/i });
+    expect(visualEditorLink).toHaveAttribute('href', '/admin/relationships/visual-editor');
+    expect(visualEditorLink).toHaveAttribute('target', '_blank');
+    expect(visualEditorLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/frontend/components/VisualRelationshipEditorPage.test.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { createQueryWrapper } from '../test/queryTestUtils';
+import VisualRelationshipEditorPage from './VisualRelationshipEditorPage';
+
+const { mockApiGet, mockHasPermission } = vi.hoisted(() => ({
+  mockApiGet: vi.fn(),
+  mockHasPermission: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  api: {
+    get: mockApiGet,
+  },
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: () => ({ hasPermission: mockHasPermission }),
+}));
+
+vi.mock('./VisualRelationshipEditor', () => ({
+  default: ({ nodes, links }: { nodes: unknown[]; links: unknown[] }) => (
+    <div>
+      Visual editor workspace {nodes.length} nodes {links.length} links
+    </div>
+  ),
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <VisualRelationshipEditorPage />
+    </MemoryRouter>,
+    { wrapper: createQueryWrapper() },
+  );
+
+describe('VisualRelationshipEditorPage', () => {
+  beforeEach(() => {
+    mockApiGet.mockReset();
+    mockHasPermission.mockReset();
+    mockHasPermission.mockReturnValue(true);
+  });
+
+  it('loads nodes and links for the full-page visual editor', async () => {
+    mockApiGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/nodes') {
+        return Promise.resolve([
+          { id: 'ci-a', label: 'Router A', type: 'INFRASTRUCTURE', status: 'OK', metadata: {} },
+        ]);
+      }
+      if (endpoint === '/links') {
+        return Promise.resolve([
+          { source: 'ci-a', target: 'ci-b', relationship: 'CONNECTS_TO' },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    renderPage();
+
+    expect(screen.getByLabelText('Loading visual relationship editor')).toBeInTheDocument();
+    expect(await screen.findByText('Visual editor workspace 1 nodes 1 links')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith('/nodes', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+      expect(mockApiGet).toHaveBeenCalledWith('/links', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    });
+  });
+
+  it('blocks direct access without CI edit permissions', () => {
+    mockHasPermission.mockReturnValue(false);
+
+    renderPage();
+
+    expect(screen.getByLabelText('Visual relationship editor access denied')).toBeInTheDocument();
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it('shows an error state when visual editor data cannot load', async () => {
+    mockApiGet.mockRejectedValue(new Error('down'));
+
+    renderPage();
+
+    expect(await screen.findByText('Could not load visual editor data')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to admin' })).toHaveAttribute('href', '/admin');
+  });
+});

--- a/frontend/components/VisualRelationshipEditorPage.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.tsx
@@ -1,0 +1,82 @@
+import type React from 'react';
+import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import VisualRelationshipEditor from './VisualRelationshipEditor';
+import { useNodesQuery } from '../hooks/queries/useNodesQuery';
+import { useLinksQuery } from '../hooks/queries/useLinksQuery';
+import { queryKeys } from '../services/queryKeys';
+import { useAuth } from '../context/AuthContext';
+
+const AccessDenied = () => (
+  <section className="flex h-full items-center justify-center bg-neutral-950 p-8 text-neutral-300" aria-label="Visual relationship editor access denied">
+    <div className="max-w-lg rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6 text-center">
+      <p className="text-sm font-black uppercase tracking-widest text-amber-200">Access denied</p>
+      <p className="mt-2 text-xs text-neutral-400">You need CI edit permissions to open the visual relationship editor.</p>
+      <Link to="/admin" className="mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-xs font-black uppercase text-white hover:bg-white/10">
+        Back to admin
+      </Link>
+    </div>
+  </section>
+);
+
+const VisualRelationshipEditorPageContent: React.FC = () => {
+  const queryClient = useQueryClient();
+  const nodesQuery = useNodesQuery();
+  const linksQuery = useLinksQuery();
+
+  const nodes = nodesQuery.data ?? [];
+  const links = linksQuery.data ?? [];
+  const isLoading = nodesQuery.isLoading || linksQuery.isLoading;
+  const error = nodesQuery.error ?? linksQuery.error;
+
+  const refreshRelationshipData = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.graphTopology() }),
+    ]);
+  };
+
+  if (isLoading) {
+    return (
+      <section className="flex h-full items-center justify-center bg-neutral-950 text-neutral-300" aria-label="Loading visual relationship editor">
+        <div className="text-center">
+          <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-brand-600 border-t-transparent" />
+          <p className="text-xs font-black uppercase tracking-widest text-neutral-500">Loading visual editor...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="flex h-full items-center justify-center bg-neutral-950 p-8 text-neutral-300" aria-label="Visual relationship editor error">
+        <div className="max-w-lg rounded-2xl border border-red-500/30 bg-red-500/10 p-6 text-center">
+          <p className="text-sm font-black uppercase tracking-widest text-red-300">Could not load visual editor data</p>
+          <p className="mt-2 text-xs text-neutral-400">Refresh the page or return to relationship management.</p>
+          <Link to="/admin" className="mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-xs font-black uppercase text-white hover:bg-white/10">
+            Back to admin
+          </Link>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <VisualRelationshipEditor
+      nodes={nodes}
+      links={links}
+      onClose={() => window.close()}
+      onMutated={refreshRelationshipData}
+    />
+  );
+};
+
+const VisualRelationshipEditorPage: React.FC = () => {
+  const { hasPermission } = useAuth();
+  const canEditRelationships = hasPermission('CI_EDIT') || hasPermission('CI_DELETE');
+
+  return canEditRelationships ? <VisualRelationshipEditorPageContent /> : <AccessDenied />;
+};
+
+export default VisualRelationshipEditorPage;


### PR DESCRIPTION
Closes #208

## Descripción del Cambio
- Adds the first chained slice for the full-page visual relationship editor.
- Registers a protected full-page visual editor route and page shell.
- Updates the Relationship Manager entry point to open the editor in a new tab.
- Adds direct-route permission gating before graph data queries run.

## Chain Context
- Chain strategy: stacked-to-main, auto-forecast, 400-line review budget.
- Current PR: PR1 — route and page shell.
- Dependency diagram: `main -> 📍 PR1 -> PR2 -> PR3 -> PR4`.
- Follow-ups:
  - PR2: reusable editor workspace and page-scale layout.
  - PR3: D3 pan/zoom and anchored force layout.
  - PR4: mutation refresh, state preservation, accessibility hardening.
- Out of scope for this PR: workspace extraction, pan/zoom, force simulation.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `frontend/App.tsx` | Adds `/admin/relationships/visual-editor` route. |
| `frontend/components/RelationshipManager.tsx` | Opens visual editor as a new-tab route instead of modal state. |
| `frontend/components/VisualRelationshipEditorPage.tsx` | Adds page shell, query loading/error states, permission gate, and mutation invalidation callback. |
| `frontend/components/*visualEditor*.test.tsx` | Covers new-tab entry, page data loading, error state, and access denial. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend test:run components/VisualRelationshipEditorPage.test.tsx components/RelationshipManager.visualEditor.test.tsx`
- [x] `pnpm --dir frontend build`
- [x] LSP diagnostics clean
- [x] `git diff --check`
- [x] Fresh reviewer clean for PR1

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
