### PR TITLE
feat(cmdb): add visual editor hover parity

### DIFF
--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -389,6 +389,113 @@ describe("VisualRelationshipEditor", () => {
 		expect(appNodeButton).not.toHaveClass("w-36", "rounded-2xl");
 	});
 
+	it("fades unrelated nodes and links while keeping related graph items prominent on hover", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={layeredNodes}
+				links={layeredLinks}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		const svg = screen.getByLabelText("Visual CI relationship map");
+		const appGroup = screen.getByRole("button", { name: "CI node App" });
+		const dbGroup = screen.getByRole("button", { name: "CI node DB" });
+		const infraGroup = screen.getByRole("button", { name: "CI node Infra" });
+		const relatedLink = svg.querySelector(
+			'[data-link-source="app-1"][data-link-target="db-1"] line',
+		);
+		const unrelatedLink = svg.querySelector(
+			'[data-link-source="app-1"][data-link-target="infra-1"] line',
+		);
+
+		expect(relatedLink).toHaveAttribute("stroke-opacity", "0.55");
+		expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.55");
+
+		fireEvent.mouseOver(dbGroup);
+
+		expect(dbGroup).toHaveAttribute("opacity", "1");
+		expect(appGroup).toHaveAttribute("opacity", "0.9");
+		expect(infraGroup).toHaveAttribute("opacity", "0.18");
+		expect(relatedLink).toHaveAttribute("stroke-opacity", "0.72");
+		expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.12");
+
+		fireEvent.mouseOut(dbGroup);
+
+		expect(appGroup).toHaveAttribute("opacity", "1");
+		expect(infraGroup).toHaveAttribute("opacity", "1");
+		expect(relatedLink).toHaveAttribute("stroke-opacity", "0.55");
+		expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.55");
+	});
+
+	it("expands truncated labels on hover and focus, then restores compact labels", () => {
+		const longLabelNode = {
+			...nodes[0],
+			label: "Very Long Router Label",
+		};
+		render(
+			<VisualRelationshipEditor
+				nodes={[longLabelNode, nodes[1]]}
+				links={[
+					{
+						...links[0],
+						source_label: longLabelNode.label,
+					},
+				]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		const longNode = screen.getByRole("button", {
+			name: "CI node Very Long Router Label",
+		});
+		expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
+
+		fireEvent.mouseOver(longNode);
+		expect(screen.getByText("Very Long Router Label")).toBeInTheDocument();
+
+		fireEvent.mouseOut(longNode);
+		expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
+
+		fireEvent.focus(longNode);
+		expect(screen.getByText("Very Long Router Label")).toBeInTheDocument();
+
+		fireEvent.blur(longNode);
+		expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
+	});
+
+	it("keeps selected source and target styling distinguishable during hover focus", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+		fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+
+		const routerNode = screen.getByRole("button", { name: "CI node Router A" });
+		const switchNode = screen.getByRole("button", { name: "CI node Switch B" });
+		const routerCircle = routerNode.querySelector("circle.node-circle");
+		const switchCircle = switchNode.querySelector("circle.node-circle");
+		expect(routerCircle).toHaveAttribute("fill", "#345bf2");
+		expect(switchCircle).toHaveAttribute("fill", "#06b6d4");
+
+		fireEvent.mouseOver(switchNode);
+
+		expect(routerCircle).toHaveAttribute("fill", "#345bf2");
+		expect(switchCircle).toHaveAttribute("fill", "#06b6d4");
+		expect(switchCircle).toHaveAttribute("stroke-width", "7");
+
+		fireEvent.mouseOut(switchNode);
+		expect(switchCircle).toHaveAttribute("stroke-width", "5");
+	});
+
 	it("positions D3 nodes from CI coordinates", () => {
 		render(
 			<VisualRelationshipEditor
@@ -652,6 +759,29 @@ describe("VisualRelationshipEditor", () => {
 			});
 		});
 		expect(onMutated).toHaveBeenCalledTimes(1);
+	});
+
+	it("excludes HAS_METRIC relationships from visual editing", () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={nodes}
+				links={[
+					...links,
+					{
+						source: "ci-a",
+						source_label: "Router A",
+						target: "ci-b",
+						target_label: "Switch B",
+						relationship: "HAS_METRIC",
+					},
+				]}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		expect(screen.queryByText("HAS_METRIC")).not.toBeInTheDocument();
+		expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
 	});
 
 	it("keeps RUNS_ON visible and labeled read-only", () => {

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -326,17 +326,21 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 		svg.call(zoom);
 		svg.call(zoom.transform, zoomTransformRef.current);
 
-		container
+		const linkEndpointIds = (link: (typeof graphLinks)[number]) => ({
+			sourceId: typeof link.source === "string" ? link.source : link.source.id,
+			targetId: typeof link.target === "string" ? link.target : link.target.id,
+		});
+
+		const linkSelection = container
 			.append("g")
 			.attr("class", "relationship-links")
 			.selectAll<SVGGElement, (typeof graphLinks)[number]>("g")
 			.data(graphLinks)
 			.join("g")
+			.attr("data-link-source", (link) => linkEndpointIds(link).sourceId)
+			.attr("data-link-target", (link) => linkEndpointIds(link).targetId)
 			.each(function (link) {
-				const sourceId =
-					typeof link.source === "string" ? link.source : link.source.id;
-				const targetId =
-					typeof link.target === "string" ? link.target : link.target.id;
+				const { sourceId, targetId } = linkEndpointIds(link);
 				const source = positionMap.get(sourceId);
 				const target = positionMap.get(targetId);
 				if (!source || !target) return;
@@ -382,6 +386,7 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 			.attr("tabindex", 0)
 			.attr("aria-label", (node) => `CI node ${node.label}`)
 			.attr("title", (node) => `${node.label} · ${node.layer}`)
+			.attr("data-node-id", (node) => node.id)
 			.attr("transform", (node) => `translate(${node.x},${node.y})`)
 			.attr("class", "cursor-pointer")
 			.on("click", (_event, node) => selectNode(node.id))
@@ -433,6 +438,80 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 			.attr("class", "node-label pointer-events-none")
 			.text((node) => truncateGraphLabel(node.label).displayLabel);
 
+		const selectedStrokeWidth = (node: EditorGraphNodeDatum) =>
+			node.id === sourceId || node.id === targetId
+				? 5
+				: (statusVisualMap.get(node.id)?.strokeWidth ?? 2);
+		const resetGraphFocus = () => {
+			nodeSelection.attr("opacity", 1);
+			nodeSelection
+				.select<SVGCircleElement>("circle.node-circle")
+				.attr("stroke-width", selectedStrokeWidth)
+				.attr("filter", null);
+			nodeSelection
+				.select<SVGTextElement>("text.node-label")
+				.attr("fill", "#a3a3a3")
+				.attr("font-weight", 700)
+				.text((node) => truncateGraphLabel(node.label).displayLabel);
+			linkSelection
+				.select<SVGLineElement>("line")
+				.attr("stroke-opacity", 0.55)
+				.attr("stroke-width", 2);
+			linkSelection.select<SVGTextElement>("text").attr("opacity", 1);
+		};
+		const applyGraphFocus = (activeNodeId: string) => {
+			const relatedNodeIds = new Set([activeNodeId]);
+			const relatedLinkIds = new Set<string>();
+			for (const link of graphLinks) {
+				const { sourceId: linkSourceId, targetId: linkTargetId } =
+					linkEndpointIds(link);
+				if (linkSourceId === activeNodeId || linkTargetId === activeNodeId) {
+					relatedNodeIds.add(linkSourceId);
+					relatedNodeIds.add(linkTargetId);
+					relatedLinkIds.add(link.id);
+				}
+			}
+
+			nodeSelection.attr("opacity", (node) => {
+				if (node.id === activeNodeId) return 1;
+				return relatedNodeIds.has(node.id) ? 0.9 : 0.18;
+			});
+			nodeSelection
+				.select<SVGCircleElement>("circle.node-circle")
+				.attr("stroke-width", (node) =>
+					node.id === activeNodeId ? 7 : selectedStrokeWidth(node),
+				)
+				.attr("filter", (node) =>
+					node.id === activeNodeId ? "drop-shadow(0 0 8px currentColor)" : null,
+				);
+			nodeSelection
+				.select<SVGTextElement>("text.node-label")
+				.attr("fill", (node) =>
+					node.id === activeNodeId ? "#ffffff" : "#a3a3a3",
+				)
+				.attr("font-weight", (node) => (node.id === activeNodeId ? 900 : 700))
+				.text((node) =>
+					node.id === activeNodeId
+						? truncateGraphLabel(node.label).fullLabel
+						: truncateGraphLabel(node.label).displayLabel,
+				);
+			linkSelection
+				.select<SVGLineElement>("line")
+				.attr("stroke-opacity", (link) =>
+					relatedLinkIds.has(link.id) ? 0.72 : 0.12,
+				)
+				.attr("stroke-width", (link) =>
+					relatedLinkIds.has(link.id) ? 3 : 1.5,
+				);
+			linkSelection
+				.select<SVGTextElement>("text")
+				.attr("opacity", (link) => (relatedLinkIds.has(link.id) ? 1 : 0.18));
+		};
+		nodeSelection
+			.on("mouseover", (_event, node) => applyGraphFocus(node.id))
+			.on("mouseout", resetGraphFocus)
+			.on("focus", (_event, node) => applyGraphFocus(node.id))
+			.on("blur", resetGraphFocus);
 
 		return () => {
 			svg.on(".zoom", null);


### PR DESCRIPTION
Closes #216

## Descripción del Cambio
Slice 4/4 for the GraphCMDB parity chain.

Dependency diagram: `main -> PR1 -> PR2 -> PR3 -> 📍 PR4`

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Adds GraphCMDB-style hover/focus behavior: active node emphasis, related node/link prominence, and unrelated fade.
- Expands truncated labels on hover/focus and restores compact labels on blur/mouseout.
- Adds selected source/target styling and `HAS_METRIC` visual-edit exclusion regressions.

## Changes
| File | Change |
|------|--------|
| `frontend/components/VisualRelationshipEditor.tsx` | Adds link endpoint attributes, node focus handlers, related/unrelated fade, and label expansion. |
| `frontend/components/VisualRelationshipEditor.test.tsx` | Adds hover/focus, label expansion, selected styling, and `HAS_METRIC` regression coverage. |

## ¿Cómo se probó?
- [x] `pnpm --dir frontend exec vitest run components/VisualRelationshipEditor.test.tsx components/visualRelationshipLayout.test.ts --reporter=dot`
- [x] `pnpm --dir frontend run test:run -- --reporter=dot`
- [x] `pnpm --dir frontend run build`
- [x] `git diff --check`

## Chain Context
- Previous: PR3 replaces the renderer with force graph/cache/zoom.
- Next: none; this completes issue #216 GraphCMDB parity.
- Out of scope: backend API changes, persisted graph coordinate edits, and 8k-CI virtualization (#214).

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
