### PR TITLE
fix(analytics): exclude propagated availability events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.18] — 2026-06-01
+
 ### Fixed
 - **Technical availability correlation filtering** (issue #242):
   - Excludes propagated/correlated availability events from MTTR/MTBF and availability report calculations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Technical availability correlation filtering** (issue #242):
+  - Excludes propagated/correlated availability events from MTTR/MTBF and availability report calculations.
+  - Keeps the existing `availability_source` `PING`/`ICMP` source-of-truth filter for direct technical availability evidence.
+  - Adds regression coverage for propagated recovered and active availability events.
+
 ## [1.12.17] — 2026-05-31
 
 ### Fixed

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -457,7 +457,20 @@ _SENSITIVE_CI_KEY_PARTS = (
 )
 
 
+def _is_authoritative_availability_event(event_data: Dict[str, Any]) -> bool:
+    event_type = str(event_data.get("event_type") or "").upper()
+    availability_source = str(event_data.get("availability_source") or "").upper()
+    correlation_type = str(event_data.get("correlation_type") or "ROOT").upper()
+    return (
+        event_type == "AVAILABILITY"
+        and availability_source in {"PING", "ICMP"}
+        and correlation_type != "PROPAGATED"
+    )
+
+
 def _availability_group_key(event_data: Dict[str, Any]) -> Optional[tuple[str, str]]:
+    if not _is_authoritative_availability_event(event_data):
+        return None
     ci_id = event_data.get("ci_id")
     event_type = event_data.get("event_type")
     if not ci_id or not event_type:
@@ -600,6 +613,7 @@ def get_availability_report(
               AND e.recovered_at IS NOT NULL
               AND e.event_type = 'AVAILABILITY'
               AND e.availability_source IN ['PING', 'ICMP']
+              AND toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'
               AND NOT e.status IN ['OPEN', 'ACK']
               AND e.created_at >= $window_start
               AND e.created_at <= $window_end
@@ -615,10 +629,6 @@ def get_availability_report(
         for record in recovered_result:
             event_data = _node_to_dict(_record_value(record, "e"))
             ci_data = _node_to_dict(_record_value(record, "ci"))
-            if event_data.get("event_type") != "AVAILABILITY":
-                continue
-            if event_data.get("availability_source") not in {"PING", "ICMP"}:
-                continue
             key = _availability_group_key(event_data)
             if key is None:
                 continue
@@ -647,9 +657,10 @@ def get_availability_report(
         active_result = session.run(
             """
             MATCH (e:Event)<-[:HAS_EVENT]-(ci:CI)
-            WHERE e.status IN ['OPEN', 'ACK']
-              AND e.event_type = 'AVAILABILITY'
+            WHERE e.event_type = 'AVAILABILITY'
               AND e.availability_source IN ['PING', 'ICMP']
+              AND toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'
+              AND e.status IN ['OPEN', 'ACK']
               AND e.created_at IS NOT NULL
               AND e.created_at <= $window_end
             OPTIONAL MATCH (ci)-[:CATEGORIZED_AS]->(cat:Category)
@@ -662,10 +673,6 @@ def get_availability_report(
         for record in active_result:
             event_data = _node_to_dict(_record_value(record, "e"))
             ci_data = _node_to_dict(_record_value(record, "ci"))
-            if event_data.get("event_type") != "AVAILABILITY":
-                continue
-            if event_data.get("availability_source") not in {"PING", "ICMP"}:
-                continue
             key = _availability_group_key(event_data)
             if key is None:
                 continue

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -325,7 +325,8 @@ class TestEventServiceSmoke:
         active_query = next(
             query
             for query in mock_neo4j_session.queries
-            if "WHERE e.status IN ['OPEN', 'ACK']" in query["query"]
+            if "e.status IN ['OPEN', 'ACK']" in query["query"]
+            and "NOT e.status IN ['OPEN', 'ACK']" not in query["query"]
         )["query"]
 
         assert "head(collect(DISTINCT cat.name)) AS category" in recovered_query
@@ -350,13 +351,16 @@ class TestEventServiceSmoke:
         active_query = next(
             query
             for query in mock_neo4j_session.queries
-            if "WHERE e.status IN ['OPEN', 'ACK']" in query["query"]
+            if "e.status IN ['OPEN', 'ACK']" in query["query"]
+            and "NOT e.status IN ['OPEN', 'ACK']" not in query["query"]
         )["query"]
 
         assert "e.event_type = 'AVAILABILITY'" in recovered_query
         assert "e.event_type = 'AVAILABILITY'" in active_query
         assert "e.availability_source IN ['PING', 'ICMP']" in recovered_query
         assert "e.availability_source IN ['PING', 'ICMP']" in active_query
+        assert "toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'" in recovered_query
+        assert "toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'" in active_query
 
     def test_get_availability_report_excludes_non_availability_event_types(
         self, mock_neo4j_session
@@ -402,6 +406,19 @@ class TestEventServiceSmoke:
                     },
                     "ci": {"id": "ci-2", "name": "Switch-01", "status": "OK"},
                 },
+                {
+                    "e": {
+                        "id": "evt-propagated-recovered",
+                        "ci_id": "ci-3",
+                        "status": "RECOVERED",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "correlation_type": "PROPAGATED",
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                        "recovered_at": datetime(2026, 1, 1, 1, 30, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-3", "name": "Propagated Switch", "status": "OK"},
+                },
             ],
         )
         mock_neo4j_session.set_response(
@@ -427,6 +444,18 @@ class TestEventServiceSmoke:
                         "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01", "status": "UNKNOWN"},
+                },
+                {
+                    "e": {
+                        "id": "evt-propagated-active",
+                        "ci_id": "ci-4",
+                        "status": "OPEN",
+                        "event_type": "AVAILABILITY",
+                        "availability_source": "ICMP",
+                        "correlation_type": "propagated",
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                    },
+                    "ci": {"id": "ci-4", "name": "Impacted Radio", "status": "DOWN"},
                 },
             ],
         )
@@ -584,7 +613,8 @@ class TestEventServiceSmoke:
         active_query = next(
             query
             for query in mock_neo4j_session.queries
-            if "WHERE e.status IN ['OPEN', 'ACK']" in query["query"]
+            if "e.status IN ['OPEN', 'ACK']" in query["query"]
+            and "NOT e.status IN ['OPEN', 'ACK']" not in query["query"]
         )
 
         assert recovered_query["params"] == {


### PR DESCRIPTION
Closes #242

## Descripción del Cambio
- Excluye eventos `correlation_type=PROPAGATED` del cálculo técnico de disponibilidad, MTTR y MTBF.
- Conserva el filtro existente de fuente autoritativa `availability_source IN ['PING', 'ICMP']`.
- Agrega cobertura de regresión para eventos propagados recuperados y activos.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_event_service_smoke.py backend/tests/test_routers_metrics_events.py backend/tests/test_snmp_service_snapshots.py -q` → 113 passed, 7 warnings.
- [x] Revisión fresca con subagent reviewer: sin blockers.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
