### PR TITLE
test(auth): stabilize localStorage login tests

### DIFF
--- a/frontend/components/LoginPage.test.tsx
+++ b/frontend/components/LoginPage.test.tsx
@@ -1,345 +1,380 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
-import LoginPage from './LoginPage';
-import { AuthProvider } from '../context/AuthContext';
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import LoginPage from "./LoginPage";
+import { AuthProvider } from "../context/AuthContext";
 
 // ─── Module mocks (must be hoisted) ────────────────────────────────
 
 const mocks = vi.hoisted(() => ({
-  navigate: vi.fn(),
-  apiRequest: vi.fn(),
-  apiGet: vi.fn(),
+	navigate: vi.fn(),
+	apiRequest: vi.fn(),
+	apiGet: vi.fn(),
 }));
 
-vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router-dom')>();
-  return {
-    ...actual,
-    useNavigate: () => mocks.navigate,
-  };
+vi.mock("react-router-dom", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-router-dom")>();
+	return {
+		...actual,
+		useNavigate: () => mocks.navigate,
+	};
 });
 
-vi.mock('../services/api', () => ({
-  api: {
-    request: mocks.apiRequest,
-    get: mocks.apiGet,
-  },
+vi.mock("../services/api", () => ({
+	api: {
+		request: mocks.apiRequest,
+		get: mocks.apiGet,
+	},
 }));
 
 // ─── Render helper ─────────────────────────────────────────────────
 
 const renderLoginPage = () => {
-  return render(
-    <MemoryRouter>
-      <AuthProvider>
-        <LoginPage />
-      </AuthProvider>
-    </MemoryRouter>,
-  );
+	return render(
+		<MemoryRouter>
+			<AuthProvider>
+				<LoginPage />
+			</AuthProvider>
+		</MemoryRouter>,
+	);
 };
 
-describe('LoginPage', () => {
-  beforeEach(() => {
-    localStorage.clear();
-    mocks.navigate.mockClear();
-    mocks.apiRequest.mockClear();
-    mocks.apiGet.mockClear();
-  });
-
-  // ─── 1. Form Rendering ───────────────────────────────────────────
-
-  describe('form rendering', () => {
-    it('renders the login form with username and password inputs', () => {
-      renderLoginPage();
-
-      // NOTE: Labels in LoginPage are not associated with inputs via htmlFor,
-      // so we query by placeholder text instead.
-      expect(screen.getByPlaceholderText('admin')).toBeInTheDocument();
-      expect(screen.getByPlaceholderText(/•••/)).toBeInTheDocument();
-    });
-
-    it('renders the submit button with AUTHENTICATE text', () => {
-      renderLoginPage();
-
-      expect(screen.getByRole('button', { name: /authenticate/i })).toBeInTheDocument();
-    });
-
-    it('renders the NEX-GEN branding', () => {
-      renderLoginPage();
-
-      expect(screen.getByText('NEX-GEN')).toBeInTheDocument();
-      expect(screen.getByText(/secure access gateway/i)).toBeInTheDocument();
-    });
-
-    it('inputs are initially empty', () => {
-      renderLoginPage();
-
-      const usernameInput = screen.getByPlaceholderText('admin') as HTMLInputElement;
-      const passwordInput = screen.getByPlaceholderText(/•••/) as HTMLInputElement;
-
-      expect(usernameInput.value).toBe('');
-      expect(passwordInput.value).toBe('');
-    });
-
-    it('password input has type password', () => {
-      renderLoginPage();
-
-      const passwordInput = screen.getByPlaceholderText(/•••/);
-      expect(passwordInput).toHaveAttribute('type', 'password');
-    });
-  });
-
-  // ─── 2. Input Changes ────────────────────────────────────────────
-
-  describe('input changes', () => {
-    it('updates username when typing', async () => {
-      const user = userEvent.setup();
-      renderLoginPage();
-
-      const usernameInput = screen.getByPlaceholderText('admin');
-      await user.type(usernameInput, 'admin');
-
-      expect(usernameInput).toHaveValue('admin');
-    });
-
-    it('updates password when typing', async () => {
-      const user = userEvent.setup();
-      renderLoginPage();
-
-      const passwordInput = screen.getByPlaceholderText(/•••/);
-      await user.type(passwordInput, 'secret123');
-
-      expect(passwordInput).toHaveValue('secret123');
-    });
-  });
-
-  // ─── 3. Submission Behavior ──────────────────────────────────────
-
-  describe('submission behavior', () => {
-    it('calls api.request with correct endpoint and form data on submit', async () => {
-      const user = userEvent.setup();
-      mocks.apiRequest.mockResolvedValue({ access_token: 'test-token' });
-      mocks.apiGet.mockResolvedValue({ username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] });
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'secret');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(mocks.apiRequest).toHaveBeenCalledWith('/auth/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: expect.any(URLSearchParams),
-        });
-      });
-
-      // Verify the body contains the right credentials
-      const callArgs = mocks.apiRequest.mock.calls[0][1];
-      const body = callArgs.body as URLSearchParams;
-      expect(body.get('username')).toBe('admin');
-      expect(body.get('password')).toBe('secret');
-    });
-
-    it('fetches user details after successful token exchange', async () => {
-      const user = userEvent.setup();
-      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
-      mocks.apiRequest.mockResolvedValue({ access_token: 'test-token' });
-      mocks.apiGet.mockResolvedValue(mockUser);
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'secret');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(mocks.apiGet).toHaveBeenCalledWith('/auth/users/me');
-      });
-    });
-  });
-
-  // ─── 4. Success Handling ─────────────────────────────────────────
-
-  describe('success handling', () => {
-    it('stores token in localStorage on successful login', async () => {
-      const user = userEvent.setup();
-      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
-      mocks.apiRequest.mockResolvedValue({ access_token: 'success-token' });
-      mocks.apiGet.mockResolvedValue(mockUser);
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(localStorage.getItem('token')).toBe('success-token');
-      });
-    });
-
-    it('navigates to home page ("/") on successful login', async () => {
-      const user = userEvent.setup();
-      const mockUser = { username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] };
-      mocks.apiRequest.mockResolvedValue({ access_token: 'tok' });
-      mocks.apiGet.mockResolvedValue(mockUser);
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(mocks.navigate).toHaveBeenCalledWith('/');
-      });
-    });
-
-    it('clears any previous error message on new submission', async () => {
-      const user = userEvent.setup();
-      // First submission fails to show an error
-      mocks.apiRequest.mockRejectedValueOnce(new Error('Invalid credentials'));
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
-      });
-
-      // Second submission succeeds — error should disappear
-      mocks.apiRequest.mockResolvedValue({ access_token: 'tok' });
-      mocks.apiGet.mockResolvedValue({ username: 'admin', role: 'ADMIN', permissions: [], allowed_locations: [] });
-
-      await user.type(screen.getByPlaceholderText(/•••/), 'correct');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.queryByText('Invalid credentials')).not.toBeInTheDocument();
-      });
-    });
-  });
-
-  // ─── 5. Error Handling ───────────────────────────────────────────
-
-  describe('error handling', () => {
-    it('displays error message when api.request fails', async () => {
-      const user = userEvent.setup();
-      mocks.apiRequest.mockRejectedValue(new Error('Invalid credentials'));
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Invalid credentials')).toBeInTheDocument();
-      });
-    });
-
-    it('displays generic "Login failed" message when error has no message', async () => {
-      const user = userEvent.setup();
-      mocks.apiRequest.mockRejectedValue({});
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Login failed')).toBeInTheDocument();
-      });
-    });
-
-    it('removes token from localStorage on login failure', async () => {
-      const user = userEvent.setup();
-      localStorage.setItem('token', 'stale-token');
-      mocks.apiRequest.mockRejectedValue(new Error('Auth error'));
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(localStorage.getItem('token')).toBeNull();
-      });
-    });
-
-    it('does NOT navigate on failure', async () => {
-      const user = userEvent.setup();
-      mocks.apiRequest.mockRejectedValue(new Error('Bad creds'));
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'wrong');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Bad creds')).toBeInTheDocument();
-      });
-
-      expect(mocks.navigate).not.toHaveBeenCalled();
-    });
-
-    it('does NOT call /auth/users/me when token request fails', async () => {
-      const user = userEvent.setup();
-      mocks.apiRequest.mockRejectedValue(new Error('Network error'));
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('Network error')).toBeInTheDocument();
-      });
-
-      expect(mocks.apiGet).not.toHaveBeenCalled();
-    });
-  });
-
-  // ─── 6. Navigation Interactions ──────────────────────────────────
-
-  describe('navigation interactions', () => {
-    it('does not navigate on initial render', () => {
-      renderLoginPage();
-
-      expect(mocks.navigate).not.toHaveBeenCalled();
-    });
-
-    it('navigates only after both api calls succeed', async () => {
-      const user = userEvent.setup();
-
-      // Token succeeds but user fetch fails
-      mocks.apiRequest.mockResolvedValue({ access_token: 'tok' });
-      mocks.apiGet.mockRejectedValue(new Error('User fetch failed'));
-
-      renderLoginPage();
-
-      await user.type(screen.getByPlaceholderText('admin'), 'admin');
-      await user.type(screen.getByPlaceholderText(/•••/), 'pass');
-      await user.click(screen.getByRole('button', { name: /authenticate/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('User fetch failed')).toBeInTheDocument();
-      });
-
-      // Should NOT have navigated because the user fetch failed
-      expect(mocks.navigate).not.toHaveBeenCalled();
-    });
-  });
+describe("LoginPage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		mocks.navigate.mockClear();
+		mocks.apiRequest.mockReset();
+		mocks.apiGet.mockReset();
+		mocks.apiGet.mockRejectedValue(new Error("Not authenticated"));
+	});
+
+	// ─── 1. Form Rendering ───────────────────────────────────────────
+
+	describe("form rendering", () => {
+		it("renders the login form with username and password inputs", () => {
+			renderLoginPage();
+
+			// NOTE: Labels in LoginPage are not associated with inputs via htmlFor,
+			// so we query by placeholder text instead.
+			expect(screen.getByPlaceholderText("admin")).toBeInTheDocument();
+			expect(screen.getByPlaceholderText(/•••/)).toBeInTheDocument();
+		});
+
+		it("renders the submit button with AUTHENTICATE text", () => {
+			renderLoginPage();
+
+			expect(
+				screen.getByRole("button", { name: /authenticate/i }),
+			).toBeInTheDocument();
+		});
+
+		it("renders the NEX-GEN branding", () => {
+			renderLoginPage();
+
+			expect(screen.getByText("NEX-GEN")).toBeInTheDocument();
+			expect(screen.getByText(/secure access gateway/i)).toBeInTheDocument();
+		});
+
+		it("inputs are initially empty", () => {
+			renderLoginPage();
+
+			const usernameInput = screen.getByPlaceholderText(
+				"admin",
+			) as HTMLInputElement;
+			const passwordInput = screen.getByPlaceholderText(
+				/•••/,
+			) as HTMLInputElement;
+
+			expect(usernameInput.value).toBe("");
+			expect(passwordInput.value).toBe("");
+		});
+
+		it("password input has type password", () => {
+			renderLoginPage();
+
+			const passwordInput = screen.getByPlaceholderText(/•••/);
+			expect(passwordInput).toHaveAttribute("type", "password");
+		});
+	});
+
+	// ─── 2. Input Changes ────────────────────────────────────────────
+
+	describe("input changes", () => {
+		it("updates username when typing", async () => {
+			const user = userEvent.setup();
+			renderLoginPage();
+
+			const usernameInput = screen.getByPlaceholderText("admin");
+			await user.type(usernameInput, "admin");
+
+			expect(usernameInput).toHaveValue("admin");
+		});
+
+		it("updates password when typing", async () => {
+			const user = userEvent.setup();
+			renderLoginPage();
+
+			const passwordInput = screen.getByPlaceholderText(/•••/);
+			await user.type(passwordInput, "secret123");
+
+			expect(passwordInput).toHaveValue("secret123");
+		});
+	});
+
+	// ─── 3. Submission Behavior ──────────────────────────────────────
+
+	describe("submission behavior", () => {
+		it("calls api.request with correct endpoint and form data on submit", async () => {
+			const user = userEvent.setup();
+			mocks.apiRequest.mockResolvedValue({ access_token: "test-token" });
+			mocks.apiGet.mockResolvedValue({
+				username: "admin",
+				role: "ADMIN",
+				permissions: [],
+				allowed_locations: [],
+			});
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "secret");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(mocks.apiRequest).toHaveBeenCalledWith("/auth/token", {
+					method: "POST",
+					headers: { "Content-Type": "application/x-www-form-urlencoded" },
+					body: expect.any(URLSearchParams),
+				});
+			});
+
+			// Verify the body contains the right credentials
+			const callArgs = mocks.apiRequest.mock.calls[0][1];
+			const body = callArgs.body as URLSearchParams;
+			expect(body.get("username")).toBe("admin");
+			expect(body.get("password")).toBe("secret");
+		});
+
+		it("fetches user details after successful token exchange", async () => {
+			const user = userEvent.setup();
+			const mockUser = {
+				username: "admin",
+				role: "ADMIN",
+				permissions: [],
+				allowed_locations: [],
+			};
+			mocks.apiRequest.mockResolvedValue({ access_token: "test-token" });
+			mocks.apiGet.mockResolvedValue(mockUser);
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "secret");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(mocks.apiGet).toHaveBeenCalledWith("/auth/users/me");
+			});
+		});
+	});
+
+	// ─── 4. Success Handling ─────────────────────────────────────────
+
+	describe("success handling", () => {
+		it("does not store token in localStorage on successful cookie-auth login", async () => {
+			const user = userEvent.setup();
+			const mockUser = {
+				username: "admin",
+				role: "ADMIN",
+				permissions: [],
+				allowed_locations: [],
+			};
+			mocks.apiRequest.mockResolvedValue({ access_token: "success-token" });
+			mocks.apiGet.mockResolvedValue(mockUser);
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "pass");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(mocks.navigate).toHaveBeenCalledWith("/");
+			});
+			expect(localStorage.getItem("token")).toBeNull();
+		});
+
+		it('navigates to home page ("/") on successful login', async () => {
+			const user = userEvent.setup();
+			const mockUser = {
+				username: "admin",
+				role: "ADMIN",
+				permissions: [],
+				allowed_locations: [],
+			};
+			mocks.apiRequest.mockResolvedValue({ access_token: "tok" });
+			mocks.apiGet.mockResolvedValue(mockUser);
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "pass");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(mocks.navigate).toHaveBeenCalledWith("/");
+			});
+		});
+
+		it("clears any previous error message on new submission", async () => {
+			const user = userEvent.setup();
+			// First submission fails to show an error
+			mocks.apiRequest.mockRejectedValueOnce(new Error("Invalid credentials"));
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "wrong");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+			});
+
+			// Second submission succeeds — error should disappear
+			mocks.apiRequest.mockResolvedValue({ access_token: "tok" });
+			mocks.apiGet.mockResolvedValue({
+				username: "admin",
+				role: "ADMIN",
+				permissions: [],
+				allowed_locations: [],
+			});
+
+			await user.type(screen.getByPlaceholderText(/•••/), "correct");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(
+					screen.queryByText("Invalid credentials"),
+				).not.toBeInTheDocument();
+			});
+		});
+	});
+
+	// ─── 5. Error Handling ───────────────────────────────────────────
+
+	describe("error handling", () => {
+		it("displays error message when api.request fails", async () => {
+			const user = userEvent.setup();
+			mocks.apiRequest.mockRejectedValue(new Error("Invalid credentials"));
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "wrong");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+			});
+		});
+
+		it('displays generic "Login failed" message when error has no message', async () => {
+			const user = userEvent.setup();
+			mocks.apiRequest.mockRejectedValue({});
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "wrong");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("Login failed")).toBeInTheDocument();
+			});
+		});
+
+		it("does not write localStorage token on login failure", async () => {
+			const user = userEvent.setup();
+			mocks.apiRequest.mockRejectedValue(new Error("Auth error"));
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "wrong");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("Auth error")).toBeInTheDocument();
+			});
+			expect(localStorage.getItem("token")).toBeNull();
+		});
+
+		it("does NOT navigate on failure", async () => {
+			const user = userEvent.setup();
+			mocks.apiRequest.mockRejectedValue(new Error("Bad creds"));
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "wrong");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("Bad creds")).toBeInTheDocument();
+			});
+
+			expect(mocks.navigate).not.toHaveBeenCalled();
+		});
+
+		it("does NOT call /auth/users/me for login when token request fails", async () => {
+			const user = userEvent.setup();
+			mocks.apiRequest.mockRejectedValue(new Error("Network error"));
+
+			renderLoginPage();
+			mocks.apiGet.mockClear();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "pass");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("Network error")).toBeInTheDocument();
+			});
+
+			expect(mocks.apiGet).not.toHaveBeenCalled();
+		});
+	});
+
+	// ─── 6. Navigation Interactions ──────────────────────────────────
+
+	describe("navigation interactions", () => {
+		it("does not navigate on initial render", () => {
+			renderLoginPage();
+
+			expect(mocks.navigate).not.toHaveBeenCalled();
+		});
+
+		it("navigates only after both api calls succeed", async () => {
+			const user = userEvent.setup();
+
+			// Token succeeds but user fetch fails
+			mocks.apiRequest.mockResolvedValue({ access_token: "tok" });
+			mocks.apiGet.mockRejectedValue(new Error("User fetch failed"));
+
+			renderLoginPage();
+
+			await user.type(screen.getByPlaceholderText("admin"), "admin");
+			await user.type(screen.getByPlaceholderText(/•••/), "pass");
+			await user.click(screen.getByRole("button", { name: /authenticate/i }));
+
+			await waitFor(() => {
+				expect(screen.getByText("User fetch failed")).toBeInTheDocument();
+			});
+
+			// Should NOT have navigated because the user fetch failed
+			expect(mocks.navigate).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -1,1 +1,33 @@
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
+
+const createMemoryStorage = (): Storage => {
+	let values = new Map<string, string>();
+	return {
+		get length() {
+			return values.size;
+		},
+		clear: () => {
+			values = new Map();
+		},
+		getItem: (key: string) => values.get(key) ?? null,
+		key: (index: number) => Array.from(values.keys())[index] ?? null,
+		removeItem: (key: string) => {
+			values.delete(key);
+		},
+		setItem: (key: string, value: string) => {
+			values.set(key, String(value));
+		},
+	};
+};
+
+const localStorageCandidate = globalThis.localStorage as Storage | undefined;
+if (
+	!localStorageCandidate ||
+	typeof localStorageCandidate.clear !== "function" ||
+	typeof localStorageCandidate.removeItem !== "function"
+) {
+	Object.defineProperty(globalThis, "localStorage", {
+		value: createMemoryStorage(),
+		configurable: true,
+	});
+}


### PR DESCRIPTION
Refs #216

## Descripción del Cambio
Slice 1/4 for the GraphCMDB parity chain.

Dependency diagram: `main -> 📍 PR1 -> PR2 -> PR3 -> PR4`

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)
- [x] Chore (Mantenimiento/tooling)

## Summary
- Adds a robust in-memory `localStorage` fallback for Vitest/jsdom.
- Updates LoginPage tests to match current cookie-auth behavior instead of localStorage token storage.
- Prepares the test suite for the GraphCMDB parity graph changes.

## Changes
| File | Change |
|------|--------|
| `frontend/test/setup.ts` | Adds localStorage fallback for environments where jsdom storage is incomplete. |
| `frontend/components/LoginPage.test.tsx` | Aligns auth tests with cookie-auth semantics and resets mocks consistently. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend run test:run -- --reporter=dot`
- [x] `pnpm --dir frontend run build`
- [x] `git diff --check`

## Chain Context
- Previous: none.
- Next: PR2 adds the editor graph layout helpers used by the GraphCMDB parity renderer.
- Out of scope: D3 renderer changes and hover/link parity.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*

