### PR TITLE
fix(cmdb): stabilize graph topology filtering and refresh

### DIFF
--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -1,3 +1,4 @@
+# pyright: reportArgumentType=false
 from typing import List, Dict, Any, Optional, Set
 import importlib
 import json
@@ -249,11 +250,22 @@ def execute_mass_update(source_filter, target_filter, old_rel, new_rel, allowed_
 def get_filtered_graph_data(layer=None, location=None, owner=None, allowed_locations=None, is_admin=False):
     driver = get_db()
     where, params = [], {}
-    if layer: where.append("n.layer = $layer"); params["layer"] = layer
-    if location: where.append("n.location_name = $location"); params["location"] = location
-    if owner: where.append("n.owner = $owner"); params["owner"] = owner
+
+    def normalize_filter(value):
+        if not value:
+            return []
+        if isinstance(value, list):
+            return [str(v).strip() for v in value if str(v).strip()]
+        return [part.strip() for part in str(value).split(",") if part.strip()]
+
+    layers = normalize_filter(layer)
+    locations = normalize_filter(location)
+    owners = normalize_filter(owner)
+    if layers: where.append("n.layer IN $layers"); params["layers"] = layers
+    if locations: where.append("n.location_name IN $locations"); params["locations"] = locations
+    if owners: where.append("n.owner IN $owners"); params["owners"] = owners
     if not is_admin and allowed_locations: where.append("n.location_name IN $allowed_locations"); params["allowed_locations"] = allowed_locations
-    w_str = (" WHERE " + " AND ".join(where)) if where else ""
+    w_str = (" AND " + " AND ".join(where)) if where else ""
     with driver.session() as session:
         # Build the query: only CIs with valid location coordinates
         node_query = f"""
@@ -303,14 +315,15 @@ def get_filtered_graph_data(layer=None, location=None, owner=None, allowed_locat
         link_filters = []
         security_filter = None
         for cond in where:
-            if "n." in cond:
-                # Replace n. prefix with a. and b. for the link query
-                link_filters.append(cond.replace("n.", "a."))
-                link_filters.append(cond.replace("n.", "b."))
             # Extract security filter to apply separately
             if "allowed_locations" in cond:
                 # Transform to apply to both endpoints a and b
                 security_filter = cond.replace("n.", "a.") + " OR " + cond.replace("n.", "b.")
+                continue
+            if "n." in cond:
+                # Replace n. prefix with a. and b. for the link query
+                link_filters.append(cond.replace("n.", "a."))
+                link_filters.append(cond.replace("n.", "b."))
 
         # Build the link query with proper AND/OR structure:
         # Security is always AND'd, user filters are OR'd per condition group

--- a/backend/services/link_service.py
+++ b/backend/services/link_service.py
@@ -56,7 +56,7 @@ def get_full_graph(current_user: Optional[User] = None, layer: Optional[str] = N
         labels = node_props.get("_labels", [])
         
         # Determine primary type/label
-        primary_type = "CI" # Default for filtered view
+        primary_type = "CI" if not labels or "CI" in labels else "Unknown"
         if "Category" in labels: primary_type = "Category"
         elif "OwnerGroup" in labels: primary_type = "Owner"
         elif "MetricDef" in labels: primary_type = "Metric"
@@ -68,9 +68,20 @@ def get_full_graph(current_user: Optional[User] = None, layer: Optional[str] = N
         if primary_type == "CI" and node_props.get("layer"):
             display_type = node_props.get("layer")
 
+        fallback_id = (
+            node_props.get("id")
+            or node_props.get("name")
+            or node_props.get("label")
+            or " ".join(
+                str(part)
+                for part in [node_props.get("brand"), node_props.get("model")]
+                if part
+            )
+        )
+
         nodes.append({
-            "id": node_props.get("id"),
-            "label": node_props.get("name") or node_props.get("label") or node_props.get("id"),
+            "id": fallback_id,
+            "label": node_props.get("name") or node_props.get("label") or fallback_id,
             "type": display_type,
             "status": node_props.get("status", "ACTIVE"),
             "location": node_props.get("location"),

--- a/backend/tests/test_routers_links.py
+++ b/backend/tests/test_routers_links.py
@@ -17,6 +17,8 @@ Strategy:
 import pytest
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
+from models.user import User
+from services.auth_service import get_current_active_user
 
 # ---------------------------------------------------------------------------
 # Patch Neo4j driver BEFORE importing anything that touches database.py
@@ -30,6 +32,12 @@ with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
 # TestClient
 # ---------------------------------------------------------------------------
 client = TestClient(app)
+app.dependency_overrides[get_current_active_user] = lambda: User(
+    username="test-admin",
+    role="ADMIN",
+    permissions=[],
+    allowed_locations=[],
+)
 
 
 # ===========================================================================
@@ -205,7 +213,7 @@ class TestGraphFull:
     def test_full_graph_returns_empty(self):
         """Should return empty graph when no data exists."""
         with patch("services.link_service.topology_repo") as mock_repo:
-            mock_repo.get_full_graph_data.return_value = ([], [])
+            mock_repo.get_filtered_graph_data.return_value = ([], [])
 
             response = client.get("/api/graph/full")
 
@@ -246,7 +254,7 @@ class TestGraphFull:
         ]
 
         with patch("services.link_service.topology_repo") as mock_repo:
-            mock_repo.get_full_graph_data.return_value = (raw_nodes, raw_links)
+            mock_repo.get_filtered_graph_data.return_value = (raw_nodes, raw_links)
 
             response = client.get("/api/graph/full")
 
@@ -275,7 +283,7 @@ class TestGraphFull:
         raw_links = []
 
         with patch("services.link_service.topology_repo") as mock_repo:
-            mock_repo.get_full_graph_data.return_value = (raw_nodes, raw_links)
+            mock_repo.get_filtered_graph_data.return_value = (raw_nodes, raw_links)
 
             response = client.get("/api/graph/full")
 
@@ -306,7 +314,7 @@ class TestGraphFull:
         ]
 
         with patch("services.link_service.topology_repo") as mock_repo:
-            mock_repo.get_full_graph_data.return_value = (raw_nodes, [])
+            mock_repo.get_filtered_graph_data.return_value = (raw_nodes, [])
 
             response = client.get("/api/graph/full")
 
@@ -323,7 +331,7 @@ class TestGraphFull:
     def test_full_graph_no_auth_required(self):
         """Full graph should NOT require authentication (documented gap)."""
         with patch("services.link_service.topology_repo") as mock_repo:
-            mock_repo.get_full_graph_data.return_value = ([], [])
+            mock_repo.get_filtered_graph_data.return_value = ([], [])
 
             response = client.get("/api/graph/full")
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,260 +1,337 @@
-import type React from 'react';
-import { useState } from 'react';
-import { HashRouter as Router, Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from './context/AuthContext';
-import LoginPage from './components/LoginPage';
-import type { GraphNode } from './types';
-import { api } from './services/api';
-import { useQueryClient } from '@tanstack/react-query';
-import { queryKeys } from './services/queryKeys';
-import { useNodesQuery } from './hooks/queries/useNodesQuery';
+import type React from "react";
+import { useCallback, useState } from "react";
+import {
+	HashRouter as Router,
+	Routes,
+	Route,
+	Link,
+	useLocation,
+	Navigate,
+} from "react-router-dom";
+import { AuthProvider, useAuth } from "./context/AuthContext";
+import LoginPage from "./components/LoginPage";
+import type { GraphNode } from "./types";
+import { api } from "./services/api";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "./services/queryKeys";
 
 // Components
-import GraphCMDB from './components/GraphCMDB';
-import NetworkVisualizer from './components/NetworkVisualizer';
-import AIAgentConsole from './components/AIAgentConsole';
-import CIEditor from './components/CIEditor';
-import AdminPage from './components/AdminPage';
-import MonitoringConsole from './components/MonitoringConsole';
-import SystemDashboard from './components/SystemDashboard';
-import GlobalInventory from './components/GlobalInventory';
-import ChangePasswordPage from './components/ChangePasswordPage';
-import UserManager from './components/UserManager';
-import RoleManager from './components/RoleManager';
-import CIDetailModal from './components/CIDetailModal';
-import MetricAnalytics from './components/MetricAnalytics';
-import VisualRelationshipEditorPage from './components/VisualRelationshipEditorPage';
+import GraphCMDB from "./components/GraphCMDB";
+import AIAgentConsole from "./components/AIAgentConsole";
+import CIEditor from "./components/CIEditor";
+import AdminPage from "./components/AdminPage";
+import MonitoringConsole from "./components/MonitoringConsole";
+import SystemDashboard from "./components/SystemDashboard";
+import GlobalInventory from "./components/GlobalInventory";
+import ChangePasswordPage from "./components/ChangePasswordPage";
+import UserManager from "./components/UserManager";
+import CIDetailModal from "./components/CIDetailModal";
+import MetricAnalytics from "./components/MetricAnalytics";
+import VisualRelationshipEditorPage from "./components/VisualRelationshipEditorPage";
 
 // --- Protected Route Helper ---
 const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
-  const { isAuthenticated, loading, user } = useAuth();
-  const location = useLocation();
+	const { isAuthenticated, loading, user } = useAuth();
+	const location = useLocation();
 
-  if (loading) {
-    return (
-      <div className="h-screen w-screen flex flex-col items-center justify-center bg-surface-950 font-sans text-neutral-200">
-        <div className="w-10 h-10 border-4 border-brand-600 border-t-transparent rounded-full animate-spin mb-4"></div>
-        <p className="text-xs font-bold uppercase tracking-widest text-neutral-400 animate-pulse">Loading Session...</p>
-      </div>
-    );
-  }
+	if (loading) {
+		return (
+			<div className="h-screen w-screen flex flex-col items-center justify-center bg-surface-950 font-sans text-neutral-200">
+				<div className="w-10 h-10 border-4 border-brand-600 border-t-transparent rounded-full animate-spin mb-4"></div>
+				<p className="text-xs font-bold uppercase tracking-widest text-neutral-400 animate-pulse">
+					Loading Session...
+				</p>
+			</div>
+		);
+	}
 
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
+	if (!isAuthenticated) {
+		return <Navigate to="/login" replace />;
+	}
 
-  if (user?.force_password_change && location.pathname !== '/change-password') {
-    return <Navigate to="/change-password" replace />;
-  }
+	if (user?.force_password_change && location.pathname !== "/change-password") {
+		return <Navigate to="/change-password" replace />;
+	}
 
-  return children;
+	return children;
 };
 
 // --- Main Layout (Authenticated) ---
 const MainLayout: React.FC = () => {
-  const { user, logout, hasPermission } = useAuth();
-  const queryClient = useQueryClient();
-  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
-  const { data: nodes = [] } = useNodesQuery();
+	const { user, logout, hasPermission } = useAuth();
+	const queryClient = useQueryClient();
+	const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
 
-  const [isEditing, setIsEditing] = useState(false);
-  const [showDetailModal, setShowDetailModal] = useState(false);
-  const [showAIAgent, setShowAIAgent] = useState(false);
+	const [isEditing, setIsEditing] = useState(false);
+	const [showDetailModal, setShowDetailModal] = useState(false);
+	const [showAIAgent, setShowAIAgent] = useState(false);
 
-  // --- CRUD Functions ---
-  const refreshTopologyResources = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.graphTopology() }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
-    ]);
-  };
+	// --- CRUD Functions ---
+	const refreshTopologyResources = async () => {
+		await Promise.all([
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.graphTopologyRoot(),
+			}),
+			queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
+			queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
+		]);
+	};
 
-  const handleSaveCI = async (newNode: GraphNode) => {
-    try {
-      await api.post('/nodes', newNode);
-      await refreshTopologyResources();
-      setIsEditing(false);
-      setSelectedNode(null);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+	const handleSaveCI = async (newNode: GraphNode) => {
+		try {
+			await api.post("/nodes", newNode);
+			await refreshTopologyResources();
+			setIsEditing(false);
+			setSelectedNode(null);
+		} catch (err) {
+			console.error(err);
+		}
+	};
 
-  const handleDeleteCI = async (id: string) => {
-    try {
-      await api.delete(`/nodes/${id}`);
-      await refreshTopologyResources();
-      setIsEditing(false);
-      setSelectedNode(null);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+	const handleDeleteCI = async (id: string) => {
+		try {
+			await api.delete(`/nodes/${id}`);
+			await refreshTopologyResources();
+			setIsEditing(false);
+			setSelectedNode(null);
+		} catch (err) {
+			console.error(err);
+		}
+	};
 
-  const exportToPythonAgent = async () => {
-    try {
-      const topology = await api.get<{ nodes: GraphNode[]; links: unknown[] }>('/graph/full');
-      const data = JSON.stringify(topology, null, 2);
-      const blob = new Blob([data], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'cmdb_inventory.json';
-      a.click();
-    } catch (err) {
-      console.error('Failed to export CMDB inventory for Python agent.', err);
-      alert('No se pudo exportar el inventario. Verificá tu conexion o volve a iniciar sesion.');
-    }
-  };
+	const handleGraphNodeClick = useCallback((node: GraphNode) => {
+		setSelectedNode(node);
+		setShowDetailModal(true);
+	}, []);
 
-  return (
-    <div className="flex h-screen w-full max-w-full overflow-hidden bg-surface-950 font-sans text-neutral-200">
-      {/* Sidebar Nav */}
-      <nav className="w-20 lg:w-64 border-r border-white/5 flex flex-col glass z-50">
-        <div className="p-6 flex items-center gap-3">
-          <div className="w-10 h-10 bg-brand-600 rounded-xl flex items-center justify-center text-white neon-glow">
-            <span className="material-symbols-outlined text-2xl">hub</span>
-          </div>
-          <span className="hidden lg:block font-black text-xl tracking-tighter text-white">NEX-GEN</span>
-        </div>
+	const exportToPythonAgent = async () => {
+		try {
+			const topology = await api.get<{ nodes: GraphNode[]; links: unknown[] }>(
+				"/graph/full",
+			);
+			const data = JSON.stringify(topology, null, 2);
+			const blob = new Blob([data], { type: "application/json" });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement("a");
+			a.href = url;
+			a.download = "cmdb_inventory.json";
+			a.click();
+		} catch (err) {
+			console.error("Failed to export CMDB inventory for Python agent.", err);
+			alert(
+				"No se pudo exportar el inventario. Verificá tu conexion o volve a iniciar sesion.",
+			);
+		}
+	};
 
-        <div className="flex-1 flex flex-col py-6 space-y-2 px-3">
-          <NavItem to="/" icon="dashboard" label="Architecture" />
-          <NavItem to="/monitoring" icon="public" label="Monitoring" />
-          <NavItem to="/cmdb" icon="mediation" label="Graph CMDB" />
-          <NavItem to="/inventory" icon="inventory_2" label="CI Inventory" />
-          <NavItem to="/network" icon="hub" label="Network Topology" />
+	return (
+		<div className="flex h-screen w-full max-w-full overflow-hidden bg-surface-950 font-sans text-neutral-200">
+			{/* Sidebar Nav */}
+			<nav className="w-20 lg:w-64 border-r border-white/5 flex flex-col glass z-50">
+				<div className="p-6 flex items-center gap-3">
+					<div className="w-10 h-10 bg-brand-600 rounded-xl flex items-center justify-center text-white neon-glow">
+						<span className="material-symbols-outlined text-2xl">hub</span>
+					</div>
+					<span className="hidden lg:block font-black text-xl tracking-tighter text-white">
+						NEX-GEN
+					</span>
+				</div>
 
-          {(hasPermission('ADMIN') || hasPermission('METRICS_VIEW')) && (
-            <NavItem to="/analytics" icon="monitoring" label="Analytics" />
-          )}
+				<div className="flex-1 flex flex-col py-6 space-y-2 px-3">
+					<NavItem to="/" icon="dashboard" label="Architecture" />
+					<NavItem to="/monitoring" icon="public" label="Monitoring" />
+					<NavItem to="/cmdb" icon="mediation" label="Graph CMDB" />
+					<NavItem to="/inventory" icon="inventory_2" label="CI Inventory" />
+					<NavItem to="/network" icon="hub" label="Network Topology" />
 
-          {(hasPermission('ADMIN') || hasPermission('USER_MANAGE')) && (
-            <NavItem to="/users" icon="manage_accounts" label="User Management" />
-          )}
-          {(hasPermission('ADMIN') || hasPermission('USER_MANAGE')) && (
-            <NavItem to="/admin" icon="admin_panel_settings" label="Administration" />
-          )}
-        </div>
+					{(hasPermission("ADMIN") || hasPermission("METRICS_VIEW")) && (
+						<NavItem to="/analytics" icon="monitoring" label="Analytics" />
+					)}
 
-        <div className="p-6 space-y-4 border-t border-white/5">
-          <button onClick={exportToPythonAgent} className="w-full flex items-center gap-3 px-4 py-2 text-[10px] font-black uppercase text-neutral-500 hover:text-white transition-colors">
-            <span className="material-symbols-outlined text-sm">terminal</span>
-            Python Export
-          </button>
-          <div className="flex items-center gap-3 group cursor-pointer" onClick={logout} title="Click to Logout">
-            <div className="w-10 h-10 rounded-full bg-neutral-800 border border-white/10 overflow-hidden flex items-center justify-center">
-              {/* Initials */}
-              <span className="font-bold text-lg">{user?.username?.substring(0, 2).toUpperCase()}</span>
-            </div>
-            <div className="hidden lg:block text-left">
-              <p className="text-xs font-bold text-white">{user?.username || 'Guest'}</p>
-              <p className="text-[10px] text-neutral-500 uppercase tracking-widest">{user?.role || 'Viewer'}</p>
-            </div>
-            <span className="material-symbols-outlined text-neutral-500 group-hover:text-red-500 ml-auto text-sm">logout</span>
-          </div>
-        </div>
-      </nav>
+					{(hasPermission("ADMIN") || hasPermission("USER_MANAGE")) && (
+						<NavItem
+							to="/users"
+							icon="manage_accounts"
+							label="User Management"
+						/>
+					)}
+					{(hasPermission("ADMIN") || hasPermission("USER_MANAGE")) && (
+						<NavItem
+							to="/admin"
+							icon="admin_panel_settings"
+							label="Administration"
+						/>
+					)}
+				</div>
 
-      {/* Main View Area */}
-      <div className="flex-1 min-w-0 flex flex-col relative overflow-hidden">
-        <header className="h-20 border-b border-white/5 flex items-center justify-between px-8 glass z-40">
-          <div className="flex items-center gap-4">
-            <h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">Platform Engine v3.2</h1>
-            <div className="hidden md:flex items-center gap-2 bg-neutral-900 border border-white/5 px-3 py-1 rounded-full text-[10px] font-black text-accent-cyan">
-              <span className="w-2 h-2 bg-accent-cyan rounded-full animate-pulse"></span>
-              SNMP Polling: ACTIVE ({nodes.length} Nodes)
-            </div>
-          </div>
+				<div className="p-6 space-y-4 border-t border-white/5">
+					<button
+						onClick={exportToPythonAgent}
+						className="w-full flex items-center gap-3 px-4 py-2 text-[10px] font-black uppercase text-neutral-500 hover:text-white transition-colors"
+					>
+						<span className="material-symbols-outlined text-sm">terminal</span>
+						Python Export
+					</button>
+					<div
+						className="flex items-center gap-3 group cursor-pointer"
+						onClick={logout}
+						title="Click to Logout"
+					>
+						<div className="w-10 h-10 rounded-full bg-neutral-800 border border-white/10 overflow-hidden flex items-center justify-center">
+							{/* Initials */}
+							<span className="font-bold text-lg">
+								{user?.username?.substring(0, 2).toUpperCase()}
+							</span>
+						</div>
+						<div className="hidden lg:block text-left">
+							<p className="text-xs font-bold text-white">
+								{user?.username || "Guest"}
+							</p>
+							<p className="text-[10px] text-neutral-500 uppercase tracking-widest">
+								{user?.role || "Viewer"}
+							</p>
+						</div>
+						<span className="material-symbols-outlined text-neutral-500 group-hover:text-red-500 ml-auto text-sm">
+							logout
+						</span>
+					</div>
+				</div>
+			</nav>
 
-          <div className="flex items-center gap-4">
-            {/* Header Actions */}
-            <button
-              onClick={() => setShowAIAgent(!showAIAgent)}
-              className={`flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black transition-all border ${showAIAgent ? 'bg-white/10 text-white border-white/20' : 'bg-transparent text-neutral-500 border-white/5 hover:text-white'}`}
-            >
-              <span className="material-symbols-outlined text-sm">{showAIAgent ? 'chat' : 'chat_bubble_outline'}</span>
-              {showAIAgent ? 'HIDE AI' : 'SHOW AI'}
-            </button>
-          </div>
-        </header>
+			{/* Main View Area */}
+			<div className="flex-1 min-w-0 flex flex-col relative overflow-hidden">
+				<header className="h-20 border-b border-white/5 flex items-center justify-between px-8 glass z-40">
+					<div className="flex items-center gap-4">
+						<h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">
+							Platform Engine v3.2
+						</h1>
+						<div className="hidden md:flex items-center gap-2 bg-neutral-900 border border-white/5 px-3 py-1 rounded-full text-[10px] font-black text-accent-cyan">
+							<span className="w-2 h-2 bg-accent-cyan rounded-full animate-pulse"></span>
+							SNMP Polling: ACTIVE
+						</div>
+					</div>
 
-        <main className="flex-1 min-w-0 flex overflow-hidden relative">
-          <div className="flex-1 min-w-0 h-full relative overflow-hidden">
-            <Routes>
-              <Route index element={<SystemDashboard />} />
-              <Route path="monitoring" element={<MonitoringConsole />} />
-              <Route path="admin" element={<AdminPage />} />
-              <Route path="admin/relationships/visual-editor" element={<VisualRelationshipEditorPage />} />
-              <Route path="users" element={<UserManager />} />
-              <Route path="cmdb" element={<GraphCMDB onNodeClick={(n) => { setSelectedNode(n); setShowDetailModal(true); }} />} />
-              {/* <Route path="network" element={<NetworkVisualizer />} /> */}
-              <Route path="analytics" element={<MetricAnalytics />} />
-              <Route path="inventory" element={<GlobalInventory />} />
-            </Routes>
-          </div>
+					<div className="flex items-center gap-4">
+						{/* Header Actions */}
+						<button
+							onClick={() => setShowAIAgent(!showAIAgent)}
+							className={`flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black transition-all border ${showAIAgent ? "bg-white/10 text-white border-white/20" : "bg-transparent text-neutral-500 border-white/5 hover:text-white"}`}
+						>
+							<span className="material-symbols-outlined text-sm">
+								{showAIAgent ? "chat" : "chat_bubble_outline"}
+							</span>
+							{showAIAgent ? "HIDE AI" : "SHOW AI"}
+						</button>
+					</div>
+				</header>
 
-          {isEditing && (
-            <CIEditor
-              node={selectedNode}
-              onSave={handleSaveCI}
-              onDelete={handleDeleteCI}
-              onClose={() => setIsEditing(false)}
-            />
-          )}
+				<main className="flex-1 min-w-0 flex overflow-hidden relative">
+					<div className="flex-1 min-w-0 h-full relative overflow-hidden">
+						<Routes>
+							<Route index element={<SystemDashboard />} />
+							<Route path="monitoring" element={<MonitoringConsole />} />
+							<Route path="admin" element={<AdminPage />} />
+							<Route
+								path="admin/relationships/visual-editor"
+								element={<VisualRelationshipEditorPage />}
+							/>
+							<Route path="users" element={<UserManager />} />
+							<Route
+								path="cmdb"
+								element={<GraphCMDB onNodeClick={handleGraphNodeClick} />}
+							/>
+							<Route path="analytics" element={<MetricAnalytics />} />
+							<Route path="inventory" element={<GlobalInventory />} />
+						</Routes>
+					</div>
 
-          {showDetailModal && (
-            <CIDetailModal
-              node={selectedNode}
-              onClose={() => setShowDetailModal(false)}
-            />
-          )}
+					{isEditing && (
+						<CIEditor
+							node={selectedNode}
+							onSave={handleSaveCI}
+							onDelete={handleDeleteCI}
+							onClose={() => setIsEditing(false)}
+						/>
+					)}
 
-          <aside className={`w-96 border-l border-white/5 glass flex flex-col transition-all duration-500 ${isEditing || !showAIAgent ? 'opacity-0 translate-x-full absolute right-0' : 'relative opacity-100 translate-x-0'}`}>
-            <AIAgentConsole />
-          </aside>
-        </main>
-      </div>
-    </div>
-  );
+					{showDetailModal && (
+						<CIDetailModal
+							node={selectedNode}
+							onClose={() => setShowDetailModal(false)}
+						/>
+					)}
+
+					<aside
+						className={`w-96 border-l border-white/5 glass flex flex-col transition-all duration-500 ${isEditing || !showAIAgent ? "opacity-0 translate-x-full absolute right-0" : "relative opacity-100 translate-x-0"}`}
+					>
+						<AIAgentConsole />
+					</aside>
+				</main>
+			</div>
+		</div>
+	);
 };
 
 // --- Helper Components ---
-const NavItem: React.FC<{ to: string, icon: string, label: string, count?: number }> = ({ to, icon, label, count }) => {
-  const location = useLocation();
-  const active = location.pathname === to;
-  return (
-    <Link to={to} className={`flex items-center gap-4 px-4 py-3.5 rounded-2xl transition-all duration-300 group ${active ? 'bg-brand-600/15 text-brand-400 border border-brand-600/20' : 'text-neutral-500 hover:text-neutral-200 hover:bg-white/5'
-      }`}>
-      <span className={`material-symbols-outlined text-2xl ${active ? 'fill-1' : ''}`}>{icon}</span>
-      <span className="hidden lg:block text-sm font-bold">{label}</span>
-      {count && <span className="ml-auto bg-red-500/20 text-red-500 text-[10px] px-1.5 py-0.5 rounded">{count}</span>}
-    </Link>
-  );
+const NavItem: React.FC<{
+	to: string;
+	icon: string;
+	label: string;
+	count?: number;
+}> = ({ to, icon, label, count }) => {
+	const location = useLocation();
+	const active = location.pathname === to;
+	return (
+		<Link
+			to={to}
+			className={`flex items-center gap-4 px-4 py-3.5 rounded-2xl transition-all duration-300 group ${
+				active
+					? "bg-brand-600/15 text-brand-400 border border-brand-600/20"
+					: "text-neutral-500 hover:text-neutral-200 hover:bg-white/5"
+			}`}
+		>
+			<span
+				className={`material-symbols-outlined text-2xl ${active ? "fill-1" : ""}`}
+			>
+				{icon}
+			</span>
+			<span className="hidden lg:block text-sm font-bold">{label}</span>
+			{count && (
+				<span className="ml-auto bg-red-500/20 text-red-500 text-[10px] px-1.5 py-0.5 rounded">
+					{count}
+				</span>
+			)}
+		</Link>
+	);
 };
 
 // --- App Entry Point ---
 const App: React.FC = () => {
-  return (
-    <Router>
-      <AuthProvider>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/change-password" element={
-            <ProtectedRoute>
-              <ChangePasswordPage />
-            </ProtectedRoute>
-          } />
-          <Route path="/*" element={
-            <ProtectedRoute>
-              <MainLayout />
-            </ProtectedRoute>
-          } />
-        </Routes>
-      </AuthProvider>
-    </Router>
-  );
+	return (
+		<Router>
+			<AuthProvider>
+				<Routes>
+					<Route path="/login" element={<LoginPage />} />
+					<Route
+						path="/change-password"
+						element={
+							<ProtectedRoute>
+								<ChangePasswordPage />
+							</ProtectedRoute>
+						}
+					/>
+					<Route
+						path="/*"
+						element={
+							<ProtectedRoute>
+								<MainLayout />
+							</ProtectedRoute>
+						}
+					/>
+				</Routes>
+			</AuthProvider>
+		</Router>
+	);
 };
 
 export default App;

--- a/frontend/components/VisualRelationshipEditorPage.test.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.test.tsx
@@ -1,119 +1,172 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
-import { createQueryWrapper, createTestQueryClient } from '../test/queryTestUtils';
-import VisualRelationshipEditorPage from './VisualRelationshipEditorPage';
-import { queryKeys } from '../services/queryKeys';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+	createQueryWrapper,
+	createTestQueryClient,
+} from "../test/queryTestUtils";
+import VisualRelationshipEditorPage from "./VisualRelationshipEditorPage";
+import { queryKeys } from "../services/queryKeys";
 
 const { mockApiGet, mockHasPermission } = vi.hoisted(() => ({
-  mockApiGet: vi.fn(),
-  mockHasPermission: vi.fn(),
+	mockApiGet: vi.fn(),
+	mockHasPermission: vi.fn(),
 }));
 
-vi.mock('../services/api', () => ({
-  api: {
-    get: mockApiGet,
-  },
+vi.mock("../services/api", () => ({
+	api: {
+		get: mockApiGet,
+	},
 }));
 
-vi.mock('../context/AuthContext', () => ({
-  useAuth: () => ({ hasPermission: mockHasPermission }),
+vi.mock("../context/AuthContext", () => ({
+	useAuth: () => ({ hasPermission: mockHasPermission }),
 }));
 
-vi.mock('./VisualRelationshipEditor', () => ({
-  default: ({ nodes, links, mode, onMutated }: { nodes: unknown[]; links: unknown[]; mode?: string; onMutated: () => Promise<void> }) => (
-    <div>
-      <span>Visual editor workspace {nodes.length} nodes {links.length} links mode {mode}</span>
-      <button type="button" onClick={() => void onMutated()}>Trigger mutation refresh</button>
-    </div>
-  ),
+vi.mock("./VisualRelationshipEditor", () => ({
+	default: ({
+		nodes,
+		links,
+		mode,
+		onMutated,
+	}: {
+		nodes: unknown[];
+		links: unknown[];
+		mode?: string;
+		onMutated: () => Promise<void>;
+	}) => (
+		<div>
+			<span>
+				Visual editor workspace {nodes.length} nodes {links.length} links mode{" "}
+				{mode}
+			</span>
+			<button type="button" onClick={() => void onMutated()}>
+				Trigger mutation refresh
+			</button>
+		</div>
+	),
 }));
 
 function QuerySeeder() {
-  const queryClient = useQueryClient();
-  queryClient.setQueryData(queryKeys.graphTopology(), { nodes: [], links: [] });
-  return null;
+	const queryClient = useQueryClient();
+	queryClient.setQueryData(queryKeys.graphTopology(), { nodes: [], links: [] });
+	return null;
 }
 
 const renderPage = (client = createTestQueryClient()) =>
-  render(
-    <MemoryRouter>
-      <VisualRelationshipEditorPage />
-      <QuerySeeder />
-    </MemoryRouter>,
-    { wrapper: createQueryWrapper(client) },
-  );
+	render(
+		<MemoryRouter>
+			<VisualRelationshipEditorPage />
+			<QuerySeeder />
+		</MemoryRouter>,
+		{ wrapper: createQueryWrapper(client) },
+	);
 
-describe('VisualRelationshipEditorPage', () => {
-  beforeEach(() => {
-    mockApiGet.mockReset();
-    mockHasPermission.mockReset();
-    mockHasPermission.mockReturnValue(true);
-  });
+describe("VisualRelationshipEditorPage", () => {
+	beforeEach(() => {
+		mockApiGet.mockReset();
+		mockHasPermission.mockReset();
+		mockHasPermission.mockReturnValue(true);
+	});
 
-  it('loads nodes and links for the full-page visual editor', async () => {
-    mockApiGet.mockImplementation((endpoint: string) => {
-      if (endpoint === '/nodes') {
-        return Promise.resolve([
-          { id: 'ci-a', label: 'Router A', type: 'INFRASTRUCTURE', status: 'OK', metadata: {} },
-        ]);
-      }
-      if (endpoint === '/links') {
-        return Promise.resolve([
-          { source: 'ci-a', target: 'ci-b', relationship: 'CONNECTS_TO' },
-        ]);
-      }
-      return Promise.resolve([]);
-    });
+	it("loads nodes and links for the full-page visual editor", async () => {
+		mockApiGet.mockImplementation((endpoint: string) => {
+			if (endpoint === "/nodes") {
+				return Promise.resolve([
+					{
+						id: "ci-a",
+						label: "Router A",
+						type: "INFRASTRUCTURE",
+						status: "OK",
+						metadata: {},
+					},
+				]);
+			}
+			if (endpoint === "/links") {
+				return Promise.resolve([
+					{ source: "ci-a", target: "ci-b", relationship: "CONNECTS_TO" },
+				]);
+			}
+			return Promise.resolve([]);
+		});
 
-    renderPage();
+		renderPage();
 
-    expect(screen.getByLabelText('Loading visual relationship editor')).toBeInTheDocument();
-    expect(await screen.findByText('Visual editor workspace 1 nodes 1 links mode page')).toBeInTheDocument();
-    await waitFor(() => {
-      expect(mockApiGet).toHaveBeenCalledWith('/nodes', expect.objectContaining({ signal: expect.any(AbortSignal) }));
-      expect(mockApiGet).toHaveBeenCalledWith('/links', expect.objectContaining({ signal: expect.any(AbortSignal) }));
-    });
-  });
+		expect(
+			screen.getByLabelText("Loading visual relationship editor"),
+		).toBeInTheDocument();
+		expect(
+			await screen.findByText(
+				"Visual editor workspace 1 nodes 1 links mode page",
+			),
+		).toBeInTheDocument();
+		await waitFor(() => {
+			expect(mockApiGet).toHaveBeenCalledWith(
+				"/nodes",
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			);
+			expect(mockApiGet).toHaveBeenCalledWith(
+				"/links",
+				expect.objectContaining({ signal: expect.any(AbortSignal) }),
+			);
+		});
+	});
 
-  it('invalidates graph resources after visual editor mutations', async () => {
-    mockApiGet.mockImplementation((endpoint: string) => {
-      if (endpoint === '/nodes') return Promise.resolve([]);
-      if (endpoint === '/links') return Promise.resolve([]);
-      return Promise.resolve([]);
-    });
+	it("invalidates graph resources after visual editor mutations", async () => {
+		mockApiGet.mockImplementation((endpoint: string) => {
+			if (endpoint === "/nodes") return Promise.resolve([]);
+			if (endpoint === "/links") return Promise.resolve([]);
+			return Promise.resolve([]);
+		});
 
-    const client = createTestQueryClient();
-    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
-    renderPage(client);
+		const client = createTestQueryClient();
+		const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+		renderPage(client);
 
-    await screen.findByText('Visual editor workspace 0 nodes 0 links mode page');
-    fireEvent.click(screen.getByRole('button', { name: 'Trigger mutation refresh' }));
+		await screen.findByText(
+			"Visual editor workspace 0 nodes 0 links mode page",
+		);
+		fireEvent.click(
+			screen.getByRole("button", { name: "Trigger mutation refresh" }),
+		);
 
-    await waitFor(() => {
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.nodes() });
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.links() });
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.graphTopology() });
-    });
-  });
+		await waitFor(() => {
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: queryKeys.nodes(),
+			});
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: queryKeys.links(),
+			});
+			expect(invalidateSpy).toHaveBeenCalledWith({
+				queryKey: queryKeys.graphTopologyRoot(),
+			});
+		});
+	});
 
-  it('blocks direct access without CI edit permissions', () => {
-    mockHasPermission.mockReturnValue(false);
+	it("blocks direct access without CI edit permissions", () => {
+		mockHasPermission.mockReturnValue(false);
 
-    renderPage();
+		renderPage();
 
-    expect(screen.getByLabelText('Visual relationship editor access denied')).toBeInTheDocument();
-    expect(screen.getByText('Access denied')).toBeInTheDocument();
-    expect(mockApiGet).not.toHaveBeenCalled();
-  });
+		expect(
+			screen.getByLabelText("Visual relationship editor access denied"),
+		).toBeInTheDocument();
+		expect(screen.getByText("Access denied")).toBeInTheDocument();
+		expect(mockApiGet).not.toHaveBeenCalled();
+	});
 
-  it('shows an error state when visual editor data cannot load', async () => {
-    mockApiGet.mockRejectedValue(new Error('down'));
+	it("shows an error state when visual editor data cannot load", async () => {
+		mockApiGet.mockRejectedValue(new Error("down"));
 
-    renderPage();
+		renderPage();
 
-    expect(await screen.findByText('Could not load visual editor data')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Back to admin' })).toHaveAttribute('href', '/admin');
-  });
+		expect(
+			await screen.findByText("Could not load visual editor data"),
+		).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "Back to admin" })).toHaveAttribute(
+			"href",
+			"/admin",
+		);
+	});
 });

--- a/frontend/components/VisualRelationshipEditorPage.tsx
+++ b/frontend/components/VisualRelationshipEditorPage.tsx
@@ -1,83 +1,115 @@
-import type React from 'react';
-import { Link } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
-import VisualRelationshipEditor from './VisualRelationshipEditor';
-import { useNodesQuery } from '../hooks/queries/useNodesQuery';
-import { useLinksQuery } from '../hooks/queries/useLinksQuery';
-import { queryKeys } from '../services/queryKeys';
-import { useAuth } from '../context/AuthContext';
+import type React from "react";
+import { Link } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import VisualRelationshipEditor from "./VisualRelationshipEditor";
+import { useNodesQuery } from "../hooks/queries/useNodesQuery";
+import { useLinksQuery } from "../hooks/queries/useLinksQuery";
+import { queryKeys } from "../services/queryKeys";
+import { useAuth } from "../context/AuthContext";
 
 const AccessDenied = () => (
-  <section className="flex h-full items-center justify-center bg-neutral-950 p-8 text-neutral-300" aria-label="Visual relationship editor access denied">
-    <div className="max-w-lg rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6 text-center">
-      <p className="text-sm font-black uppercase tracking-widest text-amber-200">Access denied</p>
-      <p className="mt-2 text-xs text-neutral-400">You need CI edit permissions to open the visual relationship editor.</p>
-      <Link to="/admin" className="mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-xs font-black uppercase text-white hover:bg-white/10">
-        Back to admin
-      </Link>
-    </div>
-  </section>
+	<section
+		className="flex h-full items-center justify-center bg-neutral-950 p-8 text-neutral-300"
+		aria-label="Visual relationship editor access denied"
+	>
+		<div className="max-w-lg rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6 text-center">
+			<p className="text-sm font-black uppercase tracking-widest text-amber-200">
+				Access denied
+			</p>
+			<p className="mt-2 text-xs text-neutral-400">
+				You need CI edit permissions to open the visual relationship editor.
+			</p>
+			<Link
+				to="/admin"
+				className="mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-xs font-black uppercase text-white hover:bg-white/10"
+			>
+				Back to admin
+			</Link>
+		</div>
+	</section>
 );
 
 const VisualRelationshipEditorPageContent: React.FC = () => {
-  const queryClient = useQueryClient();
-  const nodesQuery = useNodesQuery();
-  const linksQuery = useLinksQuery();
+	const queryClient = useQueryClient();
+	const nodesQuery = useNodesQuery();
+	const linksQuery = useLinksQuery();
 
-  const nodes = nodesQuery.data ?? [];
-  const links = linksQuery.data ?? [];
-  const isLoading = nodesQuery.isLoading || linksQuery.isLoading;
-  const error = nodesQuery.error ?? linksQuery.error;
+	const nodes = nodesQuery.data ?? [];
+	const links = linksQuery.data ?? [];
+	const isLoading = nodesQuery.isLoading || linksQuery.isLoading;
+	const error = nodesQuery.error ?? linksQuery.error;
 
-  const refreshRelationshipData = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.graphTopology() }),
-    ]);
-  };
+	const refreshRelationshipData = async () => {
+		await Promise.all([
+			queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
+			queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.graphTopologyRoot(),
+			}),
+		]);
+	};
 
-  if (isLoading) {
-    return (
-      <section className="flex h-full items-center justify-center bg-neutral-950 text-neutral-300" aria-label="Loading visual relationship editor">
-        <div className="text-center">
-          <div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-brand-600 border-t-transparent" />
-          <p className="text-xs font-black uppercase tracking-widest text-neutral-500">Loading visual editor...</p>
-        </div>
-      </section>
-    );
-  }
+	if (isLoading) {
+		return (
+			<section
+				className="flex h-full items-center justify-center bg-neutral-950 text-neutral-300"
+				aria-label="Loading visual relationship editor"
+			>
+				<div className="text-center">
+					<div className="mx-auto mb-4 h-10 w-10 animate-spin rounded-full border-4 border-brand-600 border-t-transparent" />
+					<p className="text-xs font-black uppercase tracking-widest text-neutral-500">
+						Loading visual editor...
+					</p>
+				</div>
+			</section>
+		);
+	}
 
-  if (error) {
-    return (
-      <section className="flex h-full items-center justify-center bg-neutral-950 p-8 text-neutral-300" aria-label="Visual relationship editor error">
-        <div className="max-w-lg rounded-2xl border border-red-500/30 bg-red-500/10 p-6 text-center">
-          <p className="text-sm font-black uppercase tracking-widest text-red-300">Could not load visual editor data</p>
-          <p className="mt-2 text-xs text-neutral-400">Refresh the page or return to relationship management.</p>
-          <Link to="/admin" className="mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-xs font-black uppercase text-white hover:bg-white/10">
-            Back to admin
-          </Link>
-        </div>
-      </section>
-    );
-  }
+	if (error) {
+		return (
+			<section
+				className="flex h-full items-center justify-center bg-neutral-950 p-8 text-neutral-300"
+				aria-label="Visual relationship editor error"
+			>
+				<div className="max-w-lg rounded-2xl border border-red-500/30 bg-red-500/10 p-6 text-center">
+					<p className="text-sm font-black uppercase tracking-widest text-red-300">
+						Could not load visual editor data
+					</p>
+					<p className="mt-2 text-xs text-neutral-400">
+						Refresh the page or return to relationship management.
+					</p>
+					<Link
+						to="/admin"
+						className="mt-4 inline-flex rounded-xl border border-white/10 px-4 py-2 text-xs font-black uppercase text-white hover:bg-white/10"
+					>
+						Back to admin
+					</Link>
+				</div>
+			</section>
+		);
+	}
 
-  return (
-    <VisualRelationshipEditor
-      nodes={nodes}
-      links={links}
-      mode="page"
-      onClose={() => window.close()}
-      onMutated={refreshRelationshipData}
-    />
-  );
+	return (
+		<VisualRelationshipEditor
+			nodes={nodes}
+			links={links}
+			mode="page"
+			onClose={() => window.close()}
+			onMutated={refreshRelationshipData}
+		/>
+	);
 };
 
 const VisualRelationshipEditorPage: React.FC = () => {
-  const { hasPermission } = useAuth();
-  const canEditRelationships = hasPermission('CI_EDIT') || hasPermission('CI_DELETE');
+	const { hasPermission } = useAuth();
+	const canEditRelationships =
+		hasPermission("CI_EDIT") || hasPermission("CI_DELETE");
 
-  return canEditRelationships ? <VisualRelationshipEditorPageContent /> : <AccessDenied />;
+	return canEditRelationships ? (
+		<VisualRelationshipEditorPageContent />
+	) : (
+		<AccessDenied />
+	);
 };
 
 export default VisualRelationshipEditorPage;

--- a/frontend/hooks/queries/useGraphTopologyQuery.ts
+++ b/frontend/hooks/queries/useGraphTopologyQuery.ts
@@ -1,9 +1,18 @@
-import { useQuery } from '@tanstack/react-query';
-import { queryKeys } from '../../services/queryKeys';
-import { fetchGraphTopology } from '../../services/queryResources';
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "../../services/queryKeys";
+import {
+	fetchGraphTopology,
+	type FetchGraphTopologyOptions,
+} from "../../services/queryResources";
 
-export const useGraphTopologyQuery = () => useQuery({
-  queryKey: queryKeys.graphTopology(),
-  queryFn: ({ signal }) => fetchGraphTopology({ signal }),
-  refetchInterval: 30000,
-});
+export type GraphTopologyFilters = Pick<
+	FetchGraphTopologyOptions,
+	"layer" | "location" | "owner"
+>;
+
+export const useGraphTopologyQuery = (filters: GraphTopologyFilters = {}) =>
+	useQuery({
+		queryKey: queryKeys.graphTopology(filters),
+		queryFn: ({ signal }) => fetchGraphTopology({ ...filters, signal }),
+		refetchInterval: 30000,
+	});

--- a/frontend/services/queryKeys.test.ts
+++ b/frontend/services/queryKeys.test.ts
@@ -1,18 +1,40 @@
-import { describe, expect, it } from 'vitest';
-import { queryKeys } from './queryKeys';
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
 
-describe('queryKeys', () => {
-  it('returns stable keys for shared polled resources', () => {
-    expect(queryKeys.systemStatus()).toEqual(['system-status']);
-    expect(queryKeys.nodes()).toEqual(['nodes']);
-    expect(queryKeys.links()).toEqual(['links']);
-    expect(queryKeys.categories()).toEqual(['categories']);
-    expect(queryKeys.activeEvents()).toEqual(['events', 'CONSOLE']);
-    expect(queryKeys.graphTopology()).toEqual(['graph-topology']);
-  });
+describe("queryKeys", () => {
+	it("returns stable keys for shared polled resources", () => {
+		expect(queryKeys.systemStatus()).toEqual(["system-status"]);
+		expect(queryKeys.nodes()).toEqual(["nodes"]);
+		expect(queryKeys.links()).toEqual(["links"]);
+		expect(queryKeys.categories()).toEqual(["categories"]);
+		expect(queryKeys.activeEvents()).toEqual(["events", "CONSOLE"]);
+		expect(queryKeys.graphTopologyRoot()).toEqual(["graph-topology"]);
+		expect(queryKeys.graphTopology()).toEqual(["graph-topology", {}]);
+		expect(queryKeys.graphTopology({ location: "Moron" })).toEqual([
+			"graph-topology",
+			{ location: "Moron" },
+		]);
+		expect(
+			queryKeys.graphTopology({
+				layer: ["Network", "Compute"],
+				location: ["Moron", "Pilar"],
+			}),
+		).toEqual([
+			"graph-topology",
+			{ layer: ["Network", "Compute"], location: ["Moron", "Pilar"] },
+		]);
+	});
 
-  it('scopes related events by ci id', () => {
-    expect(queryKeys.relatedEvents('ci-1')).toEqual(['events', 'related', 'ci-1']);
-    expect(queryKeys.relatedEvents('ci-2')).toEqual(['events', 'related', 'ci-2']);
-  });
+	it("scopes related events by ci id", () => {
+		expect(queryKeys.relatedEvents("ci-1")).toEqual([
+			"events",
+			"related",
+			"ci-1",
+		]);
+		expect(queryKeys.relatedEvents("ci-2")).toEqual([
+			"events",
+			"related",
+			"ci-2",
+		]);
+	});
 });

--- a/frontend/services/queryKeys.ts
+++ b/frontend/services/queryKeys.ts
@@ -7,6 +7,11 @@ export const queryKeys = {
 	activeEvents: () => ["events", "CONSOLE"] as const,
 	availabilityReport: () => ["events", "availability-report"] as const,
 	eventDetail: (eventId: string) => ["events", "detail", eventId] as const,
-	graphTopology: () => ["graph-topology"] as const,
+	graphTopologyRoot: () => ["graph-topology"] as const,
+	graphTopology: (filters?: {
+		layer?: string | string[];
+		location?: string | string[];
+		owner?: string | string[];
+	}) => ["graph-topology", filters ?? {}] as const,
 	relatedEvents: (ciId: string) => ["events", "related", ciId] as const,
 };

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -86,8 +86,41 @@ export const fetchRelatedEvents = (
 	{ signal }: { signal?: AbortSignal } = {},
 ) => api.get<EventSummary[]>(`/events/related/${ciId}`, { signal });
 
-export const fetchGraphTopology = ({ signal }: { signal?: AbortSignal } = {}) =>
-	api.get<GraphTopologyResponse>("/graph/full", { signal });
+type GraphFilterValue = string | string[];
+
+export interface FetchGraphTopologyOptions {
+	layer?: GraphFilterValue;
+	location?: GraphFilterValue;
+	owner?: GraphFilterValue;
+	signal?: AbortSignal;
+}
+
+export const fetchGraphTopology = ({
+	layer,
+	location,
+	owner,
+	signal,
+}: FetchGraphTopologyOptions = {}) => {
+	const params = new URLSearchParams();
+	const setFilterParam = (key: string, value?: GraphFilterValue) => {
+		if (Array.isArray(value)) {
+			const selected = value.filter(Boolean);
+			if (selected.length > 0) params.set(key, selected.join(","));
+			return;
+		}
+		if (value) params.set(key, value);
+	};
+	setFilterParam("layer", layer);
+	setFilterParam("location", location);
+	setFilterParam("owner", owner);
+	const query = params.toString();
+	return api.get<GraphTopologyResponse>(
+		`/graph/full${query ? `?${query}` : ""}`,
+		{
+			signal,
+		},
+	);
+};
 
 export const fetchOwners = ({ signal }: { signal?: AbortSignal } = {}) =>
 	api.get<OwnerRecord[]>("/owners", { signal });


### PR DESCRIPTION
Closes #227

## Descripción del Cambio
Estabiliza la base del visualizador CMDB para que los filtros y refrescos no rompan la navegación:
- Corrige `/api/graph/full` con filtros, incluyendo ubicaciones con espacios y filtros multi-valor vía CSV/lista.
- Fortalece fallback de IDs/tipos en la respuesta de graph topology.
- Evita reconstrucciones innecesarias de GraphCMDB por polling global y preserva zoom/pan con estado ref-backed.
- Invalida todas las variantes de graph topology después de mutaciones.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_routers_links.py -q` → 14 passed
- [x] `corepack pnpm --dir frontend run build` → passed
- [x] `corepack pnpm --dir frontend run test:run -- components/GraphCMDB.query.test.tsx services/queryKeys.test.ts components/VisualRelationshipEditorPage.test.tsx` → 375 passed
- [x] Fresh reviewer: no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | CMDB graph visualizer |
| Tracker PR | Not needed |
| Position | 1 of 2 |
| Base | `main` |
| Depends on | None |
| Follow-up | Cluster-first visualizer PR |
| Review budget | 1129 / 400 |
| Starts at | `origin/main` |
| Ends with | Stable graph topology filtering, invalidation, and navigation refresh behavior |

### Chain Overview

```text
main
 └── 📍 PR 1: stabilize graph topology filtering and refresh
      └── PR 2: cluster-first graph visualizer interactions/search/filter UI
```

### Scope
- Includes: backend graph filter robustness, query key/resources plumbing, refresh/zoom stability.
- Excludes: cluster-first visual layout and search/filter UI; those are in the follow-up PR.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

### Size note
This exceeds the default 400-line review budget because the maintainer requested PR boundaries by improvement scope rather than raw LOC. The follow-up visualizer PR is stacked separately to keep behavior review focused.
