### PR TITLE
feat(cmdb): add visual editor force graph helpers

### DIFF
--- a/frontend/components/visualRelationshipLayout.test.ts
+++ b/frontend/components/visualRelationshipLayout.test.ts
@@ -1,72 +1,199 @@
-import { describe, expect, it } from 'vitest';
-import type { GraphNode } from '../types';
-import { buildAnchoredVisualLayout, buildVisualRelationshipLayout, clusterIdForNode } from './visualRelationshipLayout';
+import { describe, expect, it } from "vitest";
+import type { GraphNode } from "../types";
+import {
+	buildEditorForceGraphLayout,
+	buildEditorGraphDatum,
+	getEditorStatusVisual,
+	truncateGraphLabel,
+} from "./visualRelationshipLayout";
 
 const baseNode = (id: string, extra: Partial<GraphNode> = {}): GraphNode => ({
-  id,
-  label: id,
-  type: 'INFRASTRUCTURE',
-  status: 'OK',
-  metadata: {},
-  ...extra,
+	id,
+	label: id,
+	type: "INFRASTRUCTURE",
+	status: "OK",
+	metadata: {},
+	...extra,
 });
 
-describe('visual relationship layout', () => {
-  it('uses location_name as the primary cluster id', () => {
-    expect(clusterIdForNode(baseNode('ci-a', { location_name: 'SITE-01', category: 'Network' }))).toBe('SITE-01');
-    expect(clusterIdForNode(baseNode('ci-b', { category: 'Network' }))).toBe('Network');
-  });
+describe("visual relationship layout", () => {
+	it("keeps editor graph datum fallback positions stable across input order changes", () => {
+		const nodes = [baseNode("b"), baseNode("a"), baseNode("c")];
+		const first = buildEditorGraphDatum(nodes).nodes;
+		const second = buildEditorGraphDatum([...nodes].reverse()).nodes;
 
-  it('creates one cluster per location and assigns nodes to cluster anchors', () => {
-    const layout = buildVisualRelationshipLayout([
-      baseNode('a-1', { location_name: 'A', x: 0, y: 0 }),
-      baseNode('a-2', { location_name: 'A', x: 0, y: 0 }),
-      baseNode('b-1', { location_name: 'B', x: 100, y: 100 }),
-    ]);
+		expect(
+			new Map(first.map((node) => [node.id, [node.anchorX, node.anchorY]])),
+		).toEqual(
+			new Map(second.map((node) => [node.id, [node.anchorX, node.anchorY]])),
+		);
+	});
 
-    expect(layout.clusters.map((cluster) => cluster.id)).toEqual(['A', 'B']);
-    expect(layout.clusters.find((cluster) => cluster.id === 'A')?.count).toBe(2);
-    expect(layout.nodes.filter((node) => node.clusterId === 'A')).toHaveLength(2);
-  });
+	it("uses explicit CI coordinates as editor force graph anchors", () => {
+		const [node] = buildEditorForceGraphLayout(
+			[
+				baseNode("router", {
+					x: 12,
+					y: 34,
+					location: { lat: 32.5, long: -117 },
+				}),
+			],
+			[],
+			{ ticks: 0 },
+		).nodes;
 
-  it('prefers explicit x/y coordinates over location coordinates', () => {
-    const [left, right] = buildAnchoredVisualLayout([
-      baseNode('left', { x: 0, y: 0, location: { lat: 1, long: 1 } }),
-      baseNode('right', { x: 10, y: 10, location: { lat: 1, long: 1 } }),
-    ]);
+		expect(node.anchorX).toBe(12);
+		expect(node.anchorY).toBe(34);
+		expect(node.x).toBe(12);
+		expect(node.y).toBe(34);
+	});
 
-    expect(left.anchorX).toBeLessThan(right.anchorX);
-  });
+	it("uses CMDB location coordinates as editor force graph fallback", () => {
+		const graph = buildEditorForceGraphLayout(
+			[
+				baseNode("origin", { location: { lat: 32.5, long: -117 } }),
+				baseNode("east", { location: { lat: 32.5, long: -116.9 } }),
+			],
+			[],
+			{ ticks: 0 },
+		).nodes;
+		const origin = graph.find((node) => node.id === "origin")!;
+		const east = graph.find((node) => node.id === "east")!;
 
-  it('uses CMDB location projection when explicit coordinates are missing', () => {
-    const [east, origin] = buildAnchoredVisualLayout([
-      baseNode('origin', { location: { lat: 32.5, long: -117 } }),
-      baseNode('east', { location: { lat: 32.5, long: -116.9 } }),
-    ]);
+		expect(east.anchorX).toBeGreaterThan(origin.anchorX);
+		expect(east.anchorY).toBe(origin.anchorY);
+	});
 
-    expect(origin.anchorX).toBeGreaterThan(east.anchorX);
-    expect(origin.anchorY).toBe(east.anchorY);
-  });
+	it("keeps editor force graph fallback positions stable across input order changes", () => {
+		const nodes = [baseNode("b"), baseNode("a"), baseNode("c")];
+		const first = buildEditorForceGraphLayout(nodes, [], { ticks: 0 }).nodes;
+		const second = buildEditorForceGraphLayout([...nodes].reverse(), [], {
+			ticks: 0,
+		}).nodes;
 
-  it('separates colocated nodes with deterministic collision forces', () => {
-    const colocated = Array.from({ length: 6 }, (_, index) =>
-      baseNode(`ci-${index}`, { location_name: 'SITE-A', x: 10, y: 10 }),
-    );
+		expect(
+			new Map(first.map((node) => [node.id, [node.anchorX, node.anchorY]])),
+		).toEqual(
+			new Map(second.map((node) => [node.id, [node.anchorX, node.anchorY]])),
+		);
+	});
 
-    const layout = buildAnchoredVisualLayout(colocated);
-    const roundedPositions = new Set(layout.map((node) => `${Math.round(node.mapX)}:${Math.round(node.mapY)}`));
+	it("separates overlapping editor force graph nodes without mutating inputs", () => {
+		const colocated = Array.from({ length: 5 }, (_, index) =>
+			baseNode(`force-${index}`, { x: 100, y: 100 }),
+		);
+		const originalSnapshot = structuredClone(colocated);
 
-    expect(roundedPositions.size).toBe(colocated.length);
-  });
+		const graph = buildEditorForceGraphLayout(colocated, [], {
+			ticks: 80,
+		}).nodes;
+		const roundedPositions = new Set(
+			graph.map((node) => `${Math.round(node.x)}:${Math.round(node.y)}`),
+		);
 
-  it('keeps fallback placement stable across input order changes', () => {
-    const nodes = [baseNode('b'), baseNode('a'), baseNode('c')];
-    const first = buildAnchoredVisualLayout(nodes);
-    const second = buildAnchoredVisualLayout([...nodes].reverse());
+		expect(roundedPositions.size).toBe(colocated.length);
+		expect(colocated).toEqual(originalSnapshot);
+	});
 
-    expect(first.map((node) => node.id)).toEqual(second.map((node) => node.id));
-    expect(first.map((node) => [node.anchorX, node.anchorY])).toEqual(
-      second.map((node) => [node.anchorX, node.anchorY]),
-    );
-  });
+	it("reuses cached editor force graph positions for repeated CI identities", () => {
+		const cache = new Map([["ci-a", { x: 321, y: 654 }]]);
+		const [node] = buildEditorForceGraphLayout(
+			[baseNode("ci-a", { x: 10, y: 20 })],
+			[],
+			{ nodePositionCache: cache, ticks: 0 },
+		).nodes;
+
+		expect(node.x).toBe(321);
+		expect(node.y).toBe(654);
+		expect(node.anchorX).toBe(10);
+		expect(node.anchorY).toBe(20);
+	});
+
+	it("builds copied editor graph datum without mutating source nodes or links", () => {
+		const sourceNode = baseNode("a", {
+			label: "Router A",
+			category: "Network",
+			x: 42,
+			y: 84,
+		});
+		const targetNode = baseNode("b", { label: "Switch B", x: 100, y: 120 });
+		const link = {
+			source: "a",
+			target: "b",
+			source_label: "Router A",
+			target_label: "Switch B",
+			relationship: "CONNECTS_TO",
+		};
+		const originalNodeSnapshot = structuredClone([sourceNode, targetNode]);
+		const originalLinkSnapshot = structuredClone([link]);
+
+		const graph = buildEditorGraphDatum([sourceNode, targetNode], [link]);
+		graph.nodes[0].x = 999;
+		graph.nodes[0].sourceNode.label = "changed reference label";
+		graph.links[0].source = graph.nodes[1];
+		graph.links[0].sourceLink.relationship = "DEPENDS_ON";
+
+		expect([sourceNode, targetNode]).toEqual(originalNodeSnapshot);
+		expect([link]).toEqual(originalLinkSnapshot);
+		expect(graph.nodes[0]).toMatchObject({
+			id: "a",
+			label: "Router A",
+			layer: "Network",
+			type: "INFRASTRUCTURE",
+			x: 999,
+		});
+		expect(graph.links[0].id).toBe("a->b:CONNECTS_TO:0");
+	});
+
+	it("truncates labels for dense graph views while preserving the full label", () => {
+		expect(truncateGraphLabel("Router A")).toEqual({
+			displayLabel: "Router A",
+			fullLabel: "Router A",
+			truncated: false,
+		});
+		expect(truncateGraphLabel("Very Long Router Label")).toEqual({
+			displayLabel: "Very Long Ro...",
+			fullLabel: "Very Long Router Label",
+			truncated: true,
+		});
+		expect(truncateGraphLabel("")).toEqual({
+			displayLabel: "Unknown CI",
+			fullLabel: "Unknown CI",
+			truncated: false,
+		});
+	});
+
+	it("normalizes GraphCMDB and editor statuses to safe visual tokens", () => {
+		expect(getEditorStatusVisual("ACTIVE")).toMatchObject({
+			status: "OK",
+			color: "#10b981",
+			radius: 24,
+		});
+		expect(getEditorStatusVisual("OK").color).toBe("#10b981");
+		expect(getEditorStatusVisual("WARNING")).toMatchObject({
+			status: "WARNING",
+			color: "#f59e0b",
+			radius: 28,
+		});
+		expect(getEditorStatusVisual("CRITICAL")).toMatchObject({
+			status: "CRITICAL",
+			color: "#ef4444",
+			radius: 32,
+		});
+		expect(getEditorStatusVisual("EXCEPTION")).toMatchObject({
+			status: "EXCEPTION",
+			color: "#ef4444",
+			radius: 32,
+		});
+		expect(getEditorStatusVisual("MAINTENANCE")).toMatchObject({
+			status: "MAINTENANCE",
+			color: "#f59e0b",
+			radius: 28,
+		});
+		expect(getEditorStatusVisual("NOT_A_STATUS")).toMatchObject({
+			status: "UNKNOWN",
+			color: "#4b5563",
+			radius: 24,
+		});
+	});
 });

--- a/frontend/components/visualRelationshipLayout.ts
+++ b/frontend/components/visualRelationshipLayout.ts
@@ -1,180 +1,283 @@
-import * as d3 from 'd3';
-import type { GraphNode } from '../types';
-import type { LinkData } from './RelationshipManager';
+import * as d3 from "d3";
+import type { GraphNode } from "../types";
+import { STATUS_COLORS } from "../utils/status";
+import type { LinkData } from "./RelationshipManager";
 
 export const VISUAL_EDITOR_VIEWBOX_WIDTH = 2200;
 export const VISUAL_EDITOR_VIEWBOX_HEIGHT = 1400;
-const COORDINATE_PADDING = 180;
-const LOCAL_NODE_SPACING = 86;
 
-type AnchorNode = GraphNode & {
-  anchorX: number;
-  anchorY: number;
-  mapX: number;
-  mapY: number;
-  layer: string;
-  clusterId: string;
-  clusterLabel: string;
-  clusterX: number;
-  clusterY: number;
-  clusterCount: number;
-};
-
-export type PositionedVisualNode = AnchorNode;
-
-export interface VisualRelationshipCluster {
-  id: string;
-  label: string;
-  x: number;
-  y: number;
-  count: number;
+export interface TruncatedGraphLabel {
+	displayLabel: string;
+	fullLabel: string;
+	truncated: boolean;
 }
 
-export interface VisualRelationshipLayout {
-  nodes: PositionedVisualNode[];
-  clusters: VisualRelationshipCluster[];
+export interface EditorStatusVisual {
+	status:
+		| "OK"
+		| "WARNING"
+		| "CRITICAL"
+		| "EXCEPTION"
+		| "MAINTENANCE"
+		| "UNKNOWN";
+	color: string;
+	radius: number;
+	strokeWidth: number;
+}
+
+export type EditorGraphNodeDatum = {
+	id: string;
+	label: string;
+	type: GraphNode["type"];
+	status?: string;
+	layer: string;
+	sourceNode: GraphNode;
+	anchorX: number;
+	anchorY: number;
+	x: number;
+	y: number;
+	vx?: number;
+	vy?: number;
+};
+
+export type EditorGraphLinkDatum = {
+	id: string;
+	source: string | EditorGraphNodeDatum;
+	target: string | EditorGraphNodeDatum;
+	type: string;
+	sourceLink: LinkData;
+};
+
+export interface EditorGraphDatum {
+	nodes: EditorGraphNodeDatum[];
+	links: EditorGraphLinkDatum[];
+}
+
+export type EditorNodePosition = {
+	x: number;
+	y: number;
+	vx?: number;
+	vy?: number;
+};
+
+export type EditorNodePositionCache = Map<string, EditorNodePosition>;
+
+export interface EditorForceGraphLayoutOptions {
+	nodePositionCache?: EditorNodePositionCache;
+	ticks?: number;
 }
 
 const nodeLabel = (node: GraphNode) => node.label || node.id;
 const nodeLayer = (node: GraphNode) => node.category ?? node.type;
-const hasNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
+const hasNumber = (value: unknown): value is number =>
+	typeof value === "number" && Number.isFinite(value);
 
-export const clusterIdForNode = (node: GraphNode) =>
-  node.location_name?.trim() || node.category?.trim() || node.type || 'Unassigned';
+const cloneGraphNode = (node: GraphNode): GraphNode => ({
+	...node,
+	metadata: { ...(node.metadata ?? {}) },
+	location: node.location ? { ...node.location } : undefined,
+});
+
+const cloneLink = (link: LinkData): LinkData => ({ ...link });
+
+export const truncateGraphLabel = (
+	label: string | null | undefined,
+	maxLength = 15,
+): TruncatedGraphLabel => {
+	const fullLabel = label?.trim() || "Unknown CI";
+	if (fullLabel.length <= maxLength) {
+		return { displayLabel: fullLabel, fullLabel, truncated: false };
+	}
+	return {
+		displayLabel: `${fullLabel.slice(0, Math.max(0, maxLength - 3))}...`,
+		fullLabel,
+		truncated: true,
+	};
+};
+
+export const getEditorStatusVisual = (
+	status?: string | null,
+): EditorStatusVisual => {
+	switch (status?.toUpperCase()) {
+		case "ACTIVE":
+		case "OK":
+			return {
+				status: "OK",
+				color: STATUS_COLORS.OK,
+				radius: 24,
+				strokeWidth: 2,
+			};
+		case "WARNING":
+			return {
+				status: "WARNING",
+				color: STATUS_COLORS.WARNING,
+				radius: 28,
+				strokeWidth: 3,
+			};
+		case "CRITICAL":
+			return {
+				status: "CRITICAL",
+				color: STATUS_COLORS.CRITICAL,
+				radius: 32,
+				strokeWidth: 4,
+			};
+		case "EXCEPTION":
+			return {
+				status: "EXCEPTION",
+				color: STATUS_COLORS.CRITICAL,
+				radius: 32,
+				strokeWidth: 4,
+			};
+		case "MAINTENANCE":
+			return {
+				status: "MAINTENANCE",
+				color: STATUS_COLORS.WARNING,
+				radius: 28,
+				strokeWidth: 3,
+			};
+		default:
+			return {
+				status: "UNKNOWN",
+				color: STATUS_COLORS.UNKNOWN,
+				radius: 24,
+				strokeWidth: 2,
+			};
+	}
+};
+
+export const buildEditorGraphDatum = (
+	visibleNodes: GraphNode[],
+	visibleLinks: LinkData[] = [],
+): EditorGraphDatum => {
+	const sortedFallbackIndexes = new Map(
+		[...visibleNodes]
+			.sort((a, b) => a.id.localeCompare(b.id))
+			.map((node, index) => [node.id, index]),
+	);
+	const nodeIds = new Set(visibleNodes.map((node) => node.id));
+	const nodes = visibleNodes.map((node) => {
+		const sourceNode = cloneGraphNode(node);
+		const positioned = node as GraphNode & {
+			anchorX?: number;
+			anchorY?: number;
+			mapX?: number;
+			mapY?: number;
+			layer?: string;
+		};
+		const fallback = rawCoordinateForNode(
+			node,
+			sortedFallbackIndexes.get(node.id) ?? 0,
+		);
+		const anchorX = hasNumber(positioned.anchorX)
+			? positioned.anchorX
+			: fallback.x;
+		const anchorY = hasNumber(positioned.anchorY)
+			? positioned.anchorY
+			: fallback.y;
+		return {
+			id: node.id,
+			label: nodeLabel(node),
+			type: node.type,
+			status: node.status,
+			layer: positioned.layer ?? nodeLayer(node),
+			sourceNode,
+			anchorX,
+			anchorY,
+			x: hasNumber(positioned.mapX) ? positioned.mapX : anchorX,
+			y: hasNumber(positioned.mapY) ? positioned.mapY : anchorY,
+		};
+	});
+	const links = visibleLinks
+		.filter((link) => nodeIds.has(link.source) && nodeIds.has(link.target))
+		.map((link, index) => ({
+			id: `${link.source}->${link.target}:${link.relationship}:${index}`,
+			source: link.source,
+			target: link.target,
+			type: link.relationship,
+			sourceLink: cloneLink(link),
+		}));
+
+	return { nodes, links };
+};
+
+export const buildEditorForceGraphLayout = (
+	visibleNodes: GraphNode[],
+	visibleLinks: LinkData[] = [],
+	options: EditorForceGraphLayoutOptions = {},
+): EditorGraphDatum => {
+	const graph = buildEditorGraphDatum(visibleNodes, visibleLinks);
+	const cache = options.nodePositionCache;
+
+	const simulationNodes = graph.nodes.map((node) => {
+		const cached = cache?.get(node.id);
+		return {
+			...node,
+			x: cached?.x ?? node.x,
+			y: cached?.y ?? node.y,
+			vx: cached?.vx ?? node.vx,
+			vy: cached?.vy ?? node.vy,
+		};
+	});
+	const simulationLinks = graph.links.map((link) => ({ ...link }));
+	const hasCachedNodes = simulationNodes.some((node) => cache?.has(node.id));
+	const ticks = options.ticks ?? (hasCachedNodes ? 40 : 120);
+
+	const simulation = d3
+		.forceSimulation<EditorGraphNodeDatum>(simulationNodes)
+		.force("charge", d3.forceManyBody<EditorGraphNodeDatum>().strength(-260))
+		.force(
+			"collision",
+			d3
+				.forceCollide<EditorGraphNodeDatum>()
+				.radius((node) => getEditorStatusVisual(node.status).radius + 34),
+		)
+		.force(
+			"link",
+			d3
+				.forceLink<EditorGraphNodeDatum, EditorGraphLinkDatum>(simulationLinks)
+				.id((node) => node.id)
+				.distance(180)
+				.strength(0.08),
+		)
+		.force(
+			"x",
+			d3.forceX<EditorGraphNodeDatum>((node) => node.anchorX).strength(0.12),
+		)
+		.force(
+			"y",
+			d3.forceY<EditorGraphNodeDatum>((node) => node.anchorY).strength(0.12),
+		)
+		.stop();
+
+	if (ticks > 0) simulation.tick(ticks);
+	simulation.stop();
+
+	const nodes = simulationNodes.map((node) => ({ ...node }));
+	for (const node of nodes) {
+		cache?.set(node.id, {
+			x: node.x,
+			y: node.y,
+			vx: node.vx,
+			vy: node.vy,
+		});
+	}
+
+	return { nodes, links: simulationLinks };
+};
 
 const rawCoordinateForNode = (node: GraphNode, fallbackIndex: number) => {
-  if (hasNumber(node.x) && hasNumber(node.y)) return { x: node.x, y: node.y };
-  if (hasNumber(node.location?.long) && hasNumber(node.location?.lat)) {
-    return {
-      x: VISUAL_EDITOR_VIEWBOX_WIDTH / 2 + (node.location.long + 117) * 3000,
-      y: VISUAL_EDITOR_VIEWBOX_HEIGHT / 2 - (node.location.lat - 32.5) * 3000,
-    };
-  }
+	if (hasNumber(node.x) && hasNumber(node.y)) return { x: node.x, y: node.y };
+	if (hasNumber(node.location?.long) && hasNumber(node.location?.lat)) {
+		return {
+			x: VISUAL_EDITOR_VIEWBOX_WIDTH / 2 + (node.location.long + 117) * 3000,
+			y: VISUAL_EDITOR_VIEWBOX_HEIGHT / 2 - (node.location.lat - 32.5) * 3000,
+		};
+	}
 
-  const angle = (fallbackIndex / Math.max(1, 12)) * Math.PI * 2 - Math.PI / 2;
-  const radius = 260 + Math.floor(fallbackIndex / 12) * 120;
-  return {
-    x: VISUAL_EDITOR_VIEWBOX_WIDTH / 2 + Math.cos(angle) * radius,
-    y: VISUAL_EDITOR_VIEWBOX_HEIGHT / 2 + Math.sin(angle) * radius,
-  };
+	const angle = (fallbackIndex / Math.max(1, 12)) * Math.PI * 2 - Math.PI / 2;
+	const radius = 260 + Math.floor(fallbackIndex / 12) * 120;
+	return {
+		x: VISUAL_EDITOR_VIEWBOX_WIDTH / 2 + Math.cos(angle) * radius,
+		y: VISUAL_EDITOR_VIEWBOX_HEIGHT / 2 + Math.sin(angle) * radius,
+	};
 };
-
-const localOffset = (index: number) => {
-  if (index === 0) return { x: 0, y: 0 };
-  const ring = Math.ceil(index / 8);
-  const slot = (index - 1) % 8;
-  const angle = slot * (Math.PI / 4);
-  const radius = ring * LOCAL_NODE_SPACING;
-  return { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
-};
-
-export const buildVisualRelationshipLayout = (visibleNodes: GraphNode[], visibleLinks: LinkData[] = []): VisualRelationshipLayout => {
-  const orderedNodes = [...visibleNodes].sort((a, b) => a.id.localeCompare(b.id));
-  if (orderedNodes.length === 0) return { nodes: [], clusters: [] };
-
-  const rawNodes = orderedNodes.map((node, index) => ({
-    node,
-    layer: nodeLayer(node),
-    clusterId: clusterIdForNode(node),
-    ...rawCoordinateForNode(node, index),
-  }));
-
-  const clusterBuckets = new Map<string, typeof rawNodes>();
-  for (const rawNode of rawNodes) {
-    clusterBuckets.set(rawNode.clusterId, [...(clusterBuckets.get(rawNode.clusterId) ?? []), rawNode]);
-  }
-
-  const rawClusters = Array.from(clusterBuckets.entries())
-    .map(([id, bucket], index) => {
-      const xMean = d3.mean(bucket, (item) => item.x);
-      const yMean = d3.mean(bucket, (item) => item.y);
-      const fallback = rawCoordinateForNode(bucket[0].node, index);
-      return {
-        id,
-        label: id,
-        count: bucket.length,
-        rawX: xMean ?? fallback.x,
-        rawY: yMean ?? fallback.y,
-      };
-    })
-    .sort((a, b) => a.id.localeCompare(b.id));
-
-  const xExtent = d3.extent(rawClusters, (cluster) => cluster.rawX);
-  const yExtent = d3.extent(rawClusters, (cluster) => cluster.rawY);
-  const xScale = d3
-    .scaleLinear()
-    .domain(xExtent[0] === xExtent[1] ? [xExtent[0] ?? 0, (xExtent[0] ?? 0) + 1] : [xExtent[0] ?? 0, xExtent[1] ?? 1])
-    .range([COORDINATE_PADDING, VISUAL_EDITOR_VIEWBOX_WIDTH - COORDINATE_PADDING]);
-  const yScale = d3
-    .scaleLinear()
-    .domain(yExtent[0] === yExtent[1] ? [yExtent[0] ?? 0, (yExtent[0] ?? 0) + 1] : [yExtent[0] ?? 0, yExtent[1] ?? 1])
-    .range([COORDINATE_PADDING, VISUAL_EDITOR_VIEWBOX_HEIGHT - COORDINATE_PADDING]);
-
-  const clusters = rawClusters.map((cluster) => ({
-    id: cluster.id,
-    label: cluster.label,
-    count: cluster.count,
-    x: xScale(cluster.rawX),
-    y: yScale(cluster.rawY),
-  }));
-  const clusterMap = new Map(clusters.map((cluster) => [cluster.id, cluster]));
-  const clusterNodeIndex = new Map<string, number>();
-
-  const layoutNodes: PositionedVisualNode[] = rawNodes.map(({ node, layer, clusterId }) => {
-    const cluster = clusterMap.get(clusterId)!;
-    const indexInCluster = clusterNodeIndex.get(clusterId) ?? 0;
-    clusterNodeIndex.set(clusterId, indexInCluster + 1);
-    const offset = localOffset(indexInCluster);
-    const anchorX = cluster.x + offset.x;
-    const anchorY = cluster.y + offset.y;
-
-    return {
-      ...node,
-      layer,
-      clusterId,
-      clusterLabel: cluster.label,
-      clusterX: cluster.x,
-      clusterY: cluster.y,
-      clusterCount: cluster.count,
-      anchorX,
-      anchorY,
-      mapX: anchorX,
-      mapY: anchorY,
-    };
-  });
-
-  const simulationNodes = layoutNodes.map((node) => ({ ...node, x: node.anchorX, y: node.anchorY }));
-  const simulationNodeIds = new Set(simulationNodes.map((node) => node.id));
-  const simulationLinks = visibleLinks
-    .filter((link) => simulationNodeIds.has(link.source) && simulationNodeIds.has(link.target))
-    .map((link) => ({ source: link.source, target: link.target }));
-
-  const simulation = d3
-    .forceSimulation(simulationNodes)
-    .force('charge', d3.forceManyBody<PositionedVisualNode & { x: number; y: number }>().strength(-320))
-    .force('collision', d3.forceCollide<PositionedVisualNode & { x: number; y: number }>().radius(62))
-    .force('link', d3.forceLink<PositionedVisualNode & { x: number; y: number }, { source: string; target: string }>(simulationLinks).id((node) => node.id).distance(190).strength(0.08))
-    .force('x', d3.forceX<PositionedVisualNode & { x: number; y: number }>((node) => node.anchorX).strength(0.1))
-    .force('y', d3.forceY<PositionedVisualNode & { x: number; y: number }>((node) => node.anchorY).strength(0.1))
-    .stop();
-
-  simulation.tick(120);
-  simulation.stop();
-
-  const simulatedById = new Map(simulationNodes.map((node) => [node.id, node]));
-  return {
-    clusters,
-    nodes: layoutNodes.map((node) => {
-      const simulated = simulatedById.get(node.id);
-      return {
-        ...node,
-        mapX: simulated?.x ?? node.mapX,
-        mapY: simulated?.y ?? node.mapY,
-        label: nodeLabel(node),
-      };
-    }),
-  };
-};
-
-export const buildAnchoredVisualLayout = (visibleNodes: GraphNode[], visibleLinks: LinkData[] = []) =>
-  buildVisualRelationshipLayout(visibleNodes, visibleLinks).nodes;


### PR DESCRIPTION
Refs #216

## Descripción del Cambio
Slice 2/4 for the GraphCMDB parity chain.

Dependency diagram: `main -> PR1 -> 📍 PR2 -> PR3 -> PR4`

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Adds copied editor graph datum helpers so D3 simulation cannot mutate source CI/link props.
- Adds deterministic force graph layout helpers with cached node positions.
- Removes dead location-cluster layout code from the visual relationship layout module.

## Changes
| File | Change |
|------|--------|
| `frontend/components/visualRelationshipLayout.ts` | Adds GraphCMDB-style force graph layout helpers and removes old cluster-only helper path. |
| `frontend/components/visualRelationshipLayout.test.ts` | Covers copied data, coordinate fallback, cache reuse, status visuals, and label truncation. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/visualRelationshipLayout.test.ts components/VisualRelationshipEditor.test.tsx --reporter=dot`
- [x] `pnpm --dir frontend run test:run -- --reporter=dot`
- [x] `pnpm --dir frontend run build`
- [x] `git diff --check`

## Chain Context
- Previous: PR1 stabilizes test infra/auth tests.
- Next: PR3 wires these helpers into the visual editor renderer.
- Out of scope: UI renderer swap and hover/link parity.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*

