### PR TITLE
feat(analytics): add SNMP coverage KPI summary

### DIFF
--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -217,12 +217,23 @@ class AvailabilityReportRow(BaseModel):
     ci: Optional[AvailabilityReportCI] = None
 
 
+class SnmpCoverageSummary(BaseModel):
+    total_ci_with_snmp: int = 0
+    functional_ci: int = 0
+    failing_ci: int = 0
+    no_response_ci: int = 0
+    no_response_event_count: int = 0
+    functional_percentage: Optional[float] = None
+    failing_percentage: Optional[float] = None
+
+
 class AvailabilityReportResponse(BaseModel):
     window_start: str
     window_end: str
     generated_at: str
     window_days: float
     total_groups: int
+    snmp_coverage: Optional[SnmpCoverageSummary] = None
     rows: List[AvailabilityReportRow]
 
 

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -478,6 +478,43 @@ def _availability_group_key(event_data: Dict[str, Any]) -> Optional[tuple[str, s
     return str(ci_id), str(event_type)
 
 
+def _empty_snmp_coverage_summary() -> Dict[str, Any]:
+    return {
+        "total_ci_with_snmp": 0,
+        "functional_ci": 0,
+        "failing_ci": 0,
+        "no_response_ci": 0,
+        "no_response_event_count": 0,
+        "functional_percentage": None,
+        "failing_percentage": None,
+    }
+
+
+def _build_snmp_coverage_summary(record: Any) -> Dict[str, Any]:
+    summary = _empty_snmp_coverage_summary()
+    if record is None:
+        return summary
+
+    total = int(record.get("total_ci_with_snmp") or 0)
+    functional = int(record.get("functional_ci") or 0)
+    failing = int(record.get("failing_ci") or 0)
+    no_response = int(record.get("no_response_ci") or 0)
+    no_response_events = int(record.get("no_response_event_count") or 0)
+    summary.update(
+        {
+            "total_ci_with_snmp": total,
+            "functional_ci": functional,
+            "failing_ci": failing,
+            "no_response_ci": no_response,
+            "no_response_event_count": no_response_events,
+        }
+    )
+    if total > 0:
+        summary["functional_percentage"] = round(functional / total * 100, 4)
+        summary["failing_percentage"] = round(failing / total * 100, 4)
+    return summary
+
+
 def _is_sensitive_ci_key(key: str) -> bool:
     normalized = key.lower()
     return any(part in normalized for part in _SENSITIVE_CI_KEY_PARTS)
@@ -579,6 +616,7 @@ def get_availability_report(
     )
     window_seconds = max((window_end - window_start).total_seconds(), 0)
     groups: Dict[tuple[str, str], Dict[str, Any]] = {}
+    snmp_coverage = _empty_snmp_coverage_summary()
 
     def ensure_group(
         key: tuple[str, str],
@@ -691,6 +729,26 @@ def get_availability_report(
                 0.0, (window_end - clipped_start).total_seconds()
             )
 
+        snmp_result = session.run(
+            """
+            MATCH (ci:CI)-[:HAS_METRIC]->(m:MetricDef)
+            WHERE toUpper(coalesce(m.protocol, '')) = 'SNMP'
+            WITH DISTINCT ci
+            OPTIONAL MATCH (ci)-[:HAS_EVENT]->(e:Event)
+            WHERE e.status IN ['OPEN', 'ACK']
+              AND e.event_type = 'COLLECTION_FAILURE'
+              AND toUpper(coalesce(e.source_protocol, '')) = 'SNMP'
+              AND e.failure_family = 'SNMP_NO_RESPONSE'
+            WITH ci, count(e) AS open_no_response_events
+            RETURN count(ci) AS total_ci_with_snmp,
+                   sum(CASE WHEN open_no_response_events = 0 THEN 1 ELSE 0 END) AS functional_ci,
+                   sum(CASE WHEN open_no_response_events > 0 THEN 1 ELSE 0 END) AS failing_ci,
+                   sum(CASE WHEN open_no_response_events > 0 THEN 1 ELSE 0 END) AS no_response_ci,
+                   sum(open_no_response_events) AS no_response_event_count
+            """
+        )
+        snmp_coverage = _build_snmp_coverage_summary(snmp_result.single())
+
     rows: List[Dict[str, Any]] = []
     for row in groups.values():
         failure_starts = sorted(row["failure_starts"])
@@ -746,6 +804,7 @@ def get_availability_report(
         "generated_at": generated_at.isoformat(),
         "window_days": round(window_seconds / 86400, 4) if window_seconds else 0,
         "total_groups": len(rows),
+        "snmp_coverage": snmp_coverage,
         "rows": rows,
     }
 

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -171,6 +171,37 @@ class TestEventServiceSmoke:
         assert row["active_downtime_seconds"] == 3600
         assert row["availability_percentage"] == 70.0
 
+    def test_get_availability_report_includes_snmp_coverage_summary(
+        self, mock_neo4j_session
+    ):
+        get_availability_report = _load_event_service_module().get_availability_report
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response(
+            "return count(ci) as total_ci_with_snmp",
+            [
+                {
+                    "total_ci_with_snmp": 4,
+                    "functional_ci": 3,
+                    "failing_ci": 1,
+                    "no_response_ci": 1,
+                    "no_response_event_count": 2,
+                }
+            ],
+        )
+
+        report = get_availability_report(start=start, end=end, now=end)
+
+        assert report["snmp_coverage"] == {
+            "total_ci_with_snmp": 4,
+            "functional_ci": 3,
+            "failing_ci": 1,
+            "no_response_ci": 1,
+            "no_response_event_count": 2,
+            "functional_percentage": 75.0,
+            "failing_percentage": 25.0,
+        }
+
     def test_get_availability_report_includes_active_failure_starts_in_mtbf(
         self, mock_neo4j_session
     ):
@@ -354,6 +385,11 @@ class TestEventServiceSmoke:
             if "e.status IN ['OPEN', 'ACK']" in query["query"]
             and "NOT e.status IN ['OPEN', 'ACK']" not in query["query"]
         )["query"]
+        snmp_query = next(
+            query
+            for query in mock_neo4j_session.queries
+            if "total_ci_with_snmp" in query["query"]
+        )["query"]
 
         assert "e.event_type = 'AVAILABILITY'" in recovered_query
         assert "e.event_type = 'AVAILABILITY'" in active_query
@@ -361,6 +397,11 @@ class TestEventServiceSmoke:
         assert "e.availability_source IN ['PING', 'ICMP']" in active_query
         assert "toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'" in recovered_query
         assert "toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'" in active_query
+        assert "MATCH (ci:CI)-[:HAS_METRIC]->(m:MetricDef)" in snmp_query
+        assert "toUpper(coalesce(m.protocol, '')) = 'SNMP'" in snmp_query
+        assert "e.event_type = 'COLLECTION_FAILURE'" in snmp_query
+        assert "toUpper(coalesce(e.source_protocol, '')) = 'SNMP'" in snmp_query
+        assert "e.failure_family = 'SNMP_NO_RESPONSE'" in snmp_query
 
     def test_get_availability_report_excludes_non_availability_event_types(
         self, mock_neo4j_session

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -1237,6 +1237,15 @@ class TestEventsList:
             "generated_at": end.isoformat(),
             "window_days": 30,
             "total_groups": 1,
+            "snmp_coverage": {
+                "total_ci_with_snmp": 2,
+                "functional_ci": 1,
+                "failing_ci": 1,
+                "no_response_ci": 1,
+                "no_response_event_count": 3,
+                "functional_percentage": 50.0,
+                "failing_percentage": 50.0,
+            },
             "rows": [
                 {
                     "ci_id": "ci-001",
@@ -1279,6 +1288,7 @@ class TestEventsList:
         assert body["generated_at"] == payload["generated_at"]
         assert body["window_days"] == 30.0
         assert body["total_groups"] == 1
+        assert body["snmp_coverage"] == payload["snmp_coverage"]
         row = body["rows"][0]
         assert row["ci_id"] == "ci-001"
         assert row["ci_name"] == "Router-01"

--- a/frontend/components/AvailabilityDashboard.test.tsx
+++ b/frontend/components/AvailabilityDashboard.test.tsx
@@ -17,6 +17,15 @@ const report: AvailabilityReportResponse = {
 	generated_at: "2026-01-31T00:05:00Z",
 	window_days: 30,
 	total_groups: 2,
+	snmp_coverage: {
+		total_ci_with_snmp: 2,
+		functional_ci: 1,
+		failing_ci: 1,
+		no_response_ci: 1,
+		no_response_event_count: 2,
+		functional_percentage: 50,
+		failing_percentage: 50,
+	},
 	rows: [
 		{
 			ci_id: "ci-1",
@@ -82,7 +91,7 @@ describe("AvailabilityDashboard", () => {
 		URL.revokeObjectURL = vi.fn();
 	});
 
-	it("renders availability MTTR and MTBF rows from the report", () => {
+	it("renders availability MTTR, MTBF, and SNMP coverage from the report", () => {
 		render(<AvailabilityDashboard />);
 
 		expect(screen.getByText("Availability MTTR/MTBF")).toBeInTheDocument();
@@ -90,6 +99,24 @@ describe("AvailabilityDashboard", () => {
 		expect(screen.getByText("Billing Database")).toBeInTheDocument();
 		expect(screen.getByText("15m")).toBeInTheDocument();
 		expect(screen.getAllByText("2h").length).toBeGreaterThan(0);
+		expect(screen.getByText("SNMP functional")).toBeInTheDocument();
+		expect(screen.getByText("1/2 (50.00%)")).toBeInTheDocument();
+		expect(screen.getByText("SNMP no-response")).toBeInTheDocument();
+		expect(screen.getByText("1 CIs / 2 events")).toBeInTheDocument();
+	});
+
+	it("handles older availability responses without SNMP coverage", () => {
+		mockUseAvailabilityReportQuery.mockReturnValueOnce({
+			data: { ...report, snmp_coverage: undefined },
+			isLoading: false,
+			error: null,
+		});
+
+		render(<AvailabilityDashboard />);
+
+		expect(screen.getByText("SNMP functional")).toBeInTheDocument();
+		expect(screen.getByText("SNMP no-response")).toBeInTheDocument();
+		expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
 	});
 
 	it("filters by enriched CI metadata and keeps the search after expanding a row", () => {

--- a/frontend/components/AvailabilityDashboard.tsx
+++ b/frontend/components/AvailabilityDashboard.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { Fragment, useMemo, useState } from "react";
 import { useAvailabilityReportQuery } from "../hooks/queries/useAvailabilityReportQuery";
-import type { AvailabilityReportRow } from "../types";
+import type { AvailabilityReportRow, SnmpCoverageSummary } from "../types";
 import {
 	averageSeconds,
 	availabilityRowsToCsv,
@@ -12,6 +12,16 @@ import {
 
 const formatPercent = (value?: number | null) =>
 	value == null ? "—" : `${value.toFixed(2)}%`;
+
+const formatSnmpFunctional = (summary?: SnmpCoverageSummary | null) => {
+	if (!summary) return "—";
+	return `${summary.functional_ci}/${summary.total_ci_with_snmp} (${formatPercent(summary.functional_percentage)})`;
+};
+
+const formatSnmpNoResponse = (summary?: SnmpCoverageSummary | null) => {
+	if (!summary) return "—";
+	return `${summary.no_response_ci} CIs / ${summary.no_response_event_count} events`;
+};
 
 const metadataEntries = (row: AvailabilityReportRow) => {
 	const metadata = row.ci?.metadata ?? {};
@@ -53,6 +63,7 @@ const AvailabilityDashboard: React.FC = () => {
 	const averageMttr = averageSeconds(filteredRows.map((row) => row.mttr_seconds));
 	const averageMtbf = averageSeconds(filteredRows.map((row) => row.mtbf_seconds));
 	const activeEvents = filteredRows.reduce((sum, row) => sum + row.active_events, 0);
+	const snmpCoverage = data?.snmp_coverage;
 	const worstAvailability = filteredRows.reduce<number | null>((worst, row) => {
 		if (row.availability_percentage == null) return worst;
 		return worst == null ? row.availability_percentage : Math.min(worst, row.availability_percentage);
@@ -84,11 +95,13 @@ const AvailabilityDashboard: React.FC = () => {
 				</button>
 			</div>
 
-			<div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+			<div className="grid grid-cols-1 gap-4 md:grid-cols-3 xl:grid-cols-6">
 				<SummaryCard label="Average MTTR" value={formatDurationSeconds(averageMttr)} />
 				<SummaryCard label="Average MTBF" value={formatDurationSeconds(averageMtbf)} />
 				<SummaryCard label="Active events" value={String(activeEvents)} />
 				<SummaryCard label="Worst availability" value={formatPercent(worstAvailability)} />
+				<SummaryCard label="SNMP functional" value={formatSnmpFunctional(snmpCoverage)} />
+				<SummaryCard label="SNMP no-response" value={formatSnmpNoResponse(snmpCoverage)} />
 			</div>
 
 			<div className="rounded-2xl border border-white/5 bg-surface-900 p-5">

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -106,12 +106,23 @@ export interface AvailabilityReportRow {
 	ci?: AvailabilityReportCI | null;
 }
 
+export interface SnmpCoverageSummary {
+	total_ci_with_snmp: number;
+	functional_ci: number;
+	failing_ci: number;
+	no_response_ci: number;
+	no_response_event_count: number;
+	functional_percentage?: number | null;
+	failing_percentage?: number | null;
+}
+
 export interface AvailabilityReportResponse {
 	window_start: string;
 	window_end: string;
 	generated_at: string;
 	window_days: number;
 	total_groups: number;
+	snmp_coverage?: SnmpCoverageSummary | null;
 	rows: AvailabilityReportRow[];
 }
 


### PR DESCRIPTION
Closes #226

## Descripción del Cambio
Agrega el primer slice chico de KPIs de desempeño/fallas/disponibilidad: cobertura SNMP funcional vs no-response dentro del reporte existente de Availability.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Agrega `snmp_coverage` al endpoint `GET /api/events/availability-report` sin cambiar la semántica actual de MTTR/MTBF basada en disponibilidad ICMP/PING.
- Calcula CIs con SNMP explícito, CIs funcionales y CIs con fallas activas `SNMP_NO_RESPONSE`.
- Muestra tarjetas compactas de `SNMP functional` y `SNMP no-response` en el dashboard de Availability.

## Cambios
| File | Change |
|------|--------|
| `backend/services/event_service.py` | Agrega query y summary builder para cobertura SNMP actual. |
| `backend/models/core.py` | Agrega `SnmpCoverageSummary` y campo opcional en `AvailabilityReportResponse`. |
| `frontend/components/AvailabilityDashboard.tsx` | Renderiza tarjetas KPI de cobertura SNMP. |
| `frontend/types.ts` | Agrega tipos frontend para `snmp_coverage`. |
| `backend/tests/test_event_service_smoke.py` | Cubre summary SNMP y filtros de query. |
| `backend/tests/test_routers_metrics_events.py` | Cubre contrato aditivo del endpoint. |
| `frontend/components/AvailabilityDashboard.test.tsx` | Cubre render SNMP y compatibilidad sin `snmp_coverage`. |

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_event_service_smoke.py backend/tests/test_routers_metrics_events.py`
- [x] `corepack pnpm --dir frontend exec vitest run components/AvailabilityDashboard.test.tsx utils/availabilityReport.test.ts`
- [x] `corepack pnpm --dir frontend run build`
- [x] `git diff --check`
- [x] Shellcheck no aplica: no se modificaron scripts shell.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notas de alcance
- Este PR mantiene el alcance chico para la cadena de #226.
- La cobertura SNMP es de estado actual, no histórica/windowed.
- Follow-up recomendado: drilldown de CIs afectados y luego KPIs CPU/RAM/disco/I/O.

---
*Generado por Alex*
