### PR TITLE
fix(metrics): provision ICMP sidecars without per-CI ping metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.13] — 2026-05-30
+
+### Fixed
+- **ICMP latency/jitter provisioning** (issue #217):
+  - Stops creating per-CI `PING-*` metric definitions when CIs are created or edited.
+  - Ensures `icmp_latency_ms` and `icmp_jitter_ms` sidecar metrics are linked for CIs with IPs, including existing CIs through the safe rebuild migration step.
+  - Keeps queue and legacy polling able to collect latency/jitter through internal ICMP probes without exposing synthetic availability metrics.
+
 ## [1.12.12] — 2026-05-29
 
 ### Added

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -23,10 +23,12 @@ from repositories.metric_repo import insert_metric_value, bulk_insert_metrics
 from postgres_db import SessionLocal
 from config import get_icmp_settings, get_polling_pipeline_settings
 from polling.icmp_measurements import (
+    ICMP_AVAILABILITY_METRIC_ID,
     ICMP_LATENCY_METRIC_ID,
     build_icmp_sidecar_samples,
     coerce_ping_measurement,
     is_icmp_availability_metric,
+    is_icmp_telemetry_metric,
     PingMeasurement,
     parse_ping_latency_ms,
 )
@@ -409,10 +411,6 @@ def poll_snmp():
                      coalesce(m.polling_interval, 60) as interval,
                      coalesce(r.last_polled, datetime({year:1970})) as last_p
                 WHERE duration.between(last_p, datetime()).seconds >= interval
-                  AND NOT (
-                    toUpper(coalesce(m.protocol, '')) = 'ICMP'
-                    AND (m.id IN ['icmp_latency_ms', 'icmp_jitter_ms'] OR coalesce(m.metric_kind, '') = 'telemetry')
-                  )
                 RETURN n.id as node_id, n.ip as ip, 
                        coalesce(n.snmp_community, 'public') as community,
                        coalesce(n.snmp_port, 161) as port,
@@ -422,8 +420,16 @@ def poll_snmp():
                        interval
             """)
             
+            records = list(result)
+            records.sort(key=lambda record: (
+                1 if normalized_protocol(record["protocol"]) == "ICMP" and is_icmp_telemetry_metric(record["metric_id"], {"metric_kind": record.get("metric_kind")}) else 0,
+                record["node_id"],
+                record["metric_id"],
+            ))
+            polled_icmp_nodes = set()
+
             # Use iterator to process one by one
-            for record in result:
+            for record in records:
                 metrics_count += 1
                 node_id = record["node_id"]
                 mid = record["metric_id"]
@@ -438,7 +444,18 @@ def poll_snmp():
                 sidecar_samples = []
                 metric_metadata = {"metric_kind": record.get("metric_kind")}
                 icmp_settings = get_icmp_settings()
-                if protocol == "ICMP" and not is_icmp_availability_metric(mid, metric_metadata):
+                internal_icmp_poll = False
+                if protocol == "ICMP" and is_icmp_telemetry_metric(mid, metric_metadata):
+                    if node_id in polled_icmp_nodes:
+                        continue
+                    polled_icmp_nodes.add(node_id)
+                    mid = ICMP_AVAILABILITY_METRIC_ID
+                    internal_icmp_poll = True
+                elif protocol == "ICMP" and is_icmp_availability_metric(mid, metric_metadata):
+                    if node_id in polled_icmp_nodes:
+                        continue
+                    polled_icmp_nodes.add(node_id)
+                elif protocol == "ICMP":
                     continue
                 if protocol == "ICMP":
                     measurement = coerce_ping_measurement(fetch_icmp_ping(
@@ -488,34 +505,36 @@ def poll_snmp():
                 
                 if val is not None:
                     primary_time = datetime.utcnow()
-                    metrics_to_save.append({
-                        "node_id": node_id,
-                        "metric_id": mid,
-                        "value": val,
-                        "time": primary_time
-                    })
+                    if not internal_icmp_poll:
+                        metrics_to_save.append({
+                            "node_id": node_id,
+                            "metric_id": mid,
+                            "value": val,
+                            "time": primary_time
+                        })
                     metrics_to_save.extend(sidecar_samples)
 
                     metric_name = record["metric_name"] or mid
                     severity = _base_severity_from_criticality(record["criticality"])
-                    latest_updates.append({
-                        "node_id": node_id,
-                        "metric_id": mid,
-                        "value": val,
-                        "protocol": protocol,
-                        "metric_name": metric_name,
-                        "criticality": record["criticality"],
-                        "status": severity if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else "OK",
-                        "message": (
-                            f"Service/Host Down: {metric_name}"
-                            if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0
-                            else "Latest sample collected by legacy SNMP worker"
-                        ),
-                        "event_type": EVENT_TYPE_AVAILABILITY if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else None,
-                        "source_protocol": SOURCE_PROTOCOL_ICMP if protocol == SOURCE_PROTOCOL_ICMP else protocol,
-                        "severity": severity,
-                        "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP else "telemetry",
-                    })
+                    if not internal_icmp_poll:
+                        latest_updates.append({
+                            "node_id": node_id,
+                            "metric_id": mid,
+                            "value": val,
+                            "protocol": protocol,
+                            "metric_name": metric_name,
+                            "criticality": record["criticality"],
+                            "status": severity if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else "OK",
+                            "message": (
+                                f"Service/Host Down: {metric_name}"
+                                if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0
+                                else "Latest sample collected by legacy SNMP worker"
+                            ),
+                            "event_type": EVENT_TYPE_AVAILABILITY if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else None,
+                            "source_protocol": SOURCE_PROTOCOL_ICMP if protocol == SOURCE_PROTOCOL_ICMP else protocol,
+                            "severity": severity,
+                            "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP else "telemetry",
+                        })
                     for sample in sidecar_samples:
                         latest_updates.append({
                             "node_id": node_id,

--- a/backend/polling/scheduler.py
+++ b/backend/polling/scheduler.py
@@ -10,7 +10,7 @@ from uuid import NAMESPACE_URL, UUID, uuid5
 
 from polling.contracts import PollingPriority, PollingProtocol
 from polling.pg_queue import create_cycle, enqueue_tasks
-from polling.icmp_measurements import is_icmp_telemetry_metric
+from polling.icmp_measurements import ICMP_AVAILABILITY_METRIC_ID, is_icmp_availability_metric, is_icmp_telemetry_metric
 from polling.protocol_contracts import build_protocol_payload
 
 
@@ -64,7 +64,7 @@ def _source(record: Mapping[str, Any], protocol: PollingProtocol) -> str:
     if protocol == PollingProtocol.SNMP:
         return f"{record.get('ip')}:{record.get('port') or record.get('snmp_port') or 161}/{record.get('oid')}"
     if protocol == PollingProtocol.ICMP:
-        return str(record.get("ip") or record.get("source") or "")
+        return str(record.get("ip") or record.get("ip_address") or record.get("source") or "")
     if protocol == PollingProtocol.CLI:
         return f"{record.get('ip')}:{record.get('cli_command')}"
     if protocol == PollingProtocol.REST:
@@ -90,18 +90,23 @@ def _priority(record: Mapping[str, Any], protocol: PollingProtocol) -> PollingPr
 
 
 def build_tasks_from_records(records: Iterable[Mapping[str, Any]], cycle: PollCycle) -> list[dict[str, Any]]:
-    """Expand due metric definition records into durable queue task rows."""
+    """Expand due metric definition records into durable queue task rows.
+
+    ICMP latency/jitter MetricDefs are derived telemetry sidecars. They should
+    not be polled directly, but their presence on a CI means the CI wants ICMP
+    collection. When no explicit ICMP availability metric exists, synthesize one
+    internal availability task so latency/jitter values can still be produced
+    without creating a per-CI PING MetricDef.
+    """
     tasks: list[dict[str, Any]] = []
-    for record in records:
-        protocol = _protocol(record)
-        ci_id = str(record.get("node_id") or record.get("ci_id") or "")
-        metric_id = str(record.get("metric_id") or record.get("id") or "")
-        if not ci_id or not metric_id:
-            raise ValueError("Scheduler records require node_id/ci_id and metric_id/id")
-        if protocol == PollingProtocol.ICMP and is_icmp_telemetry_metric(metric_id, dict(record)):
-            continue
+    sidecar_sources: dict[tuple[str, str], dict[str, Any]] = {}
+    availability_sources: set[tuple[str, str]] = set()
+
+    def add_task(record: Mapping[str, Any], protocol: PollingProtocol, ci_id: str, metric_id: str) -> None:
         source = _source(record, protocol)
         payload = build_protocol_payload({**dict(record), "protocol": protocol.value, "source": source})
+        if record.get("internal"):
+            payload["internal"] = True
         priority = _priority(record, protocol)
         tasks.append({
             "task_id": _task_id(cycle, ci_id, metric_id, protocol, source),
@@ -122,7 +127,40 @@ def build_tasks_from_records(records: Iterable[Mapping[str, Any]], cycle: PollCy
             "payload": payload,
             "metadata_version": record.get("metadata_version") or cycle.config_version,
             "metric_kind": record.get("metric_kind"),
+            "internal": bool(record.get("internal")),
         })
+
+    for record in records:
+        protocol = _protocol(record)
+        ci_id = str(record.get("node_id") or record.get("ci_id") or "")
+        metric_id = str(record.get("metric_id") or record.get("id") or "")
+        if not ci_id or not metric_id:
+            raise ValueError("Scheduler records require node_id/ci_id and metric_id/id")
+        source = _source(record, protocol)
+        source_key = (ci_id, source)
+        if protocol == PollingProtocol.ICMP and is_icmp_telemetry_metric(metric_id, dict(record)):
+            icmp_ip = record.get("ip") or record.get("ip_address")
+            if icmp_ip:
+                sidecar_sources.setdefault(source_key, {**dict(record), "ip": icmp_ip})
+            continue
+        if protocol == PollingProtocol.ICMP and is_icmp_availability_metric(metric_id, dict(record)):
+            availability_sources.add(source_key)
+        add_task(record, protocol, ci_id, metric_id)
+
+    for source_key, record in sidecar_sources.items():
+        if source_key in availability_sources:
+            continue
+        ci_id, _source_value = source_key
+        synthetic = {
+            **record,
+            "node_id": ci_id,
+            "metric_id": ICMP_AVAILABILITY_METRIC_ID,
+            "protocol": PollingProtocol.ICMP.value,
+            "metric_kind": "availability",
+            "internal": True,
+        }
+        add_task(synthetic, PollingProtocol.ICMP, ci_id, ICMP_AVAILABILITY_METRIC_ID)
+
     return sorted(tasks, key=lambda task: (int(task["priority"]), task["protocol"].value, task["metric_id"]))
 
 

--- a/backend/polling/snmp_executor.py
+++ b/backend/polling/snmp_executor.py
@@ -169,10 +169,13 @@ def execute_poll_task(
     source = str(_get(task, "source") or payload.get("target") or "")
     icmp_result_metadata: dict[str, Any] = {}
     if protocol == PollingProtocol.ICMP:
+        is_internal_icmp = bool(_get(task, "internal") or task_metadata.get("internal") or payload.get("internal"))
         if measurement is not None:
             icmp_result_metadata = {"metric_kind": "availability", "icmp": icmp_metadata(measurement)}
         elif is_icmp_telemetry_metric(metric_id, task_metadata):
             icmp_result_metadata = {"metric_kind": "telemetry"}
+        if is_internal_icmp:
+            icmp_result_metadata["internal"] = True
     return PollResultEnvelope(
         result_id=_result_id(task_id, observed, status),
         task_id=task_id,

--- a/backend/polling/writer_pool.py
+++ b/backend/polling/writer_pool.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 from models.timescale_models import MetricValue
 from polling import event_writer, pg_queue
-from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
+from polling.icmp_measurements import ICMP_AVAILABILITY_METRIC_ID, ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
 
 
 def _utc_now() -> datetime:
@@ -58,7 +58,17 @@ def _timestamp(value: Any) -> Any:
     return value
 
 
+def _is_internal_icmp_availability(envelope: Mapping[str, Any]) -> bool:
+    return (
+        str(envelope.get("protocol") or "").upper() == "ICMP"
+        and envelope.get("metric_id") == ICMP_AVAILABILITY_METRIC_ID
+        and bool((envelope.get("metadata") or {}).get("internal"))
+    )
+
+
 def _sample(envelope: Mapping[str, Any]) -> dict[str, Any] | None:
+    if _is_internal_icmp_availability(envelope):
+        return None
     numeric = _numeric(envelope)
     if numeric is None:
         return None
@@ -228,7 +238,10 @@ def run_writer_once(
             stats["retried"] += 1
         return stats
 
-    event_payloads = new_payloads + pending_payloads
+    event_payloads = [
+        item for item in new_payloads + pending_payloads
+        if not _is_internal_icmp_availability(item["envelope"])
+    ]
     try:
         event_writer.batch_update_events(neo4j_driver, [item["envelope"] for item in event_payloads])
     except Exception as exc:
@@ -238,7 +251,7 @@ def run_writer_once(
             stats["retried"] += 1
         return stats
 
-    for item in event_payloads:
+    for item in new_payloads + pending_payloads:
         pg_queue.complete_result(queue_db, item["result_id"])
         stats["written"] += 1
     return stats

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -444,14 +444,13 @@ def ensure_icmp_sidecar_metric_defs(session) -> None:
 
 
 def migrate_icmp_sidecar_metrics() -> None:
-    """Idempotently link ICMP latency/jitter MetricDefs to CIs with ping availability metrics."""
+    """Idempotently link ICMP latency/jitter MetricDefs to existing CIs with IPs."""
     driver = get_db()
     with driver.session() as session:
         ensure_icmp_sidecar_metric_defs(session)
         session.run("""
-            MATCH (n:CI)-[:HAS_METRIC]->(availability:MetricDef)
-            WHERE toUpper(coalesce(availability.protocol, '')) = 'ICMP'
-              AND (availability.id = 'PING-CHECK' OR availability.id STARTS WITH 'PING-' OR coalesce(availability.metric_kind, '') = 'availability')
+            MATCH (n:CI)
+            WHERE n.ip IS NOT NULL AND trim(toString(n.ip)) <> ''
             MATCH (latency:MetricDef {id: $latency_id})
             MATCH (jitter:MetricDef {id: $jitter_id})
             MERGE (n)-[:HAS_METRIC]->(latency)
@@ -461,27 +460,15 @@ def migrate_icmp_sidecar_metrics() -> None:
 
 def create_default_ping_metric(node_id: str, node_label: str) -> None:
     """
-    Create a default ICMP PING metric for a CI node when it has an IP address.
-    Creates a MetricDef node and links it to the CI via HAS_METRIC relationship.
+    Ensure ICMP latency and jitter metrics are available for a CI.
+
+    Do not create a per-CI PING availability MetricDef. The queue scheduler
+    derives an internal ICMP availability polling task from these sidecar links
+    so latency/jitter can be collected without polluting the metric catalog with
+    one ping metric per CI.
     """
     driver = get_db()
-    metric_id = f"PING-{node_label}"
     with driver.session() as session:
-        # Create or merge the MetricDef for ICMP PING
-        session.run("""
-            MERGE (m:MetricDef {id: $metric_id})
-            SET m.protocol = 'ICMP',
-                m.name = coalesce(m.name, 'ICMP Availability'),
-                m.description = 'ICMP Ping Monitoring',
-                m.applicable_to = $applicable_to,
-                m.operator = '>=',
-                m.criticality = 1,
-                m.metric_kind = 'availability'
-            WITH m
-            MATCH (n:CI {id: $node_id})
-            MERGE (n)-[:HAS_METRIC]->(m)
-        """, metric_id=metric_id, node_id=node_id,
-           applicable_to=json.dumps({"names": [node_label]}))
         ensure_icmp_sidecar_metric_defs(session)
         session.run("""
             MATCH (n:CI {id: $node_id})

--- a/backend/services/metric_service.py
+++ b/backend/services/metric_service.py
@@ -6,6 +6,7 @@ from database import get_db
 from models.core import MetricDef
 from services.metric_operation_guard import metric_operation_guard
 from services.operation_timing import timed_operation
+from polling.icmp_measurements import is_icmp_telemetry_metric
 
 logger = logging.getLogger(__name__)
 
@@ -511,6 +512,8 @@ def reconcile_node_metrics(node: Dict[str, Any]):
         # Parentheses required because | and - have same precedence and left-to-right would mis-evaluate
         effective_ids = ((applicable_ids | dict_metric_ids) - excluded) | extra
 
+        preserve_icmp_sidecars = bool(node.get("ip"))
+
         with driver.session() as session:
             # 1. Fetch CURRENTLY LINKED metrics
             result = session.run("""
@@ -525,6 +528,13 @@ def reconcile_node_metrics(node: Dict[str, Any]):
             # 2. Determine Removals
             for mid, apt_json in linked_metrics.items():
                 if mid not in effective_ids:
+                    # ICMP latency/jitter are derived telemetry sidecars created by
+                    # ping provisioning, not criteria/dictionary metrics. Preserve
+                    # direct links so CI updates do not drop them immediately after
+                    # create_default_ping_metric attaches them.
+                    if preserve_icmp_sidecars and is_icmp_telemetry_metric(mid, {}):
+                        continue
+
                     # Check if explicitly named (Safety check)
                     is_explicit = False
                     try:

--- a/backend/tests/test_icmp_metric_migration.py
+++ b/backend/tests/test_icmp_metric_migration.py
@@ -1,7 +1,7 @@
 from tests.conftest import MockNeo4jDriver
 
 
-def test_create_default_ping_metric_links_latency_and_jitter_sidecars(monkeypatch):
+def test_create_default_ping_metric_links_only_latency_and_jitter_sidecars(monkeypatch):
     from repositories import topology_repo
 
     driver = MockNeo4jDriver()
@@ -11,16 +11,33 @@ def test_create_default_ping_metric_links_latency_and_jitter_sidecars(monkeypatc
 
     queries = "\n".join(q["query"] for q in driver.mock_session.queries)
     params = [q["params"] for q in driver.mock_session.queries]
-    assert "PING-router-a" in str(params)
     assert "icmp_latency_ms" in str(params)
     assert "icmp_jitter_ms" in str(params)
-    assert "metric_kind = 'availability'" in queries
     assert "metric_kind = 'telemetry'" in queries
+    assert "metric_kind = 'availability'" not in queries
+    assert "PING-ci-1" not in str(params)
+    assert "PING-router-a" not in str(params)
+    assert "MERGE (m:MetricDef {id: $metric_id})" not in queries
     assert "MERGE (n)-[:HAS_METRIC]->(latency)" in queries
     assert "MERGE (n)-[:HAS_METRIC]->(jitter)" in queries
 
 
-def test_migrate_icmp_sidecar_metrics_is_idempotent_for_existing_ping_cis(monkeypatch):
+def test_create_default_ping_metric_edit_does_not_create_ping_metric(monkeypatch):
+    from repositories import topology_repo
+
+    driver = MockNeo4jDriver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.create_default_ping_metric("ci-1", "router-renamed")
+
+    queries = "\n".join(q["query"] for q in driver.mock_session.queries)
+    params = [q["params"] for q in driver.mock_session.queries]
+    assert "RETURN availability.id AS metric_id" not in queries
+    assert "PING-router-renamed" not in str(params)
+    assert "PING-ci-1" not in str(params)
+
+
+def test_migrate_icmp_sidecar_metrics_is_idempotent_for_existing_cis_with_ips(monkeypatch):
     from repositories import topology_repo
 
     driver = MockNeo4jDriver()
@@ -32,8 +49,11 @@ def test_migrate_icmp_sidecar_metrics_is_idempotent_for_existing_ping_cis(monkey
     params = [q["params"] for q in driver.mock_session.queries]
     assert "MERGE (latency:MetricDef {id: $latency_id})" in queries
     assert "MERGE (jitter:MetricDef {id: $jitter_id})" in queries
-    assert "availability.id = 'PING-CHECK'" in queries
-    assert "availability.id STARTS WITH 'PING-'" in queries
+    assert "MATCH (n:CI)" in queries
+    assert "n.ip IS NOT NULL" in queries
+    assert "trim(toString(n.ip)) <> ''" in queries
+    assert "availability.id = 'PING-CHECK'" not in queries
+    assert "availability.id STARTS WITH 'PING-'" not in queries
     assert "MERGE (n)-[:HAS_METRIC]->(latency)" in queries
     assert "MERGE (n)-[:HAS_METRIC]->(jitter)" in queries
     assert {"latency_id": "icmp_latency_ms", "jitter_id": "icmp_jitter_ms"} in params

--- a/backend/tests/test_metric_reconciliation.py
+++ b/backend/tests/test_metric_reconciliation.py
@@ -269,6 +269,83 @@ class TestReconcileNodeMetricsWithAppliedDictionary:
 
     @patch("services.metric_service.get_db")
     @patch("services.metric_service.get_applicable_metrics")
+    def test_preserves_icmp_latency_and_jitter_sidecars_when_not_applicable(
+        self, mock_get_applicable, mock_get_db
+    ):
+        """
+        ICMP latency/jitter are derived sidecars linked by ping provisioning.
+        Generic reconciliation must not remove them just because they do not
+        match brand/model/dictionary criteria.
+        """
+        from services.metric_service import reconcile_node_metrics
+
+        mock_session = MagicMock()
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__.return_value = mock_session
+        mock_get_db.return_value = mock_driver
+
+        linked_records = [
+            FakeRecord({"mid": "icmp_latency_ms", "apt": None}),
+            FakeRecord({"mid": "icmp_jitter_ms", "apt": None}),
+            FakeRecord({"mid": "old-metric", "apt": "{}"}),
+        ]
+
+        responses = {
+            "has_dictionary": FakeResult([]),
+            "return m.id as mid": FakeResult(linked_records),
+            "delete": FakeResult([]),
+        }
+        mock_session.run.side_effect = self._build_run_side_effect(responses)
+        mock_get_applicable.return_value = []
+
+        reconcile_node_metrics({"id": "ci-001", "name": "Router-01", "ip": "10.0.0.1"})
+
+        delete_mids = [
+            c[1].get("mid")
+            for c in mock_session.run.call_args_list
+            if "delete r" in c[0][0].lower()
+        ]
+        assert "old-metric" in delete_mids
+        assert "icmp_latency_ms" not in delete_mids
+        assert "icmp_jitter_ms" not in delete_mids
+
+    @patch("services.metric_service.get_db")
+    @patch("services.metric_service.get_applicable_metrics")
+    def test_removes_icmp_sidecars_when_ci_no_longer_has_ip(
+        self, mock_get_applicable, mock_get_db
+    ):
+        """Removing a CI IP should deprovision ICMP sidecars during reconcile."""
+        from services.metric_service import reconcile_node_metrics
+
+        mock_session = MagicMock()
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__.return_value = mock_session
+        mock_get_db.return_value = mock_driver
+
+        linked_records = [
+            FakeRecord({"mid": "icmp_latency_ms", "apt": None}),
+            FakeRecord({"mid": "icmp_jitter_ms", "apt": None}),
+        ]
+        responses = {
+            "has_dictionary": FakeResult([]),
+            "return m.id as mid": FakeResult(linked_records),
+            "delete": FakeResult([]),
+        }
+        mock_session.run.side_effect = self._build_run_side_effect(responses)
+        mock_get_applicable.return_value = []
+
+        reconcile_node_metrics({"id": "ci-001", "name": "Router-01", "ip": None})
+
+        delete_mids = [
+            c[1].get("mid")
+            for c in mock_session.run.call_args_list
+            if "delete r" in c[0][0].lower()
+        ]
+        assert "icmp_latency_ms" in delete_mids
+        assert "icmp_jitter_ms" in delete_mids
+
+    @patch("services.metric_service.get_db")
+    @patch("services.metric_service.get_applicable_metrics")
     def test_removes_obsolete_metrics_from_previous_dictionary(
         self, mock_get_applicable, mock_get_db
     ):

--- a/backend/tests/test_polling_scheduler.py
+++ b/backend/tests/test_polling_scheduler.py
@@ -36,7 +36,7 @@ def _records():
     ]
 
 
-def test_scheduler_skips_icmp_latency_and_jitter_sidecar_records():
+def test_scheduler_skips_icmp_sidecar_records_when_availability_exists():
     from polling.scheduler import build_cycle, build_tasks_from_records
 
     cycle = build_cycle(scheduled_for=datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc), config_version="v1")
@@ -63,6 +63,87 @@ def test_scheduler_skips_icmp_latency_and_jitter_sidecar_records():
 
     assert {task["metric_id"] for task in tasks} == {"PING-CHECK", "CPU", "CLI-CPU"}
     assert all(task["metric_id"] not in {"icmp_latency_ms", "icmp_jitter_ms"} for task in tasks)
+
+
+def test_scheduler_synthesizes_icmp_poll_task_from_sidecar_records_without_ping_metric():
+    from polling.contracts import PollingPriority, PollingProtocol
+    from polling.scheduler import build_cycle, build_tasks_from_records
+
+    cycle = build_cycle(scheduled_for=datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc), config_version="v1")
+    records = [
+        {
+            "node_id": "ci-icmp",
+            "ip": "10.0.0.1",
+            "site_id": "site-a",
+            "subnet": "10.0.0.0/24",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "metadata_version": "v1",
+        },
+        {
+            "node_id": "ci-icmp",
+            "ip": "10.0.0.1",
+            "site_id": "site-a",
+            "subnet": "10.0.0.0/24",
+            "metric_id": "icmp_jitter_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "metadata_version": "v1",
+        },
+    ]
+
+    tasks = build_tasks_from_records(records, cycle)
+
+    assert len(tasks) == 1
+    task = tasks[0]
+    assert task["metric_id"] == "icmp_availability"
+    assert task["metric_kind"] == "availability"
+    assert task["protocol"] == PollingProtocol.ICMP
+    assert task["priority"] == PollingPriority.ICMP_AVAILABILITY
+    assert task["payload"] == {"kind": "icmp_ping", "target": "10.0.0.1", "timeout_ms": 3000, "retries": 2, "internal": True}
+
+
+def test_scheduler_synthesizes_icmp_poll_task_from_ip_address_sidecar_records():
+    from polling.scheduler import build_cycle, build_tasks_from_records
+
+    cycle = build_cycle(scheduled_for=datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc), config_version="v1")
+
+    tasks = build_tasks_from_records([
+        {
+            "node_id": "ci-ip-address",
+            "ip_address": "10.0.0.9",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "metadata_version": "v1",
+        }
+    ], cycle)
+
+    assert len(tasks) == 1
+    assert tasks[0]["metric_id"] == "icmp_availability"
+    assert tasks[0]["internal"] is True
+    assert tasks[0]["payload"]["target"] == "10.0.0.9"
+    assert tasks[0]["payload"]["internal"] is True
+
+
+def test_scheduler_ignores_icmp_sidecar_records_without_ip():
+    from polling.scheduler import build_cycle, build_tasks_from_records
+
+    cycle = build_cycle(scheduled_for=datetime(2026, 5, 25, 12, 0, tzinfo=timezone.utc), config_version="v1")
+
+    tasks = build_tasks_from_records([
+        {
+            "node_id": "ci-no-ip",
+            "source": "stale-source-without-ip",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "metadata_version": "v1",
+        }
+    ], cycle)
+
+    assert tasks == []
 
 
 def test_scheduler_builds_15_minute_cycle_and_priority_ordered_tasks():

--- a/backend/tests/test_polling_snmp_executor.py
+++ b/backend/tests/test_polling_snmp_executor.py
@@ -101,6 +101,38 @@ def test_icmp_executor_maps_ping_success_and_failure_statuses():
     assert "latency_ms" not in failure.metadata["icmp"]
 
 
+def test_icmp_executor_marks_internal_synthetic_availability_in_metadata():
+    from polling.icmp_measurements import PingMeasurement
+    from polling.snmp_executor import execute_poll_task
+
+    payload = {"kind": "icmp_ping", "target": "10.0.0.1", "timeout_ms": 500, "retries": 1, "internal": True}
+    result = execute_poll_task(
+        _task("ICMP", payload, metric_id="icmp_availability", internal=True),
+        icmp_fetcher=lambda **kwargs: PingMeasurement(True, 18.25, raw="ok"),
+    )
+
+    assert result.metadata["internal"] is True
+    assert result.metadata["metric_kind"] == "availability"
+    assert result.metadata["icmp"]["latency_ms"] == 18.25
+
+
+def test_icmp_executor_preserves_internal_marker_on_fetcher_exception():
+    from polling.contracts import PollingResultStatus
+    from polling.snmp_executor import execute_poll_task
+
+    def boom(**kwargs):
+        raise RuntimeError("icmp exploded")
+
+    payload = {"kind": "icmp_ping", "target": "10.0.0.1", "timeout_ms": 500, "retries": 1, "internal": True}
+    result = execute_poll_task(
+        _task("ICMP", payload, metric_id="icmp_availability", internal=True),
+        icmp_fetcher=boom,
+    )
+
+    assert result.status == PollingResultStatus.ERROR
+    assert result.metadata["internal"] is True
+
+
 def test_icmp_executor_fetcher_exception_returns_error_envelope_without_unbound_measurement():
     from polling.contracts import PollingResultStatus
     from polling.snmp_executor import execute_poll_task

--- a/backend/tests/test_polling_writer_pool.py
+++ b/backend/tests/test_polling_writer_pool.py
@@ -85,6 +85,38 @@ def test_writer_expands_icmp_sidecar_samples_and_keeps_events_primary_only(monke
     assert [event["metric_id"] for event in event_rows] == ["PING-CHECK"]
 
 
+def test_writer_persists_only_sidecars_for_internal_icmp_availability(monkeypatch):
+    from polling import writer_pool
+
+    persisted = []
+    event_rows = []
+    completed = []
+    row = _row(key="icmp-internal", numeric=1.0)
+    row.protocol = "ICMP"
+    row.metric_id = "icmp_availability"
+    row.envelope.update({
+        "protocol": "ICMP",
+        "metric_id": "icmp_availability",
+        "metadata": {"metric_kind": "availability", "internal": True, "icmp": {"latency_ms": 20.0, "sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms"]}},
+    })
+    monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
+    monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
+    monkeypatch.setattr(writer_pool, "previous_metric_value", lambda db, node_id, metric_id, before: 12.5)
+    monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: completed.append(rid))
+
+    stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
+
+    assert stats["inserted"] == 2
+    assert persisted[0][1] == [
+        {"node_id": "ci-1", "metric_id": "icmp_latency_ms", "value": 20.0, "time": row.observed_at},
+        {"node_id": "ci-1", "metric_id": "icmp_jitter_ms", "value": 7.5, "time": row.observed_at},
+    ]
+    assert event_rows == []
+    assert completed == [row.result_id]
+
+
 def test_writer_batches_timescale_inserts_receipts_and_neo4j_updates(monkeypatch):
     from polling import writer_pool
 

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -774,6 +774,58 @@ class TestICMPDebounce:
         assert _consecutive_failures.get("ci-001", 0) >= 3
 
 
+def test_poll_snmp_prefers_legacy_availability_when_sidecars_return_first():
+    from engines.snmp_worker import _consecutive_failures
+    from polling.icmp_measurements import PingMeasurement
+
+    _consecutive_failures.clear()
+    mock_db = MagicMock()
+    mock_db.execute.return_value.first.return_value = None
+    mock_session = MockNeo4jSession()
+    mock_session.set_response("match", [
+        {
+            "node_id": "ci-001",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "metric_kind": "telemetry",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": None,
+            "port": 161,
+            "metric_name": "ICMP Latency",
+            "criticality": 1,
+        },
+        {
+            "node_id": "ci-001",
+            "metric_id": "PING-CHECK",
+            "protocol": "ICMP",
+            "metric_kind": "availability",
+            "ip": "192.168.1.1",
+            "community": "public",
+            "oid": None,
+            "port": 161,
+            "metric_name": "Ping availability",
+            "criticality": 3,
+        },
+    ])
+    mock_session.set_default_response([])
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=mock_db), \
+         patch("engines.snmp_worker.bulk_insert_metrics") as mock_bulk_insert, \
+         patch("engines.snmp_worker.fetch_icmp_ping", return_value=PingMeasurement(True, 12.0)) as mock_fetch_icmp:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()
+
+    mock_fetch_icmp.assert_called_once()
+    rows = mock_bulk_insert.call_args.args[1]
+    assert any(row["metric_id"] == "PING-CHECK" and row["value"] == 1.0 for row in rows)
+
+
 def test_poll_snmp_skips_icmp_sidecar_metrics_as_primary_poll_targets():
     from engines.snmp_worker import _consecutive_failures
     from polling.icmp_measurements import PingMeasurement

--- a/scripts/safe-rebuild.sh
+++ b/scripts/safe-rebuild.sh
@@ -156,6 +156,9 @@ printf 'Building and restarting services...\n'
 run docker compose build
 run docker compose up -d
 
+printf 'Applying ICMP latency/jitter sidecar migration...\n'
+run docker compose exec -T backend python scripts/migrate_icmp_sidecar_metrics.py
+
 printf '\nSafe rebuild flow completed. Current service status:\n'
 run docker compose ps
 


### PR DESCRIPTION
## Descripción del Cambio
Closes #217

This PR fixes ICMP metric provisioning so CI create/edit no longer creates one `PING-*` metric definition per CI while still collecting latency and jitter telemetry.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Stops per-CI `PING-*` MetricDef creation during CI create/edit and links only `icmp_latency_ms` / `icmp_jitter_ms` sidecars for CIs with IPs.
- Adds internal ICMP polling support for queue and legacy pollers so sidecar telemetry is collected without exposing synthetic availability metrics.
- Runs the ICMP sidecar migration from `scripts/safe-rebuild.sh` and documents the patch release in `CHANGELOG.md`.

## Changes
| File | Change |
|------|--------|
| `backend/repositories/topology_repo.py` | Makes ICMP provisioning sidecar-only and backfills sidecars for existing CIs with IPs. |
| `backend/polling/scheduler.py` | Synthesizes internal ICMP availability tasks from sidecar records. |
| `backend/polling/snmp_executor.py` | Propagates internal ICMP metadata through result envelopes, including error paths. |
| `backend/polling/writer_pool.py` | Suppresses internal synthetic availability persistence/events while preserving sidecar samples. |
| `backend/engines/snmp_worker.py` | Supports sidecar-driven ICMP collection in the legacy polling path. |
| `backend/services/metric_service.py` | Preserves ICMP sidecars while a CI has an IP and removes them when IP is removed. |
| `scripts/safe-rebuild.sh` | Runs the ICMP sidecar migration after rebuild/restart. |
| `CHANGELOG.md` | Adds `1.12.13` patch release notes. |
| `backend/tests/*` | Adds regression coverage for provisioning, migration, scheduler, executor, writer, reconcile, and legacy polling behavior. |

## Review size exception
This PR is intentionally kept as a single size exception (~521 changed lines) because the behavior crosses one atomic work unit: CI provisioning, both polling paths, writer suppression, deploy migration, and regression tests must change together to avoid partial states that either recreate ping metrics or stop collecting latency/jitter.

## ¿Cómo se probó?
- [x] Backend regression suite:
  ```bash
  /home/alex/dev/next-gen/next-gen/backend/.venv/bin/python -m pytest \
    backend/tests/test_metric_reconciliation.py \
    backend/tests/test_icmp_metric_migration.py \
    backend/tests/test_node_service.py \
    backend/tests/test_icmp_measurements.py \
    backend/tests/test_polling_scheduler.py \
    backend/tests/test_polling_event_writer.py \
    backend/tests/test_polling_writer_pool.py \
    backend/tests/test_polling_snmp_executor.py \
    backend/tests/test_snmp_worker.py -q
  ```
  Result: `132 passed`, warnings only.
- [x] Shell syntax check:
  ```bash
  sh -n scripts/safe-rebuild.sh
  ```
- [ ] Shellcheck: not available in this local environment (`shellcheck not installed`).
- [x] Fresh review: no blockers.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
