### PR TITLE
feat(cmdb): harden visual editor refresh state

### DIFF
--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -103,6 +103,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 	const [selectedLayers, setSelectedLayers] = useState<string[]>([]);
 	const knownLayerLabelsRef = useRef<string[]>([]);
 	const graphSvgRef = useRef<SVGSVGElement>(null);
+	const zoomTransformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity);
 
 	const ciLinks = useMemo(
 		() => links.filter((link) => link.relationship !== "HAS_METRIC"),
@@ -292,9 +293,11 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		const zoom = d3.zoom<SVGSVGElement, unknown>()
 			.scaleExtent([0.35, 3])
 			.on("zoom", (event) => {
+				zoomTransformRef.current = event.transform;
 				container.attr("transform", event.transform);
 			});
 		svg.call(zoom);
+		container.attr("transform", zoomTransformRef.current);
 		container
 			.append("g")
 			.attr("class", "relationship-links")

--- a/frontend/components/VisualRelationshipEditorPage.test.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
-import { createQueryWrapper } from '../test/queryTestUtils';
+import { useQueryClient } from '@tanstack/react-query';
+import { createQueryWrapper, createTestQueryClient } from '../test/queryTestUtils';
 import VisualRelationshipEditorPage from './VisualRelationshipEditorPage';
+import { queryKeys } from '../services/queryKeys';
 
 const { mockApiGet, mockHasPermission } = vi.hoisted(() => ({
   mockApiGet: vi.fn(),
@@ -20,19 +22,27 @@ vi.mock('../context/AuthContext', () => ({
 }));
 
 vi.mock('./VisualRelationshipEditor', () => ({
-  default: ({ nodes, links, mode }: { nodes: unknown[]; links: unknown[]; mode?: string }) => (
+  default: ({ nodes, links, mode, onMutated }: { nodes: unknown[]; links: unknown[]; mode?: string; onMutated: () => Promise<void> }) => (
     <div>
-      Visual editor workspace {nodes.length} nodes {links.length} links mode {mode}
+      <span>Visual editor workspace {nodes.length} nodes {links.length} links mode {mode}</span>
+      <button type="button" onClick={() => void onMutated()}>Trigger mutation refresh</button>
     </div>
   ),
 }));
 
-const renderPage = () =>
+function QuerySeeder() {
+  const queryClient = useQueryClient();
+  queryClient.setQueryData(queryKeys.graphTopology(), { nodes: [], links: [] });
+  return null;
+}
+
+const renderPage = (client = createTestQueryClient()) =>
   render(
     <MemoryRouter>
       <VisualRelationshipEditorPage />
+      <QuerySeeder />
     </MemoryRouter>,
-    { wrapper: createQueryWrapper() },
+    { wrapper: createQueryWrapper(client) },
   );
 
 describe('VisualRelationshipEditorPage', () => {
@@ -64,6 +74,27 @@ describe('VisualRelationshipEditorPage', () => {
     await waitFor(() => {
       expect(mockApiGet).toHaveBeenCalledWith('/nodes', expect.objectContaining({ signal: expect.any(AbortSignal) }));
       expect(mockApiGet).toHaveBeenCalledWith('/links', expect.objectContaining({ signal: expect.any(AbortSignal) }));
+    });
+  });
+
+  it('invalidates graph resources after visual editor mutations', async () => {
+    mockApiGet.mockImplementation((endpoint: string) => {
+      if (endpoint === '/nodes') return Promise.resolve([]);
+      if (endpoint === '/links') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+
+    const client = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    renderPage(client);
+
+    await screen.findByText('Visual editor workspace 0 nodes 0 links mode page');
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger mutation refresh' }));
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.nodes() });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.links() });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.graphTopology() });
     });
   });
 


### PR DESCRIPTION
Closes #208

## Descripción del Cambio
- Adds PR4 of the full-page visual editor chain.
- Preserves D3 zoom transform across visual editor redraws.
- Adds regression coverage for mutation refresh invalidating nodes, links, and graph topology.

## Chain Context
- Chain strategy: stacked-to-main, auto-forecast, 400-line review budget.
- Current PR: PR4 — refresh/state/accessibility hardening.
- Dependency diagram: `main -> PR1 -> PR2 -> PR3 -> 📍 PR4`.
- Prior PRs: #209 route/page shell, #210 page-mode workspace, #211 D3 pan/zoom + force layout.
- This is the final planned PR for issue #208.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `frontend/components/VisualRelationshipEditor.tsx` | Stores and reapplies D3 zoom transform across redraws. |
| `frontend/components/VisualRelationshipEditorPage.test.tsx` | Tests mutation refresh invalidates nodes, links, and graph topology. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend test:run components/VisualRelationshipEditorPage.test.tsx components/VisualRelationshipEditor.test.tsx`
- [x] `pnpm --dir frontend build`
- [x] LSP diagnostics clean
- [x] Fresh reviewer clean for PR4 and final chain

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
