### PR TITLE
fix(analytics): stabilize chart interactions

### DIFF
--- a/backend/repositories/metric_repo.py
+++ b/backend/repositories/metric_repo.py
@@ -101,7 +101,7 @@ def get_metric_history_days(
         try:
             start = datetime.fromisoformat(start_time.replace('Z', '+00:00'))
             end = datetime.fromisoformat(end_time.replace('Z', '+00:00'))
-            query = query.filter(MetricValue.time >= start, MetricValue.time <= end)
+            query = query.filter(MetricValue.time >= start, MetricValue.time < end)
         except ValueError:
             pass
 

--- a/frontend/components/ChartPanel.tsx
+++ b/frontend/components/ChartPanel.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
 	AreaChart,
 	Area,
@@ -9,6 +9,7 @@ import {
 	Tooltip,
 	ResponsiveContainer,
 	Brush,
+	ReferenceArea,
 } from "recharts";
 import { formatMetricValue } from "../utils/metricFormatting";
 
@@ -32,6 +33,33 @@ interface ChartPanelProps {
 	metricName?: string;
 }
 
+const MIN_DRAG_POINTS = 2;
+const MIN_DRAG_RANGE_MS = 5 * 60 * 1000;
+
+const getActiveRawTime = (event: any): string | null => {
+	return (
+		event?.activePayload?.[0]?.payload?.rawTime ?? event?.activeLabel ?? null
+	);
+};
+
+const getRangeLabel = (startTime: string, endTime: string) => {
+	const durationMs = Math.abs(
+		new Date(endTime).getTime() - new Date(startTime).getTime(),
+	);
+	if (durationMs <= 6 * 60 * 60 * 1000) {
+		return { hour: "2-digit", minute: "2-digit" } as const;
+	}
+	if (durationMs <= 48 * 60 * 60 * 1000) {
+		return {
+			day: "numeric",
+			month: "short",
+			hour: "2-digit",
+			minute: "2-digit",
+		} as const;
+	}
+	return { day: "numeric", month: "short" } as const;
+};
+
 const ChartPanel: React.FC<ChartPanelProps> = ({
 	nodeId,
 	label,
@@ -41,6 +69,10 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 	unit,
 	metricName,
 }) => {
+	const [isSelecting, setIsSelecting] = useState(false);
+	const [selectionStart, setSelectionStart] = useState<string | null>(null);
+	const [selectionEnd, setSelectionEnd] = useState<string | null>(null);
+
 	const formattedData = useMemo(() => {
 		return data
 			.sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
@@ -67,10 +99,83 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 			: formattedData;
 
 	const hasBrushApplied = brushRange !== null;
+	const xTickFormatter = useCallback(
+		(value: string) => {
+			const rangeStart = displayData[0]?.rawTime;
+			const rangeEnd = displayData[displayData.length - 1]?.rawTime;
+			if (!rangeStart || !rangeEnd) return value;
+			return new Date(value).toLocaleString(
+				[],
+				getRangeLabel(rangeStart, rangeEnd),
+			);
+		},
+		[displayData],
+	);
 
 	const handleResetView = () => {
 		onBrushChange(null);
+		setIsSelecting(false);
+		setSelectionStart(null);
+		setSelectionEnd(null);
 	};
+
+	const handleMouseDown = useCallback((event: any) => {
+		const rawTime = getActiveRawTime(event);
+		if (!rawTime) return;
+		setIsSelecting(true);
+		setSelectionStart(rawTime);
+		setSelectionEnd(rawTime);
+	}, []);
+
+	const handleMouseMove = useCallback(
+		(event: any) => {
+			const rawTime = getActiveRawTime(event);
+			if (!isSelecting || !rawTime) return;
+			setSelectionEnd(rawTime);
+		},
+		[isSelecting],
+	);
+
+	const handleMouseUp = useCallback(() => {
+		if (!isSelecting || !selectionStart || !selectionEnd) {
+			setIsSelecting(false);
+			return;
+		}
+
+		const startIdx = displayData.findIndex(
+			(point) => point.rawTime === selectionStart,
+		);
+		const endIdx = displayData.findIndex(
+			(point) => point.rawTime === selectionEnd,
+		);
+		if (startIdx !== -1 && endIdx !== -1) {
+			let [minIdx, maxIdx] =
+				startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
+			const durationMs = Math.abs(
+				new Date(displayData[maxIdx].rawTime).getTime() -
+					new Date(displayData[minIdx].rawTime).getTime(),
+			);
+			if (
+				maxIdx - minIdx + 1 < MIN_DRAG_POINTS ||
+				durationMs < MIN_DRAG_RANGE_MS
+			) {
+				const centerIdx = Math.round((minIdx + maxIdx) / 2);
+				minIdx = Math.max(0, centerIdx - 1);
+				maxIdx = Math.min(displayData.length - 1, centerIdx + 1);
+			}
+			const start = displayData[minIdx]?.rawTime;
+			const end = displayData[maxIdx]?.rawTime;
+			onBrushChange(
+				start && end && end !== start
+					? { startTime: start, endTime: end }
+					: null,
+			);
+		}
+
+		setIsSelecting(false);
+		setSelectionStart(null);
+		setSelectionEnd(null);
+	}, [isSelecting, selectionStart, selectionEnd, displayData, onBrushChange]);
 
 	const hasData = data.length > 0;
 
@@ -116,9 +221,11 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 				</div>
 			) : (
 				<div
-					className="relative min-h-0 w-full min-w-0 flex-1"
-					style={{ minWidth: 0, minHeight: 0 }}
+					className="relative min-h-0 w-full min-w-0 flex-1 select-none cursor-crosshair"
+					style={{ minWidth: 0, minHeight: 0, userSelect: "none" }}
+					onMouseDown={(event) => event.preventDefault()}
 				>
+					<style>{`.recharts-cartesian-axis-tick-value{user-select:none;pointer-events:none;}`}</style>
 					<ResponsiveContainer width="100%" height="100%">
 						<AreaChart
 							data={displayData}
@@ -128,6 +235,10 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 								left: 0,
 								bottom: 54,
 							}}
+							onMouseDown={handleMouseDown}
+							onMouseMove={handleMouseMove}
+							onMouseUp={handleMouseUp}
+							onMouseLeave={() => setIsSelecting(false)}
 						>
 							<defs>
 								<linearGradient
@@ -147,12 +258,13 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 								vertical={false}
 							/>
 							<XAxis
-								dataKey="displayTime"
+								dataKey="rawTime"
 								stroke="#525252"
 								tick={{ fill: "#525252", fontSize: 10 }}
 								tickLine={false}
 								axisLine={false}
 								minTickGap={30}
+								tickFormatter={xTickFormatter}
 							/>
 							<YAxis
 								stroke="#525252"
@@ -183,8 +295,17 @@ const ChartPanel: React.FC<ChartPanelProps> = ({
 								fillOpacity={1}
 								fill={`url(#colorValue-${nodeId})`}
 							/>
+							{isSelecting && selectionStart && selectionEnd && (
+								<ReferenceArea
+									x1={selectionStart}
+									x2={selectionEnd}
+									strokeOpacity={0.3}
+									fill="#0ea5e9"
+									fillOpacity={0.2}
+								/>
+							)}
 							<Brush
-								dataKey="displayTime"
+								dataKey="rawTime"
 								height={30}
 								stroke="#525252"
 								fill="#171717"

--- a/frontend/components/DateTimeRangePicker.test.tsx
+++ b/frontend/components/DateTimeRangePicker.test.tsx
@@ -21,9 +21,58 @@ describe("DateTimeRangePicker", () => {
 
 		expect(screen.getByLabelText("Time")).toBeInTheDocument();
 		expect(
-			screen.getByText("Green days contain metric history."),
+			screen.getByText("History markers not loaded yet."),
 		).toBeInTheDocument();
 		expect(screen.getByTitle("Metric history available")).toBeInTheDocument();
+	});
+
+	it("notifies when a visible month needs history markers", () => {
+		const onVisibleMonthChange = vi.fn();
+		render(
+			<DateTimeRangePicker
+				startDate="2026-06-10T08:30"
+				endDate=""
+				onStartDateChange={vi.fn()}
+				onEndDateChange={vi.fn()}
+				onReset={vi.fn()}
+				onVisibleMonthChange={onVisibleMonthChange}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /start/i }));
+
+		expect(onVisibleMonthChange).toHaveBeenCalledWith("2026-06");
+	});
+
+	it("distinguishes loading and confirmed-empty calendar marker states", () => {
+		const { rerender } = render(
+			<DateTimeRangePicker
+				startDate="2026-06-10T08:30"
+				endDate=""
+				onStartDateChange={vi.fn()}
+				onEndDateChange={vi.fn()}
+				onReset={vi.fn()}
+				loadingMonths={new Set(["2026-06"])}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /start/i }));
+		expect(screen.getByText("Loading history markers…")).toBeInTheDocument();
+
+		rerender(
+			<DateTimeRangePicker
+				startDate="2026-06-10T08:30"
+				endDate=""
+				onStartDateChange={vi.fn()}
+				onEndDateChange={vi.fn()}
+				onReset={vi.fn()}
+				loadedMonths={new Set(["2026-06"])}
+			/>,
+		);
+
+		expect(
+			screen.getByText("Green days contain confirmed metric history."),
+		).toBeInTheDocument();
 	});
 
 	it("updates the selected date while preserving the time", () => {

--- a/frontend/components/DateTimeRangePicker.tsx
+++ b/frontend/components/DateTimeRangePicker.tsx
@@ -8,6 +8,9 @@ interface DateTimeRangePickerProps {
 	onEndDateChange: (value: string) => void;
 	onReset: () => void;
 	availableDays?: Set<string>;
+	loadedMonths?: Set<string>;
+	loadingMonths?: Set<string>;
+	onVisibleMonthChange?: (monthKey: string) => void;
 }
 
 type PickerTarget = "start" | "end";
@@ -24,6 +27,12 @@ const toDateKey = (date: Date) => {
 const toMonthStart = (value?: string) => {
 	const base = value ? new Date(value) : new Date();
 	return new Date(base.getFullYear(), base.getMonth(), 1);
+};
+
+const toMonthKey = (date: Date) => {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	return `${year}-${month}`;
 };
 
 const formatButtonLabel = (value: string, fallback: string) => {
@@ -60,6 +69,9 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 	onEndDateChange,
 	onReset,
 	availableDays = new Set(),
+	loadedMonths = new Set(),
+	loadingMonths = new Set(),
+	onVisibleMonthChange,
 }) => {
 	const [openTarget, setOpenTarget] = useState<PickerTarget | null>(null);
 	const [visibleMonth, setVisibleMonth] = useState(() =>
@@ -72,8 +84,16 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 			setVisibleMonth(toMonthStart(endDate || startDate));
 	}, [openTarget, startDate, endDate]);
 
+	useEffect(() => {
+		if (!openTarget) return;
+		onVisibleMonthChange?.(toMonthKey(visibleMonth));
+	}, [openTarget, visibleMonth, onVisibleMonthChange]);
+
 	const selectedValue = openTarget === "end" ? endDate : startDate;
 	const selectedDay = selectedValue.split("T")[0];
+	const visibleMonthKey = toMonthKey(visibleMonth);
+	const isVisibleMonthLoaded = loadedMonths.has(visibleMonthKey);
+	const isVisibleMonthLoading = loadingMonths.has(visibleMonthKey);
 	const monthLabel = visibleMonth.toLocaleDateString([], {
 		month: "long",
 		year: "numeric",
@@ -147,6 +167,13 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 
 			{openTarget && (
 				<div className="rounded-xl border border-white/10 bg-black/70 p-3 shadow-2xl">
+					<div className="mb-2 rounded-lg border border-white/5 bg-white/[0.03] px-2 py-1 text-[10px] text-neutral-500">
+						{isVisibleMonthLoading
+							? "Loading history markers…"
+							: isVisibleMonthLoaded
+								? "Green days contain confirmed metric history."
+								: "History markers not loaded yet."}
+					</div>
 					<div className="mb-3 flex items-center justify-between gap-2">
 						<button
 							type="button"
@@ -177,10 +204,22 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 					<div className="grid grid-cols-7 gap-1">
 						{calendarDays.map((date) => {
 							const dayKey = toDateKey(date);
+							const dayMonthKey = toMonthKey(date);
 							const isCurrentMonth =
 								date.getMonth() === visibleMonth.getMonth();
+							const isMonthLoaded = loadedMonths.has(dayMonthKey);
+							const isMonthLoading = loadingMonths.has(dayMonthKey);
 							const hasHistory = availableDays.has(dayKey);
 							const isSelected = selectedDay === dayKey;
+							const dayClass = isSelected
+								? "bg-brand-600 text-white"
+								: hasHistory
+									? "bg-emerald-500/25 text-emerald-100 ring-1 ring-emerald-500/40"
+									: isMonthLoaded
+										? "bg-white/[0.02] text-neutral-600"
+										: isMonthLoading
+											? "animate-pulse bg-white/[0.05] text-neutral-500"
+											: "border border-dashed border-white/10 bg-transparent text-neutral-500 hover:bg-white/10";
 							return (
 								<button
 									key={dayKey}
@@ -189,7 +228,7 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 										updateValue(setDatePart(selectedValue, dayKey))
 									}
 									title={hasHistory ? "Metric history available" : undefined}
-									className={`relative rounded-md px-0 py-1.5 text-[10px] transition-colors ${isSelected ? "bg-brand-600 text-white" : hasHistory ? "bg-emerald-500/25 text-emerald-100 ring-1 ring-emerald-500/40" : "bg-white/[0.03] text-neutral-400 hover:bg-white/10"} ${!isCurrentMonth ? "opacity-35" : ""}`}
+									className={`relative rounded-md px-0 py-1.5 text-[10px] transition-colors ${dayClass} ${!isCurrentMonth ? "opacity-35" : ""}`}
 								>
 									{date.getDate()}
 									{hasHistory && (
@@ -212,7 +251,7 @@ const DateTimeRangePicker: React.FC<DateTimeRangePickerProps> = ({
 						/>
 					</label>
 					<p className="mt-2 text-[10px] text-neutral-500">
-						Green days contain metric history.
+						Unmarked days may still be loading; gray days are confirmed empty.
 					</p>
 				</div>
 			)}

--- a/frontend/components/MetricAnalytics.tsx
+++ b/frontend/components/MetricAnalytics.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GraphNode, MetricValue, NodeMetricData } from "../types";
 import MetricHistoryChart from "./MetricHistoryChart";
 import MultiSelectCIs from "./MultiSelectCIs";
@@ -20,6 +20,24 @@ interface BrushRange {
 
 type AnalyticsSection = "METRICS" | "AVAILABILITY";
 const ANALYTICS_SECTIONS: AnalyticsSection[] = ["METRICS", "AVAILABILITY"];
+
+interface MetricHistoryDayRequest {
+	nodeId: string;
+	metricId: string;
+}
+
+const getMonthRange = (monthKey: string) => {
+	const [year, month] = monthKey.split("-").map(Number);
+	const start = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
+	const end = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+	return { start: start.toISOString(), end: end.toISOString() };
+};
+
+const shiftMonthKey = (monthKey: string, delta: number) => {
+	const [year, month] = monthKey.split("-").map(Number);
+	const shifted = new Date(Date.UTC(year, month - 1 + delta, 1));
+	return `${shifted.getFullYear()}-${String(shifted.getMonth() + 1).padStart(2, "0")}`;
+};
 
 const MetricAnalytics: React.FC = () => {
 	const [activeSection, setActiveSection] =
@@ -300,8 +318,8 @@ const MetricAnalytics: React.FC = () => {
 		.map((nodeId) => nodes.find((node) => node.id === nodeId))
 		.filter((node): node is GraphNode => Boolean(node));
 
-	useEffect(() => {
-		const metricRequests = hasMultipleSelected
+	const historyDayRequests = useMemo<MetricHistoryDayRequest[]>(() => {
+		return hasMultipleSelected
 			? selectedNodeIds.flatMap((nodeId) => {
 					const primaryMetric = selectedMetricByNodeId[nodeId];
 					const secondaryMetric = showSecondary
@@ -314,39 +332,6 @@ const MetricAnalytics: React.FC = () => {
 			: selectedNode && selectedMetric
 				? [{ nodeId: selectedNode.id, metricId: selectedMetric.name }]
 				: [];
-
-		if (metricRequests.length === 0) {
-			setMetricHistoryDays(new Set());
-			return;
-		}
-
-		const controller = new AbortController();
-		const end = new Date();
-		const start = new Date(end);
-		start.setFullYear(end.getFullYear() - 1);
-
-		Promise.all(
-			metricRequests.map(({ nodeId, metricId }) =>
-				fetchNodeMetricHistoryDays({
-					nodeId,
-					metricId,
-					startTime: start.toISOString(),
-					endTime: end.toISOString(),
-					signal: controller.signal,
-				}),
-			),
-		)
-			.then((dayGroups) => {
-				setMetricHistoryDays(new Set(dayGroups.flat()));
-			})
-			.catch((err) => {
-				if (err.name !== "AbortError") {
-					console.error("Failed to fetch metric history days", err);
-				}
-				setMetricHistoryDays(new Set());
-			});
-
-		return () => controller.abort();
 	}, [
 		hasMultipleSelected,
 		selectedNode,
@@ -356,6 +341,168 @@ const MetricAnalytics: React.FC = () => {
 		showSecondary,
 		secondaryMetricByNodeId,
 	]);
+
+	const historyDayRequestKey = useMemo(
+		() =>
+			historyDayRequests
+				.map(({ nodeId, metricId }) => `${nodeId}:${metricId}`)
+				.sort()
+				.join("|"),
+		[historyDayRequests],
+	);
+	const historyDayCacheRef = useRef<Map<string, Set<string>>>(new Map());
+	const historyDayInFlightRef = useRef<Set<string>>(new Set());
+	const historyDayGenerationRef = useRef(0);
+	const historyDayBackgroundTimersRef = useRef<number[]>([]);
+	const [loadedHistoryMonths, setLoadedHistoryMonths] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [loadingHistoryMonths, setLoadingHistoryMonths] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [visibleHistoryMonth, setVisibleHistoryMonth] = useState<string | null>(
+		null,
+	);
+
+	const mergeHistoryDayCache = useCallback(() => {
+		const merged = new Set<string>();
+		historyDayCacheRef.current.forEach((days) => {
+			days.forEach((day) => merged.add(day));
+		});
+		setMetricHistoryDays(merged);
+	}, []);
+
+	useEffect(() => {
+		historyDayGenerationRef.current += 1;
+		historyDayCacheRef.current.clear();
+		historyDayInFlightRef.current.clear();
+		historyDayBackgroundTimersRef.current.forEach(window.clearTimeout);
+		historyDayBackgroundTimersRef.current = [];
+		setMetricHistoryDays(new Set());
+		setLoadedHistoryMonths(new Set());
+		setLoadingHistoryMonths(new Set());
+	}, [historyDayRequestKey]);
+
+	const loadHistoryMonth = useCallback(
+		(monthKey: string) => {
+			if (historyDayRequests.length === 0) return;
+
+			const generation = historyDayGenerationRef.current;
+			const { start, end } = getMonthRange(monthKey);
+			const missingRequests = historyDayRequests.filter(
+				({ nodeId, metricId }) => {
+					const cacheKey = `${nodeId}:${metricId}:${monthKey}`;
+					return (
+						!historyDayCacheRef.current.has(cacheKey) &&
+						!historyDayInFlightRef.current.has(cacheKey)
+					);
+				},
+			);
+
+			if (missingRequests.length === 0) {
+				const hasInFlightRequests = historyDayRequests.some(
+					({ nodeId, metricId }) =>
+						historyDayInFlightRef.current.has(
+							`${nodeId}:${metricId}:${monthKey}`,
+						),
+				);
+				if (!hasInFlightRequests) {
+					setLoadedHistoryMonths((previous) => new Set(previous).add(monthKey));
+					mergeHistoryDayCache();
+				}
+				return;
+			}
+
+			setLoadingHistoryMonths((previous) => new Set(previous).add(monthKey));
+			missingRequests.forEach(({ nodeId, metricId }) => {
+				historyDayInFlightRef.current.add(`${nodeId}:${metricId}:${monthKey}`);
+			});
+
+			Promise.all(
+				missingRequests.map(({ nodeId, metricId }) =>
+					fetchNodeMetricHistoryDays({
+						nodeId,
+						metricId,
+						startTime: start,
+						endTime: end,
+					}).then((days) => ({ nodeId, metricId, days })),
+				),
+			)
+				.then((results) => {
+					if (generation !== historyDayGenerationRef.current) return;
+					results.forEach(({ nodeId, metricId, days }) => {
+						historyDayCacheRef.current.set(
+							`${nodeId}:${metricId}:${monthKey}`,
+							new Set(days),
+						);
+					});
+					mergeHistoryDayCache();
+					setLoadedHistoryMonths((previous) => new Set(previous).add(monthKey));
+				})
+				.catch((err) => {
+					if (generation !== historyDayGenerationRef.current) return;
+					console.error("Failed to fetch metric history days", err);
+				})
+				.finally(() => {
+					if (generation !== historyDayGenerationRef.current) return;
+					missingRequests.forEach(({ nodeId, metricId }) => {
+						historyDayInFlightRef.current.delete(
+							`${nodeId}:${metricId}:${monthKey}`,
+						);
+					});
+					setLoadingHistoryMonths((previous) => {
+						const next = new Set(previous);
+						next.delete(monthKey);
+						return next;
+					});
+				});
+		},
+		[historyDayRequests, mergeHistoryDayCache],
+	);
+
+	const handleVisibleHistoryMonthChange = useCallback(
+		(monthKey: string) => {
+			setVisibleHistoryMonth(monthKey);
+			historyDayBackgroundTimersRef.current.forEach(window.clearTimeout);
+			historyDayBackgroundTimersRef.current = [];
+			loadHistoryMonth(monthKey);
+
+			const backgroundMonths = [
+				shiftMonthKey(monthKey, -1),
+				shiftMonthKey(monthKey, 1),
+				...Array.from({ length: 11 }, (_, index) =>
+					shiftMonthKey(monthKey, -(index + 2)),
+				),
+			];
+
+			backgroundMonths.forEach((backgroundMonth, index) => {
+				const timer = window.setTimeout(
+					() => {
+						loadHistoryMonth(backgroundMonth);
+					},
+					300 * (index + 1),
+				);
+				historyDayBackgroundTimersRef.current.push(timer);
+			});
+		},
+		[loadHistoryMonth],
+	);
+
+	useEffect(() => {
+		if (visibleHistoryMonth) {
+			handleVisibleHistoryMonthChange(visibleHistoryMonth);
+		}
+	}, [
+		historyDayRequestKey,
+		visibleHistoryMonth,
+		handleVisibleHistoryMonthChange,
+	]);
+
+	useEffect(() => {
+		return () => {
+			historyDayBackgroundTimersRef.current.forEach(window.clearTimeout);
+		};
+	}, []);
 
 	const handleResetDateRange = () => {
 		setStartDate("");
@@ -430,6 +577,9 @@ const MetricAnalytics: React.FC = () => {
 								onEndDateChange={setEndDate}
 								onReset={handleResetDateRange}
 								availableDays={metricHistoryDays}
+								loadedMonths={loadedHistoryMonths}
+								loadingMonths={loadingHistoryMonths}
+								onVisibleMonthChange={handleVisibleHistoryMonthChange}
 							/>
 						</div>
 

--- a/frontend/components/MetricHistoryChart.test.tsx
+++ b/frontend/components/MetricHistoryChart.test.tsx
@@ -1,0 +1,150 @@
+import type React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MetricHistoryChart from "./MetricHistoryChart";
+
+const { mockFetchNodeMetricHistory } = vi.hoisted(() => ({
+	mockFetchNodeMetricHistory: vi.fn(),
+}));
+
+vi.mock("../services/queryResources", () => ({
+	fetchNodeMetricHistory: mockFetchNodeMetricHistory,
+}));
+
+vi.mock("recharts", () => ({
+	ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	AreaChart: ({
+		children,
+		onMouseDown,
+		onMouseMove,
+		onMouseUp,
+	}: {
+		children: React.ReactNode;
+		onMouseDown?: (event: unknown) => void;
+		onMouseMove?: (event: unknown) => void;
+		onMouseUp?: () => void;
+	}) => (
+		<div
+			data-testid="area-chart"
+			onMouseDown={() =>
+				onMouseDown?.({
+					activeLabel: "2026-05-12T10:00:00Z",
+					activePayload: [{ payload: { rawTime: "2026-05-12T10:00:00Z" } }],
+				})
+			}
+			onMouseMove={() =>
+				onMouseMove?.({
+					activeLabel: "2026-05-12T10:00:30Z",
+					activePayload: [{ payload: { rawTime: "2026-05-12T10:00:30Z" } }],
+				})
+			}
+			onMouseUp={() => onMouseUp?.()}
+		>
+			{children}
+		</div>
+	),
+	Area: () => null,
+	XAxis: () => null,
+	YAxis: () => null,
+	CartesianGrid: () => null,
+	Tooltip: () => null,
+	ReferenceArea: () => <div data-testid="reference-area" />,
+	Brush: () => <div data-testid="brush" />,
+}));
+
+const SAMPLE_HISTORY = [
+	{ time: "2026-05-12T10:00:00Z", value: 42 },
+	{ time: "2026-05-12T10:00:30Z", value: 43 },
+	{ time: "2026-05-12T10:01:00Z", value: 44 },
+	{ time: "2026-05-12T10:01:30Z", value: 45 },
+];
+
+describe("MetricHistoryChart interactions", () => {
+	beforeEach(() => {
+		mockFetchNodeMetricHistory.mockReset();
+		mockFetchNodeMetricHistory.mockResolvedValue(SAMPLE_HISTORY);
+	});
+
+	it("requests the selected quick hour windows", async () => {
+		render(
+			<MetricHistoryChart nodeId="ci-001" metricId="cpu" metricName="CPU" />,
+		);
+
+		await waitFor(() =>
+			expect(mockFetchNodeMetricHistory).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					hours: 24,
+					nodeId: "ci-001",
+					metricId: "cpu",
+				}),
+			),
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "1H" }));
+		await waitFor(() =>
+			expect(mockFetchNodeMetricHistory).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					hours: 1,
+					nodeId: "ci-001",
+					metricId: "cpu",
+				}),
+			),
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "72H" }));
+		await waitFor(() =>
+			expect(mockFetchNodeMetricHistory).toHaveBeenLastCalledWith(
+				expect.objectContaining({
+					hours: 72,
+					nodeId: "ci-001",
+					metricId: "cpu",
+				}),
+			),
+		);
+	});
+
+	it("uses custom date range instead of quick hour windows", async () => {
+		render(
+			<MetricHistoryChart
+				nodeId="ci-001"
+				metricId="cpu"
+				metricName="CPU"
+				customRange={{
+					start: "2026-05-01T00:00:00.000Z",
+					end: "2026-06-01T00:00:00.000Z",
+				}}
+			/>,
+		);
+
+		await waitFor(() =>
+			expect(mockFetchNodeMetricHistory).toHaveBeenCalledWith(
+				expect.objectContaining({
+					startTime: "2026-05-01T00:00:00.000Z",
+					endTime: "2026-06-01T00:00:00.000Z",
+					hours: undefined,
+				}),
+			),
+		);
+		expect(
+			screen.queryByRole("button", { name: "72H" }),
+		).not.toBeInTheDocument();
+	});
+
+	it("turns a tiny mouse drag into a stable zoom range", async () => {
+		render(
+			<MetricHistoryChart nodeId="ci-001" metricId="cpu" metricName="CPU" />,
+		);
+
+		await screen.findByTestId("area-chart");
+		fireEvent.mouseDown(screen.getByTestId("area-chart"));
+		fireEvent.mouseMove(screen.getByTestId("area-chart"));
+		fireEvent.mouseUp(screen.getByTestId("area-chart"));
+
+		expect(
+			await screen.findByRole("button", { name: /reset view/i }),
+		).toBeInTheDocument();
+		expect(screen.getByText(/Zoomed:/)).toBeInTheDocument();
+	});
+});

--- a/frontend/components/MetricHistoryChart.tsx
+++ b/frontend/components/MetricHistoryChart.tsx
@@ -29,6 +29,33 @@ interface DataPoint {
 	rawTime: string;
 }
 
+const MIN_DRAG_POINTS = 2;
+const MIN_DRAG_RANGE_MS = 5 * 60 * 1000;
+
+const getActiveRawTime = (event: any): string | null => {
+	return (
+		event?.activePayload?.[0]?.payload?.rawTime ?? event?.activeLabel ?? null
+	);
+};
+
+const getRangeLabel = (startTime: string, endTime: string) => {
+	const durationMs = Math.abs(
+		new Date(endTime).getTime() - new Date(startTime).getTime(),
+	);
+	if (durationMs <= 6 * 60 * 60 * 1000) {
+		return { hour: "2-digit", minute: "2-digit" } as const;
+	}
+	if (durationMs <= 48 * 60 * 60 * 1000) {
+		return {
+			day: "numeric",
+			month: "short",
+			hour: "2-digit",
+			minute: "2-digit",
+		} as const;
+	}
+	return { day: "numeric", month: "short" } as const;
+};
+
 const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 	nodeId,
 	metricId,
@@ -120,16 +147,18 @@ const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 
 	// Mouse handlers for drag-to-zoom
 	const handleMouseDown = useCallback((e: any) => {
-		if (!e || !e.activeLabel) return;
+		const rawTime = getActiveRawTime(e);
+		if (!rawTime) return;
 		setIsSelecting(true);
-		setSelectionStart(e.activeLabel);
-		setSelectionEnd(e.activeLabel);
+		setSelectionStart(rawTime);
+		setSelectionEnd(rawTime);
 	}, []);
 
 	const handleMouseMove = useCallback(
 		(e: any) => {
-			if (!isSelecting || !e || !e.activeLabel) return;
-			setSelectionEnd(e.activeLabel);
+			const rawTime = getActiveRawTime(e);
+			if (!isSelecting || !rawTime) return;
+			setSelectionEnd(rawTime);
 		},
 		[isSelecting],
 	);
@@ -140,15 +169,25 @@ const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 			return;
 		}
 
-		// Find indices in data
-		const startIdx = data.findIndex((d) => d.displayTime === selectionStart);
-		const endIdx = data.findIndex((d) => d.displayTime === selectionEnd);
+		const startIdx = data.findIndex((d) => d.rawTime === selectionStart);
+		const endIdx = data.findIndex((d) => d.rawTime === selectionEnd);
 
 		if (startIdx !== -1 && endIdx !== -1) {
-			const [minIdx, maxIdx] =
+			let [minIdx, maxIdx] =
 				startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
-			// Only apply if selection is meaningful (at least 2 points)
-			if (maxIdx - minIdx >= 2) {
+			const durationMs = Math.abs(
+				new Date(data[maxIdx].rawTime).getTime() -
+					new Date(data[minIdx].rawTime).getTime(),
+			);
+			if (
+				maxIdx - minIdx + 1 < MIN_DRAG_POINTS ||
+				durationMs < MIN_DRAG_RANGE_MS
+			) {
+				const centerIdx = Math.round((minIdx + maxIdx) / 2);
+				minIdx = Math.max(0, centerIdx - 1);
+				maxIdx = Math.min(data.length - 1, centerIdx + 1);
+			}
+			if (maxIdx > minIdx) {
 				setBrushRange({ startIndex: minIdx, endIndex: maxIdx });
 			}
 		}
@@ -167,6 +206,18 @@ const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 			: data;
 
 	const hasBrushApplied = brushRange !== null;
+	const xTickFormatter = useCallback(
+		(value: string) => {
+			const rangeStart = displayData[0]?.rawTime;
+			const rangeEnd = displayData[displayData.length - 1]?.rawTime;
+			if (!rangeStart || !rangeEnd) return value;
+			return new Date(value).toLocaleString(
+				[],
+				getRangeLabel(rangeStart, rangeEnd),
+			);
+		},
+		[displayData],
+	);
 
 	const renderContent = () => {
 		if (loading && data.length === 0) {
@@ -193,9 +244,11 @@ const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 
 		return (
 			<div
-				className="flex-1 w-full min-h-0 relative"
-				style={{ minWidth: 0, minHeight: 0 }}
+				className="flex-1 w-full min-h-0 relative select-none cursor-crosshair"
+				style={{ minWidth: 0, minHeight: 0, userSelect: "none" }}
+				onMouseDown={(event) => event.preventDefault()}
 			>
+				<style>{`.recharts-cartesian-axis-tick-value{user-select:none;pointer-events:none;}`}</style>
 				<ResponsiveContainer width="100%" height="100%">
 					<AreaChart
 						data={displayData}
@@ -222,12 +275,13 @@ const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 							vertical={false}
 						/>
 						<XAxis
-							dataKey="displayTime"
+							dataKey="rawTime"
 							stroke="#525252"
 							tick={{ fill: "#525252", fontSize: 10 }}
 							tickLine={false}
 							axisLine={false}
 							minTickGap={30}
+							tickFormatter={xTickFormatter}
 						/>
 						<YAxis
 							stroke="#525252"
@@ -271,7 +325,7 @@ const MetricHistoryChart: React.FC<MetricHistoryChartProps> = ({
 						{/* Brush component at bottom for direct range selection */}
 						{data.length > 0 && (
 							<Brush
-								dataKey="displayTime"
+								dataKey="rawTime"
 								height={30}
 								stroke="#525252"
 								fill="#171717"

--- a/frontend/components/__tests__/ChartPanel.drag.test.tsx
+++ b/frontend/components/__tests__/ChartPanel.drag.test.tsx
@@ -1,0 +1,79 @@
+import type React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ChartPanel from "../ChartPanel";
+import type { DataPoint } from "../../types";
+
+vi.mock("recharts", () => ({
+	ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+		<div>{children}</div>
+	),
+	AreaChart: ({
+		children,
+		onMouseDown,
+		onMouseMove,
+		onMouseUp,
+	}: {
+		children: React.ReactNode;
+		onMouseDown?: (event: unknown) => void;
+		onMouseMove?: (event: unknown) => void;
+		onMouseUp?: () => void;
+	}) => (
+		<div
+			data-testid="area-chart"
+			onMouseDown={() =>
+				onMouseDown?.({
+					activeLabel: "2026-05-12T10:00:00Z",
+					activePayload: [{ payload: { rawTime: "2026-05-12T10:00:00Z" } }],
+				})
+			}
+			onMouseMove={() =>
+				onMouseMove?.({
+					activeLabel: "2026-05-12T10:00:30Z",
+					activePayload: [{ payload: { rawTime: "2026-05-12T10:00:30Z" } }],
+				})
+			}
+			onMouseUp={() => onMouseUp?.()}
+		>
+			{children}
+		</div>
+	),
+	Area: () => null,
+	XAxis: () => null,
+	YAxis: () => null,
+	CartesianGrid: () => null,
+	Tooltip: () => null,
+	ReferenceArea: () => <div data-testid="reference-area" />,
+	Brush: () => <div data-testid="brush" />,
+}));
+
+const SAMPLE_DATA: DataPoint[] = [
+	{ time: "2026-05-12T10:00:00Z", value: 42 },
+	{ time: "2026-05-12T10:00:30Z", value: 43 },
+	{ time: "2026-05-12T10:01:00Z", value: 45 },
+	{ time: "2026-05-12T10:01:30Z", value: 44 },
+];
+
+describe("ChartPanel drag selection", () => {
+	it("emits a synchronized timestamp range from mouse drag", () => {
+		const onBrushChange = vi.fn();
+		render(
+			<ChartPanel
+				nodeId="ci-001"
+				label="Router-01"
+				data={SAMPLE_DATA}
+				brushRange={null}
+				onBrushChange={onBrushChange}
+			/>,
+		);
+
+		fireEvent.mouseDown(screen.getByTestId("area-chart"));
+		fireEvent.mouseMove(screen.getByTestId("area-chart"));
+		fireEvent.mouseUp(screen.getByTestId("area-chart"));
+
+		expect(onBrushChange).toHaveBeenCalledWith({
+			startTime: "2026-05-12T10:00:00Z",
+			endTime: "2026-05-12T10:01:00Z",
+		});
+	});
+});


### PR DESCRIPTION
Closes #250

## Descripción del Cambio
Estabiliza la UX de Analytics después del selector de rango/calendario:

- Carga marcadores del calendario por mes visible y retroalimenta meses cercanos/previos en background.
- Distingue días con datos, días confirmados sin datos, meses cargando y meses aún desconocidos.
- Corrige selección con mouse en gráficas usando timestamps crudos para eje X, brush y drag.
- Agrega drag-to-zoom para paneles multi-CI y evita selección nativa de texto en etiquetas del eje X.
- Agrega regresiones para botones rápidos, custom range, drag pequeño y estados del calendario.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `frontend/components/MetricAnalytics.tsx` | Orquesta carga mensual/cache/background de history-day markers. |
| `frontend/components/DateTimeRangePicker.tsx` | Muestra estados loaded/loading/unknown y evita confusión visual. |
| `frontend/components/MetricHistoryChart.tsx` | Usa raw timestamps para X-axis/brush/drag y estabiliza drags pequeños. |
| `frontend/components/ChartPanel.tsx` | Agrega drag selection multi-CI, raw timestamps y deshabilita selección de texto. |
| `backend/repositories/metric_repo.py` | Usa rango mensual half-open para history-days. |
| `frontend/components/MetricHistoryChart.test.tsx` | Cubre botones 1H/72H, custom range y drag pequeño. |
| `frontend/components/__tests__/ChartPanel.drag.test.tsx` | Cubre drag multi-chart con rango timestamp. |
| `frontend/components/DateTimeRangePicker.test.tsx` | Cubre estados de calendario y mes visible. |

## ¿Cómo se probó?
- [x] `cd frontend && pnpm test:run components/MetricHistoryChart.test.tsx components/__tests__/ChartPanel.drag.test.tsx components/DateTimeRangePicker.test.tsx components/MetricAnalytics.test.tsx components/__tests__/ChartPanel.test.tsx components/__tests__/MultiMetricChart.test.tsx`
- [x] `cd frontend && pnpm build`
- [x] `cd backend && python -m pytest tests/test_routers_metrics_events.py -k 'history_days or TestMetricsHistory'`
- [x] Docker local rebuild/probado en `http://localhost:3000/`

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] PR vinculado a issue aprobado.
- [x] Commit en formato conventional commit.
