### PR TITLE
fix(auth): add frontend session inactivity handling

### DIFF
--- a/frontend/context/AuthContext.test.tsx
+++ b/frontend/context/AuthContext.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import { AuthProvider, useAuth } from '../context/AuthContext';
+import { publishAuthSessionEvent } from '../services/sessionBus';
 
 // Mock react-router-dom for the api.ts import chain
 vi.mock('react-router-dom', () => ({
@@ -19,6 +20,7 @@ vi.mock('../services/api', () => ({
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <AuthProvider>{children}</AuthProvider>
 );
+const baseUser = { username: 'admin', role: 'USER', permissions: [], allowed_locations: [], tier: 'T1' };
 
 describe('AuthContext', () => {
   beforeEach(() => {
@@ -28,6 +30,10 @@ describe('AuthContext', () => {
     mocks.api.post.mockReset();
     // Default: resolve with null user so hydration doesn't crash
     mocks.api.get.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('initial state', () => {
@@ -51,6 +57,22 @@ describe('AuthContext', () => {
         expect(result.current.loading).toBe(false);
         expect(result.current.user).toEqual(mockUser);
         expect(result.current.isAuthenticated).toBe(true);
+      });
+    });
+
+    it('preserves session policy metadata from /auth/users/me', async () => {
+      const mockUser = {
+        ...baseUser,
+        session_id: 'session-123',
+        session_policy: { profile: 'standard', idle_timeout_minutes: 30, persistent: false },
+      };
+      mocks.api.get.mockResolvedValue(mockUser);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.user?.session_id).toBe('session-123');
+        expect(result.current.user?.session_policy).toEqual(mockUser.session_policy);
       });
     });
 
@@ -125,6 +147,98 @@ describe('AuthContext', () => {
         expect(result.current.user).not.toBeNull();
       });
       expect(result.current.user?.tier ?? 'T1').toBe('T1');
+    });
+  });
+
+  describe('session policy and cross-tab behavior', () => {
+    it('logs out and clears standard non-persistent sessions after the configured inactivity timeout', async () => {
+      vi.useFakeTimers();
+      const mockUser = {
+        ...baseUser,
+        session_id: 'session-123',
+        session_policy: { profile: 'standard', idle_timeout_minutes: 1, persistent: false },
+      };
+      mocks.api.get.mockResolvedValue(mockUser);
+      mocks.api.post.mockResolvedValue({ status: 'success' });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.user).toEqual(mockUser);
+      expect(mocks.api.post).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+
+      expect(mocks.api.post).toHaveBeenCalledWith('/auth/logout', {}, expect.objectContaining({ skipAuthRefresh: true }));
+      expect(result.current.user).toBeNull();
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+
+    it('does not arm inactivity logout for persistent operational sessions', async () => {
+      const mockUser = {
+        ...baseUser,
+        username: 'operator',
+        role: 'OPERATOR',
+        tier: 'T2',
+        session_policy: { profile: 'operational', idle_timeout_minutes: null, persistent: true },
+      };
+      mocks.api.get.mockResolvedValue(mockUser);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isAuthenticated).toBe(true);
+      });
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(mocks.api.post).not.toHaveBeenCalledWith('/auth/logout', {}, expect.anything());
+      expect(result.current.user).toEqual(mockUser);
+    });
+
+    it('clears local authentication when another tab broadcasts session expiration', async () => {
+      const mockUser = { ...baseUser, role: 'ADMIN', tier: 'T3' };
+      mocks.api.get.mockResolvedValue(mockUser);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isAuthenticated).toBe(true);
+      });
+
+      act(() => {
+        publishAuthSessionEvent({ type: 'session-expired', reason: 'idle_timeout' });
+      });
+
+      await waitFor(() => {
+        expect(result.current.user).toBeNull();
+        expect(result.current.isAuthenticated).toBe(false);
+      });
+    });
+
+    it('ignores stale session events for a previous session id', async () => {
+      const mockUser = { ...baseUser, session_id: 'current-session' };
+      mocks.api.get.mockResolvedValue(mockUser);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => {
+        expect(result.current.isAuthenticated).toBe(true);
+      });
+
+      act(() => {
+        publishAuthSessionEvent({ type: 'session-expired', reason: 'idle_timeout', sessionId: 'previous-session' });
+      });
+
+      expect(result.current.user).toEqual(mockUser);
+      expect(result.current.isAuthenticated).toBe(true);
     });
   });
 

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -1,13 +1,22 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { api } from '../services/api';
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import { api, type ApiRequestConfig } from '../services/api';
+import { publishAuthSessionEvent, subscribeAuthSessionEvents } from '../services/sessionBus';
 
-interface User {
+export interface SessionPolicy {
+    profile: string;
+    idle_timeout_minutes: number | null;
+    persistent: boolean;
+}
+
+export interface User {
     username: string;
     role: string;
     permissions: string[];
     allowed_locations: string[];
     force_password_change?: boolean;
     tier: string;
+    session_id?: string | null;
+    session_policy?: SessionPolicy | null;
 }
 
 interface AuthContextType {
@@ -21,14 +30,64 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+const ACTIVITY_EVENTS: Array<keyof WindowEventMap> = ['click', 'keydown', 'mousemove', 'focus', 'visibilitychange'];
+let redirectedToLogin = false;
+
+function redirectToLoginOnce() {
+    if (typeof window === 'undefined') return;
+
+    const isLoginPage = window.location.pathname === '/login' || window.location.hash.startsWith('#/login');
+    if (isLoginPage) return;
+
+    const alreadyPointingAtLogin = window.location.href.endsWith('/login') || window.location.hash.startsWith('#/login');
+    if (redirectedToLogin && alreadyPointingAtLogin) return;
+
+    redirectedToLogin = true;
+    if (window.location.hash) {
+        window.location.hash = '#/login';
+    } else {
+        window.location.href = '/login';
+    }
+}
+
+function shouldArmInactivityTimer(user: User | null): user is User & { session_policy: SessionPolicy } {
+    if (!user?.session_policy) return false;
+    return !user.session_policy.persistent && !!user.session_policy.idle_timeout_minutes && user.session_policy.idle_timeout_minutes > 0;
+}
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     const [user, setUser] = useState<User | null>(null);
     const [loading, setLoading] = useState(true);
+    const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearInactivityTimer = useCallback(() => {
+        if (inactivityTimerRef.current) {
+            clearTimeout(inactivityTimerRef.current);
+            inactivityTimerRef.current = null;
+        }
+    }, []);
+
+    const endLocalSession = useCallback((reason: string, broadcastType?: 'logout' | 'session-expired', sessionId?: string | null) => {
+        clearInactivityTimer();
+        setUser(null);
+        setLoading(false);
+
+        if (broadcastType) {
+            publishAuthSessionEvent({ type: broadcastType, reason, sessionId: sessionId ?? undefined });
+        }
+
+        if (broadcastType === 'session-expired') {
+            redirectToLoginOnce();
+        }
+    }, [clearInactivityTimer]);
 
     useEffect(() => {
         // Hydrate user from cookie-authenticated endpoint on mount
         api.get<User>('/auth/users/me')
-            .then(userData => setUser(userData))
+            .then(userData => {
+                setUser(userData);
+                redirectedToLogin = false;
+            })
             .catch(() => {
                 setUser(null);
             })
@@ -37,20 +96,76 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
             });
     }, []);
 
+    useEffect(() => {
+        const currentSessionId = user?.session_id ?? undefined;
+        return subscribeAuthSessionEvents(event => {
+            if (event.sessionId && currentSessionId && event.sessionId !== currentSessionId) {
+                return;
+            }
+
+            if (event.type === 'logout' || event.type === 'session-expired') {
+                endLocalSession(event.reason ?? event.type);
+            }
+        });
+    }, [endLocalSession, user?.session_id]);
+
+    useEffect(() => {
+        clearInactivityTimer();
+
+        if (!shouldArmInactivityTimer(user)) {
+            return undefined;
+        }
+
+        const timeoutMs = user.session_policy.idle_timeout_minutes * 60 * 1000;
+        let disposed = false;
+
+        const expireForInactivity = async () => {
+            if (disposed) return;
+
+            try {
+                await api.post('/auth/logout', {}, { skipAuthRefresh: true } as ApiRequestConfig);
+            } catch {
+                // Best effort — backend remains the security authority.
+            } finally {
+                if (!disposed) {
+                    endLocalSession('idle_timeout', 'session-expired', user.session_id);
+                }
+            }
+        };
+
+        const resetTimer = () => {
+            if (inactivityTimerRef.current) {
+                clearTimeout(inactivityTimerRef.current);
+            }
+            inactivityTimerRef.current = setTimeout(expireForInactivity, timeoutMs);
+        };
+
+        ACTIVITY_EVENTS.forEach(eventName => window.addEventListener(eventName, resetTimer, { passive: true }));
+        resetTimer();
+
+        return () => {
+            disposed = true;
+            clearInactivityTimer();
+            ACTIVITY_EVENTS.forEach(eventName => window.removeEventListener(eventName, resetTimer));
+        };
+    }, [clearInactivityTimer, endLocalSession, user]);
+
     const login = useCallback((newUser: User) => {
+        redirectedToLogin = false;
         setUser(newUser);
         setLoading(false);
     }, []);
 
     const logout = useCallback(async () => {
+        const sessionId = user?.session_id;
         try {
             await api.post('/auth/logout', {});
         } catch {
             // Best effort — still clear local state
         } finally {
-            setUser(null);
+            endLocalSession('manual', 'logout', sessionId);
         }
-    }, []);
+    }, [endLocalSession, user?.session_id]);
 
     const hasPermission = (perm: string) => {
         if (!user) return false;

--- a/frontend/services/api.test.ts
+++ b/frontend/services/api.test.ts
@@ -280,28 +280,80 @@ describe('api client', () => {
   });
 
   describe('401 handling', () => {
-    it('redirects on 401 when refresh fails', async () => {
-      // Mock window.location
+    const jsonResponse = (status: number, body: any, statusText = 'Unauthorized') => ({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText,
+      headers: { get: () => 'application/json' },
+      json: () => Promise.resolve(body),
+    });
+
+    it('coalesces parallel 401 requests into a single refresh and retries each original request once', async () => {
+      const fetchMock = vi.fn(async (url: string) => {
+        if (url === '/api/auth/refresh') return jsonResponse(200, { access_token: 'rotated' });
+        const callsForUrl = fetchMock.mock.calls.filter(([calledUrl]) => calledUrl === url).length;
+        return callsForUrl === 1 ? jsonResponse(401, { detail: 'Unauthorized' }) : jsonResponse(200, { url });
+      });
+      global.fetch = fetchMock;
+
+      await expect(Promise.all([api.get('/nodes'), api.get('/devices')])).resolves.toEqual([
+        { url: '/api/nodes' },
+        { url: '/api/devices' },
+      ]);
+      expect(fetchMock.mock.calls.filter(([url]) => url === '/api/auth/refresh')).toHaveLength(1);
+      expect(fetchMock.mock.calls.filter(([url]) => url === '/api/nodes')).toHaveLength(2);
+      expect(fetchMock.mock.calls.filter(([url]) => url === '/api/devices')).toHaveLength(2);
+    });
+
+    it('bounds failed parallel refresh attempts and redirects only once', async () => {
       const originalLocation = window.location;
       delete (window as any).location;
-      window.location = {
-        pathname: '/',
-        hash: '',
-        href: '',
-      } as any;
+      window.location = { pathname: '/', hash: '', href: '' } as any;
+      const fetchMock = vi.fn(async (url: string) => (
+        url === '/api/auth/refresh'
+          ? jsonResponse(401, { detail: 'idle_timeout' })
+          : jsonResponse(401, { detail: 'Unauthorized' })
+      ));
+      global.fetch = fetchMock;
 
-      global.fetch = vi.fn().mockResolvedValue({
-        status: 401,
-        ok: false,
-        headers: { get: () => 'application/json' },
-        json: () => Promise.resolve({ detail: 'Session expired' }),
-      });
+      await expect(Promise.all([api.get('/nodes'), api.get('/devices')])).rejects.toThrow('idle_timeout');
+      expect(fetchMock.mock.calls.filter(([url]) => url === '/api/auth/refresh')).toHaveLength(1);
+      expect(window.location.href).toBe('/login');
+      window.location = originalLocation;
+    });
+
+    it('does not recursively refresh refresh requests when skipAuthRefresh is set', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(401, { detail: 'invalid_refresh_token' }));
+      global.fetch = fetchMock;
+
+      await expect(api.post('/auth/refresh', {}, { skipAuthRefresh: true } as RequestInit)).rejects.toThrow('invalid_refresh_token');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', expect.objectContaining({ method: 'POST' }));
+    });
+
+    it('surfaces SSE refresh failures without redirecting unexpectedly', async () => {
+      const originalLocation = window.location;
+      delete (window as any).location;
+      window.location = { pathname: '/', hash: '', href: '' } as any;
+      global.fetch = vi.fn(async (url: string) => (
+        url === '/api/auth/refresh'
+          ? jsonResponse(401, { detail: 'session_expired' })
+          : jsonResponse(401, { detail: 'Unauthorized' })
+      ));
+
+      await expect(api.getSSE('/events')).rejects.toThrow('session_expired');
+      expect(window.location.href).toBe('');
+      window.location = originalLocation;
+    });
+
+    it('redirects on 401 when refresh fails', async () => {
+      const originalLocation = window.location;
+      delete (window as any).location;
+      window.location = { pathname: '/', hash: '', href: '' } as any;
+      global.fetch = vi.fn().mockResolvedValue(jsonResponse(401, { detail: 'Session expired' }));
 
       await expect(api.get('/nodes')).rejects.toThrow('Session expired');
-
       expect(window.location.href).toBe('/login');
-
-      // Restore window.location
       window.location = originalLocation;
     });
   });

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,4 +1,14 @@
+import { publishAuthSessionEvent } from './sessionBus';
+
 const API_BASE = '/api';
+const MAX_AUTH_RETRY_COUNT = 1;
+
+export type ApiRequestConfig = RequestInit & {
+    responseType?: string;
+    isSSE?: boolean;
+    skipAuthRefresh?: boolean;
+    authRetryCount?: number;
+};
 
 /**
  * Custom error class for API errors
@@ -17,104 +27,71 @@ export class ApiError extends Error {
  */
 export const SSE_STREAM_HEADER = 'x-sse-stream';
 
-/**
- * Generic fetch wrapper to handle Auth and Errors
- *
- * Auth model: HttpOnly cookie is sent AUTOMATICALLY by the browser via
- * credentials: 'include'. No Authorization: Bearer header needed.
- * 401 retry: the browser re-sends the cookie automatically; we just retry once.
- */
-async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T> {
-    const url = `${API_BASE}${endpoint.startsWith('/') ? endpoint : '/' + endpoint}`;
-    const responseType = (config as RequestInit & { responseType?: string }).responseType;
-    const isSSE = !!(config as RequestInit & { isSSE?: boolean }).isSSE;
+let refreshPromise: Promise<void> | null = null;
+let redirectedToLogin = false;
 
-    // Build headers — start with any caller-provided headers, then apply defaults
-    const callerHeaders = config.headers as Record<string, string> || {};
-    const headers: Record<string, string> = { ...callerHeaders };
+function normalizeEndpoint(endpoint: string): string {
+    return endpoint.startsWith('/') ? endpoint : '/' + endpoint;
+}
 
-    // Default to JSON if no body or if body is not FormData and no Content-Type set
-    if (!(config.body instanceof FormData) && !headers['Content-Type']) {
-        headers['Content-Type'] = 'application/json';
+function isLoginPage(): boolean {
+    if (typeof window === 'undefined') return false;
+    return window.location.pathname === '/login' || window.location.hash.startsWith('#/login');
+}
+
+function redirectToLoginOnce() {
+    if (typeof window === 'undefined' || isLoginPage()) return;
+
+    const alreadyPointingAtLogin = window.location.href.endsWith('/login') || window.location.hash.startsWith('#/login');
+    if (redirectedToLogin && alreadyPointingAtLogin) return;
+
+    redirectedToLogin = true;
+    if (window.location.hash) {
+        window.location.hash = '#/login';
+    } else {
+        window.location.href = '/login';
     }
+}
 
-    const response = await fetch(url, {
-        ...config,
-        headers,
-        credentials: 'include',
-    });
+async function getErrorMessage(response: Response, fallback: string): Promise<string> {
+    const errorData = await response.json().catch(() => ({}));
+    const detail = errorData.detail;
+    if (typeof detail === 'string') return detail;
+    return detail?.message || response.statusText || fallback;
+}
 
-    // Handle 401 Unauthorized — call /auth/refresh to rotate tokens, then retry
-    if (response.status === 401) {
-        // Step 1: POST to /auth/refresh — browser sends refresh_token cookie automatically
+function shouldSkipAuthRefresh(endpoint: string, config: ApiRequestConfig): boolean {
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+    return !!config.skipAuthRefresh || normalizedEndpoint === '/auth/refresh' || normalizedEndpoint === '/auth/logout';
+}
+
+async function refreshSession(): Promise<void> {
+    if (refreshPromise) return refreshPromise;
+
+    refreshPromise = (async () => {
         const refreshResponse = await fetch(`${API_BASE}/auth/refresh`, {
             method: 'POST',
-            credentials: 'include', // Required to send the refresh_token cookie
-        });
-
-        // If refresh fails, the refresh cookie is expired — force logout
-        if (!refreshResponse.ok) {
-            if (!isSSE) {
-                const isLoginPage = window.location.pathname === '/login' || window.location.hash.startsWith('#/login');
-                if (!isLoginPage) {
-                    if (window.location.hash) {
-                        window.location.hash = '#/login';
-                    } else {
-                        window.location.href = '/login';
-                    }
-                }
-            }
-            throw new ApiError('Session expired', 401);
-        }
-
-        // Step 2: Refresh succeeded — new access_token cookie is set on the response
-        // Retry the original request; browser sends the new access_token cookie automatically
-        const retryResponse = await fetch(url, {
-            ...config,
-            headers,
             credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
         });
 
-        if (retryResponse.ok) {
-            if (responseType === 'blob') {
-                return retryResponse.blob() as unknown as T;
-            }
-            const contentType = retryResponse.headers.get("content-type");
-            if (contentType && contentType.indexOf("application/json") !== -1) {
-                return retryResponse.json();
-            }
-            return retryResponse.text() as unknown as T;
+        if (!refreshResponse.ok) {
+            const message = await getErrorMessage(refreshResponse, 'Session expired');
+            publishAuthSessionEvent({ type: 'session-expired', reason: message });
+            throw new ApiError(message, refreshResponse.status);
         }
+    })().finally(() => {
+        refreshPromise = null;
+    });
 
-        // Retry still failed — refresh cookie may have expired during the retry window
-        if (!isSSE) {
-            const isLoginPage = window.location.pathname === '/login' || window.location.hash.startsWith('#/login');
-            if (!isLoginPage) {
-                if (window.location.hash) {
-                    window.location.hash = '#/login';
-                } else {
-                    window.location.href = '/login';
-                }
-            }
-        }
-        throw new ApiError('Unauthorized', 401);
-    }
+    return refreshPromise;
+}
 
-    // Handle other errors
-    if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        const detail = errorData.detail;
-        const message = typeof detail === 'string'
-            ? detail
-            : detail?.message || response.statusText;
-        throw new ApiError(message, response.status);
-    }
-
+async function parseSuccessfulResponse<T>(response: Response, responseType?: string): Promise<T> {
     if (responseType === 'blob') {
         return response.blob() as unknown as T;
     }
 
-    // Return JSON if content exists
     const contentType = response.headers.get("content-type");
     if (contentType && contentType.indexOf("application/json") !== -1) {
         return response.json();
@@ -131,9 +108,79 @@ async function request<T>(endpoint: string, config: RequestInit = {}): Promise<T
     return response.text() as unknown as T;
 }
 
+/**
+ * Generic fetch wrapper to handle Auth and Errors
+ *
+ * Auth model: HttpOnly cookie is sent AUTOMATICALLY by the browser via
+ * credentials: 'include'. No Authorization: Bearer header needed.
+ * 401 retry: the browser re-sends the cookie automatically; we just retry once.
+ */
+async function request<T>(endpoint: string, config: ApiRequestConfig = {}): Promise<T> {
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+    const url = `${API_BASE}${normalizedEndpoint}`;
+    const {
+        responseType,
+        isSSE,
+        skipAuthRefresh: _skipAuthRefresh,
+        authRetryCount = 0,
+        ...fetchConfig
+    } = config;
+    const skipAuthRefresh = shouldSkipAuthRefresh(endpoint, config);
+
+    // Build headers — start with any caller-provided headers, then apply defaults
+    const callerHeaders = fetchConfig.headers as Record<string, string> || {};
+    const headers: Record<string, string> = { ...callerHeaders };
+
+    // Default to JSON if no body or if body is not FormData and no Content-Type set
+    if (!(fetchConfig.body instanceof FormData) && !headers['Content-Type']) {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    const response = await fetch(url, {
+        ...fetchConfig,
+        headers,
+        credentials: 'include',
+    });
+
+    // Handle 401 Unauthorized — call /auth/refresh to rotate tokens, then retry once.
+    if (response.status === 401) {
+        if (skipAuthRefresh || authRetryCount >= MAX_AUTH_RETRY_COUNT) {
+            const message = await getErrorMessage(response, 'Unauthorized');
+            if (!isSSE && !skipAuthRefresh) {
+                publishAuthSessionEvent({ type: 'session-expired', reason: message });
+                redirectToLoginOnce();
+            }
+            throw new ApiError(message, response.status);
+        }
+
+        try {
+            await refreshSession();
+        } catch (error) {
+            if (!isSSE) {
+                redirectToLoginOnce();
+            }
+            throw error;
+        }
+
+        return request<T>(endpoint, {
+            ...config,
+            authRetryCount: authRetryCount + 1,
+        });
+    }
+
+    // Handle other errors
+    if (!response.ok) {
+        const message = await getErrorMessage(response, response.statusText);
+        throw new ApiError(message, response.status);
+    }
+
+    redirectedToLogin = false;
+    return parseSuccessfulResponse<T>(response, responseType);
+}
+
 export const api = {
-    get: <T>(endpoint: string, config: RequestInit = {}) => request<T>(endpoint, { ...config, method: 'GET' }),
-    post: <T>(endpoint: string, body: any, config: RequestInit = {}) => {
+    get: <T>(endpoint: string, config: ApiRequestConfig = {}) => request<T>(endpoint, { ...config, method: 'GET' }),
+    post: <T>(endpoint: string, body: any, config: ApiRequestConfig = {}) => {
         let serializedBody: any = body;
         if (body instanceof FormData || body instanceof Blob || body instanceof ArrayBuffer) {
             serializedBody = body;
@@ -146,19 +193,19 @@ export const api = {
             body: serializedBody,
         });
     },
-    put: <T>(endpoint: string, body: any, config: RequestInit = {}) => request<T>(endpoint, {
+    put: <T>(endpoint: string, body: any, config: ApiRequestConfig = {}) => request<T>(endpoint, {
         ...config,
         method: 'PUT',
         body: JSON.stringify(body),
     }),
-    delete: <T>(endpoint: string, body?: any, config: RequestInit = {}) => request<T>(endpoint, {
+    delete: <T>(endpoint: string, body?: any, config: ApiRequestConfig = {}) => request<T>(endpoint, {
         ...config,
         method: 'DELETE',
         body: body ? JSON.stringify(body) : undefined
     }),
-    // SSE-aware get that marks the request so 401 triggers queue+wait instead of logout
-    getSSE: <T>(endpoint: string, config: RequestInit = {}) =>
-        request<T>(endpoint, { ...config, method: 'GET', isSSE: true } as RequestInit),
+    // SSE-aware get that marks the request so 401 surfaces terminal errors without forcing logout.
+    getSSE: <T>(endpoint: string, config: ApiRequestConfig = {}) =>
+        request<T>(endpoint, { ...config, method: 'GET', isSSE: true }),
     // Download a file with authentication (returns blob URL for download)
     download: (endpoint: string) => {
         return request<Blob>(endpoint, { responseType: 'blob', method: 'GET', credentials: 'include' })

--- a/frontend/services/sessionBus.test.ts
+++ b/frontend/services/sessionBus.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AUTH_SESSION_CHANNEL, AUTH_SESSION_STORAGE_KEY, publishAuthSessionEvent, subscribeAuthSessionEvents } from './sessionBus';
+
+describe('sessionBus', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    delete (window as any).BroadcastChannel;
+  });
+
+  it('publishes logout events through BroadcastChannel when available', () => {
+    const channels: Array<any> = [];
+    class MockBroadcastChannel {
+      postMessage = vi.fn();
+      close = vi.fn();
+      constructor(public name: string) { channels.push(this); }
+    }
+    (window as any).BroadcastChannel = MockBroadcastChannel;
+
+    const handler = vi.fn();
+    const unsubscribe = subscribeAuthSessionEvents(handler);
+    publishAuthSessionEvent({ type: 'logout', reason: 'manual' });
+
+    expect(channels[0].name).toBe(AUTH_SESSION_CHANNEL);
+    expect(channels[0].postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'logout', reason: 'manual', senderId: expect.any(String), timestamp: expect.any(Number),
+    }));
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ type: 'logout', reason: 'manual' }));
+
+    unsubscribe();
+    expect(channels[0].close).toHaveBeenCalled();
+  });
+
+  it('receives session-expired events through the localStorage fallback', () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeAuthSessionEvents(handler);
+    const message = { type: 'session-expired' as const, reason: 'idle_timeout', senderId: 'other-tab', timestamp: Date.now() };
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: AUTH_SESSION_STORAGE_KEY,
+      newValue: JSON.stringify(message),
+    }));
+
+    expect(handler).toHaveBeenCalledWith(message);
+    unsubscribe();
+  });
+
+  it('deduplicates the same remote event delivered by BroadcastChannel and localStorage', () => {
+    const channels: Array<any> = [];
+    class MockBroadcastChannel {
+      onmessage: ((event: MessageEvent) => void) | null = null;
+      postMessage = vi.fn();
+      close = vi.fn();
+      constructor(public name: string) { channels.push(this); }
+    }
+    (window as any).BroadcastChannel = MockBroadcastChannel;
+
+    const handler = vi.fn();
+    const unsubscribe = subscribeAuthSessionEvents(handler);
+    const message = {
+      type: 'session-expired' as const,
+      reason: 'idle_timeout',
+      sessionId: 'session-123',
+      senderId: 'other-tab',
+      timestamp: Date.now() + 1,
+    };
+
+    channels[0].onmessage?.({ data: message } as MessageEvent);
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: AUTH_SESSION_STORAGE_KEY,
+      newValue: JSON.stringify(message),
+    }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(message);
+    unsubscribe();
+  });
+});

--- a/frontend/services/sessionBus.ts
+++ b/frontend/services/sessionBus.ts
@@ -1,0 +1,94 @@
+export const AUTH_SESSION_CHANNEL = 'next-gen-auth-session';
+export const AUTH_SESSION_STORAGE_KEY = 'next-gen-auth-session-event';
+
+export type AuthSessionEventType = 'logout' | 'session-expired';
+export interface AuthSessionEvent {
+  type: AuthSessionEventType;
+  reason?: string;
+  sessionId?: string;
+  senderId?: string;
+  timestamp?: number;
+  eventId?: string;
+}
+
+type Handler = (event: AuthSessionEvent) => void;
+
+const listeners = new Set<Handler>();
+const deliveredEventKeys = new Set<string>();
+const tabId = `tab-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+let eventSequence = 0;
+let channel: BroadcastChannel | null = null;
+
+const hasWindow = () => typeof window !== 'undefined';
+const isEvent = (value: unknown): value is AuthSessionEvent => (
+  !!value && typeof value === 'object' &&
+  ((value as AuthSessionEvent).type === 'logout' || (value as AuthSessionEvent).type === 'session-expired')
+);
+const eventKey = (event: AuthSessionEvent) => event.eventId ?? [
+  event.senderId ?? '',
+  event.timestamp ?? '',
+  event.type,
+  event.reason ?? '',
+  event.sessionId ?? '',
+].join('|');
+const notify = (event: AuthSessionEvent) => listeners.forEach(listener => listener(event));
+const notifyRemoteOnce = (event: AuthSessionEvent) => {
+  const key = eventKey(event);
+  if (deliveredEventKeys.has(key)) return;
+  deliveredEventKeys.add(key);
+  notify(event);
+};
+
+function ensureChannel(): BroadcastChannel | null {
+  if (!hasWindow() || !('BroadcastChannel' in window)) return null;
+  if (channel) return channel;
+  channel = new BroadcastChannel(AUTH_SESSION_CHANNEL);
+  channel.onmessage = ({ data }: MessageEvent<AuthSessionEvent>) => {
+    if (isEvent(data) && data.senderId !== tabId) notifyRemoteOnce(data);
+  };
+  return channel;
+}
+
+export function publishAuthSessionEvent(event: AuthSessionEvent): void {
+  if (!hasWindow()) return;
+  const message = {
+    ...event,
+    senderId: event.senderId ?? tabId,
+    timestamp: event.timestamp ?? Date.now(),
+    eventId: event.eventId ?? `${tabId}-${Date.now()}-${eventSequence += 1}`,
+  };
+  notify(message);
+  ensureChannel()?.postMessage(message);
+  try {
+    window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(message));
+    window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
+  } catch {
+    // Ignore unavailable storage.
+  }
+}
+
+export function subscribeAuthSessionEvents(handler: Handler): () => void {
+  if (!hasWindow()) return () => undefined;
+  listeners.add(handler);
+  ensureChannel();
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== AUTH_SESSION_STORAGE_KEY || !event.newValue) return;
+    try {
+      const message = JSON.parse(event.newValue) as AuthSessionEvent;
+      if (isEvent(message) && message.senderId !== tabId) notifyRemoteOnce(message);
+    } catch {
+      // Ignore malformed cross-tab payloads.
+    }
+  };
+
+  window.addEventListener('storage', onStorage);
+  return () => {
+    listeners.delete(handler);
+    window.removeEventListener('storage', onStorage);
+    if (listeners.size === 0 && channel) {
+      channel.close();
+      channel = null;
+    }
+  };
+}

--- a/openspec/changes/fix-multi-window-session-timeout/apply-progress.md
+++ b/openspec/changes/fix-multi-window-session-timeout/apply-progress.md
@@ -7,7 +7,7 @@ Scope: `fix-multi-window-session-timeout` (Issue #188).
 - PR1: `fix/session-policy-foundation` -> `main`, opened as PR #245, accepted for review.
 - PR2: `fix/session-refresh-stale-recovery` -> `fix/session-policy-foundation`, backend-only stale refresh/rate-limit slice in progress.
 - PR3: `fix/session-policy-contract` -> `fix/session-refresh-stale-recovery`, backend/frontend contract bridge for session policy visibility in progress.
-- PR4: pending.
+- PR4: `fix/session-policy-contract` frontend slice implemented locally; verify report created at `verify-report-pr4.md`.
 
 ## PR1 summary
 
@@ -48,6 +48,16 @@ PR3 adds a minimal backend contract bridge for frontend inactivity decisions:
 - added router test coverage for `/auth/users/me` contract response shape
 - no frontend singleflight/cross-tab UX behavior changes in this PR
 
+## PR4 summary
+
+PR4 adds frontend session coordination and inactivity UX:
+
+- per-tab refresh singleflight with bounded original-request retry metadata
+- non-recursive refresh/logout requests via `skipAuthRefresh`
+- terminal refresh failure handling with one-time login redirect, while SSE callers receive errors without redirect
+- `sessionBus` BroadcastChannel/localStorage fallback for logout and session-expired convergence
+- AuthContext consumes `session_id`/`session_policy`, clears cross-tab session events, and arms inactivity logout only for non-persistent policies
+
 ## PR2 incident note
 
 Initial PR2 `sdd-apply` failed due an ambiguous edit in `backend/tests/test_auth_router_refresh.py`, leaving a partial but coherent backend diff. A fresh incident audit found no conflict markers or syntax failures and recommended continuing manually. The only blocker was a test patch returning a non-JWT `access_token` while decoding it. That test was corrected by letting the real `create_access_token` run.
@@ -81,6 +91,15 @@ Initial PR2 `sdd-apply` failed due an ambiguous edit in `backend/tests/test_auth
 | TRIANGULATE | Ran `cd backend && python -m pytest tests/test_routers_auth_users_roles.py::TestAuthUsersMe -q` and got **6 passed**. |
 | REFACTOR | Kept contract bridge limited to backend-only response shape required by frontend; no frontend UX logic included. |
 
+### PR4
+
+| Phase | Evidence |
+| --- | --- |
+| RED | Added frontend tests for refresh singleflight, bounded failed refresh, non-recursive refresh, SSE no-redirect behavior, session policy hydration, inactivity timeout, cross-tab expiry, and sessionBus BroadcastChannel/storage fallback. Initial run failed on missing `sessionBus` module and expected API/AuthContext behavior. |
+| GREEN | Implemented API refresh singleflight/bounded retry, session bus, and AuthContext policy-aware inactivity/cross-tab handling. |
+| TRIANGULATE | Ran `corepack pnpm --dir frontend run test:run` and got **43 passed / 401 tests passed**. |
+| REFACTOR | Trimmed PR4 diff to stay within the 700-line review budget while preserving focused frontend scope. |
+
 ## Verification commands
 
 ### PR1 accepted evidence
@@ -106,13 +125,12 @@ Initial PR2 `sdd-apply` failed due an ambiguous edit in `backend/tests/test_auth
 
 ## Remaining work
 
-- PR3 contract shape is implemented and ready for SDD verify.
-- PR4: frontend singleflight, cross-tab coordination, and inactivity UX.
+- Run fresh PR4 review before opening/updating the stacked PR.
 
 ## Known risks
 
 - Stale-token recovery must remain tightly bounded to prevent replay abuse.
-- Browser cross-tab coordination is still not implemented; backend tolerance is PR2's focus.
+- Browser cross-tab coordination is covered for logout/session-expired convergence; backend tolerance remains authoritative for refresh races.
 - PostgreSQL startup migration/backfill still needs validation against a real PostgreSQL instance.
 - Contract consumers must agree on `session_policy` semantics to avoid frontend/backend drift.
 - `open-issues-triage.md` remains untracked and outside PR2 scope.

--- a/openspec/changes/fix-multi-window-session-timeout/verify-report-pr4.md
+++ b/openspec/changes/fix-multi-window-session-timeout/verify-report-pr4.md
@@ -1,0 +1,42 @@
+# Verify Report PR4 — fix-multi-window-session-timeout
+
+Status: PASS
+Date: 2026-06-03
+Scope: PR4 frontend singleflight, bounded refresh retry, cross-tab session convergence, and inactivity UX.
+
+## Summary
+
+PR4 implements the frontend side of issue #188 on top of the PR3 `/auth/users/me` contract. The client now deduplicates per-tab refresh attempts, retries each original 401 once, avoids recursive refresh/logout handling, preserves SSE no-redirect behavior, broadcasts logout/session-expired events across tabs without duplicate remote delivery, ignores stale session-scoped events for previous sessions, and arms local inactivity logout only for non-persistent session policies.
+
+## Changed files
+
+- `frontend/services/api.ts`
+- `frontend/services/api.test.ts`
+- `frontend/services/sessionBus.ts`
+- `frontend/services/sessionBus.test.ts`
+- `frontend/context/AuthContext.tsx`
+- `frontend/context/AuthContext.test.tsx`
+- `openspec/changes/fix-multi-window-session-timeout/apply-progress.md`
+- `openspec/changes/fix-multi-window-session-timeout/verify-report-pr4.md`
+
+## Strict TDD evidence
+
+RED command: `corepack pnpm --dir frontend run test:run -- api.test.ts AuthContext.test.tsx sessionBus.test.ts`
+
+Result: failed as expected before implementation. Evidence included missing `sessionBus` module failures plus API refresh orchestration assertion failures: parallel 401s made two refresh calls, terminal refresh detail was collapsed to `Session expired`, and `skipAuthRefresh` did not prevent recursive refresh.
+
+GREEN/TRIANGULATE command: `corepack pnpm --dir frontend run test:run`
+
+Result: PASS — `43 passed`, `403 tests passed` after review fixes.
+
+Review-fix validation command: `corepack pnpm --dir frontend run test:run -- AuthContext.test.tsx sessionBus.test.ts`
+
+Result: PASS — `43 passed`, `403 tests passed`; added coverage for cross-channel event dedupe, stale session-id filtering, and fake-timer inactivity expiry.
+
+Note: jsdom printed `Not implemented: navigation to another Document` while tests exercised redirect paths; assertions still passed.
+
+## Risk review
+
+- Cross-tab refresh locking remains intentionally backend-authoritative; frontend coordinates logout/session-expired convergence only.
+- Inactivity timer is UX assist, not security authority; backend idle/session expiry remains decisive.
+- Browser-level manual two-tab behavior still merits reviewer/manual smoke before merge.


### PR DESCRIPTION
## Descripción del Cambio
Closes #188

PR4 de la cadena `fix-multi-window-session-timeout`: agrega la orquestación frontend de sesión/inactividad sobre el contrato expuesto por PR #252.

### Chain Context

```text
#245 fix/session-policy-foundation
  -> #247 fix/session-refresh-status
    -> #248 fix/session-refresh-stale-recovery
      -> #252 fix/session-policy-contract
        -> 📍 this PR: fix/session-inactivity-frontend
```

Base de este PR: `fix/session-policy-contract`.

### Summary
- Consume `session_id` y `session_policy` desde `/auth/users/me` en `AuthContext`.
- Agrega refresh singleflight con retry acotado para evitar loops y ráfagas de refresh.
- Agrega bus cross-tab (`BroadcastChannel` + fallback `localStorage`) para `session-expired` / `logout`, con dedupe y guard de `sessionId`.
- Agrega timer de inactividad para sesiones no persistentes y evidencia OpenSpec PR4.

### Cambios

| File | Change |
|------|--------|
| `frontend/services/api.ts` | Refresh singleflight, retry metadata, auth failure/session event signaling |
| `frontend/services/api.test.ts` | Regression tests for refresh coalescing, bounded retry, and SSE-safe behavior |
| `frontend/services/sessionBus.ts` | Cross-tab session event bus with BroadcastChannel/localStorage fallback and dedupe |
| `frontend/services/sessionBus.test.ts` | Session bus publish/subscribe/dedupe coverage |
| `frontend/context/AuthContext.tsx` | Session policy hydration, inactivity timeout, cross-tab logout/session expiry handling |
| `frontend/context/AuthContext.test.tsx` | Policy hydration, stale session event guard, and inactivity timer coverage |
| `openspec/changes/fix-multi-window-session-timeout/apply-progress.md` | PR4 progress/evidence update |
| `openspec/changes/fix-multi-window-session-timeout/verify-report-pr4.md` | PR4 verification report |

### Review workload
- Commit diff: 8 files, 673 insertions / 113 deletions.
- Slightly above the earlier rough estimate threshold only when counting generated review evidence separately; user approved opening as one cohesive PR4 work unit.
- Fresh final review: PASS / no blockers.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `corepack pnpm --dir frontend run test:run -- api.test.ts AuthContext.test.tsx sessionBus.test.ts` → PASS, 43 files / 403 tests.
- [x] `corepack pnpm --dir frontend run test:run` → PASS, 43 files / 403 tests.
- [x] `git diff --check` → PASS, only CRLF normalization warnings.
- [x] Fresh reviewer pass after polish → PASS / no blockers.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
