### PR TITLE
fix(analytics): tag ICMP availability source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.15] — 2026-05-31
+
 ### Fixed
+- **Availability source-of-truth hardening** (issue #239):
+  - Adds explicit `availability_source` tagging for Ping/ICMP availability metrics and events.
+  - Scopes MTTR/MTBF/availability reports to tagged `PING`/`ICMP` availability evidence, excluding untagged ICMP and `mariadb-GS` fallback behavior.
+  - Adds a safe rebuild migration to backfill existing ICMP availability metrics/events while keeping latency and jitter telemetry excluded.
+  - Adds focused backend regression coverage for report filtering, polling event emission, legacy worker behavior, and migration idempotency.
 - **Admin CI creation visibility** (PR #225, issue #189):
   - Lists newly created CIs in `/api/nodes` even when they do not have latitude/longitude coordinates yet.
   - Preserves non-admin inventory scoping by `location_name`.

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -284,23 +284,32 @@ def _refresh_snmp_collection_failures(session, failures):
     """, failures=failures)
 
 
+def _availability_source(value: Any) -> str | None:
+    source = str(value or "").strip().upper()
+    return source if source in {"PING", "ICMP"} else None
+
+
 def _refresh_icmp_availability_events(session, updates):
     availability_events = [
         u
         for u in updates
         if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
+        and _availability_source(u.get("availability_source")) is not None
         and float(u.get("value") or 0) == 0.0
     ]
     if not availability_events:
         return
     session.run("""
         UNWIND $availability_events AS row
-        WITH row WHERE row.event_type = 'AVAILABILITY' AND row.source_protocol = 'ICMP'
+        WITH row WHERE row.event_type = 'AVAILABILITY'
+          AND row.source_protocol = 'ICMP'
+          AND row.availability_source IN ['PING', 'ICMP']
         MATCH (n:CI {id: row.node_id})
         MATCH (m:MetricDef {id: row.metric_id})
         OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
         WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
           AND existing.event_type = 'AVAILABILITY'
+          AND existing.availability_source IN ['PING', 'ICMP']
           AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
         WITH row, n, m, head(collect(existing)) AS existing
         FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
@@ -308,6 +317,7 @@ def _refresh_icmp_availability_events(session, updates):
                 id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
                 status: 'OPEN', severity: row.severity, message: row.message,
                 event_type: row.event_type, source_protocol: row.source_protocol,
+                availability_source: row.availability_source,
                 created_at: datetime(), last_seen: datetime(), ack: false,
                 correlation_type: 'ROOT', root_cause_ci_id: row.node_id
             })
@@ -319,7 +329,8 @@ def _refresh_icmp_availability_events(session, updates):
                 existing.message = row.message, existing.last_seen = datetime(),
                 existing.recovered_at = NULL, existing.ack = false,
                 existing.event_type = row.event_type,
-                existing.source_protocol = row.source_protocol
+                existing.source_protocol = row.source_protocol,
+                existing.availability_source = row.availability_source
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
@@ -331,6 +342,7 @@ def _recover_icmp_availability_events(session, updates):
         u
         for u in updates
         if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
+        and _availability_source(u.get("availability_source")) is not None
         and float(u.get("value") or 0) == 1.0
     ]
     if not recoveries:
@@ -340,6 +352,7 @@ def _recover_icmp_availability_events(session, updates):
         MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
         WHERE e.status IN ['OPEN', 'ACK']
           AND e.event_type = 'AVAILABILITY'
+          AND e.availability_source IN ['PING', 'ICMP']
           AND (e.source_protocol IS NULL OR toUpper(e.source_protocol) = row.protocol)
         SET e.status = 'RECOVERED',
             e.recovered_at = datetime(),
@@ -417,6 +430,7 @@ def poll_snmp():
                        m.id as metric_id, m.name as metric_name, m.protocol as protocol,
                        m.oid as oid, m.criticality as criticality,
                        m.metric_kind as metric_kind,
+                       m.availability_source as availability_source,
                        interval
             """)
             
@@ -442,7 +456,11 @@ def poll_snmp():
 
                 val = None
                 sidecar_samples = []
-                metric_metadata = {"metric_kind": record.get("metric_kind")}
+                availability_source = _availability_source(record.get("availability_source"))
+                metric_metadata = {
+                    "metric_kind": record.get("metric_kind"),
+                    "availability_source": availability_source,
+                }
                 icmp_settings = get_icmp_settings()
                 internal_icmp_poll = False
                 if protocol == "ICMP" and is_icmp_telemetry_metric(mid, metric_metadata):
@@ -451,7 +469,7 @@ def poll_snmp():
                     polled_icmp_nodes.add(node_id)
                     mid = ICMP_AVAILABILITY_METRIC_ID
                     internal_icmp_poll = True
-                elif protocol == "ICMP" and is_icmp_availability_metric(mid, metric_metadata):
+                elif protocol == "ICMP" and availability_source and is_icmp_availability_metric(mid, metric_metadata):
                     if node_id in polled_icmp_nodes:
                         continue
                     polled_icmp_nodes.add(node_id)
@@ -524,16 +542,17 @@ def poll_snmp():
                             "protocol": protocol,
                             "metric_name": metric_name,
                             "criticality": record["criticality"],
-                            "status": severity if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else "OK",
+                            "status": severity if protocol == SOURCE_PROTOCOL_ICMP and availability_source and val == 0.0 else "OK",
                             "message": (
                                 f"Service/Host Down: {metric_name}"
-                                if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0
+                                if protocol == SOURCE_PROTOCOL_ICMP and availability_source and val == 0.0
                                 else "Latest sample collected by legacy SNMP worker"
                             ),
-                            "event_type": EVENT_TYPE_AVAILABILITY if protocol == SOURCE_PROTOCOL_ICMP and val == 0.0 else None,
+                            "event_type": EVENT_TYPE_AVAILABILITY if protocol == SOURCE_PROTOCOL_ICMP and availability_source and val == 0.0 else None,
                             "source_protocol": SOURCE_PROTOCOL_ICMP if protocol == SOURCE_PROTOCOL_ICMP else protocol,
+                            "availability_source": availability_source,
                             "severity": severity,
-                            "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP else "telemetry",
+                            "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP and availability_source else "telemetry",
                         })
                     for sample in sidecar_samples:
                         latest_updates.append({

--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -59,6 +59,7 @@ class MetricDef(BaseModel):
     applicable_to: Optional[Dict[str, List[str]]] = None
     polling_interval: Optional[int] = 60
     can_propagate: bool = True
+    availability_source: Optional[Literal["PING", "ICMP"]] = None
     # CLI-specific fields (optional, validated only when protocol == "CLI")
     cli_command: Optional[str] = None
     cli_target: Optional[str] = None

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -7,7 +7,6 @@ from enum import Enum
 from typing import Any, Iterable, Mapping
 from uuid import UUID
 
-from polling.icmp_measurements import is_icmp_availability_metric
 from services.polling_event_lifecycle import (
     COLLECTION_FAILURE_PREFIX,
     EVENT_TYPE_AVAILABILITY,
@@ -54,6 +53,11 @@ def _base_severity(metadata: Mapping[str, Any]) -> str:
     return {2: "WARNING", 3: "CRITICAL"}.get(int(metadata.get("criticality") or 1), "INFO")
 
 
+def _availability_source(metadata: Mapping[str, Any]) -> str | None:
+    source = str(metadata.get("availability_source") or "").strip().upper()
+    return source if source in {"PING", "ICMP"} else None
+
+
 def _collection_failure_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     deduped: dict[tuple[Any, Any, Any, Any], dict[str, Any]] = {}
     for row in rows:
@@ -98,7 +102,8 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
             event_type = EVENT_TYPE_COLLECTION_FAILURE
             message = collection_failure_message(envelope.get("error") or {}, result_status)
         elif numeric is not None:
-            availability = (protocol == "ICMP" and is_icmp_availability_metric(metric_id, metadata)) or metric_name == "mariadb-GS"
+            availability_source = _availability_source(metadata)
+            availability = protocol == "ICMP" and availability_source is not None
             if availability and numeric == 0:
                 severity = _base_severity(metadata)
                 is_breach = True
@@ -131,6 +136,7 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
             "event_type": event_type,
             "failure_family": failure_family,
             "source_protocol": source_protocol,
+            "availability_source": _availability_source(metadata),
             "recover_collection_failure": recover_collection_failure,
             "recover_non_collection_event": recover_non_collection_event,
             "collection_recovery_message": collection_recovery_message,
@@ -196,6 +202,7 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                 CREATE (created:Event {
                     id: randomUUID(), ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN',
                     event_type: row.event_type, failure_family: row.failure_family, source_protocol: row.source_protocol,
+                    availability_source: row.availability_source,
                     severity: row.severity, message: row.message, created_at: datetime(), last_seen: datetime(), ack: false,
                     correlation_type: row.correlation_type, propagated_from: row.propagated_from, root_cause_ci_id: row.root_cause_ci_id,
                     business_service_id: row.business_service_id, business_service_name: row.business_service_name,
@@ -211,7 +218,8 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                 SET existing.status = 'OPEN', existing.severity = row.severity, existing.message = row.message,
                     existing.last_seen = datetime(), existing.ack = false, existing.recovered_at = NULL,
                     existing.event_type = row.event_type, existing.failure_family = row.failure_family,
-                    existing.source_protocol = row.source_protocol
+                    existing.source_protocol = row.source_protocol,
+                    existing.availability_source = row.availability_source
                 MERGE (n)-[:HAS_EVENT]->(existing)
                 MERGE (existing)-[:TRIGGERED_BY]->(m)
             )
@@ -229,6 +237,7 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                 e.severity = row.severity,
                 e.message = row.message,
                 e.source_protocol = row.source_protocol,
+                e.availability_source = row.availability_source,
                 e.last_seen = datetime(),
                 e.ack = false,
                 e.correlation_type = coalesce(e.correlation_type, row.correlation_type),

--- a/backend/polling/scheduler.py
+++ b/backend/polling/scheduler.py
@@ -127,6 +127,7 @@ def build_tasks_from_records(records: Iterable[Mapping[str, Any]], cycle: PollCy
             "payload": payload,
             "metadata_version": record.get("metadata_version") or cycle.config_version,
             "metric_kind": record.get("metric_kind"),
+            "availability_source": record.get("availability_source"),
             "internal": bool(record.get("internal")),
         })
 
@@ -157,6 +158,7 @@ def build_tasks_from_records(records: Iterable[Mapping[str, Any]], cycle: PollCy
             "metric_id": ICMP_AVAILABILITY_METRIC_ID,
             "protocol": PollingProtocol.ICMP.value,
             "metric_kind": "availability",
+            "availability_source": "ICMP",
             "internal": True,
         }
         add_task(synthetic, PollingProtocol.ICMP, ci_id, ICMP_AVAILABILITY_METRIC_ID)

--- a/backend/polling/snmp_executor.py
+++ b/backend/polling/snmp_executor.py
@@ -170,8 +170,11 @@ def execute_poll_task(
     icmp_result_metadata: dict[str, Any] = {}
     if protocol == PollingProtocol.ICMP:
         is_internal_icmp = bool(_get(task, "internal") or task_metadata.get("internal") or payload.get("internal"))
+        availability_source = _get(task, "availability_source") or task_metadata.get("availability_source")
         if measurement is not None:
             icmp_result_metadata = {"metric_kind": "availability", "icmp": icmp_metadata(measurement)}
+            if availability_source:
+                icmp_result_metadata["availability_source"] = str(availability_source).upper()
         elif is_icmp_telemetry_metric(metric_id, task_metadata):
             icmp_result_metadata = {"metric_kind": "telemetry"}
         if is_internal_icmp:
@@ -207,6 +210,7 @@ def execute_poll_task(
             "credential_ref": _get(task, "credential_ref"),
             "endpoint": _get(task, "endpoint"),
             "metadata_version": _get(task, "metadata_version"),
+            "availability_source": _get(task, "availability_source") or task_metadata.get("availability_source"),
             "worker_id": worker_id,
         },
         timing={

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -471,6 +471,47 @@ def migrate_icmp_sidecar_metrics() -> None:
         """, latency_id=ICMP_LATENCY_METRIC_ID, jitter_id=ICMP_JITTER_METRIC_ID)
 
 
+def migrate_icmp_availability_source() -> None:
+    """Backfill explicit availability_source for existing ICMP availability metrics/events.
+
+    ICMP latency and jitter sidecars stay telemetry-only and are intentionally
+    excluded from the availability source-of-truth tag.
+    """
+    excluded_metric_ids = [ICMP_LATENCY_METRIC_ID, ICMP_JITTER_METRIC_ID, "mariadb-GS"]
+    driver = get_db()
+    with driver.session() as session:
+        session.run("""
+            MATCH (m:MetricDef)
+            WHERE toUpper(coalesce(m.protocol, '')) = 'ICMP'
+              AND NOT m.id IN $excluded_metric_ids
+              AND coalesce(m.name, '') <> 'mariadb-GS'
+              AND coalesce(m.metric_kind, 'availability') <> 'telemetry'
+            SET m.availability_source = coalesce(m.availability_source, 'ICMP'),
+                m.metric_kind = coalesce(m.metric_kind, 'availability')
+        """, excluded_metric_ids=excluded_metric_ids)
+        session.run("""
+            MATCH (e:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+            WHERE e.event_type = 'AVAILABILITY'
+              AND toUpper(coalesce(e.source_protocol, '')) = 'ICMP'
+              AND toUpper(coalesce(m.protocol, '')) = 'ICMP'
+              AND m.availability_source IN ['PING', 'ICMP']
+              AND NOT m.id IN $excluded_metric_ids
+              AND coalesce(m.name, '') <> 'mariadb-GS'
+            SET e.availability_source = m.availability_source
+        """, excluded_metric_ids=excluded_metric_ids)
+        session.run("""
+            MATCH (e:Event)
+            WHERE e.event_type = 'AVAILABILITY'
+              AND toUpper(coalesce(e.source_protocol, '')) = 'ICMP'
+              AND e.metric_id IS NOT NULL
+              AND NOT e.metric_id IN $excluded_metric_ids
+              AND NOT EXISTS {
+                MATCH (e)-[:TRIGGERED_BY]->(:MetricDef)
+              }
+            SET e.availability_source = coalesce(e.availability_source, 'ICMP')
+        """, excluded_metric_ids=excluded_metric_ids)
+
+
 def create_default_ping_metric(node_id: str, node_label: str) -> None:
     """
     Ensure ICMP latency and jitter metrics are available for a CI.

--- a/backend/scripts/migrate_icmp_availability_source.py
+++ b/backend/scripts/migrate_icmp_availability_source.py
@@ -1,0 +1,29 @@
+"""Backfill explicit availability_source tags for existing ICMP availability data.
+
+Run from the repository root with:
+    python backend/scripts/migrate_icmp_availability_source.py
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+# Add backend to path for direct script execution.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from repositories import topology_repo
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    logger.info("Starting ICMP availability source migration...")
+    topology_repo.migrate_icmp_availability_source()
+    logger.info("ICMP availability source migration complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -598,6 +598,8 @@ def get_availability_report(
             MATCH (e:Event)<-[:HAS_EVENT]-(ci:CI)
             WHERE e.created_at IS NOT NULL
               AND e.recovered_at IS NOT NULL
+              AND e.event_type = 'AVAILABILITY'
+              AND e.availability_source IN ['PING', 'ICMP']
               AND NOT e.status IN ['OPEN', 'ACK']
               AND e.created_at >= $window_start
               AND e.created_at <= $window_end
@@ -613,6 +615,10 @@ def get_availability_report(
         for record in recovered_result:
             event_data = _node_to_dict(_record_value(record, "e"))
             ci_data = _node_to_dict(_record_value(record, "ci"))
+            if event_data.get("event_type") != "AVAILABILITY":
+                continue
+            if event_data.get("availability_source") not in {"PING", "ICMP"}:
+                continue
             key = _availability_group_key(event_data)
             if key is None:
                 continue
@@ -642,6 +648,8 @@ def get_availability_report(
             """
             MATCH (e:Event)<-[:HAS_EVENT]-(ci:CI)
             WHERE e.status IN ['OPEN', 'ACK']
+              AND e.event_type = 'AVAILABILITY'
+              AND e.availability_source IN ['PING', 'ICMP']
               AND e.created_at IS NOT NULL
               AND e.created_at <= $window_end
             OPTIONAL MATCH (ci)-[:CATEGORIZED_AS]->(cat:Category)
@@ -654,6 +662,10 @@ def get_availability_report(
         for record in active_result:
             event_data = _node_to_dict(_record_value(record, "e"))
             ci_data = _node_to_dict(_record_value(record, "ci"))
+            if event_data.get("event_type") != "AVAILABILITY":
+                continue
+            if event_data.get("availability_source") not in {"PING", "ICMP"}:
+                continue
             key = _availability_group_key(event_data)
             if key is None:
                 continue

--- a/backend/services/metric_service.py
+++ b/backend/services/metric_service.py
@@ -86,6 +86,7 @@ def get_metrics() -> List[Dict[str, Any]]:
                 "applicable_to": criteria,
                 "polling_interval": m.get("polling_interval", 60),
                 "can_propagate": m.get("can_propagate", True),
+                "availability_source": m.get("availability_source"),
                 # CLI-specific fields
                 "cli_command": m.get("cli_command"),
                 "cli_target": m.get("cli_target"),
@@ -128,6 +129,7 @@ def get_metric(metric_id: str) -> Optional[Dict[str, Any]]:
             "applicable_to": criteria,
             "polling_interval": m.get("polling_interval", 60),
             "can_propagate": m.get("can_propagate", True),
+            "availability_source": m.get("availability_source"),
             # CLI-specific fields
             "cli_command": m.get("cli_command"),
             "cli_target": m.get("cli_target"),
@@ -190,6 +192,7 @@ def create_metric(metric: MetricDef) -> Dict[str, str]:
                         m.operator = $operator, m.criticality = $criticality,
                         m.polling_interval = $polling_interval,
                         m.can_propagate = $can_propagate,
+                        m.availability_source = $availability_source,
                         m.cli_command = $cli_command,
                         m.cli_target = $cli_target,
                         m.cli_value_extractor = $cli_value_extractor,
@@ -203,6 +206,7 @@ def create_metric(metric: MetricDef) -> Dict[str, str]:
                      operator=metric.operator or ">=", criticality=metric.criticality or 1,
                      polling_interval=metric.polling_interval or 60,
                      can_propagate=metric.can_propagate,
+                     availability_source=metric.availability_source,
                      cli_command=metric.cli_command,
                      cli_target=metric.cli_target,
                      cli_value_extractor=metric.cli_value_extractor,

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -351,6 +351,9 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
     event_type = None
     failure_family = None
     source_protocol = normalized_protocol(metric_def.get("protocol")) or None
+    availability_source = str(metric_def.get("availability_source") or "").strip().upper()
+    if availability_source not in {"PING", "ICMP"}:
+        availability_source = None
     message = f"Metric {metric_def.get('name', metric_def['id'])} is OK. Value: {val}"
     numeric_value = None
 
@@ -371,10 +374,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
         try:
             num_val = float(val)
             numeric_value = num_val
-            is_availability_metric = (
-                source_protocol == "ICMP"
-                or metric_def.get("name") == "mariadb-GS"
-            )
+            is_availability_metric = source_protocol == "ICMP" and availability_source is not None
 
             if not is_availability_metric:
                 operator = metric_def.get("operator", ">=")
@@ -526,7 +526,8 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         existing.recovered_at = NULL,
                         existing.event_type = $event_type,
                         existing.failure_family = $failure_family,
-                        existing.source_protocol = $source_protocol
+                        existing.source_protocol = $source_protocol,
+                        existing.availability_source = $availability_source
                 """,
                     existing_element_id=existing_element_id,
                     msg=message,
@@ -534,6 +535,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     event_type=event_type,
                     failure_family=failure_family,
                     source_protocol=source_protocol,
+                    availability_source=availability_source,
                 )
             else:
                 snapshot = resolve_event_snapshot(session, ci.get("id"))
@@ -570,6 +572,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         event_type: $event_type,
                         failure_family: $failure_family,
                         source_protocol: $source_protocol,
+                        availability_source: $availability_source,
                         created_at: datetime(),
                         last_seen: datetime(),
                         ack: false,
@@ -599,6 +602,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     event_type=event_type,
                     failure_family=failure_family,
                     source_protocol=source_protocol,
+                    availability_source=availability_source,
                     propagated_from=propagated_from,
                     correlation_type=correlation_type,
                     root_cause_ci_id=root_cause_ci_id,

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -105,6 +105,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
                         "recovered_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
                     },
@@ -116,6 +117,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "CLOSED",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
                         "recovered_at": datetime(2026, 1, 1, 2, 20, tzinfo=timezone.utc),
                     },
@@ -127,6 +129,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
                         "recovered_at": None,
                     },
@@ -143,6 +146,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "OPEN",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 4, 0, tzinfo=timezone.utc),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
@@ -182,6 +186,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
                         "recovered_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
                     },
@@ -198,6 +203,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "ACK",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
@@ -228,6 +234,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
                         "recovered_at": datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc),
                     },
@@ -326,6 +333,240 @@ class TestEventServiceSmoke:
         assert "RETURN e, ci, category" in recovered_query
         assert "RETURN e, ci, category" in active_query
 
+    def test_get_availability_report_queries_scope_to_availability_events(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+
+        get_availability_report(start=start, end=end, now=end)
+
+        recovered_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "NOT e.status IN ['OPEN', 'ACK']" in query["query"]
+        )["query"]
+        active_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "WHERE e.status IN ['OPEN', 'ACK']" in query["query"]
+        )["query"]
+
+        assert "e.event_type = 'AVAILABILITY'" in recovered_query
+        assert "e.event_type = 'AVAILABILITY'" in active_query
+        assert "e.availability_source IN ['PING', 'ICMP']" in recovered_query
+        assert "e.availability_source IN ['PING', 'ICMP']" in active_query
+
+    def test_get_availability_report_excludes_non_availability_event_types(
+        self, mock_neo4j_session
+    ):
+        """Only availability incidents should drive MTTR/MTBF/availability rows."""
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 4, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response(
+            "not e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-availability-recovered",
+                        "ci_id": "ci-1",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-1", "name": "Router-01", "status": "OK"},
+                },
+                {
+                    "e": {
+                        "id": "evt-threshold-recovered",
+                        "ci_id": "ci-1",
+                        "status": "RECOVERED",
+                        "event_type": "THRESHOLD_BREACH",
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-1", "name": "Router-01", "status": "DEGRADED"},
+                },
+                {
+                    "e": {
+                        "id": "evt-collection-closed",
+                        "ci_id": "ci-2",
+                        "status": "CLOSED",
+                        "event_type": "COLLECTION_FAILURE",
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 1, 15, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-2", "name": "Switch-01", "status": "OK"},
+                },
+            ],
+        )
+        mock_neo4j_session.set_response(
+            "e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-availability-active",
+                        "ci_id": "ci-1",
+                        "status": "ACK",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-1", "name": "Router-01", "status": "DOWN"},
+                },
+                {
+                    "e": {
+                        "id": "evt-snmp-active",
+                        "ci_id": "ci-1",
+                        "status": "OPEN",
+                        "event_type": "COLLECTION_FAILURE",
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-1", "name": "Router-01", "status": "UNKNOWN"},
+                },
+            ],
+        )
+
+        report = get_availability_report(start=start, end=end, now=end)
+
+        assert report["total_groups"] == 1
+        row = report["rows"][0]
+        assert row["ci_id"] == "ci-1"
+        assert row["event_type"] == "AVAILABILITY"
+        assert row["recovered_incidents"] == 1
+        assert row["active_events"] == 1
+        assert row["downtime_seconds"] == 1800
+        assert row["active_downtime_seconds"] == 3600
+        assert row["availability_percentage"] == 62.5
+
+    def test_get_availability_report_excludes_untagged_availability_events(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response(
+            "not e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-tagged-ping",
+                        "ci_id": "ci-1",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "PING",
+                        "metric_id": "PING-CHECK",
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-1", "name": "Router-01", "status": "OK"},
+                },
+                {
+                    "e": {
+                        "id": "evt-untagged-icmp",
+                        "ci_id": "ci-2",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "source_protocol": "ICMP",
+                        "metric_id": "PING-CHECK",
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-2", "name": "Legacy Ping", "status": "OK"},
+                },
+                {
+                    "e": {
+                        "id": "evt-mariadb",
+                        "ci_id": "ci-3",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "metric_id": "mariadb-GS",
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-3", "name": "MariaDB", "status": "OK"},
+                },
+            ],
+        )
+
+        report = get_availability_report(start=start, end=end, now=end)
+
+        assert report["total_groups"] == 1
+        assert report["rows"][0]["ci_id"] == "ci-1"
+
+    def test_get_availability_report_handles_ci_status_variants_for_availability_events(
+        self, mock_neo4j_session
+    ):
+        """CI state at event time should not change event-status availability math."""
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 1, 6, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response(
+            "not e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-online-recovered",
+                        "ci_id": "ci-online",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 1, 20, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-online", "name": "Router Online", "status": "OK"},
+                },
+                {
+                    "e": {
+                        "id": "evt-maint-recovered",
+                        "ci_id": "ci-maint",
+                        "status": "CLOSED",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 2, 45, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-maint", "name": "Router Maintenance", "status": "MAINTENANCE"},
+                },
+            ],
+        )
+        mock_neo4j_session.set_response(
+            "e.status in ['open', 'ack']",
+            [
+                {
+                    "e": {
+                        "id": "evt-down-active",
+                        "ci_id": "ci-down",
+                        "status": "OPEN",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "created_at": datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-down", "name": "Router Down", "status": "DOWN"},
+                }
+            ],
+        )
+
+        report = get_availability_report(start=start, end=end, now=end)
+
+        rows = {row["ci_id"]: row for row in report["rows"]}
+        assert rows["ci-online"]["ci"]["status"] == "OK"
+        assert rows["ci-online"]["recovered_incidents"] == 1
+        assert rows["ci-online"]["downtime_seconds"] == 1200
+        assert rows["ci-online"]["availability_percentage"] == 94.4444
+        assert rows["ci-maint"]["ci"]["status"] == "MAINTENANCE"
+        assert rows["ci-maint"]["recovered_incidents"] == 1
+        assert rows["ci-maint"]["downtime_seconds"] == 2700
+        assert rows["ci-maint"]["availability_percentage"] == 87.5
+        assert rows["ci-down"]["ci"]["status"] == "DOWN"
+        assert rows["ci-down"]["active_events"] == 1
+        assert rows["ci-down"]["active_downtime_seconds"] == 3600
+        assert rows["ci-down"]["availability_percentage"] == 83.3333
+
     def test_get_availability_report_queries_filter_window_in_cypher(
         self, mock_neo4j_session
     ):
@@ -374,6 +615,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "OPEN",
                         "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
                         "created_at": datetime(2025, 12, 31, 23, 0, tzinfo=timezone.utc),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},

--- a/backend/tests/test_icmp_metric_migration.py
+++ b/backend/tests/test_icmp_metric_migration.py
@@ -67,3 +67,32 @@ def test_migrate_icmp_sidecar_metrics_script_entrypoint_invokes_repository(monke
 
     assert script.main() == 0
     assert calls == ["migrated"]
+
+
+def test_migrate_icmp_availability_source_tags_icmp_except_sidecars(monkeypatch):
+    from repositories import topology_repo
+
+    driver = MockNeo4jDriver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.migrate_icmp_availability_source()
+
+    queries = "\n".join(q["query"] for q in driver.mock_session.queries)
+    params = [q["params"] for q in driver.mock_session.queries]
+    assert "m.availability_source = coalesce(m.availability_source, 'ICMP')" in queries
+    assert "e.availability_source = m.availability_source" in queries
+    assert "e.availability_source = coalesce(e.availability_source, 'ICMP')" in queries
+    assert "NOT m.id IN $excluded_metric_ids" in queries
+    assert "NOT e.metric_id IN $excluded_metric_ids" in queries
+    assert "coalesce(m.name, '') <> 'mariadb-GS'" in queries
+    assert {"excluded_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms", "mariadb-GS"]} in params
+
+
+def test_migrate_icmp_availability_source_script_entrypoint_invokes_repository(monkeypatch):
+    from scripts import migrate_icmp_availability_source as script
+
+    calls = []
+    monkeypatch.setattr(script.topology_repo, "migrate_icmp_availability_source", lambda: calls.append("migrated"))
+
+    assert script.main() == 0
+    assert calls == ["migrated"]

--- a/backend/tests/test_metric_polling_interval.py
+++ b/backend/tests/test_metric_polling_interval.py
@@ -42,7 +42,7 @@ def test_create_metric_persists_interval(mock_get_db):
     metric_service.create_metric(metric)
     
     # THEN
-    args, kwargs = mock_session.run.call_args
+    args, kwargs = mock_session.run.call_args_list[0]
     assert "polling_interval" in kwargs
     assert kwargs["polling_interval"] == 15
     assert "m.polling_interval = $polling_interval" in args[0]

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -22,8 +22,8 @@ def test_event_writer_ignores_icmp_latency_and_jitter_as_availability_events():
     from polling.event_writer import build_event_rows
 
     rows = build_event_rows([
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-router", "metadata": {"name": "PING-router", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3, "availability_source": "PING"}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-router", "metadata": {"name": "PING-router", "criticality": 3, "availability_source": "ICMP"}},
         {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_latency_ms", "metadata": {"name": "ICMP Latency", "criticality": 3}},
         {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_jitter_ms", "metadata": {"name": "ICMP Jitter", "criticality": 3}},
         {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_latency_ms", "metadata": {"name": "ICMP Latency", "criticality": 3, "metric_kind": "availability"}},
@@ -37,13 +37,30 @@ def test_event_writer_ignores_icmp_latency_and_jitter_as_availability_events():
         assert row["is_breach"] is False
 
 
+def test_event_writer_requires_explicit_availability_source_tag():
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "SNMP", "metric_id": "mariadb-GS", "metadata": {"name": "mariadb-GS", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3, "availability_source": "PING"}},
+    ])
+
+    assert rows[0]["event_type"] is None
+    assert rows[0]["is_breach"] is False
+    assert rows[1]["event_type"] is None
+    assert rows[1]["is_breach"] is False
+    assert rows[2]["event_type"] == "AVAILABILITY"
+    assert rows[2]["availability_source"] == "PING"
+
+
 def test_event_writer_derives_threshold_breach_and_availability_recovery_rows():
     from polling.event_writer import build_event_rows
 
     rows = build_event_rows([
         _event_row(97.0),
-        {**_event_row(1.0), "protocol": "ICMP", "metric_id": "PING-CHECK"},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK"},
+        {**_event_row(1.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"availability_source": "PING", "criticality": 3}},
+        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"availability_source": "PING", "criticality": 3}},
     ])
 
     assert rows[0]["is_breach"] is True
@@ -56,6 +73,7 @@ def test_event_writer_derives_threshold_breach_and_availability_recovery_rows():
     assert rows[2]["is_breach"] is True
     assert rows[2]["event_type"] == "AVAILABILITY"
     assert rows[2]["source_protocol"] == "ICMP"
+    assert rows[2]["availability_source"] == "PING"
     assert rows[2]["severity"] == "CRITICAL"
     assert "Service/Host Down" in rows[2]["message"]
 

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -533,6 +533,7 @@ class TestICMPDebounce:
         mock_session.set_response("match", [{
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "ip": "192.168.1.1",
             "community": "public",
@@ -583,6 +584,7 @@ class TestICMPDebounce:
         mock_session.set_response("match", [{
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "ip": "192.168.1.1",
             "community": "public",
@@ -645,6 +647,7 @@ class TestICMPDebounce:
         mock_session.set_response("match", [{
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "ip": "192.168.1.1",
             "community": "public",
@@ -683,6 +686,7 @@ class TestICMPDebounce:
         mock_session.set_response("match", [{
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "ip": "192.168.1.1",
             "community": "public",
@@ -738,6 +742,7 @@ class TestICMPDebounce:
         mock_session.set_response("match", [{
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "ip": "192.168.1.1",
             "community": "public",
@@ -798,6 +803,7 @@ def test_poll_snmp_prefers_legacy_availability_when_sidecars_return_first():
         {
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "metric_kind": "availability",
             "ip": "192.168.1.1",
@@ -838,6 +844,7 @@ def test_poll_snmp_skips_icmp_sidecar_metrics_as_primary_poll_targets():
         {
             "node_id": "ci-001",
             "metric_id": "PING-CHECK",
+            "availability_source": "ICMP",
             "protocol": "ICMP",
             "metric_kind": "availability",
             "ip": "192.168.1.1",

--- a/scripts/safe-rebuild.sh
+++ b/scripts/safe-rebuild.sh
@@ -208,6 +208,9 @@ run docker compose up -d
 printf 'Applying ICMP latency/jitter sidecar migration...\n'
 run docker compose exec -T backend python scripts/migrate_icmp_sidecar_metrics.py
 
+printf 'Applying ICMP availability source migration...\n'
+run docker compose exec -T backend python scripts/migrate_icmp_availability_source.py
+
 printf '\nSafe rebuild flow completed. Current service status:\n'
 run docker compose ps
 


### PR DESCRIPTION
## Descripción del Cambio
Closes #239

Endurece la fuente de verdad del reporte de disponibilidad/MTTR/MTBF para que use evidencia explícitamente etiquetada como Ping/ICMP:

- Agrega `availability_source` a `MetricDef` y lo propaga a eventos de disponibilidad.
- Filtra el reporte de disponibilidad a eventos `AVAILABILITY` con `availability_source IN ['PING', 'ICMP']`.
- Elimina el fallback implícito de `mariadb-GS` para el reporte, salvo que se etiquete explícitamente en el futuro.
- Agrega migración de `safe-rebuild` para backfillear métricas/eventos ICMP existentes excluyendo `icmp_latency_ms`, `icmp_jitter_ms` y `mariadb-GS`.
- Prepara changelog para patch release `v1.12.17`.

| Archivo | Cambio |
|---|---|
| `backend/models/core.py` | Agrega `availability_source` en `MetricDef`. |
| `backend/services/event_service.py` | Filtra disponibilidad por evento y tag explícito. |
| `backend/polling/event_writer.py` | Emite disponibilidad solo con `availability_source` explícito. |
| `backend/services/snmp_service.py` / `backend/engines/snmp_worker.py` | Gatean flujos legacy por tag explícito. |
| `backend/repositories/topology_repo.py` | Agrega migración de backfill ICMP excluyendo telemetry y `mariadb-GS`. |
| `backend/scripts/migrate_icmp_availability_source.py` | Nuevo entrypoint de migración. |
| `scripts/safe-rebuild.sh` | Ejecuta la migración después de sidecars ICMP. |
| `backend/tests/*` | Cobertura de reporte, writer, legacy worker y migración. |
| `CHANGELOG.md` | Entrada `1.12.17`. |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && python -m pytest tests/test_icmp_metric_migration.py tests/test_metric_service_smoke.py tests/test_metric_polling_interval.py tests/test_models.py tests/test_event_service_smoke.py tests/test_polling_event_writer.py tests/test_snmp_worker.py tests/test_polling_scheduler.py tests/test_snmp_service_collection_failures.py tests/test_snmp_service_snapshots.py -q` → `153 passed, 23 warnings`
- [x] `git diff --check`
- [ ] `shellcheck scripts/safe-rebuild.sh scripts/pre-rebuild-backup.sh scripts/validate-env.sh` — no disponible localmente (`shellcheck: command not found`)

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
