### PR TITLE
chore(backup): add neo4j offline dump workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Lists newly created CIs in `/api/nodes` even when they do not have latitude/longitude coordinates yet.
   - Preserves non-admin inventory scoping by `location_name`.
   - Adds backend query regression coverage and Admin inventory refresh coverage.
+- **Neo4j offline backup workflow** (issue #130):
+  - Adds an explicit `--neo4j-offline` mode for `pre-rebuild-backup.sh` and `safe-rebuild.sh`.
+  - Creates PostgreSQL backups unchanged, then stops only Neo4j to run a timestamped `neo4j-admin` offline dump.
+  - Documents offline dump and restore procedures for maintenance windows.
 
 ## [1.12.14] — 2026-05-31
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -26,6 +26,8 @@ Use this path when you want the script to validate `.env`, create the backup dir
 git pull origin main
 # Review/update .env from .env.example before continuing.
 sh scripts/safe-rebuild.sh
+# Or, during a Neo4j maintenance window when APOC export is unavailable:
+# sh scripts/safe-rebuild.sh --neo4j-offline
 docker compose ps
 docker compose logs --tail=100 backend
 ```
@@ -101,6 +103,8 @@ The script performs the deploy preflight and rebuild in order:
 
 Use `sh scripts/safe-rebuild.sh --dry-run` to print the flow without creating directories, rebuilding images, or restarting containers. The dry run still validates `.env` and resolves `BACKUP_DIR`.
 
+Use `sh scripts/safe-rebuild.sh --neo4j-offline` only during a maintenance window. It still creates the PostgreSQL dump, but it passes `--neo4j-offline` to `pre-rebuild-backup.sh`, which stops only Neo4j, runs a `neo4j-admin` dump, and starts Neo4j again before the rebuild continues.
+
 ## Manual Fallback
 
 Use this only when you need to run each step by hand. Unlike `safe-rebuild.sh`, `pre-rebuild-backup.sh` stays strict and expects `BACKUP_DIR` to already exist. Docker Compose direct commands do not auto-run these safety checks.
@@ -130,8 +134,9 @@ If `BACKUP_DIR` is customized, create and validate that resolved path instead of
 | Env validation | Calls `scripts/validate-env.sh --check-backup-dir` before Docker Compose checks or dumps. In the recommended flow, `scripts/safe-rebuild.sh` creates and verifies the directory before this strict check runs. |
 | PostgreSQL | Runs `pg_dump -Fc` inside the `postgres` service using the container environment. |
 | Neo4j | Attempts an online APOC Cypher export when `apoc.export.cypher.all` is available. |
-| Neo4j fallback | Writes an operator note explaining the offline dump command when online export is unavailable. |
-| Docker safety | Uses `docker compose config`, `ps`, and `exec`; it never stops services or removes volumes. |
+| Neo4j fallback | Writes an operator note explaining `sh scripts/pre-rebuild-backup.sh --neo4j-offline` when online export is unavailable. |
+| Neo4j offline mode | With `--neo4j-offline`, stops only Neo4j, creates a timestamped `neo4j_YYYYMMDD_HHMMSS_dump/` directory under `BACKUP_DIR`, runs `neo4j-admin database dump`, and starts Neo4j again. |
+| Docker safety | Uses `docker compose config`, `ps`, and `exec`; the default path never stops services or removes volumes. Offline Neo4j mode stops and restarts only `neo4j` during the maintenance window. |
 
 Generated files use UTC timestamps, for example `postgres_20260524_153000.dump`.
 
@@ -165,23 +170,38 @@ docker compose exec -T neo4j sh -c '
 
 This replay can duplicate data if the target is not empty. Use it for a clean restore target unless you have reviewed the Cypher content.
 
-## Neo4j Full Dump Limitation
+## Neo4j Offline Dump Workflow
 
 Neo4j Community/dev images do not provide Enterprise online backup. A full `neo4j-admin database dump` is an offline maintenance action.
 
 Run this only when you intentionally accept a Neo4j service interruption:
 
 ```sh
-docker compose stop neo4j
-docker compose run --rm --no-deps --entrypoint neo4j-admin neo4j database dump neo4j --to-path=/backups --overwrite-destination=true
-docker compose up -d neo4j
+sh scripts/pre-rebuild-backup.sh --neo4j-offline
+# Or as part of the full rebuild flow:
+sh scripts/safe-rebuild.sh --neo4j-offline
 ```
+
+The offline mode:
+
+1. Creates the normal PostgreSQL dump first.
+2. Stops only the `neo4j` service.
+3. Creates a timestamped `neo4j_YYYYMMDD_HHMMSS_dump/` directory under `BACKUP_DIR`.
+4. Runs:
+
+   ```sh
+   docker compose run --rm --no-deps --entrypoint neo4j-admin neo4j database dump neo4j --to-path=/backups/neo4j_YYYYMMDD_HHMMSS_dump --overwrite-destination=true
+   ```
+
+5. Starts `neo4j` again even when the dump command fails.
+
+After the command completes, confirm the dump directory exists under `BACKUP_DIR`, then check Neo4j health with `docker compose ps` and application smoke tests.
 
 Restore an offline dump into a stopped, empty Neo4j data directory only after separately preserving the current data directory:
 
 ```sh
 docker compose stop neo4j
-docker compose run --rm --no-deps --entrypoint neo4j-admin neo4j database load neo4j --from-path=/backups --overwrite-destination=true
+docker compose run --rm --no-deps --entrypoint neo4j-admin neo4j database load neo4j --from-path=/backups/neo4j_YYYYMMDD_HHMMSS_dump --overwrite-destination=true
 docker compose up -d neo4j
 ```
 
@@ -191,5 +211,5 @@ Do not delete `docker/neo4j/data` unless you have an explicit, tested restore pl
 
 - [ ] `sh scripts/safe-rebuild.sh` completed successfully from a POSIX shell.
 - [ ] PostgreSQL dump exists in `BACKUP_DIR`.
-- [ ] Neo4j has either an APOC export file or an offline-dump-required note.
+- [ ] Neo4j has an APOC export file, an offline dump directory, or an offline-dump-required note.
 - [ ] No command uses `docker compose down -v`.

--- a/scripts/pre-rebuild-backup.sh
+++ b/scripts/pre-rebuild-backup.sh
@@ -3,21 +3,26 @@ set -eu
 
 usage() {
     cat <<'USAGE'
-Usage: sh scripts/pre-rebuild-backup.sh [--skip-neo4j]
+Usage: sh scripts/pre-rebuild-backup.sh [--skip-neo4j] [--neo4j-offline]
 
-Creates a pre-rebuild PostgreSQL dump and attempts a safe Neo4j online export.
+Creates a pre-rebuild PostgreSQL dump and attempts a safe Neo4j backup.
 The script never runs destructive Docker commands and never removes volumes.
 
 Options:
-  --skip-neo4j  Only create the PostgreSQL dump.
+  --skip-neo4j      Only create the PostgreSQL dump.
+  --neo4j-offline   Stop only Neo4j, run a neo4j-admin dump, then restart Neo4j.
 USAGE
 }
 
 skip_neo4j=0
+offline_neo4j=0
 while [ "$#" -gt 0 ]; do
     case "$1" in
         --skip-neo4j)
             skip_neo4j=1
+            ;;
+        --neo4j-offline)
+            offline_neo4j=1
             ;;
         -h|--help)
             usage
@@ -30,6 +35,11 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
+
+if [ "$skip_neo4j" -eq 1 ] && [ "$offline_neo4j" -eq 1 ]; then
+    printf 'ERROR: --skip-neo4j and --neo4j-offline cannot be used together.\n' >&2
+    exit 2
+fi
 
 compose() {
     docker compose "$@"
@@ -63,11 +73,53 @@ service explicitly, run the dump, then start Neo4j again. Do not use docker
 compose down -v.
 
 Operator command during a maintenance window:
-  docker compose stop neo4j
-  docker compose run --rm --no-deps --entrypoint neo4j-admin neo4j database dump neo4j --to-path=/backups --overwrite-destination=true
-  docker compose up -d neo4j
+  sh scripts/pre-rebuild-backup.sh --neo4j-offline
 NOTE
 }
+
+run_neo4j_offline_dump() {
+    dump_dir_name=$1
+    dump_host_dir=$backup_dir/$dump_dir_name
+
+    printf 'Stopping Neo4j for offline dump maintenance window...\n'
+    if ! compose stop neo4j; then
+        printf 'ERROR: could not stop Neo4j; offline dump was not attempted.\n' >&2
+        exit 1
+    fi
+
+    if ! mkdir -p "$dump_host_dir"; then
+        printf 'ERROR: could not create Neo4j dump directory: %s\n' "$dump_host_dir" >&2
+        printf 'Restarting Neo4j before exiting.\n' >&2
+        compose up -d neo4j
+        exit 1
+    fi
+
+    printf 'Creating Neo4j offline dump under /backups/%s\n' "$dump_dir_name"
+    if compose run --rm --no-deps --entrypoint neo4j-admin neo4j \
+        database dump neo4j \
+        --to-path="/backups/$dump_dir_name" \
+        --overwrite-destination=true; then
+        printf 'Neo4j offline dump created under: %s\n' "$dump_host_dir"
+        dump_status=0
+    else
+        printf 'ERROR: Neo4j offline dump failed. Restarting Neo4j before exiting.\n' >&2
+        dump_status=1
+    fi
+
+    printf 'Restarting Neo4j after offline dump attempt...\n'
+    compose up -d neo4j
+
+    if [ "$dump_status" -ne 0 ]; then
+        exit "$dump_status"
+    fi
+}
+
+if [ "${PRE_REBUILD_BACKUP_LIB_ONLY:-0}" = "1" ]; then
+    return 0 2>/dev/null || {
+        printf 'ERROR: PRE_REBUILD_BACKUP_LIB_ONLY is only supported when sourcing this script for tests.\n' >&2
+        exit 2
+    }
+fi
 
 require_command docker
 
@@ -76,6 +128,7 @@ backup_dir=$(sh scripts/validate-env.sh --check-backup-dir --print-backup-dir)
 timestamp=$(date -u '+%Y%m%d_%H%M%S')
 postgres_file="postgres_${timestamp}.dump"
 neo4j_file="neo4j_${timestamp}.cypher"
+neo4j_dump_dir="neo4j_${timestamp}_dump"
 neo4j_note="neo4j_${timestamp}_offline-dump-required.txt"
 
 printf 'Validating Docker Compose configuration...\n'
@@ -95,6 +148,8 @@ compose exec -T postgres sh -c '
 
 if [ "$skip_neo4j" -eq 1 ]; then
     printf 'Skipping Neo4j export by request.\n'
+elif [ "$offline_neo4j" -eq 1 ]; then
+    run_neo4j_offline_dump "$neo4j_dump_dir"
 else
     require_running_service neo4j
 

--- a/scripts/safe-rebuild.sh
+++ b/scripts/safe-rebuild.sh
@@ -3,19 +3,21 @@ set -eu
 
 usage() {
     cat <<'USAGE'
-Usage: sh scripts/safe-rebuild.sh [--dry-run] [--skip-neo4j]
+Usage: sh scripts/safe-rebuild.sh [--dry-run] [--skip-neo4j] [--neo4j-offline]
 
 Safely bootstraps backup storage, creates a pre-rebuild backup, rebuilds images,
 and restarts services without deleting Docker volumes.
 
 Options:
-  --dry-run     Print the deploy flow without creating directories or changing containers.
-  --skip-neo4j  Pass through to pre-rebuild-backup.sh to skip the Neo4j online export.
+  --dry-run        Print the deploy flow without creating directories or changing containers.
+  --skip-neo4j     Pass through to pre-rebuild-backup.sh to skip the Neo4j backup.
+  --neo4j-offline  Pass through to pre-rebuild-backup.sh to run a Neo4j offline dump.
 USAGE
 }
 
 dry_run=0
 skip_neo4j=0
+offline_neo4j=0
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -24,6 +26,9 @@ while [ "$#" -gt 0 ]; do
             ;;
         --skip-neo4j)
             skip_neo4j=1
+            ;;
+        --neo4j-offline)
+            offline_neo4j=1
             ;;
         -h|--help)
             usage
@@ -36,6 +41,11 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
+
+if [ "$skip_neo4j" -eq 1 ] && [ "$offline_neo4j" -eq 1 ]; then
+    printf 'ERROR: --skip-neo4j and --neo4j-offline cannot be used together.\n' >&2
+    exit 2
+fi
 
 require_command() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -183,6 +193,8 @@ verify_container_backups backend
 printf 'Creating pre-rebuild backup...\n'
 if [ "$skip_neo4j" -eq 1 ]; then
     run sh scripts/pre-rebuild-backup.sh --skip-neo4j
+elif [ "$offline_neo4j" -eq 1 ]; then
+    run sh scripts/pre-rebuild-backup.sh --neo4j-offline
 else
     run sh scripts/pre-rebuild-backup.sh
 fi
@@ -201,7 +213,7 @@ cat <<'NEXT'
 
 Next verification:
 1. Confirm the PostgreSQL dump exists in BACKUP_DIR.
-2. Confirm Neo4j has either an APOC export or an offline-dump-required note.
+2. Confirm Neo4j has an APOC export, an offline dump directory, or an offline-dump-required note.
 3. Check backend/frontend health in the browser or API.
 4. Do not run docker compose down -v, docker volume rm, or delete data directories.
 NEXT

--- a/scripts/test-neo4j-offline-backup-flags.sh
+++ b/scripts/test-neo4j-offline-backup-flags.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+cd "$REPO_ROOT"
+
+failures=0
+
+fail() {
+    printf 'FAIL: %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+assert_exit_code() {
+    expected=$1
+    shift
+    set +e
+    "$@" >/tmp/neo4j-offline-test-out.$$ 2>/tmp/neo4j-offline-test-err.$$
+    actual=$?
+    set -e
+    rm -f /tmp/neo4j-offline-test-out.$$ /tmp/neo4j-offline-test-err.$$
+    if [ "$actual" -ne "$expected" ]; then
+        fail "expected exit $expected from: $*; got $actual"
+    fi
+}
+
+assert_help_contains() {
+    script=$1
+    if ! sh "$script" --help | grep -q -- '--neo4j-offline'; then
+        fail "$script help should document --neo4j-offline"
+    fi
+}
+
+assert_help_contains scripts/pre-rebuild-backup.sh
+assert_help_contains scripts/safe-rebuild.sh
+assert_exit_code 2 sh scripts/pre-rebuild-backup.sh --skip-neo4j --neo4j-offline
+assert_exit_code 2 sh scripts/safe-rebuild.sh --skip-neo4j --neo4j-offline
+assert_exit_code 2 sh scripts/pre-rebuild-backup.sh --unknown-option
+assert_exit_code 2 sh scripts/safe-rebuild.sh --unknown-option
+
+if [ "${PRE_REBUILD_BACKUP_LIB_ONLY:-}" = "1" ]; then
+    fail 'test should not inherit PRE_REBUILD_BACKUP_LIB_ONLY'
+fi
+
+if [ "$failures" -gt 0 ]; then
+    exit 1
+fi
+
+printf 'neo4j offline backup flag tests passed\n'


### PR DESCRIPTION
Closes #130

## Descripción del Cambio
Adds an explicit Neo4j offline dump workflow for maintenance windows when APOC online export is unavailable.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)
- [x] Maintenance/tooling

## Summary
- Adds `--neo4j-offline` to `scripts/pre-rebuild-backup.sh` and pass-through support in `scripts/safe-rebuild.sh`.
- Preserves PostgreSQL dump behavior while stopping/restarting only Neo4j for offline `neo4j-admin` dumps.
- Documents dump/restore workflow and records the change under `[Unreleased]` for the next patch release.

## Changes
| File | Change |
|------|--------|
| `scripts/pre-rebuild-backup.sh` | Adds explicit offline Neo4j dump mode and flag conflict handling. |
| `scripts/safe-rebuild.sh` | Adds `--neo4j-offline` pass-through to the backup script. |
| `scripts/test-neo4j-offline-backup-flags.sh` | Adds POSIX shell tests for help text, conflicts, and unknown options. |
| `docs/backup-restore.md` | Documents offline dump and restore procedures. |
| `CHANGELOG.md` | Adds the issue #130 entry under `[Unreleased]`. |

## ¿Cómo se probó?
- [x] `sh -n scripts/pre-rebuild-backup.sh scripts/safe-rebuild.sh scripts/test-neo4j-offline-backup-flags.sh scripts/test-safe-rebuild-path-validation.sh`
- [x] `sh scripts/test-neo4j-offline-backup-flags.sh`
- [x] `sh scripts/test-safe-rebuild-path-validation.sh`
- [x] `git diff --check`
- [ ] Real Docker/Neo4j offline dump in staging — not run locally because it stops Neo4j and requires a maintenance window.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:chore`
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

---
*Generado por Alex*
