### PR TITLE
feat(cmdb): support page mode visual editor workspace

### DIFF
--- a/frontend/components/VisualRelationshipEditor.mode.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.mode.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GraphNode } from '../types';
+import VisualRelationshipEditor from './VisualRelationshipEditor';
+
+const { mockApiPost, mockApiDelete } = vi.hoisted(() => ({
+  mockApiPost: vi.fn(),
+  mockApiDelete: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  api: {
+    post: mockApiPost,
+    delete: mockApiDelete,
+  },
+}));
+
+const nodes: GraphNode[] = [
+  { id: 'ci-a', label: 'Router A', type: 'INFRASTRUCTURE', status: 'OK', metadata: {} },
+];
+
+describe('VisualRelationshipEditor page mode', () => {
+  beforeEach(() => {
+    mockApiPost.mockReset();
+    mockApiDelete.mockReset();
+  });
+
+  it('renders as a full-page workspace without modal overlay constraints', () => {
+    const { container } = render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={[]}
+        mode="page"
+        onClose={vi.fn()}
+        onMutated={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Visual Relationship Editor')).toBeInTheDocument();
+    expect(screen.getByLabelText('Visual CI relationship map')).toBeInTheDocument();
+    expect(container.querySelector('.fixed.inset-0')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -59,6 +59,7 @@ interface VisualRelationshipEditorProps {
 	links: LinkData[];
 	onClose: () => void;
 	onMutated: () => void | Promise<void>;
+	mode?: "modal" | "page";
 }
 
 const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
@@ -158,6 +159,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	links,
 	onClose,
 	onMutated,
+	mode = "modal",
 }) => {
 	const [sourceId, setSourceId] = useState("");
 	const [targetId, setTargetId] = useState("");
@@ -556,9 +558,10 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		}
 	};
 
-	return (
-		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-6 backdrop-blur-xl">
-			<div className="flex h-full w-full max-w-7xl flex-col rounded-2xl border border-white/10 bg-neutral-950 shadow-2xl">
+	const isPageMode = mode === "page";
+
+	const editorContent = (
+		<div className={`${isPageMode ? "flex h-full w-full flex-col bg-neutral-950" : "flex h-full w-full max-w-7xl flex-col rounded-2xl border border-white/10 bg-neutral-950 shadow-2xl"}`}>
 				<div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
 					<div>
 						<h2 className="text-xl font-black uppercase text-white">
@@ -841,6 +844,13 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 					</aside>
 				</div>
 			</div>
+	);
+
+	if (isPageMode) return editorContent;
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-6 backdrop-blur-xl">
+			{editorContent}
 		</div>
 	);
 };

--- a/frontend/components/VisualRelationshipEditorPage.test.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.test.tsx
@@ -20,9 +20,9 @@ vi.mock('../context/AuthContext', () => ({
 }));
 
 vi.mock('./VisualRelationshipEditor', () => ({
-  default: ({ nodes, links }: { nodes: unknown[]; links: unknown[] }) => (
+  default: ({ nodes, links, mode }: { nodes: unknown[]; links: unknown[]; mode?: string }) => (
     <div>
-      Visual editor workspace {nodes.length} nodes {links.length} links
+      Visual editor workspace {nodes.length} nodes {links.length} links mode {mode}
     </div>
   ),
 }));
@@ -60,7 +60,7 @@ describe('VisualRelationshipEditorPage', () => {
     renderPage();
 
     expect(screen.getByLabelText('Loading visual relationship editor')).toBeInTheDocument();
-    expect(await screen.findByText('Visual editor workspace 1 nodes 1 links')).toBeInTheDocument();
+    expect(await screen.findByText('Visual editor workspace 1 nodes 1 links mode page')).toBeInTheDocument();
     await waitFor(() => {
       expect(mockApiGet).toHaveBeenCalledWith('/nodes', expect.objectContaining({ signal: expect.any(AbortSignal) }));
       expect(mockApiGet).toHaveBeenCalledWith('/links', expect.objectContaining({ signal: expect.any(AbortSignal) }));

--- a/frontend/components/VisualRelationshipEditorPage.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.tsx
@@ -66,6 +66,7 @@ const VisualRelationshipEditorPageContent: React.FC = () => {
     <VisualRelationshipEditor
       nodes={nodes}
       links={links}
+      mode="page"
       onClose={() => window.close()}
       onMutated={refreshRelationshipData}
     />


### PR DESCRIPTION
Closes #208

## Descripción del Cambio
- Adds PR2 of the full-page visual editor chain.
- Lets the existing visual editor render in `page` mode without the modal overlay/max-width constraints.
- Keeps modal mode as the default for compatibility.
- Wires the full-page route shell to page mode.

## Chain Context
- Chain strategy: stacked-to-main, auto-forecast, 400-line review budget.
- Current PR: PR2 — reusable/page-scale editor workspace.
- Dependency diagram: `main -> PR1 -> 📍 PR2 -> PR3 -> PR4`.
- Prior PR: #209 route and page shell.
- Follow-ups:
  - PR3: D3 pan/zoom and anchored force layout.
  - PR4: mutation refresh, state preservation, accessibility hardening.
- Out of scope for this PR: D3 zoom, force simulation, refresh hardening.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `frontend/components/VisualRelationshipEditor.tsx` | Adds `mode` prop and page rendering without modal overlay. |
| `frontend/components/VisualRelationshipEditorPage.tsx` | Uses `mode="page"`. |
| `frontend/components/VisualRelationshipEditor*.test.tsx` | Covers page mode and preserves existing editor behavior. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend test:run components/VisualRelationshipEditor.mode.test.tsx components/VisualRelationshipEditorPage.test.tsx components/VisualRelationshipEditor.test.tsx`
- [x] `pnpm --dir frontend build`
- [x] LSP diagnostics clean
- [x] Fresh reviewer clean for PR2

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
