### PR TITLE
chore(deploy): add healthchecks and shellcheck ci

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,30 @@
+name: ShellCheck
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**/*.sh"
+      - "monitor_performance.sh"
+      - "docker/neo4j/entrypoint.sh"
+      - ".github/workflows/shellcheck.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/**/*.sh"
+      - "monitor_performance.sh"
+      - "docker/neo4j/entrypoint.sh"
+      - ".github/workflows/shellcheck.yml"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Run ShellCheck
+        run: shellcheck -x scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adds an explicit `--neo4j-offline` mode for `pre-rebuild-backup.sh` and `safe-rebuild.sh`.
   - Creates PostgreSQL backups unchanged, then stops only Neo4j to run a timestamped `neo4j-admin` offline dump.
   - Documents offline dump and restore procedures for maintenance windows.
+- **Deploy healthchecks and ShellCheck validation** (issue #132):
+  - Adds Docker Compose healthchecks for frontend and `snmp-engine`.
+  - Adds a GitHub Actions ShellCheck workflow for shell scripts.
+  - Documents ShellCheck as part of deploy preflight validation.
 
 ## [1.12.14] — 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Flujo recomendado:
 5. Solo si validacion y backup terminaron bien, ejecuta `docker compose build && docker compose up -d`.
 6. Verifica con `docker compose ps` y `docker compose logs --tail=100 backend`.
 
-Comandos check-only: `sh scripts/safe-rebuild.sh --dry-run`, `sh -n scripts/*.sh` y `docker compose config --quiet`. Ejecuta los scripts desde Linux/macOS/Git Bash/WSL, no desde PowerShell. No uses `docker compose down -v` en rebuilds porque elimina volumenes. Ver [`docs/backup-restore.md`](docs/backup-restore.md) para restore, fallback manual y limitaciones de Neo4j Community.
+Comandos check-only: `sh scripts/safe-rebuild.sh --dry-run`, `sh -n scripts/*.sh`, `shellcheck -x scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh` y `docker compose config --quiet`. Ejecuta los scripts desde Linux/macOS/Git Bash/WSL, no desde PowerShell. No uses `docker compose down -v` en rebuilds porque elimina volumenes. Ver [`docs/backup-restore.md`](docs/backup-restore.md) para restore, fallback manual y limitaciones de Neo4j Community.
 
 ## Tests focalizados
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,18 @@ services:
       - /app/node_modules
     environment:
       - VITE_API_TARGET=${VITE_API_TARGET:-http://nexgen_backend:8000}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://127.0.0.1:3000/', (r) => process.exit(r.statusCode >= 200 && r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
 
   # Engines / Workers
@@ -161,4 +173,16 @@ services:
       - POLLING_BENCHMARK_DURATION_SECONDS=${POLLING_BENCHMARK_DURATION_SECONDS:-0}
       - POLLING_BENCHMARK_PROTOCOL_MIX=${POLLING_BENCHMARK_PROTOCOL_MIX:-ICMP:0.15,SNMP:0.55,CLI:0.15,REST:0.10,MQTT_STUB:0.05}
       - POLLING_BENCHMARK_SINK=${POLLING_BENCHMARK_SINK:-synthetic}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import os,sys; from neo4j import GraphDatabase; d=GraphDatabase.driver(os.environ['NEO4J_URI'], auth=(os.environ['NEO4J_USER'], os.environ['NEO4J_PASSWORD'])); d.verify_connectivity(); d.close(); sys.exit(0)",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 45s
     restart: unless-stopped

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -7,7 +7,7 @@ Use this runbook before Docker rebuilds or releases. Docker Compose commands do 
 1. Update code on the deploy host: `git pull origin main` or checkout the intended release branch/tag.
 2. Review `.env` against `.env.example` and add any new required values.
 3. Run `sh scripts/safe-rebuild.sh` for the full safe rebuild flow.
-4. Verify services with `docker compose ps` and logs or health checks.
+4. Verify services with `docker compose ps` and confirm backend, frontend, snmp-engine, PostgreSQL, and Neo4j health checks are healthy.
 5. Confirm backup files exist under `BACKUP_DIR`, default `.docker/backups`.
 
 Do not run `docker compose down -v` as part of rebuilds. That deletes named volumes and can destroy database state.
@@ -58,6 +58,7 @@ Use these before a deploy when you want to inspect the scripts and Compose confi
 ```sh
 sh scripts/safe-rebuild.sh --dry-run
 sh -n scripts/*.sh
+shellcheck -x scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh
 docker compose config --quiet
 ```
 

--- a/scripts/pre-rebuild-backup.sh
+++ b/scripts/pre-rebuild-backup.sh
@@ -115,6 +115,7 @@ run_neo4j_offline_dump() {
 }
 
 if [ "${PRE_REBUILD_BACKUP_LIB_ONLY:-0}" = "1" ]; then
+    # shellcheck disable=SC2317
     return 0 2>/dev/null || {
         printf 'ERROR: PRE_REBUILD_BACKUP_LIB_ONLY is only supported when sourcing this script for tests.\n' >&2
         exit 2
@@ -138,6 +139,7 @@ printf 'Validated BACKUP_DIR: %s\n' "$backup_dir"
 require_running_service postgres
 
 printf 'Creating PostgreSQL dump: /backups/%s\n' "$postgres_file"
+# shellcheck disable=SC2016
 compose exec -T postgres sh -c '
     set -eu
     : "${POSTGRES_USER:?POSTGRES_USER is required}"
@@ -154,6 +156,7 @@ else
     require_running_service neo4j
 
     printf 'Attempting Neo4j online APOC export: /backups/%s\n' "$neo4j_file"
+    # shellcheck disable=SC2016
     if compose exec -T neo4j sh -c '
         set -eu
         : "${NEO4J_AUTH:?NEO4J_AUTH is required}"

--- a/scripts/safe-rebuild.sh
+++ b/scripts/safe-rebuild.sh
@@ -153,6 +153,7 @@ verify_container_backups() {
         return
     fi
 
+    # shellcheck disable=SC2016
     compose exec -T "$service_name" sh -c '
         set -eu
         test -d /backups
@@ -164,6 +165,7 @@ verify_container_backups() {
 }
 
 if [ "${SAFE_REBUILD_LIB_ONLY:-0}" = "1" ]; then
+    # shellcheck disable=SC2317
     return 0 2>/dev/null || {
         printf 'ERROR: SAFE_REBUILD_LIB_ONLY is only supported when sourcing this script for tests.\n' >&2
         exit 2

--- a/scripts/test-neo4j-offline-backup-flags.sh
+++ b/scripts/test-neo4j-offline-backup-flags.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
 cd "$REPO_ROOT"
 
 failures=0

--- a/scripts/test-safe-rebuild-path-validation.sh
+++ b/scripts/test-safe-rebuild-path-validation.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
 
 SAFE_REBUILD_LIB_ONLY=1
 export SAFE_REBUILD_LIB_ONLY


### PR DESCRIPTION
Closes #132

## Descripción del Cambio
Adds deployment health visibility for frontend/snmp-engine and introduces ShellCheck validation in GitHub Actions.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)
- [x] Maintenance/tooling

## Summary
- Adds Docker Compose healthchecks for `frontend` and `snmp-engine`.
- Adds a ShellCheck GitHub Actions workflow for shell scripts.
- Documents ShellCheck in deploy preflight/check-only commands and records the change under `[Unreleased]`.

## Changes
| File | Change |
|------|--------|
| `docker-compose.yml` | Adds frontend and snmp-engine healthchecks. |
| `.github/workflows/shellcheck.yml` | Adds ShellCheck CI for shell scripts. |
| `README.md` | Adds ShellCheck to deploy check-only commands. |
| `docs/backup-restore.md` | Adds ShellCheck to backup/deploy preflight commands. |
| `CHANGELOG.md` | Adds the issue #132 entry under `[Unreleased]`. |

## ¿Cómo se probó?
- [x] `sh -n scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh`
- [x] `docker compose config --quiet` — passed with expected warnings for missing local `.env` values.
- [x] `git diff --check`
- [ ] `shellcheck -x scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh` — unavailable locally (`shellcheck` not installed); added CI workflow to run it.
- [ ] Real container health status validation — not run locally; should be validated in staging/deploy environment.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:chore`
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

---
*Generado por Alex*
