### PR TITLE
feat(cmdb): show graph geo quality indicators

### DIFF
--- a/frontend/components/GraphCMDB.tsx
+++ b/frontend/components/GraphCMDB.tsx
@@ -9,6 +9,7 @@ import { useOwnersQuery } from "../hooks/queries/useOwnersQuery";
 import {
 	clampClusterCenterToBounds,
 	getBoundedClusterDelta,
+	summarizeClusterGeoQuality,
 } from "./graphLayout";
 
 interface GraphCMDBProps {
@@ -179,48 +180,28 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 			string,
 			{ x: number; y: number; radius: number; count: number; hasGeo: boolean }
 		> = {};
-		const isValidCoordinate = (lat: unknown, lon: unknown) =>
-			typeof lat === "number" &&
-			typeof lon === "number" &&
-			Number.isFinite(lat) &&
-			Number.isFinite(lon) &&
-			lat >= -90 &&
-			lat <= 90 &&
-			lon >= -180 &&
-			lon <= 180;
-		const median = (values: number[]) => {
-			const sorted = values.slice().sort((a, b) => a - b);
-			const mid = Math.floor(sorted.length / 2);
-			return sorted.length % 2 === 0
-				? (sorted[mid - 1] + sorted[mid]) / 2
-				: sorted[mid];
-		};
+		const clusterGeoQuality = new Map<
+			string,
+			ReturnType<typeof summarizeClusterGeoQuality>
+		>();
 		const clusterRadius = (count: number) =>
 			Math.min(180, Math.max(82, 34 + Math.sqrt(count) * 32));
 		const clusterBounds = { width, height, padding: 24 };
 		if (groupByLocation && clusterEntries.length > 0) {
 			const layouts = clusterEntries.map(([clusterName, group], index) => {
-				const coords = group
-					.map((node) => ({
-						lat: node.location?.lat,
-						lon: node.location?.long,
-					}))
-					.filter(({ lat, lon }) => isValidCoordinate(lat, lon)) as Array<{
-					lat: number;
-					lon: number;
-				}>;
+				const quality = summarizeClusterGeoQuality(group);
+				clusterGeoQuality.set(clusterName, quality);
 				return {
 					clusterName,
 					group,
 					index,
 					radius: clusterRadius(group.length),
-					geo:
-						coords.length > 0
-							? {
-									lat: median(coords.map((c) => c.lat)),
-									lon: median(coords.map((c) => c.lon)),
-								}
-							: null,
+					geo: quality.medianCoordinate
+						? {
+								lat: quality.medianCoordinate.lat,
+								lon: quality.medianCoordinate.long,
+							}
+						: null,
 				};
 			});
 			const geoLayouts = layouts.filter((layout) => layout.geo);
@@ -532,6 +513,8 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 			const cached = nodeStateRef.current.get(node.id);
 			const target = getClusterTarget(node);
 			n.clusterName = getClusterName(node);
+			const quality = clusterGeoQuality.get(n.clusterName);
+			n.isGeoOutlier = quality?.outlierNodeIds.has(node.id) ?? false;
 			n.targetX = target.x;
 			n.targetY = target.y;
 
@@ -613,6 +596,24 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 			typeof endpoint === "object"
 				? endpoint
 				: validNodeById.get(endpoint) || nodeById.get(endpoint);
+		const clusterQualityTooltip = (name: string) => {
+			const center = clusterCenters[name];
+			const quality = clusterGeoQuality.get(name);
+			if (!center || !quality) return `${name}: coordinate quality unavailable`;
+			const notes = [
+				`${name}: ${quality.validCoordinateCount}/${center.count} CIs with valid coordinates`,
+			];
+			if (!center.hasGeo) {
+				notes.push("Fallback lane: no valid coordinates in this cluster");
+			}
+			if (quality.missingCoordinateCount > 0) {
+				notes.push(`${quality.missingCoordinateCount} CIs without coordinates`);
+			}
+			if (quality.outlierNodeIds.size > 0) {
+				notes.push(`${quality.outlierNodeIds.size} possible geo outlier CIs`);
+			}
+			return notes.join(" • ");
+		};
 
 		const clusterSelection = groupByLocation
 			? container
@@ -631,6 +632,10 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 						setSelectedCluster((current) => (current === name ? null : name));
 					})
 			: null;
+
+		clusterSelection
+			?.append("title")
+			.text(([name]) => clusterQualityTooltip(name));
 
 		clusterSelection
 			?.append("circle")
@@ -686,6 +691,37 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 			.attr("font-weight", 800)
 			.attr("letter-spacing", "0.05em")
 			.text(([name, center]) => `${name} (${center.count})`);
+
+		const clusterBadgeSelection = clusterSelection
+			?.append("g")
+			.attr("class", "geo-quality-badges pointer-events-none")
+			.attr("transform", ([, center]) => `translate(0,${center.radius - 20})`);
+
+		clusterBadgeSelection
+			?.append("text")
+			.attr("text-anchor", "middle")
+			.attr("fill", ([name]) =>
+				clusterCenters[name]?.hasGeo ? "#fbbf24" : "#fb7185",
+			)
+			.attr("font-size", "10px")
+			.attr("font-weight", 800)
+			.attr("paint-order", "stroke")
+			.attr("stroke", "#0f172a")
+			.attr("stroke-width", 3)
+			.text(([name]) => {
+				const center = clusterCenters[name];
+				const quality = clusterGeoQuality.get(name);
+				if (!center || !quality) return "";
+				const badges: string[] = [];
+				if (!center.hasGeo) badges.push("sin coords");
+				else if (quality.missingCoordinateCount > 0) {
+					badges.push(`${quality.missingCoordinateCount} sin coords`);
+				}
+				if (quality.outlierNodeIds.size > 0) {
+					badges.push(`${quality.outlierNodeIds.size} outlier`);
+				}
+				return badges.join(" • ");
+			});
 
 		const clusterLinkSelection = container
 			.append("g")
@@ -940,6 +976,23 @@ const GraphCMDB = ({ onNodeClick }: GraphCMDBProps) => {
 				const linkCount = linkCountByNodeId.get(node.id) || 0;
 				return linkCount > 4 ? `+${linkCount} links` : "";
 			});
+
+		nodeSelection
+			.append("text")
+			.attr("dy", "-3.8em")
+			.attr("text-anchor", "middle")
+			.attr("fill", "#fb7185")
+			.attr("font-size", "9px")
+			.attr("font-weight", 800)
+			.attr("paint-order", "stroke")
+			.attr("stroke", "#0f172a")
+			.attr("stroke-width", 3)
+			.attr("class", "geo-outlier-badge pointer-events-none")
+			.text((node: any) =>
+				selectedCluster === node.clusterName && node.isGeoOutlier
+					? "geo outlier"
+					: "",
+			);
 
 		const enforceContainment = () => {
 			validNodes.forEach((node: any) => {

--- a/frontend/components/graphLayout.test.ts
+++ b/frontend/components/graphLayout.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
 	clampClusterCenterToBounds,
 	getBoundedClusterDelta,
+	isValidGeoCoordinate,
+	summarizeClusterGeoQuality,
 } from "./graphLayout";
 
 describe("graph layout bounds", () => {
@@ -33,5 +35,38 @@ describe("graph layout bounds", () => {
 
 		expect(result.x).toBe(400);
 		expect(result.y).toBe(300);
+	});
+});
+
+describe("graph geo quality", () => {
+	it("validates geographic coordinates", () => {
+		expect(isValidGeoCoordinate(-34.6, -58.4)).toBe(true);
+		expect(isValidGeoCoordinate(91, -58.4)).toBe(false);
+		expect(isValidGeoCoordinate(-34.6, Number.NaN)).toBe(false);
+	});
+
+	it("summarizes missing coordinates and median coordinates", () => {
+		const quality = summarizeClusterGeoQuality([
+			{ id: "a", location: { lat: -34.6, long: -58.4 } },
+			{ id: "b", location: { lat: -34.7, long: -58.5 } },
+			{ id: "c" },
+		]);
+
+		expect(quality.validCoordinateCount).toBe(2);
+		expect(quality.missingCoordinateCount).toBe(1);
+		expect(quality.medianCoordinate?.lat).toBeCloseTo(-34.65);
+		expect(quality.medianCoordinate?.long).toBeCloseTo(-58.45);
+	});
+
+	it("marks distant CIs as geo outliers relative to the cluster median", () => {
+		const quality = summarizeClusterGeoQuality([
+			{ id: "near-1", location: { lat: -34.6, long: -58.4 } },
+			{ id: "near-2", location: { lat: -34.61, long: -58.41 } },
+			{ id: "near-3", location: { lat: -34.62, long: -58.42 } },
+			{ id: "far", location: { lat: -31.4, long: -64.2 } },
+		]);
+
+		expect(quality.outlierNodeIds.has("far")).toBe(true);
+		expect(quality.outlierNodeIds.has("near-1")).toBe(false);
 	});
 });

--- a/frontend/components/graphLayout.ts
+++ b/frontend/components/graphLayout.ts
@@ -10,9 +10,103 @@ export type ClusterCircle = {
 	radius: number;
 };
 
+export type GeoPoint = {
+	lat?: number;
+	long?: number;
+};
+
+export type GeoQualityNode = {
+	id: string;
+	location?: GeoPoint;
+};
+
+export type ClusterGeoQuality = {
+	validCoordinateCount: number;
+	missingCoordinateCount: number;
+	outlierNodeIds: Set<string>;
+	medianCoordinate: { lat: number; long: number } | null;
+};
+
+const GEO_OUTLIER_DISTANCE_KM = 50;
+
 const clamp = (value: number, min: number, max: number) => {
 	if (min > max) return (min + max) / 2;
 	return Math.min(max, Math.max(min, value));
+};
+
+const median = (values: number[]) => {
+	const sorted = values.slice().sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 === 0
+		? (sorted[mid - 1] + sorted[mid]) / 2
+		: sorted[mid];
+};
+
+export const isValidGeoCoordinate = (lat: unknown, lon: unknown) =>
+	typeof lat === "number" &&
+	typeof lon === "number" &&
+	Number.isFinite(lat) &&
+	Number.isFinite(lon) &&
+	lat >= -90 &&
+	lat <= 90 &&
+	lon >= -180 &&
+	lon <= 180;
+
+const distanceKm = (
+	from: { lat: number; long: number },
+	to: { lat: number; long: number },
+) => {
+	const earthRadiusKm = 6371;
+	const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+	const dLat = toRadians(to.lat - from.lat);
+	const dLon = toRadians(to.long - from.long);
+	const lat1 = toRadians(from.lat);
+	const lat2 = toRadians(to.lat);
+	const a =
+		Math.sin(dLat / 2) ** 2 +
+		Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+	return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+export const summarizeClusterGeoQuality = <T extends GeoQualityNode>(
+	nodes: T[],
+): ClusterGeoQuality => {
+	const validCoordinates = nodes
+		.map((node) => ({
+			id: node.id,
+			lat: node.location?.lat,
+			long: node.location?.long,
+		}))
+		.filter(({ lat, long }) => isValidGeoCoordinate(lat, long)) as Array<{
+		id: string;
+		lat: number;
+		long: number;
+	}>;
+	const validCoordinateCount = validCoordinates.length;
+	const missingCoordinateCount = nodes.length - validCoordinateCount;
+	const medianCoordinate =
+		validCoordinateCount > 0
+			? {
+					lat: median(validCoordinates.map((coordinate) => coordinate.lat)),
+					long: median(validCoordinates.map((coordinate) => coordinate.long)),
+				}
+			: null;
+	const outlierNodeIds = new Set<string>();
+
+	if (medianCoordinate && validCoordinateCount >= 3) {
+		validCoordinates.forEach((coordinate) => {
+			if (distanceKm(coordinate, medianCoordinate) > GEO_OUTLIER_DISTANCE_KM) {
+				outlierNodeIds.add(coordinate.id);
+			}
+		});
+	}
+
+	return {
+		validCoordinateCount,
+		missingCoordinateCount,
+		outlierNodeIds,
+		medianCoordinate,
+	};
 };
 
 export const clampClusterCenterToBounds = <T extends ClusterCircle>(


### PR DESCRIPTION
Closes #234

## Descripción del Cambio
Agrega indicadores de calidad geográfica en GraphCMDB para explicar cuándo el layout usa fallback o cuándo hay CIs con coordenadas sospechosas.

Incluye:
- resumen de calidad geo por cluster;
- tooltip en cluster con conteo de coordenadas válidas, CIs sin coordenadas, fallback lane y outliers;
- badges compactos en cluster: `sin coords`, `N sin coords`, `N outlier`;
- badge `geo outlier` en CIs cuando el cluster está seleccionado;
- tests unitarios para validación de coordenadas, medianas, faltantes y outliers.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `corepack pnpm --dir frontend run test:run -- components/graphLayout.test.ts components/__tests__/GraphCMDB.query.test.tsx` → 41 files / 381 tests passed
- [x] `corepack pnpm --dir frontend run build` → passed
- [x] Fresh reviewer → no blockers
- [x] Docker local rebuilt with `docker compose up -d --build frontend`
- [x] `curl -I http://localhost:3000` → HTTP 200

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Scope
- Includes: geo/fallback quality summaries, cluster tooltip/badges, selected-CI outlier badge.
- Excludes: large-scale LOD/performance mode (#230) and filter sidebar polish (#236).
