### PR TITLE
feat(cmdb): add cluster-first graph exploration

### DIFF
--- a/frontend/components/GraphCMDB.tsx
+++ b/frontend/components/GraphCMDB.tsx
@@ -1,451 +1,1437 @@
-import { type RefObject, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
-import * as d3 from 'd3';
-import { GraphLink, GraphNode } from '../types';
-import { STATUS_COLORS } from '../utils/status';
-import { useGraphTopologyQuery } from '../hooks/queries/useGraphTopologyQuery';
-import { useCategoriesQuery } from '../hooks/queries/useCategoriesQuery';
-import { useOwnersQuery } from '../hooks/queries/useOwnersQuery';
+import { type RefObject, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import * as d3 from "d3";
+import type { GraphLink, GraphNode } from "../types";
+import { STATUS_COLORS } from "../utils/status";
+import { useGraphTopologyQuery } from "../hooks/queries/useGraphTopologyQuery";
+import { useCategoriesQuery } from "../hooks/queries/useCategoriesQuery";
+import { useOwnersQuery } from "../hooks/queries/useOwnersQuery";
 
 interface GraphCMDBProps {
-  onNodeClick: (node: GraphNode) => void;
+	onNodeClick: (node: GraphNode) => void;
 }
 
-const AnimatedLinksLayer = ({ svgRef, links }: { svgRef: RefObject<SVGSVGElement | null>; links: GraphLink[] }) => {
-  const portalSvgRef = useRef<SVGSVGElement>(null);
+const AnimatedLinksLayer = ({
+	svgRef,
+	links,
+}: {
+	svgRef: RefObject<SVGSVGElement | null>;
+	links: GraphLink[];
+}) => {
+	const portalSvgRef = useRef<SVGSVGElement>(null);
 
-  useEffect(() => {
-    const portalRoot = document.getElementById('d3-portal-root');
-    if (!portalRoot || !portalSvgRef.current || !svgRef.current) {
-      return;
-    }
+	useEffect(() => {
+		const portalRoot = document.getElementById("d3-portal-root");
+		if (!portalRoot || !portalSvgRef.current || !svgRef.current) {
+			return;
+		}
 
-    const rect = svgRef.current.getBoundingClientRect();
-    const portalSvg = d3.select(portalSvgRef.current)
-      .attr('width', rect.width)
-      .attr('height', rect.height)
-      .style('position', 'absolute')
-      .style('top', `${rect.top + window.scrollY}px`)
-      .style('left', `${rect.left + window.scrollX}px`)
-      .style('pointer-events', 'none')
-      .style('overflow', 'visible');
+		const rect = svgRef.current.getBoundingClientRect();
+		const portalSvg = d3
+			.select(portalSvgRef.current)
+			.attr("width", rect.width)
+			.attr("height", rect.height)
+			.style("position", "absolute")
+			.style("top", `${rect.top + window.scrollY}px`)
+			.style("left", `${rect.left + window.scrollX}px`)
+			.style("pointer-events", "none")
+			.style("overflow", "visible");
 
-    const pulseGroup = portalSvg.append('g').attr('class', 'd3-pulse-layer');
-    pulseGroup
-      .selectAll('circle')
-      .data(links.filter((link: any) => link.relationship === 'CONNECTS_TO'), (link: any) => link.id)
-      .join(
-        (enter) => enter.append('circle').attr('r', 5).attr('fill', '#10b981').attr('opacity', 0.8),
-        (update) => update,
-        (exit) => exit.remove(),
-      );
+		const pulseGroup = portalSvg.append("g").attr("class", "d3-pulse-layer");
+		pulseGroup
+			.selectAll("circle")
+			.data(
+				links.filter((link: any) => link.relationship === "CONNECTS_TO"),
+				(link: any) => link.id,
+			)
+			.join(
+				(enter) =>
+					enter
+						.append("circle")
+						.attr("r", 5)
+						.attr("fill", "#10b981")
+						.attr("opacity", 0.8),
+				(update) => update,
+				(exit) => exit.remove(),
+			);
 
-    return () => {
-      portalSvg.selectAll('*').remove();
-    };
-  }, [links, svgRef]);
+		return () => {
+			portalSvg.selectAll("*").remove();
+		};
+	}, [links, svgRef]);
 
-  const portalRoot = document.getElementById('d3-portal-root');
-  if (!portalRoot) {
-    return null;
-  }
+	const portalRoot = document.getElementById("d3-portal-root");
+	if (!portalRoot) {
+		return null;
+	}
 
-  return createPortal(
-    <svg ref={portalSvgRef} style={{ position: 'absolute', pointerEvents: 'none' }} />,
-    portalRoot,
-  );
+	return createPortal(
+		<svg
+			ref={portalSvgRef}
+			style={{ position: "absolute", pointerEvents: "none" }}
+		/>,
+		portalRoot,
+	);
 };
 
 const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
-  const [filterLayer, setFilterLayer] = useState<string>('');
-  const [filterLocation, setFilterLocation] = useState<string>('');
-  const [filterOwner, setFilterOwner] = useState<string>('');
-  const [groupByLocation, setGroupByLocation] = useState<boolean>(true);
-  const [searchLocation, setSearchLocation] = useState<string>('');
+	const [filterLayers, setFilterLayers] = useState<string[]>([]);
+	const [filterLocations, setFilterLocations] = useState<string[]>([]);
+	const [filterOwners, setFilterOwners] = useState<string[]>([]);
+	const [groupByLocation, setGroupByLocation] = useState<boolean>(true);
+	const [searchLocation, setSearchLocation] = useState<string>("");
+	const [graphSearch, setGraphSearch] = useState<string>("");
+	const [selectedCluster, setSelectedCluster] = useState<string | null>(null);
 
-  const svgRef = useRef<SVGSVGElement>(null);
-  const zoomTransformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity);
-  const nodeStateRef = useRef<Map<string, {x: number, y: number, vx: number, vy: number}>>(new Map());
+	const svgRef = useRef<SVGSVGElement>(null);
+	const zoomTransformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity);
+	const nodeStateRef = useRef<
+		Map<string, { x: number; y: number; vx: number; vy: number }>
+	>(new Map());
+	const clusterOffsetRef = useRef<Map<string, { dx: number; dy: number }>>(
+		new Map(),
+	);
+	const layoutSignatureRef = useRef<string>("");
 
-  const { data, isLoading } = useGraphTopologyQuery({ 
-    layer: filterLayer, 
-    location: filterLocation, 
-    owner: filterOwner 
-  });
-  
-  const { data: fullData } = useGraphTopologyQuery({});
-  const { data: categories } = useCategoriesQuery();
-  const { data: owners } = useOwnersQuery();
+	const { data, isLoading } = useGraphTopologyQuery({
+		layer: filterLayers,
+		location: filterLocations,
+		owner: filterOwners,
+	});
 
-  const nodes = data?.nodes ?? [];
-  const links = data?.links ?? [];
+	const { data: fullData } = useGraphTopologyQuery({});
+	const { data: categories } = useCategoriesQuery();
+	const { data: owners } = useOwnersQuery();
 
-  const allLocations = Array.from(new Set((fullData?.nodes ?? []).map(n => n.location_name).filter(Boolean))).sort();
-  const filteredLocations = allLocations.filter(loc => loc.toLowerCase().includes(searchLocation.toLowerCase()));
+	const nodes = data?.nodes ?? [];
+	const links = data?.links ?? [];
 
-  useEffect(() => {
-    if (!svgRef.current) return;
+	const allLocations = Array.from(
+		new Set(
+			(fullData?.nodes ?? []).map((n) => n.location_name).filter(Boolean),
+		),
+	).sort();
+	const filteredLocations = allLocations.filter((loc) =>
+		loc.toLowerCase().includes(searchLocation.toLowerCase()),
+	);
+	const toggleSelection = (
+		value: string,
+		setter: React.Dispatch<React.SetStateAction<string[]>>,
+	) => {
+		setter((current) =>
+			current.includes(value)
+				? current.filter((item) => item !== value)
+				: [...current, value],
+		);
+	};
 
-    const width = svgRef.current.clientWidth || 1200;
-    const height = svgRef.current.clientHeight || 800;
-    const svg = d3.select(svgRef.current);
-    
-    // PERSIST ZOOM: Read current transform before clearing
-    const currentTransform = d3.zoomTransform(svgRef.current);
-    svg.selectAll('*').remove();
+	useEffect(() => {
+		if (!svgRef.current) return;
 
-    const container = svg.append('g').attr('class', 'main-container');
+		const width = svgRef.current.clientWidth || 1200;
+		const height = svgRef.current.clientHeight || 800;
+		const svg = d3.select(svgRef.current);
 
-    const zoomBehavior = d3.zoom<SVGSVGElement, unknown>()
-      .scaleExtent([0.01, 12])
-      .on('zoom', (event) => {
-        zoomTransformRef.current = event.transform;
-        container.attr('transform', event.transform);
-      });
+		// PERSIST ZOOM: prefer the ref-backed transform because the SVG DOM
+		// is fully rebuilt on data refreshes and DOM-derived state can be stale.
+		const currentTransform =
+			zoomTransformRef.current || d3.zoomTransform(svgRef.current);
+		svg.selectAll("*").remove();
 
-    svg.call(zoomBehavior);
-    
-    // RESTORE ZOOM: Re-apply the transform
-    svg.call(zoomBehavior.transform, currentTransform);
+		const container = svg.append("g").attr("class", "main-container");
 
-    // Calculate cluster centers if grouped
-    const locationCenters: Record<string, { x: number; y: number }> = {};
-    if (groupByLocation) {
-      const uniqueLocs = Array.from(new Set(nodes.map(n => n.location_name).filter(Boolean)));
-      uniqueLocs.forEach((loc, i) => {
-        const angle = (i / uniqueLocs.length) * 2 * Math.PI;
-        const radius = Math.min(width, height) * 0.4;
-        locationCenters[loc] = {
-          x: width / 2 + Math.cos(angle) * radius,
-          y: height / 2 + Math.sin(angle) * radius
-        };
-      });
-    }
+		const zoomBehavior = d3
+			.zoom<SVGSVGElement, unknown>()
+			.scaleExtent([0.01, 12])
+			.on("zoom", (event) => {
+				zoomTransformRef.current = event.transform;
+				container.attr("transform", event.transform);
+			});
 
-    const defs = container.append('defs');
-    Object.values(STATUS_COLORS).forEach((color) => {
-      const idColor = color.replace('#', '');
-      defs.append('marker')
-        .attr('id', `arrow-${idColor}`)
-        .attr('viewBox', '0 -5 10 10')
-        .attr('refX', 28).attr('refY', 0)
-        .attr('markerWidth', 6).attr('markerHeight', 6)
-        .attr('orient', 'auto')
-        .append('path').attr('d', 'M0,-5L10,0L0,5').attr('fill', color);
-    });
+		svg.call(zoomBehavior);
 
-    const validLinks = links.filter((link) => {
-      const sourceId = typeof link.source === 'object' ? (link.source as any).id : link.source;
-      const targetId = typeof link.target === 'object' ? (link.target as any).id : link.target;
-      return nodes.some((node) => node.id === sourceId) && nodes.some((node) => node.id === targetId);
-    }).map((link) => Object.create(link));
+		// RESTORE ZOOM: Re-apply the transform
+		svg.call(zoomBehavior.transform, currentTransform);
 
-    const cachedNodesExist = nodes.some(n => nodeStateRef.current.has(n.id));
+		const getClusterName = (node: GraphNode) => {
+			const raw =
+				(node as any).cluster_name ||
+				node.location_name ||
+				node.owner ||
+				"Unassigned";
+			return String(raw);
+		};
 
-    const validNodes = nodes.map((node) => {
-      const n = Object.create(node);
-      const cached = nodeStateRef.current.get(node.id);
-      
-      if (cached) {
-        n.x = cached.x;
-        n.y = cached.y;
-        n.vx = cached.vx;
-        n.vy = cached.vy;
-        if (cached.fx !== undefined) {
-            n.fx = cached.fx;
-            n.fy = cached.fy;
-        }
-      } else if (node.location?.lat && node.location?.long) {
-          // PROYECCIÓN BALANCEADA: 0.1 grado = ~300px
-          const centerX = width / 2;
-          const centerY = height / 2;
-          n.x = centerX + (node.location.long + 117) * 3000; 
-          n.y = centerY - (node.location.lat - 32.5) * 3000;
-      }
-      return n;
-    });
+		const clusterEntries = Array.from(
+			d3.group(nodes, getClusterName).entries(),
+		).sort(([a], [b]) => a.localeCompare(b));
+		const layoutSignature = `${groupByLocation}:${clusterEntries.map(([name, group]) => `${name}:${group.length}`).join("|")}`;
+		if (layoutSignatureRef.current !== layoutSignature) {
+			nodeStateRef.current.clear();
+			layoutSignatureRef.current = layoutSignature;
+		}
 
-    const simulation = d3.forceSimulation<GraphNode>(validNodes)
-      .force('link', d3.forceLink<GraphNode, GraphLink>(validLinks).id((node) => node.id).distance(80)) 
-      .force('charge', d3.forceManyBody().strength((d: any) => {
-          if (d.type !== 'CI') return -2000; // Flotantes se repelen FUERTE
-          return -500; // CIs se repelen normal
-      }))
-      .force('center', d3.forceCenter(width / 2, height / 2).strength(0.01)) // Fuerza de centrado MUY débil
-      .force('collision', d3.forceCollide().radius((d: any) => d.type === 'CI' ? 45 : 90))
-      .alpha(cachedNodesExist ? 0.08 : 1.0);
+		const clusterCenters: Record<
+			string,
+			{ x: number; y: number; radius: number; count: number; hasGeo: boolean }
+		> = {};
+		const isValidCoordinate = (lat: unknown, lon: unknown) =>
+			typeof lat === "number" &&
+			typeof lon === "number" &&
+			Number.isFinite(lat) &&
+			Number.isFinite(lon) &&
+			lat >= -90 &&
+			lat <= 90 &&
+			lon >= -180 &&
+			lon <= 180;
+		const median = (values: number[]) => {
+			const sorted = values.slice().sort((a, b) => a - b);
+			const mid = Math.floor(sorted.length / 2);
+			return sorted.length % 2 === 0
+				? (sorted[mid - 1] + sorted[mid]) / 2
+				: sorted[mid];
+		};
+		const clusterRadius = (count: number) =>
+			Math.min(180, Math.max(82, 34 + Math.sqrt(count) * 32));
+		if (groupByLocation && clusterEntries.length > 0) {
+			const layouts = clusterEntries.map(([clusterName, group], index) => {
+				const coords = group
+					.map((node) => ({
+						lat: node.location?.lat,
+						lon: node.location?.long,
+					}))
+					.filter(({ lat, lon }) => isValidCoordinate(lat, lon)) as Array<{
+					lat: number;
+					lon: number;
+				}>;
+				return {
+					clusterName,
+					group,
+					index,
+					radius: clusterRadius(group.length),
+					geo:
+						coords.length > 0
+							? {
+									lat: median(coords.map((c) => c.lat)),
+									lon: median(coords.map((c) => c.lon)),
+								}
+							: null,
+				};
+			});
+			const geoLayouts = layouts.filter((layout) => layout.geo);
+			const fallbackLayouts = layouts.filter((layout) => !layout.geo);
+			const fallbackLaneWidth =
+				geoLayouts.length > 0 && fallbackLayouts.length > 0
+					? Math.min(280, Math.max(180, width * 0.22))
+					: 0;
+			const paddingX = Math.max(130, width * 0.08);
+			const paddingY = Math.max(120, height * 0.1);
+			const geoMinX = paddingX;
+			const geoMaxX = Math.max(geoMinX, width - paddingX - fallbackLaneWidth);
+			const geoMinY = paddingY;
+			const geoMaxY = Math.max(geoMinY, height - paddingY);
+			const lats = geoLayouts.map((layout) => layout.geo?.lat ?? 0);
+			const lons = geoLayouts.map((layout) => layout.geo?.lon ?? 0);
+			const minLat = Math.min(...lats);
+			const maxLat = Math.max(...lats);
+			const minLon = Math.min(...lons);
+			const maxLon = Math.max(...lons);
+			const geoBase = new Map<string, { x: number; y: number }>();
+			geoLayouts.forEach((layout) => {
+				const lat = layout.geo?.lat ?? 0;
+				const lon = layout.geo?.lon ?? 0;
+				geoBase.set(layout.clusterName, {
+					x:
+						maxLon === minLon
+							? (geoMinX + geoMaxX) / 2
+							: geoMinX +
+								((lon - minLon) / (maxLon - minLon)) * (geoMaxX - geoMinX),
+					y:
+						maxLat === minLat
+							? (geoMinY + geoMaxY) / 2
+							: geoMaxY -
+								((lat - minLat) / (maxLat - minLat)) * (geoMaxY - geoMinY),
+				});
+			});
+			const sameCoordinateGroups = d3.group(
+				geoLayouts,
+				(layout) =>
+					`${layout.geo?.lat.toFixed(4)},${layout.geo?.lon.toFixed(4)}`,
+			);
+			sameCoordinateGroups.forEach((sameGeoLayouts) => {
+				sameGeoLayouts.forEach((layout, index) => {
+					const base = geoBase.get(layout.clusterName) || {
+						x: width / 2,
+						y: height / 2,
+					};
+					const spreadRadius =
+						sameGeoLayouts.length > 1 ? Math.max(110, layout.radius + 44) : 0;
+					const angle =
+						(index / sameGeoLayouts.length) * Math.PI * 2 - Math.PI / 2;
+					const offset = clusterOffsetRef.current.get(layout.clusterName) || {
+						dx: 0,
+						dy: 0,
+					};
+					clusterCenters[layout.clusterName] = {
+						x: base.x + Math.cos(angle) * spreadRadius + offset.dx,
+						y: base.y + Math.sin(angle) * spreadRadius + offset.dy,
+						radius: layout.radius,
+						count: layout.group.length,
+						hasGeo: true,
+					};
+				});
+			});
+			if (fallbackLayouts.length > 0) {
+				const cols =
+					geoLayouts.length > 0
+						? 1
+						: Math.ceil(Math.sqrt(fallbackLayouts.length));
+				const rows = Math.ceil(fallbackLayouts.length / cols);
+				const laneMinX = geoLayouts.length > 0 ? width - fallbackLaneWidth : 0;
+				const cellWidth = (width - laneMinX) / Math.max(cols, 1);
+				const cellHeight = height / Math.max(rows, 1);
+				fallbackLayouts.forEach((layout, i) => {
+					const col = i % cols;
+					const row = Math.floor(i / cols);
+					const offset = clusterOffsetRef.current.get(layout.clusterName) || {
+						dx: 0,
+						dy: 0,
+					};
+					clusterCenters[layout.clusterName] = {
+						x: laneMinX + cellWidth * (col + 0.5) + offset.dx,
+						y: cellHeight * (row + 0.5) + offset.dy,
+						radius: layout.radius,
+						count: layout.group.length,
+						hasGeo: false,
+					};
+				});
+			}
+		}
 
-    if (groupByLocation) {
-      simulation.force('x', d3.forceX().x((d: any) => {
-        if (d.location?.long) return width/2 + (d.location.long + 117) * 3000;
-        return locationCenters[d.location_name]?.x || width / 2;
-      }).strength(0.15));
-      simulation.force('y', d3.forceY().y((d: any) => {
-        if (d.location?.lat) return height/2 - (d.location.lat - 32.5) * 3000;
-        return locationCenters[d.location_name]?.y || height / 2;
-      }).strength(0.15));
-    } else {
-        // Anclaje por Lat/Long cuando no hay grupos
-        simulation.force('x', d3.forceX().x((d: any) => {
-            if (d.location?.long) return width/2 + (d.location.long + 117) * 3000;
-            return width / 2;
-        }).strength((d: any) => d.location?.long ? 0.2 : 0.02));
-        simulation.force('y', d3.forceY().y((d: any) => {
-            if (d.location?.lat) return height/2 - (d.location.lat - 32.5) * 3000;
-            return height / 2;
-        }).strength((d: any) => d.location?.lat ? 0.2 : 0.02));
-    }
+		if (
+			selectedCluster &&
+			groupByLocation &&
+			!clusterCenters[selectedCluster]
+		) {
+			setSelectedCluster(null);
+		}
 
-    const linkSelection = container.append('g')
-      .selectAll('line').data(validLinks).join('line')
-      .attr('stroke-opacity', 0.6).attr('stroke-width', 2)
-      .attr('stroke', (link: any) => {
-        const targetStatus = link.target?.status || 'UNKNOWN';
-        if (targetStatus === 'CRITICAL') return STATUS_COLORS.CRITICAL;
-        if (targetStatus === 'WARNING') return STATUS_COLORS.WARNING;
-        return (targetStatus === 'ACTIVE' || targetStatus === 'OK') ? STATUS_COLORS.OK : STATUS_COLORS.UNKNOWN;
-      })
-      .attr('marker-end', (link: any) => {
-        const targetStatus = link.target?.status || 'UNKNOWN';
-        let color = STATUS_COLORS.UNKNOWN;
-        if (targetStatus === 'CRITICAL') color = STATUS_COLORS.CRITICAL;
-        else if (targetStatus === 'WARNING') color = STATUS_COLORS.WARNING;
-        else if (targetStatus === 'ACTIVE' || targetStatus === 'OK') color = STATUS_COLORS.OK;
-        return `url(#arrow-${color.replace('#', '')})`;
-      })
-      .attr('stroke-dasharray', (link: any) => {
-        if (link.relationship === 'DEPENDS_ON') return '5, 8';
-        if (link.relationship === 'HOSTED_ON') return '2, 2';
-        return 'none';
-      })
-      .style('pointer-events', 'none');
+		const nodeClusterIndex = new Map<
+			string,
+			{ index: number; total: number; clusterName: string }
+		>();
+		clusterEntries.forEach(([clusterName, group]) => {
+			group
+				.slice()
+				.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }))
+				.forEach((node, index) => {
+					nodeClusterIndex.set(node.id, {
+						index,
+						total: group.length,
+						clusterName,
+					});
+				});
+		});
 
-    const trafficLink = container.append('g')
-      .selectAll('line').data(validLinks.filter((link: any) => link.relationship === 'CONNECTS_TO')).join('line')
-      .attr('stroke-width', 3).attr('stroke', '#10b981').attr('stroke-dasharray', '4, 16').attr('opacity', 0.7);
+		const clampPointToCluster = (clusterName: string, x: number, y: number) => {
+			if (!groupByLocation) return { x, y };
+			const center = clusterCenters[clusterName];
+			if (!center) return { x, y };
+			const maxRadius = Math.max(0, center.radius - 38);
+			const dx = x - center.x;
+			const dy = y - center.y;
+			const distance = Math.hypot(dx, dy);
+			if (distance <= maxRadius) return { x, y };
+			if (distance === 0) return { x: center.x, y: center.y };
+			const scale = maxRadius / distance;
+			return { x: center.x + dx * scale, y: center.y + dy * scale };
+		};
 
-    trafficLink.append('animate')
-      .attr('attributeName', 'stroke-dashoffset')
-      .attr('from', '20')
-      .attr('to', '0')
-      .attr('dur', '1s')
-      .attr('repeatCount', 'indefinite');
+		const getClusterTarget = (node: GraphNode) => {
+			const info = nodeClusterIndex.get(node.id);
+			if (!groupByLocation || !info) {
+				if (node.location?.lat && node.location?.long) {
+					return {
+						x: width / 2 + (node.location.long + 117) * 3000,
+						y: height / 2 - (node.location.lat - 32.5) * 3000,
+					};
+				}
+				return { x: width / 2, y: height / 2 };
+			}
 
-    const nodeSelection = container.append('g')
-      .selectAll('g').data(validNodes).join('g')
-      .attr('class', 'cursor-pointer group')
-      .on('click', (_event, node) => onNodeClick(node))
-      .call(d3.drag<SVGGElement, GraphNode>()
-        .on('start', dragstarted)
-        .on('drag', dragged)
-        .on('end', dragended) as any);
+			const center = clusterCenters[info.clusterName] || {
+				x: width / 2,
+				y: height / 2,
+				radius: 90,
+			};
+			if (info.total === 1) return { x: center.x, y: center.y };
 
-    nodeSelection.append('circle')
-      .attr('r', (node) => node.status === 'CRITICAL' ? 32 : node.status === 'WARNING' ? 28 : 24)
-      .attr('fill', '#1a1a1a')
-      .attr('stroke', (node) => {
-        if (node.status === 'CRITICAL') return STATUS_COLORS.CRITICAL;
-        if (node.status === 'WARNING') return STATUS_COLORS.WARNING;
-        return '#345bf2';
-      })
-      .attr('stroke-width', (node) => node.status === 'CRITICAL' ? 4 : 2)
-      .attr('class', 'node-circle transition-all duration-300');
+			const angle = (info.index / info.total) * Math.PI * 2 - Math.PI / 2;
+			const ringRadius = Math.min(
+				Math.max(0, center.radius - 38),
+				Math.max(34, 18 + info.total * 7),
+			);
+			return {
+				x: center.x + Math.cos(angle) * ringRadius,
+				y: center.y + Math.sin(angle) * ringRadius,
+			};
+		};
 
-    // Label inferior persistente (truncado para no ensuciar)
-    nodeSelection.append('text')
-      .attr('dy', '3.5em')
-      .attr('text-anchor', 'middle')
-      .attr('fill', '#a3a3a3')
-      .attr('font-size', '10px')
-      .attr('class', 'node-label pointer-events-none')
-      .text((node) => node.label.length > 15 ? node.label.substring(0, 12) + '...' : node.label);
+		const defs = container.append("defs");
+		Object.values(STATUS_COLORS).forEach((color) => {
+			const idColor = color.replace("#", "");
+			defs
+				.append("marker")
+				.attr("id", `arrow-${idColor}`)
+				.attr("viewBox", "0 -5 10 10")
+				.attr("refX", 28)
+				.attr("refY", 0)
+				.attr("markerWidth", 6)
+				.attr("markerHeight", 6)
+				.attr("orient", "auto")
+				.append("path")
+				.attr("d", "M0,-5L10,0L0,5")
+				.attr("fill", color);
+		});
 
-    // Hover interactions
-    nodeSelection
-      .on('mouseover', function(event, d) {
-          // Highlight current
-          d3.select(this).select('circle')
-            .attr('stroke-width', 6)
-            .attr('filter', 'drop-shadow(0 0 8px currentColor)');
-          
-          d3.select(this).select('.node-label')
-            .attr('fill', 'white')
-            .attr('font-weight', 'bold')
-            .text(d.label); // Show full label on hover
+		const nodeById = new Map(nodes.map((node) => [node.id, node]));
+		const getLinkEndpointId = (endpoint: string | GraphNode) =>
+			typeof endpoint === "object" ? (endpoint as any).id : endpoint;
+		const validLinks = links
+			.filter((link) => {
+				const sourceId = getLinkEndpointId(link.source as any);
+				const targetId = getLinkEndpointId(link.target as any);
+				return nodeById.has(sourceId) && nodeById.has(targetId);
+			})
+			.map((link) => Object.create(link));
 
-          // Fade others
-          nodeSelection.filter(n => n.id !== d.id).attr('opacity', 0.3);
-          linkSelection.attr('opacity', 0.1);
-          trafficLink.attr('opacity', 0.1);
-      })
-      .on('mouseout', function() {
-          // Reset current
-          const d: any = d3.select(this).datum();
-          d3.select(this).select('circle')
-            .attr('stroke-width', d.status === 'CRITICAL' ? 4 : 2)
-            .attr('filter', null);
+		const linkCountByNodeId = new Map<string, number>();
+		validLinks.forEach((link: any) => {
+			const sourceId = getLinkEndpointId(link.source);
+			const targetId = getLinkEndpointId(link.target);
+			linkCountByNodeId.set(
+				sourceId,
+				(linkCountByNodeId.get(sourceId) || 0) + 1,
+			);
+			linkCountByNodeId.set(
+				targetId,
+				(linkCountByNodeId.get(targetId) || 0) + 1,
+			);
+		});
+		const isHighConnectivityNode = (nodeId: string) =>
+			(linkCountByNodeId.get(nodeId) || 0) > 4;
 
-          d3.select(this).select('.node-label')
-            .attr('fill', '#a3a3a3')
-            .attr('font-weight', 'normal')
-            .text(d.label.length > 15 ? d.label.substring(0, 12) + '...' : d.label);
+		const clusterMode = groupByLocation && clusterEntries.length > 1;
+		const isNoisyDetailedLink = (link: any) => {
+			if (!clusterMode || !selectedCluster) return false;
+			const sourceId = getLinkEndpointId(link.source);
+			const targetId = getLinkEndpointId(link.target);
+			return (
+				isHighConnectivityNode(sourceId) || isHighConnectivityNode(targetId)
+			);
+		};
+		const getDefaultDetailedLinkOpacity = (link: any, fallback = 0.6) =>
+			isNoisyDetailedLink(link) ? 0 : fallback;
+		const detailedLinks = clusterMode
+			? selectedCluster
+				? validLinks.filter((link: any) => {
+						const sourceNode = nodeById.get(getLinkEndpointId(link.source));
+						const targetNode = nodeById.get(getLinkEndpointId(link.target));
+						return (
+							(sourceNode && getClusterName(sourceNode) === selectedCluster) ||
+							(targetNode && getClusterName(targetNode) === selectedCluster)
+						);
+					})
+				: []
+			: validLinks;
 
-          // Reset others
-          nodeSelection.attr('opacity', 1);
-          linkSelection.attr('opacity', 0.6);
-          trafficLink.attr('opacity', 0.7);
-      });
+		const clusterLinkMap = new Map<
+			string,
+			{
+				source: string;
+				target: string;
+				count: number;
+				relationships: Set<string>;
+			}
+		>();
+		if (clusterMode) {
+			validLinks.forEach((link: any) => {
+				const sourceNode = nodeById.get(getLinkEndpointId(link.source));
+				const targetNode = nodeById.get(getLinkEndpointId(link.target));
+				if (!sourceNode || !targetNode) return;
+				const sourceCluster = getClusterName(sourceNode);
+				const targetCluster = getClusterName(targetNode);
+				if (sourceCluster === targetCluster) return;
+				const key = `${sourceCluster}→${targetCluster}`;
+				const current = clusterLinkMap.get(key) || {
+					source: sourceCluster,
+					target: targetCluster,
+					count: 0,
+					relationships: new Set<string>(),
+				};
+				current.count += 1;
+				current.relationships.add(link.relationship);
+				clusterLinkMap.set(key, current);
+			});
+		}
+		const clusterLinks = Array.from(clusterLinkMap.values()).map((link) => ({
+			...link,
+			isBidirectional: clusterLinkMap.has(`${link.target}→${link.source}`),
+		}));
+		const visibleClusterLinks = selectedCluster
+			? clusterLinks.filter(
+					(link) =>
+						link.source === selectedCluster || link.target === selectedCluster,
+				)
+			: clusterLinks;
 
-    let tickCount = 0;
-    simulation.on('tick', () => {
-      linkSelection
-        .attr('x1', (link: any) => link.source.x).attr('y1', (link: any) => link.source.y)
-        .attr('x2', (link: any) => link.target.x).attr('y2', (link: any) => link.target.y);
-      trafficLink
-        .attr('x1', (link: any) => link.source.x).attr('y1', (link: any) => link.source.y)
-        .attr('x2', (link: any) => link.target.x).attr('y2', (link: any) => link.target.y);
-      nodeSelection.attr('transform', (node: any) => `translate(${node.x},${node.y})`);
+		const curvedPath = (source: any, target: any, bend = 0.18) => {
+			const sx = source.x ?? source.targetX ?? 0;
+			const sy = source.y ?? source.targetY ?? 0;
+			const tx = target.x ?? target.targetX ?? 0;
+			const ty = target.y ?? target.targetY ?? 0;
+			const dx = tx - sx;
+			const dy = ty - sy;
+			const mx = (sx + tx) / 2;
+			const my = (sy + ty) / 2;
+			const cx = mx - dy * bend;
+			const cy = my + dx * bend;
+			return `M${sx},${sy} Q${cx},${cy} ${tx},${ty}`;
+		};
 
-      // SAVE STATE: Persistent Cartesian Plane
-      validNodes.forEach((n: any) => {
-        nodeStateRef.current.set(n.id, { x: n.x, y: n.y, vx: n.vx, vy: n.vy });
-      });
+		const cachedNodesExist = nodes.some((n) => nodeStateRef.current.has(n.id));
 
-      // DEBUG TICK
-      tickCount++;
-      if (tickCount % 100 === 0 && validNodes.length > 0) {
-          const s = validNodes[0];
-          console.debug(`[GraphCMDB] Tick 100: ${s.id} está en x=${s.x?.toFixed(2)}, y=${s.y?.toFixed(2)}`);
-      }
-    });
+		const validNodes = nodes.map((node) => {
+			const n = Object.create(node);
+			const cached = nodeStateRef.current.get(node.id);
+			const target = getClusterTarget(node);
+			n.clusterName = getClusterName(node);
+			n.targetX = target.x;
+			n.targetY = target.y;
 
-    function dragstarted(event: any) {
-      if (!event.active) simulation.alphaTarget(0.3).restart();
-      event.subject.fx = event.subject.x;
-      event.subject.fy = event.subject.y;
-    }
-    function dragged(event: any) { event.subject.fx = event.x; event.subject.fy = event.y; }
-    function dragended(event: any) {
-      if (!event.active) simulation.alphaTarget(0);
-      event.subject.fx = null;
-      event.subject.fy = null;
-    }
+			if (cached) {
+				n.x = cached.x;
+				n.y = cached.y;
+				n.vx = cached.vx;
+				n.vy = cached.vy;
+			} else {
+				n.x = target.x;
+				n.y = target.y;
+			}
+			const contained = clampPointToCluster(n.clusterName, n.x, n.y);
+			n.x = contained.x;
+			n.y = contained.y;
+			return n;
+		});
+		const validNodeById = new Map(
+			validNodes.map((node: any) => [node.id, node]),
+		);
+		const normalizedGraphSearch = graphSearch.trim().toLowerCase();
+		const searchableText = (value: unknown): string => {
+			if (value === null || value === undefined) return "";
+			if (
+				typeof value === "string" ||
+				typeof value === "number" ||
+				typeof value === "boolean"
+			) {
+				return String(value);
+			}
+			if (Array.isArray(value)) return value.map(searchableText).join(" ");
+			if (typeof value === "object") {
+				return Object.entries(value as Record<string, unknown>)
+					.map(([key, entryValue]) => `${key} ${searchableText(entryValue)}`)
+					.join(" ");
+			}
+			return "";
+		};
+		const nodeMatchesSearch = (node: any) => {
+			if (!normalizedGraphSearch) return false;
+			const apiNode = nodeById.get(node.id) || node;
+			const searchPayload = {
+				...apiNode,
+				metadata: (apiNode as any).metadata,
+				clusterName: node.clusterName,
+				cluster_name: (apiNode as any).cluster_name,
+				location_name: (apiNode as any).location_name,
+				owner: (apiNode as any).owner,
+				ip: (apiNode as any).ip,
+				label: (apiNode as any).label,
+				type: (apiNode as any).type,
+				status: (apiNode as any).status,
+			};
+			return searchableText(searchPayload)
+				.toLowerCase()
+				.includes(normalizedGraphSearch);
+		};
+		const matchingNodeIds = new Set(
+			validNodes
+				.filter((node: any) => nodeMatchesSearch(node))
+				.map((node: any) => node.id),
+		);
+		const matchingClusterNames = new Set<string>();
+		if (normalizedGraphSearch) {
+			clusterEntries.forEach(([clusterName, group]) => {
+				const clusterText =
+					`${clusterName} ${searchableText(clusterCenters[clusterName])}`.toLowerCase();
+				if (
+					clusterText.includes(normalizedGraphSearch) ||
+					group.some((node) => matchingNodeIds.has(node.id))
+				) {
+					matchingClusterNames.add(clusterName);
+				}
+			});
+		}
+		const hasSearchMatches =
+			normalizedGraphSearch.length > 0 && matchingNodeIds.size > 0;
+		const getRenderedEndpoint = (endpoint: string | GraphNode) =>
+			typeof endpoint === "object"
+				? endpoint
+				: validNodeById.get(endpoint) || nodeById.get(endpoint);
 
-    return () => simulation.stop();
-  }, [links, nodes, onNodeClick, groupByLocation]);
+		const clusterSelection = groupByLocation
+			? container
+					.append("g")
+					.attr("class", "cluster-layer")
+					.selectAll("g")
+					.data(Object.entries(clusterCenters))
+					.join("g")
+					.attr("class", "cursor-pointer")
+					.attr(
+						"transform",
+						([, center]) => `translate(${center.x},${center.y})`,
+					)
+					.on("click", (event, [name]) => {
+						event.stopPropagation();
+						setSelectedCluster((current) => (current === name ? null : name));
+					})
+			: null;
 
-  return (
-    <div className='w-full h-full relative overflow-hidden bg-surface-950 grid-bg flex'>
-      {/* Filter Sidebar */}
-      <div className="w-64 bg-neutral-900/80 backdrop-blur border-r border-white/5 p-6 flex flex-col space-y-6 z-20 overflow-y-auto custom-scrollbar">
-        <div>
-          <h3 className="text-xs font-black text-neutral-500 uppercase tracking-widest mb-4">Discovery Filters</h3>
-          
-          <div className="space-y-4">
-            <label className="block">
-                <span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">Group by Location</span>
-                <button 
-                    onClick={() => setGroupByLocation(!groupByLocation)}
-                    className={`w-full flex items-center justify-between px-3 py-2 rounded-lg border transition-all ${groupByLocation ? 'bg-brand-500/10 border-brand-500 text-brand-400' : 'bg-neutral-950 border-white/5 text-neutral-500'}`}
-                >
-                    <span className="text-[10px] font-black uppercase tracking-tighter">{groupByLocation ? 'Enabled' : 'Disabled'}</span>
-                    <span className="material-symbols-outlined text-sm">{groupByLocation ? 'group_work' : 'blur_off'}</span>
-                </button>
-            </label>
+		clusterSelection
+			?.append("circle")
+			.attr("r", ([, center]) => center.radius)
+			.attr("fill", ([name]) =>
+				matchingClusterNames.has(name)
+					? "#3a2f08"
+					: selectedCluster === name
+						? "#1e3a5f"
+						: "#172033",
+			)
+			.attr("fill-opacity", ([name]) =>
+				matchingClusterNames.has(name)
+					? 0.46
+					: selectedCluster === name
+						? 0.38
+						: 0.24,
+			)
+			.attr("stroke", ([name]) =>
+				matchingClusterNames.has(name)
+					? "#facc15"
+					: selectedCluster === name
+						? "#60a5fa"
+						: "#345bf2",
+			)
+			.attr("stroke-opacity", ([name]) =>
+				matchingClusterNames.has(name)
+					? 1
+					: hasSearchMatches
+						? 0.12
+						: selectedCluster === name
+							? 0.8
+							: 0.35,
+			)
+			.attr("stroke-width", ([name]) =>
+				matchingClusterNames.has(name)
+					? 4
+					: selectedCluster === name
+						? 2.5
+						: 1.5,
+			)
+			.attr("filter", ([name]) =>
+				matchingClusterNames.has(name) ? "drop-shadow(0 0 14px #facc15)" : null,
+			)
+			.attr("stroke-dasharray", "6,6");
 
-            <label className="block">
-              <span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">Technology</span>
-              <select 
-                className="w-full bg-neutral-950 border border-white/5 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-brand-500 transition-colors"
-                value={filterLayer}
-                onChange={(e) => setFilterLayer(e.target.value)}
-              >
-                <option value="">All Layers</option>
-                {categories?.map(c => <option key={c.name} value={c.name}>{c.name}</option>)}
-              </select>
-            </label>
+		clusterSelection
+			?.append("text")
+			.attr("y", ([, center]) => -center.radius - 10)
+			.attr("text-anchor", "middle")
+			.attr("fill", "#d4d4d4")
+			.attr("font-size", "11px")
+			.attr("font-weight", 800)
+			.attr("letter-spacing", "0.05em")
+			.text(([name, center]) => `${name} (${center.count})`);
 
-            <label className="block">
-              <span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">Location Search</span>
-              <div className="relative mb-2">
-                  <input 
-                    type="text"
-                    className="w-full bg-neutral-950 border border-white/5 rounded-lg pl-8 pr-3 py-2 text-xs text-white outline-none focus:border-brand-500 transition-colors"
-                    placeholder="Search locations..."
-                    value={searchLocation}
-                    onChange={(e) => setSearchLocation(e.target.value)}
-                  />
-                  <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-neutral-600">search</span>
-              </div>
-              <select 
-                className="w-full bg-neutral-950 border border-white/5 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-brand-500 transition-colors"
-                value={filterLocation}
-                onChange={(e) => setFilterLocation(e.target.value)}
-              >
-                <option value="">All Locations ({filteredLocations.length})</option>
-                {filteredLocations.map(loc => <option key={loc} value={loc}>{loc}</option>)}
-              </select>
-            </label>
+		const clusterLinkSelection = container
+			.append("g")
+			.attr("class", "cluster-links")
+			.selectAll("g")
+			.data(visibleClusterLinks)
+			.join("g")
+			.attr("opacity", (link) => {
+				if (hasSearchMatches) {
+					return matchingClusterNames.has(link.source) ||
+						matchingClusterNames.has(link.target)
+						? 0.78
+						: 0.08;
+				}
+				if (selectedCluster) return link.isBidirectional ? 0.95 : 0.82;
+				return link.count > 4 ? 0.22 : 0.42;
+			});
 
-            <label className="block">
-              <span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">Owner Group</span>
-              <select 
-                className="w-full bg-neutral-950 border border-white/5 rounded-lg px-3 py-2 text-xs text-white outline-none focus:border-brand-500 transition-colors"
-                value={filterOwner}
-                onChange={(e) => setFilterOwner(e.target.value)}
-              >
-                <option value="">All Owners</option>
-                {owners?.map(o => <option key={o.name} value={o.name}>{o.name}</option>)}
-              </select>
-            </label>
+		clusterLinkSelection
+			.append("path")
+			.attr("class", "cluster-link-base")
+			.attr("d", (link) => {
+				const source = clusterCenters[link.source];
+				const target = clusterCenters[link.target];
+				return source && target ? curvedPath(source, target, 0.12) : "";
+			})
+			.attr("fill", "none")
+			.attr("stroke", (link) => (link.isBidirectional ? "#34d399" : "#10b981"))
+			.attr("stroke-width", (link) => Math.min(5, 1.5 + Math.sqrt(link.count)))
+			.attr("stroke-linecap", "round")
+			.attr("stroke-dasharray", (link) =>
+				link.isBidirectional ? "6,10" : link.count > 4 ? "2,10" : "none",
+			)
+			.attr("marker-end", `url(#arrow-${STATUS_COLORS.OK.replace("#", "")})`)
+			.style("pointer-events", "none");
 
-            <button 
-              onClick={() => {
-                setFilterLayer('');
-                setFilterLocation('');
-                setFilterOwner('');
-                setSearchLocation('');
-              }}
-              className="w-full py-2 text-[10px] font-black text-neutral-500 hover:text-white transition-colors uppercase tracking-widest"
-            >
-              Reset All
-            </button>
-          </div>
-        </div>
+		const standbyClusterLink = clusterLinkSelection
+			.append("path")
+			.attr("class", "cluster-link-standby-flow")
+			.attr("d", (link) => {
+				const source = clusterCenters[link.source];
+				const target = clusterCenters[link.target];
+				return source && target ? curvedPath(source, target, 0.12) : "";
+			})
+			.attr("fill", "none")
+			.attr("stroke", "#6ee7b7")
+			.attr("stroke-width", 1.6)
+			.attr("stroke-linecap", "round")
+			.attr("stroke-dasharray", "1,22")
+			.attr("opacity", selectedCluster ? 0.55 : 0.38)
+			.style("pointer-events", "none");
 
-        <div className="pt-6 border-t border-white/5">
-          <div className="flex items-center gap-2 mb-2">
-            <div className="w-2 h-2 rounded-full bg-brand-500 shadow-[0_0_8px_rgba(52,91,242,0.5)]"></div>
-            <span className="text-[10px] font-bold text-neutral-300 uppercase">Visible Nodes: {nodes.length}</span>
-          </div>
-        </div>
-      </div>
+		standbyClusterLink
+			.append("animate")
+			.attr("attributeName", "stroke-dashoffset")
+			.attr("from", "28")
+			.attr("to", "0")
+			.attr("dur", "1.8s")
+			.attr("repeatCount", "indefinite");
 
-      {/* Graph Canvas */}
-      <div className="flex-1 relative">
-        <svg ref={svgRef} className='w-full h-full' />
-        <AnimatedLinksLayer svgRef={svgRef} links={links} />
-        
-        {isLoading && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/20 backdrop-blur-sm z-10">
-            <div className="flex flex-col items-center gap-4">
-              <div className="w-12 h-12 border-4 border-brand-500/20 border-t-brand-500 rounded-full animate-spin"></div>
-              <span className="text-xs font-black text-brand-500 uppercase tracking-widest">Calculating Topology...</span>
-            </div>
-          </div>
-        )}
+		const bilateralClusterLink = clusterLinkSelection
+			.filter((link) => link.isBidirectional)
+			.append("path")
+			.attr("class", "cluster-link-bilateral-flow")
+			.attr("d", (link) => {
+				const source = clusterCenters[link.source];
+				const target = clusterCenters[link.target];
+				return source && target ? curvedPath(source, target, 0.12) : "";
+			})
+			.attr("fill", "none")
+			.attr("stroke", "#a7f3d0")
+			.attr("stroke-width", 2)
+			.attr("stroke-linecap", "round")
+			.attr("stroke-dasharray", "1,18")
+			.attr("opacity", selectedCluster ? 0.95 : 0.55)
+			.attr("marker-end", `url(#arrow-${STATUS_COLORS.OK.replace("#", "")})`)
+			.style("pointer-events", "none");
 
-        <div className='absolute bottom-4 left-4 flex flex-col gap-2 p-3 glass rounded-lg text-xs pointer-events-none select-none'>
-          <div className='flex items-center gap-2'><div className='w-3 h-3 bg-brand-500 rounded-full'></div> Operational</div>
-          <div className='flex items-center gap-2'><div className='w-3 h-3 bg-orange-500 rounded-full'></div> Degraded</div>
-          <div className='flex items-center gap-2'><div className='w-3 h-3 bg-red-500 rounded-full'></div> Critical</div>
-          <div className='h-px bg-white/10 my-1'></div>
-          <p className="text-[8px] text-neutral-500 uppercase font-black">Controls</p>
-          <p className="text-[9px] text-neutral-400">Wheel: Zoom | Drag: Pan | Click: Detail</p>
-        </div>
-      </div>
-    </div>
-  );
+		bilateralClusterLink
+			.append("animate")
+			.attr("attributeName", "stroke-dashoffset")
+			.attr("from", "24")
+			.attr("to", "0")
+			.attr("dur", "1.1s")
+			.attr("repeatCount", "indefinite");
+
+		const simulation = d3
+			.forceSimulation<GraphNode>(validNodes)
+			.force(
+				"link",
+				clusterMode
+					? null
+					: d3
+							.forceLink<GraphNode, GraphLink>(validLinks)
+							.id((node) => node.id)
+							.distance(90)
+							.strength(0.2),
+			)
+			.force(
+				"charge",
+				d3
+					.forceManyBody()
+					.strength(clusterMode ? -25 : groupByLocation ? -120 : -420),
+			)
+			.force("center", d3.forceCenter(width / 2, height / 2).strength(0.02))
+			.force("collision", d3.forceCollide().radius(34))
+			.force(
+				"x",
+				d3
+					.forceX()
+					.x((d: any) => d.targetX ?? width / 2)
+					.strength(groupByLocation ? 0.58 : 0.22),
+			)
+			.force(
+				"y",
+				d3
+					.forceY()
+					.y((d: any) => d.targetY ?? height / 2)
+					.strength(groupByLocation ? 0.58 : 0.22),
+			)
+			.alpha(cachedNodesExist ? 0.18 : 1.0);
+
+		const linkSelection = container
+			.append("g")
+			.selectAll("path")
+			.data(detailedLinks)
+			.join("path")
+			.attr("fill", "none")
+			.attr("stroke-opacity", 0.6)
+			.attr("stroke-width", 2)
+			.attr("stroke", (link: any) => {
+				const targetNode = getRenderedEndpoint(link.target) as
+					| GraphNode
+					| undefined;
+				const targetStatus = String(targetNode?.status || "UNKNOWN");
+				if (targetStatus === "CRITICAL") return STATUS_COLORS.CRITICAL;
+				if (targetStatus === "WARNING") return STATUS_COLORS.WARNING;
+				return targetStatus === "ACTIVE" || targetStatus === "OK"
+					? STATUS_COLORS.OK
+					: STATUS_COLORS.UNKNOWN;
+			})
+			.attr("marker-end", (link: any) => {
+				const targetNode = getRenderedEndpoint(link.target) as
+					| GraphNode
+					| undefined;
+				const targetStatus = String(targetNode?.status || "UNKNOWN");
+				let color = STATUS_COLORS.UNKNOWN;
+				if (targetStatus === "CRITICAL") color = STATUS_COLORS.CRITICAL;
+				else if (targetStatus === "WARNING") color = STATUS_COLORS.WARNING;
+				else if (targetStatus === "ACTIVE" || targetStatus === "OK")
+					color = STATUS_COLORS.OK;
+				return `url(#arrow-${color.replace("#", "")})`;
+			})
+			.attr("stroke-dasharray", (link: any) => {
+				if (link.relationship === "DEPENDS_ON") return "5, 8";
+				if (link.relationship === "HOSTED_ON") return "2, 2";
+				return "none";
+			})
+			.attr("opacity", (link: any) => getDefaultDetailedLinkOpacity(link, 0.6))
+			.style("pointer-events", "none");
+
+		const trafficLink = container
+			.append("g")
+			.selectAll("path")
+			.data(
+				detailedLinks.filter(
+					(link: any) => link.relationship === "CONNECTS_TO",
+				),
+			)
+			.join("path")
+			.attr("fill", "none")
+			.attr("stroke-width", 3)
+			.attr("stroke", "#10b981")
+			.attr("stroke-dasharray", "4, 16")
+			.attr("opacity", (link: any) => getDefaultDetailedLinkOpacity(link, 0.7));
+
+		trafficLink
+			.append("animate")
+			.attr("attributeName", "stroke-dashoffset")
+			.attr("from", "20")
+			.attr("to", "0")
+			.attr("dur", "1s")
+			.attr("repeatCount", "indefinite");
+
+		const nodeSelection = container
+			.append("g")
+			.selectAll("g")
+			.data(validNodes)
+			.join("g")
+			.attr("class", "cursor-pointer group")
+			.attr("opacity", (node) => {
+				if (!hasSearchMatches) return 1;
+				return matchingNodeIds.has(node.id) ||
+					matchingClusterNames.has(node.clusterName)
+					? 1
+					: 0.18;
+			})
+			.on("click", (_event, node) => onNodeClick(node))
+			.call(
+				d3
+					.drag<SVGGElement, GraphNode>()
+					.on("start", dragstarted)
+					.on("drag", dragged)
+					.on("end", dragended) as any,
+			);
+
+		nodeSelection
+			.append("circle")
+			.attr("r", (node) =>
+				node.status === "CRITICAL" ? 32 : node.status === "WARNING" ? 28 : 24,
+			)
+			.attr("fill", (node) =>
+				matchingNodeIds.has(node.id) ? "#3a2f08" : "#1a1a1a",
+			)
+			.attr("stroke", (node) => {
+				if (matchingNodeIds.has(node.id)) return "#facc15";
+				if (node.status === "CRITICAL") return STATUS_COLORS.CRITICAL;
+				if (node.status === "WARNING") return STATUS_COLORS.WARNING;
+				return "#345bf2";
+			})
+			.attr("stroke-width", (node) =>
+				matchingNodeIds.has(node.id) ? 5 : node.status === "CRITICAL" ? 4 : 2,
+			)
+			.attr("filter", (node) =>
+				matchingNodeIds.has(node.id) ? "drop-shadow(0 0 14px #facc15)" : null,
+			)
+			.attr("class", "node-circle transition-all duration-300");
+
+		// Label inferior persistente (truncado para no ensuciar)
+		nodeSelection
+			.append("text")
+			.attr("dy", "3.5em")
+			.attr("text-anchor", "middle")
+			.attr("fill", "#a3a3a3")
+			.attr("font-size", "10px")
+			.attr("class", "node-label pointer-events-none")
+			.text((node) =>
+				node.label.length > 15
+					? node.label.substring(0, 12) + "..."
+					: node.label,
+			);
+
+		nodeSelection
+			.append("text")
+			.attr("dy", "-2.6em")
+			.attr("text-anchor", "middle")
+			.attr("fill", "#fbbf24")
+			.attr("font-size", "9px")
+			.attr("font-weight", 800)
+			.attr("class", "link-count-badge pointer-events-none")
+			.text((node) => {
+				const linkCount = linkCountByNodeId.get(node.id) || 0;
+				return linkCount > 4 ? `+${linkCount} links` : "";
+			});
+
+		const enforceContainment = () => {
+			validNodes.forEach((node: any) => {
+				if (!node.clusterName) return;
+				const contained = clampPointToCluster(node.clusterName, node.x, node.y);
+				if (contained.x === node.x && contained.y === node.y) return;
+				node.x = contained.x;
+				node.y = contained.y;
+				node.vx = 0;
+				node.vy = 0;
+			});
+		};
+
+		const renderPositions = () => {
+			enforceContainment();
+			clusterSelection?.attr(
+				"transform",
+				([, center]) => `translate(${center.x},${center.y})`,
+			);
+			clusterLinkSelection
+				.selectAll(
+					"path.cluster-link-base, path.cluster-link-standby-flow, path.cluster-link-bilateral-flow",
+				)
+				.attr("d", (link) => {
+					const source = clusterCenters[link.source];
+					const target = clusterCenters[link.target];
+					return source && target ? curvedPath(source, target, 0.12) : "";
+				});
+			linkSelection.attr("d", (link: any) => {
+				const source = getRenderedEndpoint(link.source);
+				const target = getRenderedEndpoint(link.target);
+				return source && target ? curvedPath(source, target, 0.16) : "";
+			});
+			trafficLink.attr("d", (link: any) => {
+				const source = getRenderedEndpoint(link.source);
+				const target = getRenderedEndpoint(link.target);
+				return source && target ? curvedPath(source, target, 0.16) : "";
+			});
+			nodeSelection.attr(
+				"transform",
+				(node: any) => `translate(${node.x},${node.y})`,
+			);
+		};
+
+		const moveClusterWithMembers = (name: string, dx: number, dy: number) => {
+			if (dx === 0 && dy === 0) return;
+			const center = clusterCenters[name];
+			if (!center) return;
+			center.x += dx;
+			center.y += dy;
+			const previousOffset = clusterOffsetRef.current.get(name) || {
+				dx: 0,
+				dy: 0,
+			};
+			clusterOffsetRef.current.set(name, {
+				dx: previousOffset.dx + dx,
+				dy: previousOffset.dy + dy,
+			});
+			validNodes.forEach((node: any) => {
+				if (node.clusterName !== name) return;
+				node.targetX += dx;
+				node.targetY += dy;
+				const contained = clampPointToCluster(
+					name,
+					(node.x ?? node.targetX) + dx,
+					(node.y ?? node.targetY) + dy,
+				);
+				node.x = contained.x;
+				node.y = contained.y;
+				node.vx = 0;
+				node.vy = 0;
+				nodeStateRef.current.set(node.id, {
+					x: node.x,
+					y: node.y,
+					vx: 0,
+					vy: 0,
+				});
+			});
+		};
+
+		const resolveClusterCollisions = (activeName: string) => {
+			for (let pass = 0; pass < 5; pass++) {
+				let moved = false;
+				const entries = Object.entries(clusterCenters);
+				for (let i = 0; i < entries.length; i++) {
+					for (let j = i + 1; j < entries.length; j++) {
+						const [nameA, centerA] = entries[i];
+						const [nameB, centerB] = entries[j];
+						const minDistance = centerA.radius + centerB.radius + 28;
+						const dx = centerB.x - centerA.x;
+						const dy = centerB.y - centerA.y;
+						const distance = Math.hypot(dx, dy) || 1;
+						if (distance >= minDistance) continue;
+						const ux = dx / distance;
+						const uy = dy / distance;
+						const overlap = minDistance - distance;
+						if (nameA === activeName) {
+							moveClusterWithMembers(nameB, ux * overlap, uy * overlap);
+						} else if (nameB === activeName) {
+							moveClusterWithMembers(nameA, -ux * overlap, -uy * overlap);
+						} else {
+							moveClusterWithMembers(
+								nameA,
+								(-ux * overlap) / 2,
+								(-uy * overlap) / 2,
+							);
+							moveClusterWithMembers(
+								nameB,
+								(ux * overlap) / 2,
+								(uy * overlap) / 2,
+							);
+						}
+						moved = true;
+					}
+				}
+				if (!moved) break;
+			}
+		};
+
+		clusterSelection?.call(
+			d3
+				.drag<
+					SVGGElement,
+					[
+						string,
+						{
+							x: number;
+							y: number;
+							radius: number;
+							count: number;
+							hasGeo: boolean;
+						},
+					]
+				>()
+				.on("start", (event) => {
+					event.sourceEvent?.stopPropagation();
+				})
+				.on("drag", (event, [name]) => {
+					moveClusterWithMembers(name, event.dx, event.dy);
+					resolveClusterCollisions(name);
+					renderPositions();
+					simulation.alpha(0.08).restart();
+				}) as any,
+		);
+
+		// Hover interactions
+		nodeSelection
+			.on("mouseover", (_event, d) => {
+				const connectedNodeIds = new Set<string>([d.id]);
+				validLinks.forEach((link: any) => {
+					const sourceId = getLinkEndpointId(link.source);
+					const targetId = getLinkEndpointId(link.target);
+					if (sourceId === d.id) connectedNodeIds.add(targetId);
+					if (targetId === d.id) connectedNodeIds.add(sourceId);
+				});
+				const isConnectedLink = (link: any) => {
+					const sourceId = getLinkEndpointId(link.source);
+					const targetId = getLinkEndpointId(link.target);
+					return sourceId === d.id || targetId === d.id;
+				};
+
+				nodeSelection.attr("opacity", (node) =>
+					connectedNodeIds.has(node.id) ? 1 : 0.18,
+				);
+				nodeSelection
+					.select("circle")
+					.attr("stroke-width", (node) => {
+						if (node.id === d.id) return 6;
+						if (connectedNodeIds.has(node.id)) return 4;
+						return node.status === "CRITICAL" ? 4 : 2;
+					})
+					.attr("filter", (node) =>
+						connectedNodeIds.has(node.id)
+							? "drop-shadow(0 0 8px currentColor)"
+							: null,
+					);
+				nodeSelection
+					.select(".node-label")
+					.attr("fill", (node) =>
+						connectedNodeIds.has(node.id) ? "white" : "#a3a3a3",
+					)
+					.attr("font-weight", (node) =>
+						connectedNodeIds.has(node.id) ? "bold" : "normal",
+					)
+					.text((node) =>
+						connectedNodeIds.has(node.id)
+							? node.label
+							: node.label.length > 15
+								? node.label.substring(0, 12) + "..."
+								: node.label,
+					);
+
+				linkSelection.attr("opacity", (link: any) =>
+					isConnectedLink(link) ? 0.9 : 0.08,
+				);
+				trafficLink.attr("opacity", (link: any) =>
+					isConnectedLink(link) ? 0.95 : 0.08,
+				);
+			})
+			.on("mouseout", () => {
+				nodeSelection.attr("opacity", (node) => {
+					if (!hasSearchMatches) return 1;
+					return matchingNodeIds.has(node.id) ||
+						matchingClusterNames.has(node.clusterName)
+						? 1
+						: 0.18;
+				});
+				nodeSelection
+					.select("circle")
+					.attr("stroke", (node) => {
+						if (matchingNodeIds.has(node.id)) return "#facc15";
+						if (node.status === "CRITICAL") return STATUS_COLORS.CRITICAL;
+						if (node.status === "WARNING") return STATUS_COLORS.WARNING;
+						return "#345bf2";
+					})
+					.attr("stroke-width", (node) =>
+						matchingNodeIds.has(node.id)
+							? 5
+							: node.status === "CRITICAL"
+								? 4
+								: 2,
+					)
+					.attr("filter", (node) =>
+						matchingNodeIds.has(node.id)
+							? "drop-shadow(0 0 14px #facc15)"
+							: null,
+					);
+				nodeSelection
+					.select(".node-label")
+					.attr("fill", "#a3a3a3")
+					.attr("font-weight", "normal")
+					.text((node) =>
+						node.label.length > 15
+							? node.label.substring(0, 12) + "..."
+							: node.label,
+					);
+				linkSelection.attr("opacity", (link: any) =>
+					getDefaultDetailedLinkOpacity(link, 0.6),
+				);
+				trafficLink.attr("opacity", (link: any) =>
+					getDefaultDetailedLinkOpacity(link, 0.7),
+				);
+			});
+
+		simulation.on("tick", () => {
+			enforceContainment();
+			renderPositions();
+
+			// SAVE STATE: Persistent Cartesian Plane
+			validNodes.forEach((n: any) => {
+				nodeStateRef.current.set(n.id, { x: n.x, y: n.y, vx: n.vx, vy: n.vy });
+			});
+		});
+
+		function clampToCluster(subject: any, x: number, y: number) {
+			if (!subject.clusterName) return { x, y };
+			return clampPointToCluster(subject.clusterName, x, y);
+		}
+
+		function dragstarted(event: any) {
+			if (!event.active) simulation.alphaTarget(0.3).restart();
+			event.subject.fx = event.subject.x;
+			event.subject.fy = event.subject.y;
+		}
+		function dragged(event: any) {
+			const next = clampToCluster(event.subject, event.x, event.y);
+			event.subject.fx = next.x;
+			event.subject.fy = next.y;
+			event.subject.x = next.x;
+			event.subject.y = next.y;
+			renderPositions();
+		}
+		function dragended(event: any) {
+			if (!event.active) simulation.alphaTarget(0);
+			const next = clampToCluster(
+				event.subject,
+				event.subject.x,
+				event.subject.y,
+			);
+			event.subject.x = next.x;
+			event.subject.y = next.y;
+			event.subject.vx = 0;
+			event.subject.vy = 0;
+			event.subject.fx = null;
+			event.subject.fy = null;
+			nodeStateRef.current.set(event.subject.id, {
+				x: next.x,
+				y: next.y,
+				vx: 0,
+				vy: 0,
+			});
+		}
+
+		return () => {
+			simulation.stop();
+			svg.on(".zoom", null);
+		};
+	}, [
+		links,
+		nodes,
+		onNodeClick,
+		groupByLocation,
+		selectedCluster,
+		graphSearch,
+	]);
+
+	return (
+		<div className="w-full h-full relative overflow-hidden bg-surface-950 grid-bg flex">
+			{/* Filter Sidebar */}
+			<div className="w-64 bg-neutral-900/80 backdrop-blur border-r border-white/5 p-6 flex flex-col space-y-6 z-20 overflow-y-auto custom-scrollbar">
+				<div>
+					<h3 className="text-xs font-black text-neutral-500 uppercase tracking-widest mb-4">
+						Discovery Filters
+					</h3>
+
+					<div className="space-y-4">
+						<label className="block">
+							<span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">
+								Graph Search
+							</span>
+							<div className="relative">
+								<input
+									type="text"
+									className="w-full bg-neutral-950 border border-yellow-500/20 rounded-lg pl-8 pr-8 py-2 text-xs text-white outline-none focus:border-yellow-400 transition-colors"
+									placeholder="Search any CI field..."
+									value={graphSearch}
+									onChange={(e) => setGraphSearch(e.target.value)}
+								/>
+								<span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-yellow-400">
+									search
+								</span>
+								{graphSearch && (
+									<button
+										type="button"
+										onClick={() => setGraphSearch("")}
+										className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-yellow-300"
+									>
+										×
+									</button>
+								)}
+							</div>
+						</label>
+
+						<label className="block">
+							<span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">
+								Group by Location
+							</span>
+							<button
+								onClick={() => setGroupByLocation(!groupByLocation)}
+								className={`w-full flex items-center justify-between px-3 py-2 rounded-lg border transition-all ${groupByLocation ? "bg-brand-500/10 border-brand-500 text-brand-400" : "bg-neutral-950 border-white/5 text-neutral-500"}`}
+							>
+								<span className="text-[10px] font-black uppercase tracking-tighter">
+									{groupByLocation ? "Enabled" : "Disabled"}
+								</span>
+								<span className="material-symbols-outlined text-sm">
+									{groupByLocation ? "group_work" : "blur_off"}
+								</span>
+							</button>
+						</label>
+
+						<div className="block">
+							<span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">
+								Technology{" "}
+								{filterLayers.length > 0 ? `(${filterLayers.length})` : ""}
+							</span>
+							<div className="max-h-32 overflow-y-auto rounded-lg border border-white/5 bg-neutral-950 p-2 space-y-1 custom-scrollbar">
+								{categories?.map((c) => (
+									<label
+										key={c.name}
+										className="flex items-center gap-2 text-xs text-neutral-300 hover:text-white"
+									>
+										<input
+											type="checkbox"
+											checked={filterLayers.includes(c.name)}
+											onChange={() => toggleSelection(c.name, setFilterLayers)}
+											className="accent-brand-500"
+										/>
+										<span>{c.name}</span>
+									</label>
+								))}
+								{(!categories || categories.length === 0) && (
+									<span className="text-[10px] text-neutral-600">
+										No layers
+									</span>
+								)}
+							</div>
+						</div>
+
+						<label className="block">
+							<span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">
+								Location Search
+							</span>
+							<div className="relative mb-2">
+								<input
+									type="text"
+									className="w-full bg-neutral-950 border border-white/5 rounded-lg pl-8 pr-3 py-2 text-xs text-white outline-none focus:border-brand-500 transition-colors"
+									placeholder="Search locations..."
+									value={searchLocation}
+									onChange={(e) => setSearchLocation(e.target.value)}
+								/>
+								<span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-neutral-600">
+									search
+								</span>
+							</div>
+							<div className="max-h-36 overflow-y-auto rounded-lg border border-white/5 bg-neutral-950 p-2 space-y-1 custom-scrollbar">
+								<div className="text-[10px] text-neutral-500 mb-1">
+									{filterLocations.length > 0
+										? `${filterLocations.length} selected`
+										: `All Locations (${filteredLocations.length})`}
+								</div>
+								{filteredLocations.map((loc) => (
+									<label
+										key={loc}
+										className="flex items-center gap-2 text-xs text-neutral-300 hover:text-white"
+									>
+										<input
+											type="checkbox"
+											checked={filterLocations.includes(loc)}
+											onChange={() => toggleSelection(loc, setFilterLocations)}
+											className="accent-brand-500"
+										/>
+										<span>{loc}</span>
+									</label>
+								))}
+							</div>
+						</label>
+
+						<div className="block">
+							<span className="text-[10px] font-bold text-neutral-400 uppercase mb-1 block">
+								Owner Group{" "}
+								{filterOwners.length > 0 ? `(${filterOwners.length})` : ""}
+							</span>
+							<div className="max-h-32 overflow-y-auto rounded-lg border border-white/5 bg-neutral-950 p-2 space-y-1 custom-scrollbar">
+								{owners?.map((o) => (
+									<label
+										key={o.name}
+										className="flex items-center gap-2 text-xs text-neutral-300 hover:text-white"
+									>
+										<input
+											type="checkbox"
+											checked={filterOwners.includes(o.name)}
+											onChange={() => toggleSelection(o.name, setFilterOwners)}
+											className="accent-brand-500"
+										/>
+										<span>{o.name}</span>
+									</label>
+								))}
+								{(!owners || owners.length === 0) && (
+									<span className="text-[10px] text-neutral-600">
+										No owners
+									</span>
+								)}
+							</div>
+						</div>
+
+						<button
+							onClick={() => {
+								setFilterLayers([]);
+								setFilterLocations([]);
+								setFilterOwners([]);
+								setSearchLocation("");
+								setGraphSearch("");
+							}}
+							className="w-full py-2 text-[10px] font-black text-neutral-500 hover:text-white transition-colors uppercase tracking-widest"
+						>
+							Reset All
+						</button>
+					</div>
+				</div>
+
+				<div className="pt-6 border-t border-white/5">
+					<div className="flex items-center gap-2 mb-2">
+						<div className="w-2 h-2 rounded-full bg-brand-500 shadow-[0_0_8px_rgba(52,91,242,0.5)]"></div>
+						<span className="text-[10px] font-bold text-neutral-300 uppercase">
+							Visible Nodes: {nodes.length}
+						</span>
+					</div>
+				</div>
+			</div>
+
+			{/* Graph Canvas */}
+			<div className="flex-1 relative">
+				<svg ref={svgRef} className="w-full h-full" />
+				<AnimatedLinksLayer svgRef={svgRef} links={links} />
+
+				{isLoading && (
+					<div className="absolute inset-0 flex items-center justify-center bg-black/20 backdrop-blur-sm z-10">
+						<div className="flex flex-col items-center gap-4">
+							<div className="w-12 h-12 border-4 border-brand-500/20 border-t-brand-500 rounded-full animate-spin"></div>
+							<span className="text-xs font-black text-brand-500 uppercase tracking-widest">
+								Calculating Topology...
+							</span>
+						</div>
+					</div>
+				)}
+
+				<div className="absolute bottom-4 left-4 flex flex-col gap-2 p-3 glass rounded-lg text-xs pointer-events-none select-none">
+					<div className="flex items-center gap-2">
+						<div className="w-3 h-3 bg-brand-500 rounded-full"></div>{" "}
+						Operational
+					</div>
+					<div className="flex items-center gap-2">
+						<div className="w-3 h-3 bg-orange-500 rounded-full"></div> Degraded
+					</div>
+					<div className="flex items-center gap-2">
+						<div className="w-3 h-3 bg-red-500 rounded-full"></div> Critical
+					</div>
+					<div className="h-px bg-white/10 my-1"></div>
+					<p className="text-[8px] text-neutral-500 uppercase font-black">
+						Controls
+					</p>
+					<p className="text-[9px] text-neutral-400">
+						Wheel: Zoom | Drag: Pan | Click: Detail
+					</p>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default GraphCMDB;


### PR DESCRIPTION
Closes #228
Closes #229

## Descripción del Cambio
Agrega la experiencia cluster-first del Graph CMDB encima de la base estabilizada:
- Clusters como contenedores geográficos/fallback con CIs contenidos, drag, repulsión y links agregados/animados.
- Click/hover progresivo para revelar detalle sin ruido visual.
- Graph Search con highlight amarillo sobre campos/metadata.
- Filtros multi-select por tecnología, ubicación y owner.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_routers_links.py -q` → 14 passed
- [x] `corepack pnpm --dir frontend run build` → passed
- [x] `corepack pnpm --dir frontend run test:run -- components/GraphCMDB.query.test.tsx services/queryKeys.test.ts components/VisualRelationshipEditorPage.test.tsx` → 375 passed
- [x] Fresh reviewer: no blockers
- [x] Local Docker frontend/backend rebuilt and healthy during implementation

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | CMDB graph visualizer |
| Tracker PR | Not needed |
| Position | 2 of 2 |
| Base | `fix/cmdb-graph-stability` / PR #232 |
| Depends on | #232 |
| Follow-up | #230 performance/LOD planning |
| Review budget | 1868 / 400 |
| Starts at | Stable graph topology/filter foundation from #232 |
| Ends with | Cluster-first visualizer, graph search, and multi-select filter UX |

### Chain Overview

```text
main
 └── #232 stabilize graph topology filtering and refresh
      └── 📍 PR 2: cluster-first graph visualizer interactions/search/filter UI
```

### Scope
- Includes: GraphCMDB visual interaction redesign, cluster containment/repulsion/geographic fallback, search highlight, multi-select filter UI.
- Excludes: 8k-CI level-of-detail/performance mode, tracked separately in #230.

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes after #232
- [x] Tests, docs, or manual verification cover this unit

### Size note
This exceeds the default 400-line review budget because the maintainer requested scope-based PR boundaries rather than LOC-based slicing. The high-risk backend/refresh foundation is isolated in #232; this PR is focused on the visualizer UX layer.
