### PR TITLE
fix(roles): validate role permission payloads

### DIFF
--- a/backend/routers/roles.py
+++ b/backend/routers/roles.py
@@ -1,9 +1,51 @@
 
-from typing import List
+from typing import Any, List
 from fastapi import APIRouter, Depends, HTTPException, status
 from services.auth_service import get_current_active_user, check_permission
 from models.user import Role, RoleCreate, RoleUpdate, User, UserPermission
 from database import get_db
+
+
+ALLOWED_PERMISSIONS = {perm.value for perm in UserPermission}
+
+
+def _normalize_and_validate_permissions(permissions: list[Any] | None) -> list[str] | None:
+    """Normalize role permissions to canonical string values and validate against UserPermission."""
+
+    if permissions is None:
+        return None
+
+    normalized: list[str] = []
+    invalid_permissions: list[Any] = []
+
+    for permission in permissions:
+        if not isinstance(permission, str):
+            invalid_permissions.append(permission)
+            continue
+
+        clean = permission.strip()
+        if not clean:
+            invalid_permissions.append(permission)
+            continue
+
+        if clean not in ALLOWED_PERMISSIONS:
+            invalid_permissions.append(clean)
+            continue
+
+        if clean not in normalized:
+            normalized.append(clean)
+
+    if invalid_permissions:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": "Invalid permissions",
+                "invalid_permissions": invalid_permissions,
+                "allowed_permissions": sorted(ALLOWED_PERMISSIONS),
+            },
+        )
+
+    return normalized
 
 router = APIRouter(
     prefix="/roles",
@@ -61,11 +103,10 @@ async def create_role(role: RoleCreate, current_user: User = Depends(get_current
         is_system: false 
     }) RETURN r
     """
-    
+
     params = role.dict()
-    # permissions enum list to string list
-    params["permissions"] = [p.value for p in role.permissions]
-    
+    params["permissions"] = _normalize_and_validate_permissions(role.permissions)
+
     results, _, _ = driver.execute_query(create_query, **params)
     node = results[0]["r"]
     return Role(**dict(node))
@@ -97,10 +138,10 @@ async def update_role(name: str, role_update: RoleUpdate, current_user: User = D
     
     params = {"name": name, "description": role_update.description}
     if role_update.permissions is not None:
-        params["permissions"] = [p.value for p in role_update.permissions]
+        params["permissions"] = _normalize_and_validate_permissions(role_update.permissions)
     else:
         params["permissions"] = None
-        
+
     results, _, _ = driver.execute_query(update_query, **params)
     return Role(**dict(results[0]["r"]))
 

--- a/backend/tests/test_routers_auth_users_roles.py
+++ b/backend/tests/test_routers_auth_users_roles.py
@@ -1049,11 +1049,76 @@ class TestRolesCreate:
                 json={
                     "name": "CustomRole",
                     "description": "A custom role",
-                    "permissions": ["EVENT_VIEW"],
+                    "permissions": ["EVENT_VIEW", "EVENT_VIEW", " EVENT_VIEW ", "METRICS_VIEW"],
                 },
             )
 
             assert response.status_code == 200
+            assert response.json()["name"] == "CustomRole"
+
+            # Create query should receive normalized, deduped, trimmed permissions
+            create_query_params = mock_neo4j_driver.execute_query.call_args_list[1].kwargs
+            assert create_query_params["permissions"] == ["EVENT_VIEW", "METRICS_VIEW"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_role_invalid_permission_is_rejected(self, mock_neo4j_driver):
+        """Create should reject unknown permissions and avoid persistence."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_neo4j_driver.execute_query.return_value = ([], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.post(
+                "/api/roles/",
+                json={
+                    "name": "CustomRole",
+                    "description": "A bad role",
+                    "permissions": ["EVENT_VIEW", "BOGUS_PERMISSION"],
+                },
+            )
+
+            assert response.status_code == 400
+            error = response.json()
+            assert "invalid_permissions" in error["detail"]
+
+        # only existence check should run; create query must not run
+        assert mock_neo4j_driver.execute_query.call_count == 1
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_create_role_rejects_empty_permission(self, mock_neo4j_driver):
+        """Create should reject blank permission strings."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_neo4j_driver.execute_query.return_value = ([], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.post(
+                "/api/roles/",
+                json={
+                    "name": "CustomRole",
+                    "description": "A bad role",
+                    "permissions": [""],
+                },
+            )
+
+            assert response.status_code == 400
+            assert "invalid_permissions" in response.json()["detail"]
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -1124,13 +1189,56 @@ class TestRolesUpdate:
             override_get_current_active_user
         )
 
-        mock_node = _FakeNeo4jNode(
+        mock_record = {"r": _FakeNeo4jNode(
             {
                 "name": "CustomRole",
                 "description": "Updated description",
-                "permissions": ["EVENT_VIEW", "CI_EDIT"],
+                "permissions": ["EVENT_ACK", "METRICS_VIEW"],
                 "is_system": False,
             }
+        )}
+
+        def mock_execute(*args, **kwargs):
+            # First call: lookup by name; second call: update
+            if mock_execute.call_count == 0:
+                mock_execute.call_count += 1
+                return ([{"r": _FakeNeo4jNode({"name": "CustomRole", "is_system": False})}], None, None)
+            mock_execute.call_count += 1
+            return ([mock_record], None, None)
+
+        mock_execute.call_count = 0
+        mock_neo4j_driver.execute_query.side_effect = mock_execute
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.put(
+                "/api/roles/CustomRole",
+                json={
+                    "description": "Updated description",
+                    "permissions": ["EVENT_ACK", " EVENT_ACK ", "METRICS_VIEW"],
+                },
+            )
+
+            assert response.status_code == 200
+
+            # Update payload should be normalized and deduped
+            update_params = mock_neo4j_driver.execute_query.call_args_list[1].kwargs
+            assert update_params["permissions"] == ["EVENT_ACK", "METRICS_VIEW"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_update_role_with_invalid_permission_rejected(self, mock_neo4j_driver):
+        """Update should reject non-string permissions and avoid write query."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_node = _FakeNeo4jNode(
+            {"name": "CustomRole", "description": "Existing", "is_system": False}
         )
         mock_record = {"r": mock_node}
         mock_neo4j_driver.execute_query.return_value = ([mock_record], None, None)
@@ -1138,10 +1246,50 @@ class TestRolesUpdate:
         with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
             response = client.put(
                 "/api/roles/CustomRole",
-                json={"description": "Updated description"},
+                json={"permissions": ["EVENT_VIEW", 123]},
             )
 
-            assert response.status_code == 200
+            assert response.status_code in (400, 422)
+            if response.status_code == 400:
+                assert "invalid_permissions" in response.json()["detail"]
+
+        # either route rejected by service validation (400) or schema validation (422);
+        # in neither case should an update write query run
+        assert mock_neo4j_driver.execute_query.call_count <= 1
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_update_system_role_forbidden_no_update_query(self, mock_neo4j_driver):
+        """System roles cannot be updated and should skip update write query."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        mock_node = _FakeNeo4jNode(
+            {
+                "name": "ADMIN",
+                "is_system": True,
+            }
+        )
+        mock_record = {"r": mock_node}
+
+        mock_neo4j_driver.execute_query.return_value = ([mock_record], None, None)
+
+        with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
+            response = client.put(
+                "/api/roles/ADMIN",
+                json={"description": "Should not work"},
+            )
+
+            assert response.status_code == 400
+
+        # Only initial lookup query should execute
+        assert mock_neo4j_driver.execute_query.call_count == 1
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -1173,8 +1321,10 @@ class TestRolesUpdate:
 
             assert response.status_code == 400
 
-        app.dependency_overrides.pop(get_current_active_user, None)
+        # only lookup should have run
+        assert mock_neo4j_driver.execute_query.call_count == 1
 
+        app.dependency_overrides.pop(get_current_active_user, None)
     def test_update_role_not_found(self, mock_neo4j_driver):
         """Updating non-existent role should return 404."""
         fake_user = _make_pydantic_user(username="admin", role="ADMIN")

--- a/frontend/components/RoleManager.test.tsx
+++ b/frontend/components/RoleManager.test.tsx
@@ -62,17 +62,17 @@ describe('RoleManager', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
-  it('renders access denied when the user lacks role management permissions', () => {
+  it('renders access denied when the user lacks view/mutate permissions', () => {
     setAuth([]);
 
     render(<RoleManager />);
 
-    expect(screen.getByText(/access denied\. required: role_manage/i)).toBeInTheDocument();
+    expect(screen.getByText(/access denied\. required: user_manage or role_manage/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
-    expect(mocks.api.get).toHaveBeenCalledWith('/roles/');
+    expect(mocks.api.get).not.toHaveBeenCalled();
   });
 
-  it('allows ADMIN permission even without explicit ROLE_MANAGE permission', async () => {
+  it('allows ADMIN permission without explicit ROLE_MANAGE permission', async () => {
     setAuth(['ADMIN']);
     mocks.api.get.mockResolvedValue([customRole]);
 
@@ -82,6 +82,21 @@ describe('RoleManager', () => {
     await waitFor(() => {
       expect(screen.getByText('Operator')).toBeInTheDocument();
     });
+  });
+
+  it('allows USER_MANAGE-only users to view roles but not mutate', async () => {
+    setAuth(['USER_MANAGE']);
+    mocks.api.get.mockResolvedValue([customRole]);
+
+    render(<RoleManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Operator')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
   });
 
   it('starts with no role cards while the fetch is still pending and then renders data', async () => {
@@ -142,7 +157,7 @@ describe('RoleManager', () => {
     expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
   });
 
-  it('shows create, edit, and delete actions for a user with permission', async () => {
+  it('shows create, edit, and delete actions for a user with mutate permissions', async () => {
     mocks.api.get.mockResolvedValue([customRole]);
 
     render(<RoleManager />);
@@ -154,30 +169,23 @@ describe('RoleManager', () => {
     });
   });
 
-  it('does not render action buttons for a user without permission', () => {
-    setAuth([]);
+  it('does not render edit control for system roles', async () => {
+    mocks.api.get.mockResolvedValue([systemRole]);
 
     render(<RoleManager />);
 
-    expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('ADMIN')).toBeInTheDocument();
+    });
+
     expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
   });
 
-  it('opens the create form with empty editable fields', async () => {
-    render(<RoleManager />);
-
-    fireEvent.click(screen.getByRole('button', { name: /new role/i }));
-
-    expect(screen.getByRole('heading', { name: /create role/i })).toBeInTheDocument();
-    const inputs = screen.getAllByRole('textbox');
-    expect(inputs[0]).toHaveValue('');
-    expect(inputs[0]).not.toBeDisabled();
-    expect(inputs[1]).toHaveValue('');
-  });
-
   it('creates a new role and reloads the list', async () => {
-    mocks.api.get.mockResolvedValueOnce([]).mockResolvedValueOnce([customRole]);
+    mocks.api.get
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([customRole]);
 
     render(<RoleManager />);
 
@@ -194,13 +202,23 @@ describe('RoleManager', () => {
         name: 'Operator',
         description: 'Handles incidents and diagnostics',
         permissions: ['EVENT_VIEW'],
-        is_system: false,
       });
     });
 
     await waitFor(() => {
       expect(screen.getByText('Operator')).toBeInTheDocument();
     });
+  });
+
+  it('renders explicit permission catalog options in create/edit form', async () => {
+    mocks.api.get.mockResolvedValue([]);
+
+    render(<RoleManager />);
+
+    fireEvent.click(screen.getByRole('button', { name: /new role/i }));
+
+    expect(screen.getByLabelText('EVENT_FORCED_CLOSE')).toBeInTheDocument();
+    expect(screen.getByLabelText('METRICS_VIEW')).toBeInTheDocument();
   });
 
   it('edits an existing role and keeps the name immutable', async () => {
@@ -224,7 +242,6 @@ describe('RoleManager', () => {
 
     await waitFor(() => {
       expect(mocks.api.put).toHaveBeenCalledWith('/roles/Operator', {
-        ...customRole,
         description: 'Updated operator description',
         permissions: ['EVENT_VIEW'],
       });
@@ -321,7 +338,7 @@ describe('RoleManager', () => {
     });
   });
 
-  it('returns to the role list when cancelling the edit form', async () => {
+  it('returns to the role list when cancelling the edit form', () => {
     render(<RoleManager />);
 
     fireEvent.click(screen.getByRole('button', { name: /new role/i }));

--- a/frontend/components/RoleManager.tsx
+++ b/frontend/components/RoleManager.tsx
@@ -11,7 +11,7 @@ interface Role {
 }
 
 const ALL_PERMISSIONS = [
-    { category: "Event Management", perms: ["EVENT_VIEW", "EVENT_ACK", "EVENT_CLOSE"] },
+    { category: "Event Management", perms: ["EVENT_VIEW", "EVENT_ACK", "EVENT_CLOSE", "EVENT_FORCED_CLOSE"] },
     { category: "CI Management", perms: ["CI_VIEW", "CI_EDIT", "CI_DELETE"] },
     { category: "Diagnostics", perms: ["RUN_DIAGNOSTICS"] },
     { category: "System", perms: ["USER_MANAGE", "ROLE_MANAGE"] },
@@ -27,9 +27,15 @@ const RoleManager: React.FC = () => {
     });
     const [isNew, setIsNew] = useState(false);
 
+    const canViewRoles = hasPermission('USER_MANAGE') || hasPermission('ROLE_MANAGE') || hasPermission('ADMIN');
+    const canMutateRoles = hasPermission('ROLE_MANAGE') || hasPermission('ADMIN');
+
     useEffect(() => {
+        if (!canViewRoles) {
+            return;
+        }
         fetchRoles();
-    }, []);
+    }, [canViewRoles]);
 
     const fetchRoles = async () => {
         try {
@@ -41,6 +47,9 @@ const RoleManager: React.FC = () => {
     };
 
     const handleEdit = (role: Role) => {
+        if (role.is_system) {
+            return;
+        }
         setCurrentRole(role);
         setIsNew(false);
         setView('edit');
@@ -54,12 +63,22 @@ const RoleManager: React.FC = () => {
 
     const handleSave = async () => {
         const url = isNew ? '/roles/' : `/roles/${currentRole.name}`;
+        const payload = isNew
+            ? {
+                name: currentRole.name,
+                description: currentRole.description,
+                permissions: currentRole.permissions,
+            }
+            : {
+                description: currentRole.description,
+                permissions: currentRole.permissions,
+            };
 
         try {
             if (isNew) {
-                await api.post(url, currentRole);
+                await api.post(url, payload);
             } else {
-                await api.put(url, currentRole);
+                await api.put(url, payload);
             }
             fetchRoles();
             setView('list');
@@ -86,8 +105,8 @@ const RoleManager: React.FC = () => {
         setCurrentRole({ ...currentRole, permissions: Array.from(perms) });
     };
 
-    if (!hasPermission('ROLE_MANAGE') && !hasPermission('ADMIN')) {
-        return <div className="p-8 text-neutral-500">Access Denied. Required: ROLE_MANAGE</div>;
+    if (!canViewRoles) {
+        return <div className="p-8 text-neutral-500">Access Denied. Required: USER_MANAGE or ROLE_MANAGE</div>;
     }
 
     if (view === 'edit') {
@@ -156,13 +175,15 @@ const RoleManager: React.FC = () => {
         <div>
             <div className="flex justify-between items-center mb-6">
                 <h3 className="text-xl font-bold text-white uppercase tracking-wider">Available Roles</h3>
-                <button
-                    onClick={handleCreate}
-                    className="bg-brand-600 hover:bg-brand-500 text-white px-6 py-2 rounded-lg text-xs font-bold uppercase tracking-widest flex items-center gap-2"
-                >
-                    <span className="material-symbols-outlined text-sm">add_security</span>
-                    New Role
-                </button>
+                {canMutateRoles && (
+                    <button
+                        onClick={handleCreate}
+                        className="bg-brand-600 hover:bg-brand-500 text-white px-6 py-2 rounded-lg text-xs font-bold uppercase tracking-widest flex items-center gap-2"
+                    >
+                        <span className="material-symbols-outlined text-sm">add_security</span>
+                        New Role
+                    </button>
+                )}
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -183,14 +204,16 @@ const RoleManager: React.FC = () => {
                         </div>
 
                         <div className="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                            {!role.is_system && (
+                            {canMutateRoles && !role.is_system && (
                                 <button onClick={() => handleDelete(role.name)} className="text-red-500 hover:text-red-400 p-2 hover:bg-white/5 rounded-lg" title="Delete">
                                     <span className="material-symbols-outlined text-lg">delete</span>
                                 </button>
                             )}
-                            <button onClick={() => handleEdit(role)} className="text-brand-400 hover:text-white p-2 hover:bg-white/5 rounded-lg" title="Edit">
-                                <span className="material-symbols-outlined text-lg">edit_note</span>
-                            </button>
+                            {canMutateRoles && !role.is_system && (
+                                <button onClick={() => handleEdit(role)} className="text-brand-400 hover:text-white p-2 hover:bg-white/5 rounded-lg" title="Edit">
+                                    <span className="material-symbols-outlined text-lg">edit_note</span>
+                                </button>
+                            )}
                         </div>
                     </div>
                 ))}

--- a/frontend/services/api.test.ts
+++ b/frontend/services/api.test.ts
@@ -70,6 +70,35 @@ describe('api client', () => {
       await expect(api.get('/nodes')).rejects.toHaveProperty('status', 500);
     });
 
+    it('supports structured detail payloads and surfaces message', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({
+          detail: {
+            message: 'Invalid permission',
+            invalid_permissions: ['BOGUS_PERMISSION'],
+          },
+        }),
+      });
+
+      await expect(api.get('/roles/')).rejects.toThrow('Invalid permission');
+    });
+
+    it('falls back to statusText when detail body is unavailable or malformed', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { get: () => 'text/plain' },
+        json: () => Promise.reject(new Error('Malformed JSON')),
+      });
+
+      await expect(api.get('/roles/')).rejects.toThrow('Internal Server Error');
+    });
+
     it('throws ApiError with statusText when no detail in body', async () => {
       global.fetch = vi.fn().mockResolvedValue({
         ok: false,


### PR DESCRIPTION
## Descripción del Cambio
Closes #246

- Fixes RoleManager role save 500s caused by backend `.value` access on string permission payloads.
- Adds backend permission normalization/validation for role create/update with actionable 400 responses.
- Aligns RoleManager read-vs-mutate access, blocks system-role edit/delete UI, and adds API error-shape regression coverage.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `backend/routers/roles.py` | Validates, trims, dedupes, and whitelists role permission string payloads before persistence. |
| `backend/tests/test_routers_auth_users_roles.py` | Adds regression coverage for valid strings, invalid/blank/non-string permissions, canonicalization, and system-role no-write behavior. |
| `frontend/components/RoleManager.tsx` | Separates role view/mutate permissions, hides mutation controls for read-only users/system roles, sends explicit save payloads, and includes `EVENT_FORCED_CLOSE`. |
| `frontend/components/RoleManager.test.tsx` | Covers read-only role viewing, system-role edit blocking, explicit payload shape, and permission catalog entries. |
| `frontend/services/api.test.ts` | Covers structured error detail and malformed/non-JSON fallback behavior. |

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_routers_auth_users_roles.py -k "Roles"` — 43 passed
- [x] `corepack pnpm --dir frontend run test:run -- components/RoleManager.test.tsx services/api.test.ts` — 394 passed
- [x] `git diff --check` — passed; non-blocking LF/CRLF warning on `RoleManager.test.tsx`

Strict TDD note: RED evidence was recovered in isolated tests-only worktree `.worktrees/role-access-red-evidence` and documented locally in `sdd-red-green-evidence.md` before final verify. Broader `python -m pytest backend/tests -m "auth or api"` currently fails unrelated RTU router 404 tests and was waived for this issue.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
