### PR TITLE
fix(auth): harden frontend session event handling

### DIFF
--- a/frontend/services/api.test.ts
+++ b/frontend/services/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { api, ApiError } from './api';
+import { subscribeAuthSessionEvents } from './sessionBus';
 
 describe('api client', () => {
   beforeEach(() => {
@@ -12,6 +13,7 @@ describe('api client', () => {
         hash: '',
         href: '',
       } as any;
+      document.cookie = 'access_token=; Max-Age=0; path=/';
     }
   });
 
@@ -355,6 +357,50 @@ describe('api client', () => {
       await expect(api.get('/nodes')).rejects.toThrow('Session expired');
       expect(window.location.href).toBe('/login');
       window.location = originalLocation;
+    });
+
+    it('includes the current access-token session id on terminal refresh-failure events', async () => {
+      const payload = btoa(JSON.stringify({ sid: 'session-from-token' }))
+        .replace(/=/g, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+      document.cookie = `access_token=header.${payload}.signature; path=/`;
+      const events: any[] = [];
+      const unsubscribe = subscribeAuthSessionEvents(event => events.push(event));
+      global.fetch = vi.fn(async (url: string) => (
+        url === '/api/auth/refresh'
+          ? jsonResponse(401, { detail: 'idle_timeout' })
+          : jsonResponse(401, { detail: 'Unauthorized' })
+      ));
+
+      await expect(api.get('/nodes')).rejects.toThrow('idle_timeout');
+
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'session-expired',
+        reason: 'idle_timeout',
+        sessionId: 'session-from-token',
+      }));
+      unsubscribe();
+    });
+
+    it('omits session id on terminal refresh-failure events when the access token is unavailable or invalid', async () => {
+      document.cookie = 'access_token=not-a-jwt; path=/';
+      const events: any[] = [];
+      const unsubscribe = subscribeAuthSessionEvents(event => events.push(event));
+      global.fetch = vi.fn(async (url: string) => (
+        url === '/api/auth/refresh'
+          ? jsonResponse(401, { detail: 'session_expired' })
+          : jsonResponse(401, { detail: 'Unauthorized' })
+      ));
+
+      await expect(api.get('/nodes')).rejects.toThrow('session_expired');
+
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'session-expired',
+        reason: 'session_expired',
+      }));
+      expect(events.some(event => event.sessionId)).toBe(false);
+      unsubscribe();
     });
   });
 

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -53,6 +53,42 @@ function redirectToLoginOnce() {
     }
 }
 
+function base64UrlDecode(value: string): string {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(normalized.length + ((4 - normalized.length % 4) % 4), '=');
+    return atob(padded);
+}
+
+function readCookie(name: string): string | undefined {
+    if (typeof document === 'undefined') return undefined;
+    const prefix = `${name}=`;
+    return document.cookie
+        .split(';')
+        .map(cookie => cookie.trim())
+        .find(cookie => cookie.startsWith(prefix))
+        ?.slice(prefix.length);
+}
+
+function getCurrentSessionIdFromAccessToken(): string | undefined {
+    try {
+        const token = readCookie('access_token');
+        const payload = token?.split('.')[1];
+        if (!payload) return undefined;
+        const decoded = JSON.parse(base64UrlDecode(payload));
+        return typeof decoded.sid === 'string' ? decoded.sid : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+function publishSessionExpired(reason: string) {
+    publishAuthSessionEvent({
+        type: 'session-expired',
+        reason,
+        sessionId: getCurrentSessionIdFromAccessToken(),
+    });
+}
+
 async function getErrorMessage(response: Response, fallback: string): Promise<string> {
     const errorData = await response.json().catch(() => ({}));
     const detail = errorData.detail;
@@ -77,7 +113,7 @@ async function refreshSession(): Promise<void> {
 
         if (!refreshResponse.ok) {
             const message = await getErrorMessage(refreshResponse, 'Session expired');
-            publishAuthSessionEvent({ type: 'session-expired', reason: message });
+            publishSessionExpired(message);
             throw new ApiError(message, refreshResponse.status);
         }
     })().finally(() => {
@@ -147,7 +183,7 @@ async function request<T>(endpoint: string, config: ApiRequestConfig = {}): Prom
         if (skipAuthRefresh || authRetryCount >= MAX_AUTH_RETRY_COUNT) {
             const message = await getErrorMessage(response, 'Unauthorized');
             if (!isSSE && !skipAuthRefresh) {
-                publishAuthSessionEvent({ type: 'session-expired', reason: message });
+                publishSessionExpired(message);
                 redirectToLoginOnce();
             }
             throw new ApiError(message, response.status);

--- a/frontend/services/sessionBus.test.ts
+++ b/frontend/services/sessionBus.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { AUTH_SESSION_CHANNEL, AUTH_SESSION_STORAGE_KEY, publishAuthSessionEvent, subscribeAuthSessionEvents } from './sessionBus';
+import {
+  AUTH_SESSION_CHANNEL,
+  AUTH_SESSION_DEDUPE_MAX_KEYS,
+  AUTH_SESSION_DEDUPE_TTL_MS,
+  AUTH_SESSION_STORAGE_KEY,
+  publishAuthSessionEvent,
+  subscribeAuthSessionEvents,
+} from './sessionBus';
 
 describe('sessionBus', () => {
   beforeEach(() => {
@@ -73,6 +80,71 @@ describe('sessionBus', () => {
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(message);
+    unsubscribe();
+  });
+
+  it('expires remote-event dedupe keys after the TTL', () => {
+    vi.useFakeTimers();
+    const handler = vi.fn();
+    const unsubscribe = subscribeAuthSessionEvents(handler);
+
+    try {
+      const message = {
+        type: 'session-expired' as const,
+        eventId: 'remote-event-ttl',
+        reason: 'idle_timeout',
+        senderId: 'other-tab',
+        timestamp: Date.now(),
+      };
+
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: AUTH_SESSION_STORAGE_KEY,
+        newValue: JSON.stringify(message),
+      }));
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: AUTH_SESSION_STORAGE_KEY,
+        newValue: JSON.stringify(message),
+      }));
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(AUTH_SESSION_DEDUPE_TTL_MS + 1);
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: AUTH_SESSION_STORAGE_KEY,
+        newValue: JSON.stringify(message),
+      }));
+
+      expect(handler).toHaveBeenCalledTimes(2);
+    } finally {
+      unsubscribe();
+      vi.useRealTimers();
+    }
+  });
+
+  it('caps remote-event dedupe keys to prevent unbounded growth', () => {
+    const handler = vi.fn();
+    const unsubscribe = subscribeAuthSessionEvents(handler);
+    const firstMessage = {
+      type: 'logout' as const,
+      eventId: 'remote-event-0',
+      reason: 'manual',
+      senderId: 'other-tab',
+      timestamp: Date.now(),
+    };
+
+    for (let index = 0; index <= AUTH_SESSION_DEDUPE_MAX_KEYS; index += 1) {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: AUTH_SESSION_STORAGE_KEY,
+        newValue: JSON.stringify({ ...firstMessage, eventId: `remote-event-${index}` }),
+      }));
+    }
+    expect(handler).toHaveBeenCalledTimes(AUTH_SESSION_DEDUPE_MAX_KEYS + 1);
+
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: AUTH_SESSION_STORAGE_KEY,
+      newValue: JSON.stringify(firstMessage),
+    }));
+
+    expect(handler).toHaveBeenCalledTimes(AUTH_SESSION_DEDUPE_MAX_KEYS + 2);
     unsubscribe();
   });
 });

--- a/frontend/services/sessionBus.ts
+++ b/frontend/services/sessionBus.ts
@@ -1,5 +1,7 @@
 export const AUTH_SESSION_CHANNEL = 'next-gen-auth-session';
 export const AUTH_SESSION_STORAGE_KEY = 'next-gen-auth-session-event';
+export const AUTH_SESSION_DEDUPE_MAX_KEYS = 256;
+export const AUTH_SESSION_DEDUPE_TTL_MS = 10 * 60 * 1000;
 
 export type AuthSessionEventType = 'logout' | 'session-expired';
 export interface AuthSessionEvent {
@@ -14,7 +16,7 @@ export interface AuthSessionEvent {
 type Handler = (event: AuthSessionEvent) => void;
 
 const listeners = new Set<Handler>();
-const deliveredEventKeys = new Set<string>();
+const deliveredEventKeys = new Map<string, number>();
 const tabId = `tab-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 let eventSequence = 0;
 let channel: BroadcastChannel | null = null;
@@ -32,10 +34,27 @@ const eventKey = (event: AuthSessionEvent) => event.eventId ?? [
   event.sessionId ?? '',
 ].join('|');
 const notify = (event: AuthSessionEvent) => listeners.forEach(listener => listener(event));
+
+function pruneDeliveredEventKeys(now = Date.now()) {
+  for (const [key, deliveredAt] of deliveredEventKeys) {
+    if (now - deliveredAt > AUTH_SESSION_DEDUPE_TTL_MS) {
+      deliveredEventKeys.delete(key);
+    }
+  }
+
+  while (deliveredEventKeys.size >= AUTH_SESSION_DEDUPE_MAX_KEYS) {
+    const oldestKey = deliveredEventKeys.keys().next().value;
+    if (!oldestKey) break;
+    deliveredEventKeys.delete(oldestKey);
+  }
+}
+
 const notifyRemoteOnce = (event: AuthSessionEvent) => {
+  const now = Date.now();
+  pruneDeliveredEventKeys(now);
   const key = eventKey(event);
   if (deliveredEventKeys.has(key)) return;
-  deliveredEventKeys.add(key);
+  deliveredEventKeys.set(key, now);
   notify(event);
 };
 

--- a/openspec/changes/fix-multi-window-session-timeout/apply-progress.md
+++ b/openspec/changes/fix-multi-window-session-timeout/apply-progress.md
@@ -7,7 +7,8 @@ Scope: `fix-multi-window-session-timeout` (Issue #188).
 - PR1: `fix/session-policy-foundation` -> `main`, opened as PR #245, accepted for review.
 - PR2: `fix/session-refresh-stale-recovery` -> `fix/session-policy-foundation`, backend-only stale refresh/rate-limit slice in progress.
 - PR3: `fix/session-policy-contract` -> `fix/session-refresh-stale-recovery`, backend/frontend contract bridge for session policy visibility in progress.
-- PR4: `fix/session-policy-contract` frontend slice implemented locally; verify report created at `verify-report-pr4.md`.
+- PR4: `fix/session-inactivity-frontend` -> `fix/session-policy-contract`, opened as PR #253 for frontend session/inactivity UX.
+- PR5: `fix/session-stack-hardening` -> `fix/session-inactivity-frontend`, local hardening slice in progress; verify report created at `verify-report-pr5.md`.
 
 ## PR1 summary
 
@@ -58,6 +59,15 @@ PR4 adds frontend session coordination and inactivity UX:
 - `sessionBus` BroadcastChannel/localStorage fallback for logout and session-expired convergence
 - AuthContext consumes `session_id`/`session_policy`, clears cross-tab session events, and arms inactivity logout only for non-persistent policies
 
+## PR5 summary
+
+PR5 hardens the PR4 frontend session-event layer without backend semantics changes:
+
+- bounds `sessionBus` remote-event dedupe with a 10-minute TTL and 256-key cap
+- preserves duplicate suppression when BroadcastChannel and localStorage both deliver the same remote event
+- best-effort enriches terminal frontend `session-expired` events with the readable access-token `sid` when available
+- documents remaining manual two-tab and PostgreSQL validation plans in `verify-report-pr5.md`
+
 ## PR2 incident note
 
 Initial PR2 `sdd-apply` failed due an ambiguous edit in `backend/tests/test_auth_router_refresh.py`, leaving a partial but coherent backend diff. A fresh incident audit found no conflict markers or syntax failures and recommended continuing manually. The only blocker was a test patch returning a non-JWT `access_token` while decoding it. That test was corrected by letting the real `create_access_token` run.
@@ -100,6 +110,15 @@ Initial PR2 `sdd-apply` failed due an ambiguous edit in `backend/tests/test_auth
 | TRIANGULATE | Ran `corepack pnpm --dir frontend run test:run` and got **43 passed / 401 tests passed**. |
 | REFACTOR | Trimmed PR4 diff to stay within the 700-line review budget while preserving focused frontend scope. |
 
+### PR5
+
+| Phase | Evidence |
+| --- | --- |
+| RED | Added tests for sessionBus TTL/cap dedupe and API terminal auth-failure session-id enrichment before implementation. Initial focused run failed on missing hardening behavior; a temporary test syntax typo was corrected before GREEN. |
+| GREEN | Implemented bounded/TTL remote-event dedupe and safe best-effort JWT `sid` extraction for terminal `session-expired` events. |
+| TRIANGULATE | Focused and full frontend tests passed: `corepack pnpm --dir frontend run test:run -- sessionBus.test.ts api.test.ts AuthContext.test.tsx` and `corepack pnpm --dir frontend run test:run` — **43 files passed / 407 tests passed**. |
+| REFACTOR | Kept PR5 to frontend hardening and OpenSpec verification; no backend refresh/token/rate-limit changes. |
+
 ## Verification commands
 
 ### PR1 accepted evidence
@@ -125,7 +144,8 @@ Initial PR2 `sdd-apply` failed due an ambiguous edit in `backend/tests/test_auth
 
 ## Remaining work
 
-- Run fresh PR4 review before opening/updating the stacked PR.
+- Run final full frontend validation and fresh review for PR5 before opening the stacked PR.
+- Complete manual two-tab browser smoke and PostgreSQL schema validation before merging/deploying the full issue #188 stack.
 
 ## Known risks
 

--- a/openspec/changes/fix-multi-window-session-timeout/verify-report-pr5.md
+++ b/openspec/changes/fix-multi-window-session-timeout/verify-report-pr5.md
@@ -1,0 +1,91 @@
+# Verify Report PR5 — fix-multi-window-session-timeout
+
+## Status
+
+PASS for PR5 local hardening scope.
+
+## Scope
+
+Stack continuation after PR4 (#253): `fix/session-stack-hardening` targets `fix/session-inactivity-frontend`.
+
+PR5 is intentionally small and non-backend:
+
+- Bound `sessionBus` remote-event dedupe memory by TTL and max key count.
+- Preserve duplicate suppression when both `BroadcastChannel` and `localStorage` deliver the same event.
+- Add best-effort frontend session-id enrichment for terminal auth-failure `session-expired` events when a readable `access_token` JWT payload includes `sid`.
+- Do not change backend refresh/token/rate-limit semantics.
+
+## Strict TDD Evidence
+
+| Phase | Evidence |
+| --- | --- |
+| RED | Added tests for sessionBus TTL/cap dedupe and API terminal auth-failure session-id enrichment before implementation. Initial focused run failed as expected for missing hardening behavior; the run also exposed a temporary test syntax typo that was corrected before GREEN. Targeted failures included TTL duplicate still suppressed after expiry and cap constants/behavior unavailable. |
+| GREEN | Implemented `Map<string, number>`-based dedupe with 10-minute TTL and 256-key cap in `frontend/services/sessionBus.ts`; added safe JWT payload parsing in `frontend/services/api.ts` and included `sessionId` in terminal `session-expired` events when derivable. |
+| TRIANGULATE | Focused frontend command passed: `corepack pnpm --dir frontend run test:run -- sessionBus.test.ts api.test.ts AuthContext.test.tsx` → **43 files passed / 407 tests passed**. |
+| REFACTOR | Kept PR5 to frontend hardening + verification docs only; no backend/API contract change and no broad bus redesign. |
+
+## Commands Run
+
+### RED
+
+```bash
+cd /c/Users/polop/OneDrive/PROGRAMMING/next-gen-issues && corepack pnpm --dir frontend run test:run -- sessionBus.test.ts api.test.ts AuthContext.test.tsx
+```
+
+Observed failures before implementation included:
+
+- `services/sessionBus.test.ts > expires remote-event dedupe keys after the TTL`
+  - expected duplicate remote event to deliver again after TTL, but it remained suppressed.
+- `services/sessionBus.test.ts > caps remote-event dedupe keys to prevent unbounded growth`
+  - cap behavior/constants were not implemented.
+
+### GREEN / Focused
+
+```bash
+cd /c/Users/polop/OneDrive/PROGRAMMING/next-gen-issues && corepack pnpm --dir frontend run test:run -- sessionBus.test.ts api.test.ts AuthContext.test.tsx
+```
+
+Result: **PASS — 43 files passed / 407 tests passed**.
+
+### Final
+
+```bash
+cd /c/Users/polop/OneDrive/PROGRAMMING/next-gen-issues && corepack pnpm --dir frontend run test:run
+```
+
+Result: **PASS — 43 files passed / 407 tests passed**.
+
+```bash
+cd /c/Users/polop/OneDrive/PROGRAMMING/next-gen-issues && git diff --check
+```
+
+Result: **PASS**. Git reported only existing CRLF normalization warnings for edited frontend files.
+
+## Manual Smoke Plan
+
+Not run in this PR5 implementation pass. Recommended before merging the full stack:
+
+1. Start or reuse the compose stack.
+2. Open two browser tabs on the same frontend origin.
+3. Login as the same non-persistent user/session.
+4. Trigger idle timeout or revoke/expire the refresh session.
+5. Verify both tabs converge to logged-out/login state without repeated redirects or refresh thrash.
+6. Verify repeated cross-tab `session-expired`/`logout` events do not cause duplicate user-visible effects.
+
+## PostgreSQL Validation Plan
+
+Not run in this PR5 implementation pass. Recommended non-destructive validation before merging/deploying the full backend stack:
+
+```bash
+docker compose -f docker-compose.yml exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "\d refresh_tokens"
+docker compose -f docker-compose.yml exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT column_name FROM information_schema.columns WHERE table_name='refresh_tokens' ORDER BY column_name;"
+docker compose -f docker-compose.yml logs --tail=200 backend
+```
+
+Expected schema fields from PR1/PR2 include `session_id`, `policy_profile`, `last_activity_at`, `rotated_at`, `replaced_by_token_id`, `revoked_reason`, and `stale_recovery_count`.
+
+## Risks / Remaining Issues
+
+- Session-id enrichment is best-effort only: production HttpOnly cookies are intentionally not readable by JavaScript, so many real terminal events may still omit `sessionId` and fall back to broad session-expired handling.
+- Dedupe TTL/cap values are conservative (`10m`, `256` keys). If auth-event volume grows significantly, tune with production telemetry.
+- Manual two-tab and PostgreSQL checks remain planned, not completed, unless this report is updated with actual command/browser evidence.


### PR DESCRIPTION
## Descripción del Cambio
Closes #188

PR5 de hardening sobre la cadena `fix-multi-window-session-timeout`: refuerza el bus frontend de sesión y documenta la verificación final pendiente sin cambiar la semántica backend.

### Chain Context

```text
#245 fix/session-policy-foundation
  -> #247 fix/session-refresh-status
    -> #248 fix/session-refresh-stale-recovery
      -> #252 fix/session-policy-contract
        -> #253 fix/session-inactivity-frontend
          -> 📍 this PR: fix/session-stack-hardening
```

Base de este PR: `fix/session-inactivity-frontend`.

### Summary
- Acota la deduplicación de eventos cross-tab por TTL y límite de claves para evitar crecimiento indefinido.
- Enriquece eventos terminales `session-expired` con `sessionId` best-effort cuando puede derivarse del access token legible.
- Agrega tests de TTL/cap, dedupe, parseo seguro de session id y fallback sin token válido.
- Agrega reporte OpenSpec PR5 con evidencia de tests y checklist de smoke/PostgreSQL pendiente.

### Cambios

| File | Change |
|------|--------|
| `frontend/services/sessionBus.ts` | TTL + cap para dedupe de eventos remotos |
| `frontend/services/sessionBus.test.ts` | Cobertura de TTL/cap/dedupe y limpieza robusta de timers |
| `frontend/services/api.ts` | Session-id best-effort en eventos terminales de auth failure |
| `frontend/services/api.test.ts` | Cobertura de enriquecimiento/fallback de `sessionId` |
| `openspec/changes/fix-multi-window-session-timeout/apply-progress.md` | Resumen PR5 |
| `openspec/changes/fix-multi-window-session-timeout/verify-report-pr5.md` | Evidencia PR5 y planes de smoke/DB no ejecutados |

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `corepack pnpm --dir frontend run test:run -- sessionBus.test.ts api.test.ts AuthContext.test.tsx` → PASS, 43 files / 407 tests.
- [x] `corepack pnpm --dir frontend run test:run` → PASS, 43 files / 407 tests.
- [x] `git diff --check` → PASS, only CRLF normalization warnings.
- [x] Fresh reviewer pass → PASS / no blockers.

Pendiente/documentado, no ejecutado en este PR:
- [ ] Smoke manual dos tabs para expiración/logout.
- [ ] Validación PostgreSQL de columnas/backfill `refresh_tokens` en entorno Docker/real.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
