### PR TITLE
feat(cmdb): add visual editor pan zoom force layout

### DIFF
--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -361,12 +361,15 @@ describe("VisualRelationshipEditor", () => {
 			/>,
 		);
 
-		expect(
-			screen.getByRole("button", { name: "CI node Router A" }),
-		).toHaveAttribute("transform", "translate(240,80)");
-		expect(
-			screen.getByRole("button", { name: "CI node Switch B" }),
-		).toHaveAttribute("transform", "translate(920,540)");
+		const routerTransform = screen
+			.getByRole("button", { name: "CI node Router A" })
+			.getAttribute("transform");
+		const switchTransform = screen
+			.getByRole("button", { name: "CI node Switch B" })
+			.getAttribute("transform");
+		expect(routerTransform).toMatch(/^translate\(/);
+		expect(switchTransform).toMatch(/^translate\(/);
+		expect(routerTransform).not.toBe(switchTransform);
 	});
 
 	it("uses CMDB lat/long projection and offsets duplicate coordinates", () => {
@@ -390,8 +393,7 @@ describe("VisualRelationshipEditor", () => {
 				.getByRole("button", { name: `CI node ${node.label}` })
 				.getAttribute("transform"),
 		);
-		expect(transforms[0]).toBe("translate(240,80)");
-		expect(transforms[1]).toBe("translate(268,80)");
+		expect(transforms.every((transform) => transform?.startsWith("translate("))).toBe(true);
 		expect(new Set(transforms).size).toBe(colocatedNodes.length);
 	});
 

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -9,6 +9,12 @@ import {
 	isReadOnlyRelationship,
 } from "./relationshipCapabilities";
 import { getStatusColorHex } from "../utils/status";
+import {
+	buildAnchoredVisualLayout,
+	type PositionedVisualNode,
+	VISUAL_EDITOR_VIEWBOX_HEIGHT,
+	VISUAL_EDITOR_VIEWBOX_WIDTH,
+} from "./visualRelationshipLayout";
 
 const SUPPORTED_RELATIONSHIP_TYPES = [
 	"CONNECTS_TO",
@@ -66,83 +72,6 @@ const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
 const nodeLayer = (node: GraphNode) => node.category ?? node.type;
 const sameLayers = (a: string[], b: string[]) =>
 	a.length === b.length && a.every((layer, index) => layer === b[index]);
-const VIEWBOX_WIDTH = 1000;
-const VIEWBOX_HEIGHT = 620;
-const COORDINATE_PADDING = 80;
-
-type PositionedNode = GraphNode & {
-	mapX: number;
-	mapY: number;
-	layer: string;
-};
-
-const hasNumber = (value: unknown): value is number =>
-	typeof value === "number" && Number.isFinite(value);
-
-const rawCoordinateForNode = (node: GraphNode, index: number) => {
-	if (hasNumber(node.x) && hasNumber(node.y)) {
-		return { x: node.x, y: node.y };
-	}
-	if (hasNumber(node.location?.long) && hasNumber(node.location?.lat)) {
-		return {
-			x: VIEWBOX_WIDTH / 2 + (node.location.long + 117) * 3000,
-			y: VIEWBOX_HEIGHT / 2 - (node.location.lat - 32.5) * 3000,
-		};
-	}
-
-	const angle = (index / Math.max(1, 12)) * Math.PI * 2 - Math.PI / 2;
-	const radius = 180 + Math.floor(index / 12) * 70;
-	return {
-		x: VIEWBOX_WIDTH / 2 + Math.cos(angle) * radius,
-		y: VIEWBOX_HEIGHT / 2 + Math.sin(angle) * radius,
-	};
-};
-
-const buildCoordinateLayout = (visibleNodes: GraphNode[]): PositionedNode[] => {
-	const rawNodes = visibleNodes.map((node, index) => ({
-		node,
-		layer: nodeLayer(node),
-		...rawCoordinateForNode(node, index),
-	}));
-	if (rawNodes.length === 0) return [];
-
-	const xExtent = d3.extent(rawNodes, (item) => item.x);
-	const yExtent = d3.extent(rawNodes, (item) => item.y);
-	const xScale = d3
-		.scaleLinear()
-		.domain(
-			xExtent[0] === xExtent[1]
-				? [xExtent[0] ?? 0, (xExtent[0] ?? 0) + 1]
-				: [xExtent[0] ?? 0, xExtent[1] ?? 1],
-		)
-		.range([COORDINATE_PADDING + 160, VIEWBOX_WIDTH - COORDINATE_PADDING]);
-	const yScale = d3
-		.scaleLinear()
-		.domain(
-			yExtent[0] === yExtent[1]
-				? [yExtent[0] ?? 0, (yExtent[0] ?? 0) + 1]
-				: [yExtent[0] ?? 0, yExtent[1] ?? 1],
-		)
-		.range([COORDINATE_PADDING, VIEWBOX_HEIGHT - COORDINATE_PADDING]);
-
-	const duplicateCounts = new Map<string, number>();
-	return rawNodes.map(({ node, layer, x, y }) => {
-		const coordinateKey = `${x}:${y}`;
-		const duplicateIndex = duplicateCounts.get(coordinateKey) ?? 0;
-		duplicateCounts.set(coordinateKey, duplicateIndex + 1);
-		const duplicateRing = Math.floor((duplicateIndex - 1) / 8) + 1;
-		const duplicateSlot = (duplicateIndex - 1) % 8;
-		const duplicateAngle = duplicateSlot * (Math.PI / 4);
-		const duplicateRadius = duplicateIndex === 0 ? 0 : 28 * duplicateRing;
-
-		return {
-			...node,
-			layer,
-			mapX: xScale(x) + Math.cos(duplicateAngle) * duplicateRadius,
-			mapY: yScale(y) + Math.sin(duplicateAngle) * duplicateRadius,
-		};
-	});
-};
 
 const toCiForm = (node: GraphNode): CiFormState => ({
 	id: node.id,
@@ -228,8 +157,8 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		[nodes],
 	);
 	const positionedNodes = useMemo(
-		() => buildCoordinateLayout(visibleNodes),
-		[visibleNodes],
+		() => buildAnchoredVisualLayout(visibleNodes, visibleCiLinks),
+		[visibleNodes, visibleCiLinks],
 	);
 	const positionMap = useMemo(
 		() => new Map(positionedNodes.map((item) => [item.id, item])),
@@ -359,7 +288,13 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		const svg = d3.select(svgElement);
 		svg.selectAll("*").remove();
 
-		const container = svg.append("g").attr("class", "visual-editor-d3-layer");
+		const container = svg.append("g").attr("class", "visual-editor-zoom-root");
+		const zoom = d3.zoom<SVGSVGElement, unknown>()
+			.scaleExtent([0.35, 3])
+			.on("zoom", (event) => {
+				container.attr("transform", event.transform);
+			});
+		svg.call(zoom);
 		container
 			.append("g")
 			.attr("class", "relationship-links")
@@ -405,7 +340,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		const nodeSelection = container
 			.append("g")
 			.attr("class", "relationship-nodes")
-			.selectAll<SVGGElement, PositionedNode>("g")
+			.selectAll<SVGGElement, PositionedVisualNode>("g")
 			.data(positionedNodes, (node) => node.id)
 			.join("g")
 			.attr("role", "button")
@@ -483,7 +418,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 					.attr("opacity", 0.3);
 			})
 			.on("mouseout", function () {
-				const node = d3.select(this).datum() as PositionedNode;
+				const node = d3.select(this).datum() as PositionedVisualNode;
 				d3.select(this)
 					.select("circle")
 					.attr(
@@ -635,7 +570,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 						<svg
 							ref={graphSvgRef}
 							className="absolute inset-0 h-full w-full"
-							viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+							viewBox={`0 0 ${VISUAL_EDITOR_VIEWBOX_WIDTH} ${VISUAL_EDITOR_VIEWBOX_HEIGHT}`}
 							aria-label="Visual CI relationship map"
 						/>
 						{visibleNodes.length === 0 && (

--- a/frontend/components/visualRelationshipLayout.test.ts
+++ b/frontend/components/visualRelationshipLayout.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { GraphNode } from '../types';
+import { buildAnchoredVisualLayout } from './visualRelationshipLayout';
+
+const baseNode = (id: string, extra: Partial<GraphNode> = {}): GraphNode => ({
+  id,
+  label: id,
+  type: 'INFRASTRUCTURE',
+  status: 'OK',
+  metadata: {},
+  ...extra,
+});
+
+describe('visual relationship layout', () => {
+  it('prefers explicit x/y coordinates over location coordinates', () => {
+    const [left, right] = buildAnchoredVisualLayout([
+      baseNode('left', { x: 0, y: 0, location: { lat: 1, long: 1 } }),
+      baseNode('right', { x: 10, y: 10, location: { lat: 1, long: 1 } }),
+    ]);
+
+    expect(left.anchorX).toBeLessThan(right.anchorX);
+    expect(left.anchorY).toBeLessThan(right.anchorY);
+  });
+
+  it('uses CMDB location projection when explicit coordinates are missing', () => {
+    const [origin, east] = buildAnchoredVisualLayout([
+      baseNode('origin', { location: { lat: 32.5, long: -117 } }),
+      baseNode('east', { location: { lat: 32.5, long: -116.9 } }),
+    ]);
+
+    expect(origin.anchorX).toBeGreaterThan(east.anchorX);
+    expect(origin.anchorY).toBe(east.anchorY);
+  });
+
+  it('separates colocated nodes with deterministic collision forces', () => {
+    const colocated = Array.from({ length: 6 }, (_, index) =>
+      baseNode(`ci-${index}`, { x: 10, y: 10 }),
+    );
+
+    const layout = buildAnchoredVisualLayout(colocated);
+    const roundedPositions = new Set(layout.map((node) => `${Math.round(node.mapX)}:${Math.round(node.mapY)}`));
+
+    expect(roundedPositions.size).toBe(colocated.length);
+  });
+
+  it('keeps fallback placement stable across input order changes', () => {
+    const nodes = [baseNode('b'), baseNode('a'), baseNode('c')];
+    const first = buildAnchoredVisualLayout(nodes);
+    const second = buildAnchoredVisualLayout([...nodes].reverse());
+
+    expect(first.map((node) => node.id)).toEqual(second.map((node) => node.id));
+    expect(first.map((node) => [node.anchorX, node.anchorY])).toEqual(
+      second.map((node) => [node.anchorX, node.anchorY]),
+    );
+  });
+});

--- a/frontend/components/visualRelationshipLayout.ts
+++ b/frontend/components/visualRelationshipLayout.ts
@@ -1,0 +1,97 @@
+import * as d3 from 'd3';
+import type { GraphNode } from '../types';
+import type { LinkData } from './RelationshipManager';
+
+export const VISUAL_EDITOR_VIEWBOX_WIDTH = 1600;
+export const VISUAL_EDITOR_VIEWBOX_HEIGHT = 1000;
+const COORDINATE_PADDING = 120;
+
+type AnchorNode = GraphNode & {
+  anchorX: number;
+  anchorY: number;
+  mapX: number;
+  mapY: number;
+  layer: string;
+};
+
+export type PositionedVisualNode = AnchorNode;
+
+const nodeLabel = (node: GraphNode) => node.label || node.id;
+const nodeLayer = (node: GraphNode) => node.category ?? node.type;
+const hasNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
+
+const rawCoordinateForNode = (node: GraphNode, fallbackIndex: number) => {
+  if (hasNumber(node.x) && hasNumber(node.y)) return { x: node.x, y: node.y };
+  if (hasNumber(node.location?.long) && hasNumber(node.location?.lat)) {
+    return {
+      x: VISUAL_EDITOR_VIEWBOX_WIDTH / 2 + (node.location.long + 117) * 3000,
+      y: VISUAL_EDITOR_VIEWBOX_HEIGHT / 2 - (node.location.lat - 32.5) * 3000,
+    };
+  }
+
+  const angle = (fallbackIndex / Math.max(1, 12)) * Math.PI * 2 - Math.PI / 2;
+  const radius = 240 + Math.floor(fallbackIndex / 12) * 90;
+  return {
+    x: VISUAL_EDITOR_VIEWBOX_WIDTH / 2 + Math.cos(angle) * radius,
+    y: VISUAL_EDITOR_VIEWBOX_HEIGHT / 2 + Math.sin(angle) * radius,
+  };
+};
+
+export const buildAnchoredVisualLayout = (visibleNodes: GraphNode[], visibleLinks: LinkData[] = []): PositionedVisualNode[] => {
+  const orderedNodes = [...visibleNodes].sort((a, b) => a.id.localeCompare(b.id));
+  const rawNodes = orderedNodes.map((node, index) => ({
+    node,
+    layer: nodeLayer(node),
+    ...rawCoordinateForNode(node, index),
+  }));
+  if (rawNodes.length === 0) return [];
+
+  const xExtent = d3.extent(rawNodes, (item) => item.x);
+  const yExtent = d3.extent(rawNodes, (item) => item.y);
+  const xScale = d3
+    .scaleLinear()
+    .domain(xExtent[0] === xExtent[1] ? [xExtent[0] ?? 0, (xExtent[0] ?? 0) + 1] : [xExtent[0] ?? 0, xExtent[1] ?? 1])
+    .range([COORDINATE_PADDING, VISUAL_EDITOR_VIEWBOX_WIDTH - COORDINATE_PADDING]);
+  const yScale = d3
+    .scaleLinear()
+    .domain(yExtent[0] === yExtent[1] ? [yExtent[0] ?? 0, (yExtent[0] ?? 0) + 1] : [yExtent[0] ?? 0, yExtent[1] ?? 1])
+    .range([COORDINATE_PADDING, VISUAL_EDITOR_VIEWBOX_HEIGHT - COORDINATE_PADDING]);
+
+  const layoutNodes: PositionedVisualNode[] = rawNodes.map(({ node, layer, x, y }) => ({
+    ...node,
+    layer,
+    anchorX: xScale(x),
+    anchorY: yScale(y),
+    mapX: xScale(x),
+    mapY: yScale(y),
+  }));
+
+  const simulationNodes = layoutNodes.map((node) => ({ ...node, x: node.anchorX, y: node.anchorY }));
+  const simulationNodeIds = new Set(simulationNodes.map((node) => node.id));
+  const simulationLinks = visibleLinks
+    .filter((link) => simulationNodeIds.has(link.source) && simulationNodeIds.has(link.target))
+    .map((link) => ({ source: link.source, target: link.target }));
+
+  const simulation = d3
+    .forceSimulation(simulationNodes)
+    .force('charge', d3.forceManyBody<PositionedVisualNode & { x: number; y: number }>().strength(-140))
+    .force('collision', d3.forceCollide<PositionedVisualNode & { x: number; y: number }>().radius(54))
+    .force('link', d3.forceLink<PositionedVisualNode & { x: number; y: number }, { source: string; target: string }>(simulationLinks).id((node) => node.id).distance(150).strength(0.12))
+    .force('x', d3.forceX<PositionedVisualNode & { x: number; y: number }>((node) => node.anchorX).strength(0.18))
+    .force('y', d3.forceY<PositionedVisualNode & { x: number; y: number }>((node) => node.anchorY).strength(0.18))
+    .stop();
+
+  simulation.tick(100);
+  simulation.stop();
+
+  const simulatedById = new Map(simulationNodes.map((node) => [node.id, node]));
+  return layoutNodes.map((node) => {
+    const simulated = simulatedById.get(node.id);
+    return {
+      ...node,
+      mapX: simulated?.x ?? node.mapX,
+      mapY: simulated?.y ?? node.mapY,
+      label: nodeLabel(node),
+    };
+  });
+};


### PR DESCRIPTION
Closes #208

## Descripción del Cambio
- Adds PR3 of the full-page visual editor chain.
- Extracts deterministic visual layout helpers.
- Adds D3 pan/zoom on the SVG graph root.
- Uses anchored D3 force layout with repulsion, collision, links, and x/y anchor forces.
- Keeps CI nodes non-draggable.

## Chain Context
- Chain strategy: stacked-to-main, auto-forecast, 400-line review budget.
- Current PR: PR3 — D3 pan/zoom and anchored force layout.
- Dependency diagram: `main -> PR1 -> PR2 -> 📍 PR3 -> PR4`.
- Prior PRs: #209 route/page shell, #210 page-mode workspace.
- Follow-up: PR4 refresh/state/accessibility hardening.
- Out of scope for this PR: mutation invalidation/state preservation hardening beyond existing behavior.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `frontend/components/visualRelationshipLayout.ts` | Adds coordinate priority, fallback, and deterministic force layout helper. |
| `frontend/components/VisualRelationshipEditor.tsx` | Uses the helper and attaches D3 zoom to the graph root. |
| `frontend/components/*test*` | Covers coordinate priority, location projection, collision separation, fallback stability, and behavior regressions. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend test:run components/visualRelationshipLayout.test.ts components/VisualRelationshipEditor.test.tsx`
- [x] `pnpm --dir frontend build`
- [x] LSP diagnostics clean
- [x] Fresh reviewer clean for PR3

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
