### PR TITLE
fix(auth): add refresh verification statuses

### DIFF
--- a/backend/models/refresh_token.py
+++ b/backend/models/refresh_token.py
@@ -1,6 +1,7 @@
 import secrets
 import hashlib
 from datetime import datetime
+from enum import Enum
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 from pydantic import BaseModel
@@ -52,10 +53,28 @@ class RefreshTokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
-class RefreshTokenVerifyResult(BaseModel):
+class RefreshVerificationStatus(str, Enum):
+    """Refresh verification terminal/recoverable status codes."""
+
+    VALID = "valid"
+    MISSING = "missing"
+    EXPIRED = "expired"
+    IDLE_EXPIRED = "idle_expired"
+    REVOKED = "revoked"
+    ROTATED_STALE_REJECTED = "rotated_stale_rejected"
+    ROTATED_STALE_RECOVERABLE = "rotated_stale_recoverable"
+    USER_INACTIVE = "user_inactive"
+
+
+class RefreshVerificationResult(BaseModel):
     """Result of verify_refresh_token."""
 
-    user_id: int
+    status: RefreshVerificationStatus
+    user_id: int | None = None
+    session_id: str | None = None
+    policy_profile: str | None = None
+    token_id: int | None = None
+    should_count_rate_limit: bool = True
 
 
 def hash_token(token: str) -> str:

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -11,10 +11,17 @@ from pydantic import BaseModel
 from typing import Optional
 from postgres_db import get_pg_db
 from repositories import user_repo
-from models.refresh_token import RefreshToken, hash_token, generate_opaque_token
+from models.refresh_token import (
+    RefreshToken,
+    RefreshVerificationResult,
+    RefreshVerificationStatus,
+    hash_token,
+    generate_opaque_token,
+)
 from services.session_policy import (
     SessionPolicy,
     get_standard_session_policy,
+    get_session_policy_by_profile,
 )
 
 # ── Secret Configuration ─────────────────────────────────────────────────────
@@ -52,10 +59,13 @@ def create_refresh_token(
     policy: SessionPolicy | None = None,
     *,
     session_id: str | None = None,
-) -> str:
+    return_token_row: bool = False,
+) -> str | tuple[str, RefreshToken]:
     """
     Create an opaque refresh token, store its SHA-256 hash in DB.
-    Returns the raw opaque token (to be sent to client).
+
+    By default, returns the raw opaque token.
+    Set `return_token_row=True` to return a tuple of `(raw_token, refresh_token_row)`.
     """
     now = datetime.utcnow()
     policy = policy or get_standard_session_policy()
@@ -74,9 +84,42 @@ def create_refresh_token(
         stale_recovery_count=0,
     )
     db.add(rt)
+    db.flush()
     db.commit()
+
+    if return_token_row:
+        return raw_token, rt
+
     return raw_token
 
+
+
+def _now_utc() -> datetime:
+    return datetime.utcnow()
+
+
+def _is_token_idle_expired(rt: RefreshToken, now: datetime, policy: SessionPolicy) -> bool:
+    if policy.idle_timeout_minutes is None:
+        return False
+
+    if rt.last_activity_at is None:
+        return False
+
+    return now - rt.last_activity_at > timedelta(minutes=policy.idle_timeout_minutes)
+
+
+def _format_refresh_verification_result(
+    result: RefreshVerificationResult,
+    include_session_metadata: bool,
+) -> RefreshVerificationResult | int | tuple[int, str | None] | None:
+    """Preserve PR1 legacy return shape until router status handling lands."""
+    if not include_session_metadata:
+        return result
+
+    if result.status != RefreshVerificationStatus.VALID or result.user_id is None:
+        return None
+
+    return result.user_id, result.session_id
 
 
 def verify_refresh_token(
@@ -84,33 +127,163 @@ def verify_refresh_token(
     db: Session,
     *,
     include_session_metadata: bool = False,
-) -> Optional[int | tuple[int, str | None]]:
+) -> RefreshVerificationResult | int | tuple[int, str | None] | None:
     """
-    Verify a refresh token.
+    Verify a refresh token and return a structured status result.
 
-    By default, returns user_id if valid and not revoked/expired.
-    When include_session_metadata=True, returns (user_id, session_id).
-    Returns None if invalid, revoked, or expired.
+    `include_session_metadata=True` preserves the PR1 legacy return shape for
+    stacked compatibility until router status handling is applied in the next PR.
     """
     token_hash = hash_token(token)
     rt = db.query(RefreshToken).filter(RefreshToken.token_hash == token_hash).first()
 
     if rt is None:
-        return None
+        return _format_refresh_verification_result(
+            RefreshVerificationResult(status=RefreshVerificationStatus.MISSING),
+            include_session_metadata,
+        )
+
+    policy = get_session_policy_by_profile(rt.policy_profile)
+
+    if rt.expires_at is not None and rt.expires_at < _now_utc():
+        return _format_refresh_verification_result(
+            RefreshVerificationResult(
+                status=RefreshVerificationStatus.EXPIRED,
+                user_id=rt.user_id,
+                session_id=rt.session_id,
+                policy_profile=rt.policy_profile,
+                token_id=rt.id,
+            ),
+            include_session_metadata,
+        )
+
+    if _is_token_idle_expired(rt, _now_utc(), policy):
+        return _format_refresh_verification_result(
+            RefreshVerificationResult(
+                status=RefreshVerificationStatus.IDLE_EXPIRED,
+                user_id=rt.user_id,
+                session_id=rt.session_id,
+                policy_profile=rt.policy_profile,
+                token_id=rt.id,
+            ),
+            include_session_metadata,
+        )
 
     if rt.revoked_at is not None:
-        return None
+        # Distinguish stale rotation overlap from terminal revocation.
+        if rt.revoked_reason == "rotated":
+            grace_seconds = policy.stale_rotation_grace_seconds
+            if rt.rotated_at is None or (_now_utc() - rt.rotated_at).total_seconds() > grace_seconds:
+                return _format_refresh_verification_result(
+                    RefreshVerificationResult(
+                        status=RefreshVerificationStatus.ROTATED_STALE_REJECTED,
+                        user_id=rt.user_id,
+                        session_id=rt.session_id,
+                        policy_profile=rt.policy_profile,
+                        token_id=rt.id,
+                    ),
+                    include_session_metadata,
+                )
 
-    if rt.expires_at < datetime.utcnow():
-        return None
+            max_recoveries = policy.stale_rotation_max_recoveries
+            if rt.stale_recovery_count >= max_recoveries:
+                return _format_refresh_verification_result(
+                    RefreshVerificationResult(
+                        status=RefreshVerificationStatus.ROTATED_STALE_REJECTED,
+                        user_id=rt.user_id,
+                        session_id=rt.session_id,
+                        policy_profile=rt.policy_profile,
+                        token_id=rt.id,
+                    ),
+                    include_session_metadata,
+                )
 
-    if include_session_metadata:
-        return rt.user_id, rt.session_id
+            return _format_refresh_verification_result(
+                RefreshVerificationResult(
+                    status=RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE,
+                    user_id=rt.user_id,
+                    session_id=rt.session_id,
+                    policy_profile=rt.policy_profile,
+                    token_id=rt.id,
+                    should_count_rate_limit=False,
+                ),
+                include_session_metadata,
+            )
 
-    return rt.user_id
+        return _format_refresh_verification_result(
+            RefreshVerificationResult(
+                status=RefreshVerificationStatus.REVOKED,
+                user_id=rt.user_id,
+                session_id=rt.session_id,
+                policy_profile=rt.policy_profile,
+                token_id=rt.id,
+            ),
+            include_session_metadata,
+        )
+
+    return _format_refresh_verification_result(
+        RefreshVerificationResult(
+            status=RefreshVerificationStatus.VALID,
+            user_id=rt.user_id,
+            session_id=rt.session_id,
+            policy_profile=rt.policy_profile,
+            token_id=rt.id,
+            should_count_rate_limit=False,
+        ),
+        include_session_metadata,
+    )
 
 
-def revoke_refresh_token(token: str, db: Session) -> bool:
+def increment_refresh_recovery_count(db: Session, token_id: int) -> None:
+    """Backward-compatible stale recovery increment helper."""
+    try_increment_refresh_recovery_count(db, token_id, max_recoveries=10**9)
+
+
+def try_increment_refresh_recovery_count(
+    db: Session,
+    token_id: int,
+    max_recoveries: int,
+) -> bool:
+    """Atomically reserve one stale-recovery attempt for a refresh token row."""
+    updated = (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.id == token_id,
+            RefreshToken.stale_recovery_count < max_recoveries,
+        )
+        .update(
+            {RefreshToken.stale_recovery_count: RefreshToken.stale_recovery_count + 1},
+            synchronize_session=False,
+        )
+    )
+    db.commit()
+    return updated == 1
+
+
+def rotate_refresh_token(
+    db: Session,
+    old_refresh_token: str | None,
+    new_refresh_token_id: int,
+) -> None:
+    """Mark an old refresh token as rotated and link replacement id."""
+    if old_refresh_token is None:
+        return
+
+    token_hash = hash_token(old_refresh_token)
+    old_rt = db.query(RefreshToken).filter(RefreshToken.token_hash == token_hash).first()
+    if old_rt is None:
+        return
+
+    now = _now_utc()
+    old_rt.revoked_at = now
+    old_rt.revoked_reason = "rotated"
+    old_rt.rotated_at = now
+    old_rt.replaced_by_token_id = new_refresh_token_id
+    old_rt.stale_recovery_count = old_rt.stale_recovery_count or 0
+    db.commit()
+
+
+def revoke_refresh_token(token: str, db: Session, reason: str = "revoked") -> bool:
     """
     Revoke a refresh token by setting revoked_at.
     Returns True if token was revoked, False if not found.
@@ -122,7 +295,7 @@ def revoke_refresh_token(token: str, db: Session) -> bool:
         return False
 
     rt.revoked_at = datetime.utcnow()
-    rt.revoked_reason = "revoked"
+    rt.revoked_reason = reason
     db.commit()
     return True
 

--- a/backend/services/session_policy.py
+++ b/backend/services/session_policy.py
@@ -11,6 +11,8 @@ class SessionPolicy:
     access_token_minutes: int
     refresh_token_days: int
     idle_timeout_minutes: int | None
+    stale_rotation_grace_seconds: int
+    stale_rotation_max_recoveries: int
     persistent: bool = False
 
 
@@ -44,6 +46,14 @@ def _parse_int(value: str | None, *, default: int) -> int:
     return parsed if parsed > 0 else default
 
 
+def get_stale_recovery_grace_seconds() -> int:
+    return _parse_int(os.getenv("SESSION_STALE_ROTATION_GRACE_SECONDS"), default=30)
+
+
+def get_stale_recovery_max_recoveries() -> int:
+    return _parse_int(os.getenv("SESSION_STALE_ROTATION_MAX_RECOVERIES"), default=3)
+
+
 def get_standard_session_policy() -> SessionPolicy:
     """Default non-operational policy."""
     return SessionPolicy(
@@ -54,6 +64,8 @@ def get_standard_session_policy() -> SessionPolicy:
             os.getenv("SESSION_STANDARD_IDLE_TIMEOUT_MINUTES"),
             default=15,
         ),
+        stale_rotation_grace_seconds=get_stale_recovery_grace_seconds(),
+        stale_rotation_max_recoveries=get_stale_recovery_max_recoveries(),
         persistent=False,
     )
 
@@ -66,6 +78,8 @@ def get_operational_session_policy() -> SessionPolicy:
         # Keep long-lived (configurable) refresh for operational users.
         refresh_token_days=_parse_int(os.getenv("SESSION_OPERATIONAL_REFRESH_DAYS"), default=30),
         idle_timeout_minutes=None,
+        stale_rotation_grace_seconds=get_stale_recovery_grace_seconds(),
+        stale_rotation_max_recoveries=get_stale_recovery_max_recoveries(),
         persistent=True,
     )
 
@@ -89,6 +103,14 @@ def _normalize_username(username: str | None) -> str:
     if username is None:
         return ""
     return str(username).strip().lower()
+
+
+def get_session_policy_by_profile(profile: str) -> SessionPolicy:
+    """Resolve policy from persisted profile string."""
+    normalized = (profile or "").strip().lower()
+    if normalized == "operational":
+        return get_operational_session_policy()
+    return get_standard_session_policy()
 
 
 def resolve_session_policy_for_user(user: object) -> SessionPolicy:

--- a/backend/tests/test_auth_service_refresh.py
+++ b/backend/tests/test_auth_service_refresh.py
@@ -13,11 +13,20 @@ from services.auth_service import (
     revoke_refresh_token,
     revoke_all_user_refresh_tokens,
     create_refresh_token,
+    try_increment_refresh_recovery_count,
     SECRET_KEY,
     ALGORITHM,
 )
-from models.refresh_token import hash_token, generate_opaque_token
-from services.session_policy import get_standard_session_policy, get_operational_session_policy
+from models.refresh_token import (
+    RefreshVerificationStatus,
+    hash_token,
+    generate_opaque_token,
+)
+from services.session_policy import (
+    get_standard_session_policy,
+    get_operational_session_policy,
+    get_stale_recovery_grace_seconds,
+)
 
 
 class TestHashToken:
@@ -74,17 +83,36 @@ class TestGenerateOpaqueToken:
 class TestVerifyRefreshToken:
     """Tests for refresh token verification with mocked DB."""
 
-    def _mock_rt(self, token_hash: str, user_id: int, expires_at: datetime, revoked_at: datetime | None = None, session_id: str | None = None):
+    def _mock_rt(
+        self,
+        token_hash: str,
+        user_id: int,
+        expires_at: datetime,
+        revoked_at: datetime | None = None,
+        session_id: str | None = None,
+        *,
+        revoked_reason: str | None = None,
+        rotated_at: datetime | None = None,
+        stale_recovery_count: int = 0,
+        policy_profile: str = "standard",
+        last_activity_at: datetime | None = None,
+    ):
         """Create a mock RefreshToken object."""
         rt = MagicMock()
+        rt.id = 1
         rt.token_hash = token_hash
         rt.user_id = user_id
         rt.expires_at = expires_at
         rt.revoked_at = revoked_at
-        rt.session_id = session_id
+        rt.session_id = session_id or "sess-default"
+        rt.revoked_reason = revoked_reason
+        rt.rotated_at = rotated_at
+        rt.stale_recovery_count = stale_recovery_count
+        rt.policy_profile = policy_profile
+        rt.last_activity_at = last_activity_at or datetime.utcnow() - timedelta(minutes=1)
         return rt
 
-    def test_returns_user_id_for_valid_token(self):
+    def test_valid_token_returns_valid_status(self):
         token = "valid-refresh-token"
         token_hash = hash_token(token)
         mock_db = MagicMock()
@@ -92,19 +120,23 @@ class TestVerifyRefreshToken:
             token_hash=token_hash,
             user_id=42,
             expires_at=datetime.utcnow() + timedelta(days=7),
+            session_id="sess-valid",
+            policy_profile="standard",
         )
 
         result = verify_refresh_token(token, mock_db)
-        assert result == 42
+        assert result.status == RefreshVerificationStatus.VALID
+        assert result.user_id == 42
+        assert result.session_id == "sess-valid"
 
-    def test_returns_none_for_unknown_token(self):
+    def test_unknown_token_returns_missing(self):
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
         result = verify_refresh_token("unknown-token", mock_db)
-        assert result is None
+        assert result.status == RefreshVerificationStatus.MISSING
 
-    def test_returns_none_for_revoked_token(self):
+    def test_revoked_token_returns_revoked(self):
         token = "revoked-token"
         token_hash = hash_token(token)
         mock_db = MagicMock()
@@ -116,9 +148,9 @@ class TestVerifyRefreshToken:
         )
 
         result = verify_refresh_token(token, mock_db)
-        assert result is None
+        assert result.status == RefreshVerificationStatus.REVOKED
 
-    def test_returns_none_for_expired_token(self):
+    def test_expired_token_returns_expired(self):
         token = "expired-token"
         token_hash = hash_token(token)
         mock_db = MagicMock()
@@ -129,21 +161,107 @@ class TestVerifyRefreshToken:
         )
 
         result = verify_refresh_token(token, mock_db)
-        assert result is None
+        assert result.status == RefreshVerificationStatus.EXPIRED
 
-    def test_returns_session_metadata_when_requested(self):
-        token = "token-with-session"
+    def test_standard_session_idles_out(self):
+        token = "idle-token"
         token_hash = hash_token(token)
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = self._mock_rt(
             token_hash=token_hash,
-            user_id=77,
+            user_id=1,
             expires_at=datetime.utcnow() + timedelta(days=7),
-            session_id="sess-77",
+            last_activity_at=datetime.utcnow() - timedelta(minutes=25),
+            policy_profile="standard",
         )
 
-        result = verify_refresh_token(token, mock_db, include_session_metadata=True)
-        assert result == (77, "sess-77")
+        result = verify_refresh_token(token, mock_db)
+        assert result.status == RefreshVerificationStatus.IDLE_EXPIRED
+
+    def test_recently_rotated_token_is_recoverable(self):
+        token = "stale-token"
+        token_hash = hash_token(token)
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = self._mock_rt(
+            token_hash=token_hash,
+            user_id=88,
+            expires_at=datetime.utcnow() + timedelta(days=7),
+            session_id="sess-88",
+            revoked_at=datetime.utcnow() - timedelta(seconds=1),
+            revoked_reason="rotated",
+            rotated_at=datetime.utcnow() - timedelta(seconds=10),
+            stale_recovery_count=0,
+            policy_profile="standard",
+            last_activity_at=datetime.utcnow(),
+        )
+
+        result = verify_refresh_token(token, mock_db)
+        assert result.status == RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE
+        assert result.should_count_rate_limit is False
+
+    def test_rotated_token_beyond_grace_is_rejected(self):
+        token = "late-stale-token"
+        token_hash = hash_token(token)
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = self._mock_rt(
+            token_hash=token_hash,
+            user_id=88,
+            expires_at=datetime.utcnow() + timedelta(days=7),
+            session_id="sess-88",
+            revoked_at=datetime.utcnow() - timedelta(seconds=1),
+            revoked_reason="rotated",
+            rotated_at=datetime.utcnow() - timedelta(seconds=get_stale_recovery_grace_seconds() + 1),
+            stale_recovery_count=0,
+            policy_profile="standard",
+            last_activity_at=datetime.utcnow(),
+        )
+
+        result = verify_refresh_token(token, mock_db)
+        assert result.status == RefreshVerificationStatus.ROTATED_STALE_REJECTED
+
+    def test_recovery_count_cap_rejects_stale_token(self):
+        token = "stale-token-cap"
+        token_hash = hash_token(token)
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = self._mock_rt(
+            token_hash=token_hash,
+            user_id=88,
+            expires_at=datetime.utcnow() + timedelta(days=7),
+            session_id="sess-88",
+            revoked_at=datetime.utcnow() - timedelta(seconds=1),
+            revoked_reason="rotated",
+            rotated_at=datetime.utcnow() - timedelta(seconds=1),
+            stale_recovery_count=3,
+            policy_profile="standard",
+            last_activity_at=datetime.utcnow(),
+        )
+
+        result = verify_refresh_token(token, mock_db)
+        assert result.status == RefreshVerificationStatus.ROTATED_STALE_REJECTED
+
+
+class TestTryIncrementRefreshRecoveryCount:
+    """Tests for atomic stale recovery reservation."""
+
+    def test_returns_true_when_atomic_update_reserves_recovery(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.update.return_value = 1
+
+        result = try_increment_refresh_recovery_count(mock_db, token_id=123, max_recoveries=3)
+
+        assert result is True
+        mock_db.query.return_value.filter.return_value.update.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_returns_false_when_recovery_cap_is_already_consumed(self):
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.update.return_value = 0
+
+        result = try_increment_refresh_recovery_count(mock_db, token_id=123, max_recoveries=3)
+
+        assert result is False
+        mock_db.query.return_value.filter.return_value.update.assert_called_once()
+        mock_db.commit.assert_called_once()
 
 
 class TestRevokeRefreshToken:


### PR DESCRIPTION
## Descripción del Cambio
Refs #188

Stacked PR for #188. This is **PR2a** in the chain: it adds the backend refresh verification status/result foundation while preserving PR1 router compatibility. The stale refresh endpoint behavior is completed in the next stacked PR.

## Chain Context

```text
main
 └─ PR1 #245: fix/session-policy-foundation
     └─ 📍 PR2a: fix/session-refresh-status
         └─ PR2b: fix/session-refresh-stale-recovery
```

- Base branch: `fix/session-policy-foundation`
- Current branch: `fix/session-refresh-status`
- Follow-up: PR2b will target this branch.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Summary
- Adds structured `RefreshVerificationStatus` / `RefreshVerificationResult` handling for refresh-token verification.
- Adds policy-backed stale rotation grace/cap config and service tests.
- Adds atomic stale recovery reservation helper while keeping PR1 refresh router compatibility.

## Changes
| File | Change |
|------|--------|
| `backend/models/refresh_token.py` | Adds refresh verification status/result model. |
| `backend/services/auth_service.py` | Returns structured refresh verification results and adds bounded recovery reservation helper. |
| `backend/services/session_policy.py` | Adds stale-rotation recovery grace/cap policy knobs. |
| `backend/tests/test_auth_service_refresh.py` | Adds service tests for valid/missing/expired/revoked/idle/stale refresh states and atomic reservation. |

## ¿Cómo se probó?
- [x] `cd backend && python -m pytest tests/test_auth_service_refresh.py tests/test_auth_router_refresh.py tests/test_session_policy.py tests/test_auth_service.py tests/test_rate_limit.py` — 96 passed

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notes / Follow-ups
- PR2b will wire the router to consume the structured statuses for stale-refresh recovery and rate-limit behavior.
- PR3/PR4 remain backend/frontend contract and frontend orchestration/inactivity UX.

---
*Generado por Alex*
