### PR TITLE
fix(admin): show newly created CIs without coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Admin CI creation visibility** (PR #225, issue #189):
+  - Lists newly created CIs in `/api/nodes` even when they do not have latitude/longitude coordinates yet.
+  - Preserves non-admin inventory scoping by `location_name`.
+  - Adds backend query regression coverage and Admin inventory refresh coverage.
+
 ## [1.12.14] — 2026-05-31
 
 ### Fixed

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -14,11 +14,11 @@ validate_ci_relationship_type = _relationship_types.validate_ci_relationship_typ
 
 def get_nodes(allowed_locations: Optional[List[str]] = None, is_admin: bool = False) -> List[Dict[str, Any]]:
     driver = get_db()
-    query = "MATCH (n:CI) WHERE n.location IS NOT NULL AND n.location.latitude IS NOT NULL AND n.location.longitude IS NOT NULL"
+    query = "MATCH (n:CI)"
     params = {}
     if not is_admin:
         if not allowed_locations: return []
-        query += " AND n.location_name IN $allowed_locations "
+        query += " WHERE n.location_name IN $allowed_locations "
         params["allowed_locations"] = allowed_locations
     query += """
         OPTIONAL MATCH (n)-[:CATEGORIZED_AS]->(c:Category)

--- a/backend/tests/test_topology_repo_nodes.py
+++ b/backend/tests/test_topology_repo_nodes.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+
+def _mock_driver():
+    driver = MagicMock()
+    session = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+    driver.session.return_value.__exit__.return_value = False
+    session.run.return_value = []
+    return driver, session
+
+
+def test_get_nodes_does_not_require_coordinates_for_admin(monkeypatch):
+    from repositories import topology_repo
+
+    driver, session = _mock_driver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.get_nodes(allowed_locations=None, is_admin=True)
+
+    query = session.run.call_args.args[0]
+    assert "MATCH (n:CI)" in query
+    assert "n.location IS NOT NULL" not in query
+    assert "n.location.latitude IS NOT NULL" not in query
+    assert "n.location.longitude IS NOT NULL" not in query
+
+
+def test_get_nodes_keeps_location_scope_for_non_admin(monkeypatch):
+    from repositories import topology_repo
+
+    driver, session = _mock_driver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.get_nodes(allowed_locations=["HQ-Madrid"], is_admin=False)
+
+    query = session.run.call_args.args[0]
+    params = session.run.call_args.kwargs
+    assert "n.location_name IN $allowed_locations" in query
+    assert params["allowed_locations"] == ["HQ-Madrid"]

--- a/frontend/components/AdminPage.test.tsx
+++ b/frontend/components/AdminPage.test.tsx
@@ -23,7 +23,19 @@ vi.mock('../context/AuthContext', () => ({
 
 vi.mock('./MetricsManager', () => ({ default: () => <div>Metrics Manager</div> }));
 vi.mock('./DictionaryManager', () => ({ default: () => <div>Dictionary Manager</div> }));
-vi.mock('./CIEditor', () => ({ default: () => <div>CI Editor</div> }));
+vi.mock('./CIEditor', () => ({
+    default: ({ onSave }: { onSave: (node: any) => Promise<void> }) => (
+        <div>
+            CI Editor
+            <button
+                type="button"
+                onClick={() => onSave({ id: 'ci-new', label: 'New Router', type: 'Network', status: 'ACTIVE' })}
+            >
+                Save mock CI
+            </button>
+        </div>
+    ),
+}));
 vi.mock('./RelationshipManager', () => ({ default: () => <div>Relationship Manager</div> }));
 vi.mock('./MassLinkEditor', () => ({ default: () => <div>Mass Link Editor</div> }));
 vi.mock('./CatalogManager', () => ({ default: () => <div>Catalog Manager</div> }));
@@ -94,5 +106,33 @@ describe('AdminPage inventory relationships', () => {
         expect(screen.getByText('CONNECTS_TO')).toBeInTheDocument();
         expect(screen.getAllByText('Switch B').length).toBeGreaterThan(0);
         expect(screen.getAllByText('ci-b').length).toBeGreaterThan(0);
+    });
+
+    it('refreshes inventory after creating a CI from the editor', async () => {
+        const createdNode = { id: 'ci-new', label: 'New Router', type: 'Network', status: 'ACTIVE', ip: undefined };
+        mockApiGet.mockImplementation((endpoint: string) => {
+            if (endpoint === '/nodes') {
+                const createCompleted = mockApiPost.mock.calls.some(([postEndpoint]) => postEndpoint === '/nodes');
+                return Promise.resolve(createCompleted ? [...nodes, createdNode] : nodes);
+            }
+            return Promise.resolve([]);
+        });
+
+        render(<AdminPage />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'INVENTORY' }));
+        expect(await screen.findByText('Router A')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save mock CI' }));
+
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledWith('/nodes', {
+                id: 'ci-new',
+                label: 'New Router',
+                type: 'Network',
+                status: 'ACTIVE',
+            });
+        });
+        expect(await screen.findByText('New Router')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
Closes #189

## Descripción del Cambio
Fixes Admin CI creation visibility when a CI is saved without latitude/longitude coordinates.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Allows `/api/nodes` to return CIs without geolocation coordinates.
- Preserves non-admin inventory scoping by `location_name`.
- Adds backend regression coverage for the query contract and frontend coverage for Admin inventory refresh after CI creation.

## Changes
| File | Change |
|------|--------|
| `backend/repositories/topology_repo.py` | Removes coordinate requirement from `/nodes` listing while preserving non-admin location scoping. |
| `backend/tests/test_topology_repo_nodes.py` | Adds regression tests for coordinate-free admin listing and scoped non-admin listing. |
| `frontend/components/AdminPage.test.tsx` | Adds a create/save refresh regression test for the Admin inventory flow. |

## ¿Cómo se probó?
- [x] `python -m pytest tests/test_topology_repo_nodes.py tests/test_routers_nodes.py::TestCreateNode::test_create_node_admin_success tests/test_routers_nodes.py::TestGetNodes -q`
- [x] `python -m pytest tests/test_node_service.py::TestGetNodes -q`
- [x] `git diff --check`
- [ ] `corepack pnpm run test:run components/AdminPage.test.tsx` — blocked locally because `frontend/node_modules`/`vitest` are missing.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:bug`
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

---
*Generado por Alex*
