### PR TITLE
feat(cmdb): keep graph clusters within bounds

### DIFF
--- a/frontend/components/GraphCMDB.tsx
+++ b/frontend/components/GraphCMDB.tsx
@@ -6,6 +6,10 @@ import { STATUS_COLORS } from "../utils/status";
 import { useGraphTopologyQuery } from "../hooks/queries/useGraphTopologyQuery";
 import { useCategoriesQuery } from "../hooks/queries/useCategoriesQuery";
 import { useOwnersQuery } from "../hooks/queries/useOwnersQuery";
+import {
+	clampClusterCenterToBounds,
+	getBoundedClusterDelta,
+} from "./graphLayout";
 
 interface GraphCMDBProps {
 	onNodeClick: (node: GraphNode) => void;
@@ -193,6 +197,7 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 		};
 		const clusterRadius = (count: number) =>
 			Math.min(180, Math.max(82, 34 + Math.sqrt(count) * 32));
+		const clusterBounds = { width, height, padding: 24 };
 		if (groupByLocation && clusterEntries.length > 0) {
 			const layouts = clusterEntries.map(([clusterName, group], index) => {
 				const coords = group
@@ -306,6 +311,27 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 					};
 				});
 			}
+		}
+
+		if (groupByLocation) {
+			Object.entries(clusterCenters).forEach(([name, center]) => {
+				const bounded = clampClusterCenterToBounds(center, clusterBounds);
+				const correction = {
+					dx: bounded.x - center.x,
+					dy: bounded.y - center.y,
+				};
+				clusterCenters[name] = bounded;
+				if (correction.dx !== 0 || correction.dy !== 0) {
+					const previousOffset = clusterOffsetRef.current.get(name) || {
+						dx: 0,
+						dy: 0,
+					};
+					clusterOffsetRef.current.set(name, {
+						dx: previousOffset.dx + correction.dx,
+						dy: previousOffset.dy + correction.dy,
+					});
+				}
+			});
 		}
 
 		if (
@@ -962,24 +988,31 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 			if (dx === 0 && dy === 0) return;
 			const center = clusterCenters[name];
 			if (!center) return;
-			center.x += dx;
-			center.y += dy;
+			const boundedDelta = getBoundedClusterDelta(
+				center,
+				dx,
+				dy,
+				clusterBounds,
+			);
+			if (boundedDelta.dx === 0 && boundedDelta.dy === 0) return;
+			center.x += boundedDelta.dx;
+			center.y += boundedDelta.dy;
 			const previousOffset = clusterOffsetRef.current.get(name) || {
 				dx: 0,
 				dy: 0,
 			};
 			clusterOffsetRef.current.set(name, {
-				dx: previousOffset.dx + dx,
-				dy: previousOffset.dy + dy,
+				dx: previousOffset.dx + boundedDelta.dx,
+				dy: previousOffset.dy + boundedDelta.dy,
 			});
 			validNodes.forEach((node: any) => {
 				if (node.clusterName !== name) return;
-				node.targetX += dx;
-				node.targetY += dy;
+				node.targetX += boundedDelta.dx;
+				node.targetY += boundedDelta.dy;
 				const contained = clampPointToCluster(
 					name,
-					(node.x ?? node.targetX) + dx,
-					(node.y ?? node.targetY) + dy,
+					(node.x ?? node.targetX) + boundedDelta.dx,
+					(node.y ?? node.targetY) + boundedDelta.dy,
 				);
 				node.x = contained.x;
 				node.y = contained.y;

--- a/frontend/components/graphLayout.test.ts
+++ b/frontend/components/graphLayout.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+	clampClusterCenterToBounds,
+	getBoundedClusterDelta,
+} from "./graphLayout";
+
+describe("graph layout bounds", () => {
+	it("keeps a cluster circle inside the canvas padding", () => {
+		const result = clampClusterCenterToBounds(
+			{ x: -50, y: 900, radius: 100 },
+			{ width: 800, height: 600, padding: 20 },
+		);
+
+		expect(result).toEqual({ x: 120, y: 480, radius: 100 });
+	});
+
+	it("reduces manual drag deltas at the graph boundary", () => {
+		const delta = getBoundedClusterDelta(
+			{ x: 690, y: 300, radius: 80 },
+			200,
+			0,
+			{ width: 800, height: 600, padding: 24 },
+		);
+
+		expect(delta).toEqual({ dx: 6, dy: 0 });
+	});
+
+	it("centers oversized clusters instead of producing invalid bounds", () => {
+		const result = clampClusterCenterToBounds(
+			{ x: 10, y: 10, radius: 500 },
+			{ width: 800, height: 600, padding: 24 },
+		);
+
+		expect(result.x).toBe(400);
+		expect(result.y).toBe(300);
+	});
+});

--- a/frontend/components/graphLayout.ts
+++ b/frontend/components/graphLayout.ts
@@ -1,0 +1,49 @@
+export type ClusterBounds = {
+	width: number;
+	height: number;
+	padding?: number;
+};
+
+export type ClusterCircle = {
+	x: number;
+	y: number;
+	radius: number;
+};
+
+const clamp = (value: number, min: number, max: number) => {
+	if (min > max) return (min + max) / 2;
+	return Math.min(max, Math.max(min, value));
+};
+
+export const clampClusterCenterToBounds = <T extends ClusterCircle>(
+	center: T,
+	{ width, height, padding = 24 }: ClusterBounds,
+): T => {
+	const minX = center.radius + padding;
+	const maxX = width - center.radius - padding;
+	const minY = center.radius + padding;
+	const maxY = height - center.radius - padding;
+
+	return {
+		...center,
+		x: clamp(center.x, minX, maxX),
+		y: clamp(center.y, minY, maxY),
+	};
+};
+
+export const getBoundedClusterDelta = (
+	center: ClusterCircle,
+	dx: number,
+	dy: number,
+	bounds: ClusterBounds,
+) => {
+	const bounded = clampClusterCenterToBounds(
+		{ ...center, x: center.x + dx, y: center.y + dy },
+		bounds,
+	);
+
+	return {
+		dx: bounded.x - center.x,
+		dy: bounded.y - center.y,
+	};
+};


### PR DESCRIPTION
Closes #235

## Descripción del Cambio
Agrega boundary clamp para que los clusters del GraphCMDB no puedan quedar fuera del canvas durante drag manual o repulsión entre clusters.

Incluye:
- helpers compartidos para clamp de centros de cluster y delta limitado;
- clamp inicial de posiciones de clusters al calcular layout;
- drag/collision con delta acotado por canvas;
- sincronización de `clusterOffsetRef` cuando el clamp corrige una posición, evitando saltos en rerenders;
- tests unitarios para la matemática de bounds.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `corepack pnpm --dir frontend run test:run -- components/graphLayout.test.ts components/__tests__/GraphCMDB.query.test.tsx` → 41 files / 378 tests passed
- [x] `corepack pnpm --dir frontend run test:run` → 41 files / 378 tests passed
- [x] `corepack pnpm --dir frontend run build` → passed
- [x] Fresh reviewer after blocker fix → no blockers

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Scope
- Includes: cluster center boundary clamp, bounded manual drag/repulsion, offset persistence consistency.
- Excludes: data quality badges (#234) and large-scale LOD/performance (#230).
