### PR TITLE
feat(analytics): add SNMP no-response drilldown

### DIFF
--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -237,6 +237,41 @@ class AvailabilityReportResponse(BaseModel):
     rows: List[AvailabilityReportRow]
 
 
+class AvailabilitySnmpNoResponseSummary(BaseModel):
+    total_ci_with_no_response: int = 0
+    total_events_with_no_response: int = 0
+
+
+class AvailabilitySnmpNoResponseEvent(BaseModel):
+    id: Optional[str] = None
+    message: Optional[str] = None
+    status: Optional[str] = None
+    created_at: Optional[str] = None
+    last_seen: Optional[str] = None
+
+
+class AvailabilitySnmpNoResponseCI(BaseModel):
+    ci_id: str
+    ci_name: Optional[str] = None
+    category: Optional[str] = None
+    status: Optional[str] = None
+    ip: Optional[str] = None
+    owner: Optional[str] = None
+    brand: Optional[str] = None
+    model: Optional[str] = None
+    event_count: int
+    latest_event_at: Optional[str] = None
+    events: List[AvailabilitySnmpNoResponseEvent] = []
+
+
+class AvailabilitySnmpNoResponseResponse(BaseModel):
+    generated_at: str
+    limit: int
+    offset: int
+    summary: AvailabilitySnmpNoResponseSummary
+    rows: List[AvailabilitySnmpNoResponseCI]
+
+
 class MetricDictionary(BaseModel):
     """A reusable OID bundle for a specific brand+model combination."""
     id: str

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -8,7 +8,12 @@ import services.event_service as event_service
 from services.auth_service import get_current_active_user, check_permission, get_current_ai_agent, AIAgentInfo
 from services.ai_guard_service import check_all_guards, record_operation
 from services.escalation_notifier import notify_critical_event_escalation
-from models.core import AvailabilityReportResponse, EventDetailResponse, EventFeedSummary
+from models.core import (
+    AvailabilityReportResponse,
+    AvailabilitySnmpNoResponseResponse,
+    EventDetailResponse,
+    EventFeedSummary,
+)
 from models.user import User, UserPermission
 
 router = APIRouter(
@@ -48,6 +53,24 @@ async def get_availability_report(
 ):
     """Fetch additive availability MTTR/MTBF metrics for the event dashboard."""
     return event_service.get_availability_report(start=start, end=end)
+
+
+@router.get(
+    "/availability-report/snmp-no-response",
+    response_model=AvailabilitySnmpNoResponseResponse,
+)
+async def get_availability_snmp_no_response(
+    limit: int = Query(25, ge=1, le=100, description="Maximum affected CIs to return"),
+    offset: int = Query(0, ge=0, description="Affected CI pagination offset"),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Fetch affected CIs with active SNMP no-response collection failures."""
+    if not check_permission(UserPermission.EVENT_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view events")
+    return event_service.get_availability_snmp_no_response_drilldown(
+        limit=limit,
+        offset=offset,
+    )
 
 
 @router.get("/{event_id}", response_model=EventDetailResponse)

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -515,6 +515,28 @@ def _build_snmp_coverage_summary(record: Any) -> Dict[str, Any]:
     return summary
 
 
+def _isoformat_or_none(value: Any) -> Optional[str]:
+    parsed = _parse_datetime(value)
+    if parsed is not None:
+        return parsed.isoformat()
+    if value is None:
+        return None
+    return str(value)
+
+
+def _snmp_no_response_event_summary(event_data: Dict[str, Any]) -> Dict[str, Any]:
+    return _clean_dict(
+        {
+            "id": event_data.get("id"),
+            "message": event_data.get("message"),
+            "status": event_data.get("status"),
+            "created_at": _isoformat_or_none(event_data.get("created_at")),
+            "last_seen": _isoformat_or_none(event_data.get("last_seen")),
+        }
+    )
+
+
+
 def _is_sensitive_ci_key(key: str) -> bool:
     normalized = key.lower()
     return any(part in normalized for part in _SENSITIVE_CI_KEY_PARTS)
@@ -805,6 +827,122 @@ def get_availability_report(
         "window_days": round(window_seconds / 86400, 4) if window_seconds else 0,
         "total_groups": len(rows),
         "snmp_coverage": snmp_coverage,
+        "rows": rows,
+    }
+
+
+def get_availability_snmp_no_response_drilldown(
+    limit: int = 25,
+    offset: int = 0,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Return affected CIs with active SNMP no-response collection failures."""
+    safe_limit = max(1, min(int(limit or 25), 100))
+    safe_offset = max(0, int(offset or 0))
+    generated_at = now or datetime.now(timezone.utc)
+    summary = {
+        "total_ci_with_no_response": 0,
+        "total_events_with_no_response": 0,
+    }
+    rows: List[Dict[str, Any]] = []
+
+    driver = get_db()
+    with driver.session() as session:
+        summary_record = session.run(
+            """
+            MATCH (ci:CI)-[:HAS_METRIC]->(m:MetricDef)
+            WHERE toUpper(coalesce(m.protocol, '')) = 'SNMP'
+            WITH DISTINCT ci
+            MATCH (ci)-[:HAS_EVENT]->(e:Event)
+            WHERE e.status IN ['OPEN', 'ACK']
+              AND e.event_type = 'COLLECTION_FAILURE'
+              AND toUpper(coalesce(e.source_protocol, '')) = 'SNMP'
+              AND e.failure_family = 'SNMP_NO_RESPONSE'
+            RETURN count(DISTINCT ci) AS total_ci_with_no_response,
+                   count(e) AS total_events_with_no_response
+            """
+        ).single()
+        if summary_record is not None:
+            summary = {
+                "total_ci_with_no_response": int(
+                    summary_record.get("total_ci_with_no_response") or 0
+                ),
+                "total_events_with_no_response": int(
+                    summary_record.get("total_events_with_no_response") or 0
+                ),
+            }
+
+        result = session.run(
+            """
+            MATCH (ci:CI)-[:HAS_METRIC]->(m:MetricDef)
+            WHERE toUpper(coalesce(m.protocol, '')) = 'SNMP'
+            WITH DISTINCT ci
+            MATCH (ci)-[:HAS_EVENT]->(e:Event)
+            WHERE e.status IN ['OPEN', 'ACK']
+              AND e.event_type = 'COLLECTION_FAILURE'
+              AND toUpper(coalesce(e.source_protocol, '')) = 'SNMP'
+              AND e.failure_family = 'SNMP_NO_RESPONSE'
+            OPTIONAL MATCH (ci)-[:CATEGORIZED_AS]->(cat:Category)
+            WITH ci, e, head(collect(DISTINCT cat.name)) AS category
+            ORDER BY e.created_at DESC
+            WITH ci,
+                 category,
+                 count(e) AS event_count,
+                 max(e.created_at) AS latest_event_at,
+                 collect(e) AS events
+            ORDER BY event_count DESC,
+                     latest_event_at DESC,
+                     coalesce(ci.name, ci.label, ci.id) ASC
+            SKIP $offset
+            LIMIT $limit
+            RETURN ci,
+                   category,
+                   event_count,
+                   latest_event_at,
+                   [event IN events[..5] | {
+                       id: event.id,
+                       message: event.message,
+                       status: event.status,
+                       created_at: event.created_at,
+                       last_seen: event.last_seen
+                   }] AS events
+            """,
+            limit=safe_limit,
+            offset=safe_offset,
+        )
+
+        for record in result:
+            ci_data = _node_to_dict(_record_value(record, "ci"))
+            event_items = _record_value(record, "events") or []
+            events = [
+                _snmp_no_response_event_summary(_node_to_dict(event))
+                for event in event_items
+            ]
+            rows.append(
+                _clean_dict(
+                    {
+                        "ci_id": ci_data.get("id"),
+                        "ci_name": ci_data.get("name") or ci_data.get("label"),
+                        "category": _record_value(record, "category"),
+                        "status": ci_data.get("status"),
+                        "ip": ci_data.get("ip"),
+                        "owner": ci_data.get("owner"),
+                        "brand": ci_data.get("brand"),
+                        "model": ci_data.get("model"),
+                        "event_count": int(_record_value(record, "event_count") or 0),
+                        "latest_event_at": _isoformat_or_none(
+                            _record_value(record, "latest_event_at")
+                        ),
+                        "events": events,
+                    }
+                )
+            )
+
+    return {
+        "generated_at": generated_at.isoformat(),
+        "limit": safe_limit,
+        "offset": safe_offset,
+        "summary": summary,
         "rows": rows,
     }
 

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -35,6 +35,7 @@ class TestEventServiceImports:
         assert hasattr(event_service, "prune_recovered_events")
         assert hasattr(event_service, "run_event_diagnostic")
         assert hasattr(event_service, "get_availability_report")
+        assert hasattr(event_service, "get_availability_snmp_no_response_drilldown")
 
 
 class TestEventServiceSmoke:
@@ -201,6 +202,106 @@ class TestEventServiceSmoke:
             "functional_percentage": 75.0,
             "failing_percentage": 25.0,
         }
+
+    def test_get_availability_snmp_no_response_drilldown_returns_affected_cis(
+        self, mock_neo4j_session
+    ):
+        get_drilldown = (
+            _load_event_service_module().get_availability_snmp_no_response_drilldown
+        )
+        now = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+        mock_neo4j_session.set_response(
+            "return count(distinct ci) as total_ci_with_no_response",
+            [
+                {
+                    "total_ci_with_no_response": 2,
+                    "total_events_with_no_response": 3,
+                }
+            ],
+        )
+        mock_neo4j_session.set_response(
+            "return ci,",
+            [
+                {
+                    "ci": {
+                        "id": "ci-1",
+                        "name": "Core Router",
+                        "status": "DEGRADED",
+                        "ip": "10.0.0.1",
+                        "owner": "NOC",
+                        "brand": "Cisco",
+                        "model": "ISR4331",
+                    },
+                    "category": "Routers",
+                    "event_count": 2,
+                    "latest_event_at": now,
+                    "events": [
+                        {
+                            "id": "evt-1",
+                            "message": "SNMP no response",
+                            "status": "OPEN",
+                            "created_at": now,
+                            "last_seen": now,
+                        }
+                    ],
+                }
+            ],
+        )
+
+        report = get_drilldown(limit=10, offset=5, now=now)
+
+        assert report["generated_at"] == now.isoformat()
+        assert report["limit"] == 10
+        assert report["offset"] == 5
+        assert report["summary"] == {
+            "total_ci_with_no_response": 2,
+            "total_events_with_no_response": 3,
+        }
+        assert report["rows"] == [
+            {
+                "ci_id": "ci-1",
+                "ci_name": "Core Router",
+                "category": "Routers",
+                "status": "DEGRADED",
+                "ip": "10.0.0.1",
+                "owner": "NOC",
+                "brand": "Cisco",
+                "model": "ISR4331",
+                "event_count": 2,
+                "latest_event_at": now.isoformat(),
+                "events": [
+                    {
+                        "id": "evt-1",
+                        "message": "SNMP no response",
+                        "status": "OPEN",
+                        "created_at": now.isoformat(),
+                        "last_seen": now.isoformat(),
+                    }
+                ],
+            }
+        ]
+        assert mock_neo4j_session.queries[1]["params"] == {"limit": 10, "offset": 5}
+        query = mock_neo4j_session.queries[1]["query"]
+        assert "toUpper(coalesce(m.protocol, '')) = 'SNMP'" in query
+        assert "e.status IN ['OPEN', 'ACK']" in query
+        assert "e.event_type = 'COLLECTION_FAILURE'" in query
+        assert "toUpper(coalesce(e.source_protocol, '')) = 'SNMP'" in query
+        assert "e.failure_family = 'SNMP_NO_RESPONSE'" in query
+        assert "SKIP $offset" in query
+        assert "LIMIT $limit" in query
+
+    def test_get_availability_snmp_no_response_drilldown_bounds_pagination(
+        self, mock_neo4j_session
+    ):
+        get_drilldown = (
+            _load_event_service_module().get_availability_snmp_no_response_drilldown
+        )
+
+        report = get_drilldown(limit=500, offset=-4)
+
+        assert report["limit"] == 100
+        assert report["offset"] == 0
+        assert mock_neo4j_session.queries[1]["params"] == {"limit": 100, "offset": 0}
 
     def test_get_availability_report_includes_active_failure_starts_in_mtbf(
         self, mock_neo4j_session

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -1305,6 +1305,113 @@ class TestEventsList:
         assert get_report.call_args.kwargs["start"] == start
         assert get_report.call_args.kwargs["end"] == end
 
+    def test_availability_snmp_no_response_endpoint_returns_drilldown(self):
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        generated_at = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        payload = {
+            "generated_at": generated_at.isoformat(),
+            "limit": 25,
+            "offset": 0,
+            "summary": {
+                "total_ci_with_no_response": 1,
+                "total_events_with_no_response": 2,
+            },
+            "rows": [
+                {
+                    "ci_id": "ci-001",
+                    "ci_name": "Router-01",
+                    "category": "Routers",
+                    "status": "DEGRADED",
+                    "ip": "10.0.0.1",
+                    "owner": "NOC",
+                    "brand": "Cisco",
+                    "model": "ISR4331",
+                    "event_count": 2,
+                    "latest_event_at": generated_at.isoformat(),
+                    "events": [
+                        {
+                            "id": "evt-001",
+                            "message": "SNMP no response",
+                            "status": "OPEN",
+                            "created_at": generated_at.isoformat(),
+                            "last_seen": generated_at.isoformat(),
+                        }
+                    ],
+                }
+            ],
+        }
+
+        with patch(
+            "routers.events.event_service.get_availability_snmp_no_response_drilldown",
+            return_value=payload,
+        ) as get_drilldown:
+            response = client.get(
+                "/api/events/availability-report/snmp-no-response",
+                params={"limit": 25, "offset": 0},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body == payload
+        get_drilldown.assert_called_once_with(limit=25, offset=0)
+
+    def test_availability_snmp_no_response_endpoint_requires_authentication(self):
+        response = client.get("/api/events/availability-report/snmp-no-response")
+
+        assert response.status_code == 401
+
+    def test_availability_snmp_no_response_endpoint_forbidden_without_event_view_permission(self):
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            permissions=[UserPermission.EVENT_ACK],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get("/api/events/availability-report/snmp-no-response")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to view events"
+
+    def test_availability_snmp_no_response_endpoint_bounds_limit(self):
+        fake_user = _make_pydantic_user(
+            username="viewer",
+            role="VIEWER",
+            permissions=[UserPermission.EVENT_VIEW],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = (
+            override_get_current_active_user
+        )
+
+        response = client.get(
+            "/api/events/availability-report/snmp-no-response",
+            params={"limit": 101},
+        )
+
+        assert response.status_code == 422
+
     def test_availability_report_endpoint_keeps_old_rows_valid(self):
         start = datetime(2026, 1, 1, tzinfo=timezone.utc)
         payload = {

--- a/frontend/components/AvailabilityDashboard.test.tsx
+++ b/frontend/components/AvailabilityDashboard.test.tsx
@@ -1,14 +1,22 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AvailabilityDashboard from "./AvailabilityDashboard";
-import type { AvailabilityReportResponse } from "../types";
+import type {
+	AvailabilityReportResponse,
+	AvailabilitySnmpNoResponseResponse,
+} from "../types";
 
-const { mockUseAvailabilityReportQuery } = vi.hoisted(() => ({
+const { mockUseAvailabilityReportQuery, mockUseAvailabilitySnmpNoResponseQuery } = vi.hoisted(() => ({
 	mockUseAvailabilityReportQuery: vi.fn(),
+	mockUseAvailabilitySnmpNoResponseQuery: vi.fn(),
 }));
 
 vi.mock("../hooks/queries/useAvailabilityReportQuery", () => ({
 	useAvailabilityReportQuery: mockUseAvailabilityReportQuery,
+}));
+
+vi.mock("../hooks/queries/useAvailabilitySnmpNoResponseQuery", () => ({
+	useAvailabilitySnmpNoResponseQuery: mockUseAvailabilitySnmpNoResponseQuery,
 }));
 
 const report: AvailabilityReportResponse = {
@@ -80,10 +88,48 @@ const report: AvailabilityReportResponse = {
 	],
 };
 
+const snmpNoResponseReport: AvailabilitySnmpNoResponseResponse = {
+	generated_at: "2026-01-31T00:06:00Z",
+	limit: 25,
+	offset: 0,
+	summary: {
+		total_ci_with_no_response: 1,
+		total_events_with_no_response: 2,
+	},
+	rows: [
+		{
+			ci_id: "ci-1",
+			ci_name: "Core Router",
+			category: "Network",
+			status: "DEGRADED",
+			ip: "10.0.0.1",
+			owner: "NOC",
+			brand: "Cisco",
+			model: "ISR4331",
+			event_count: 2,
+			latest_event_at: "2026-01-31T00:04:00Z",
+			events: [
+				{
+					id: "evt-snmp-1",
+					message: "SNMP no response from Core Router",
+					status: "OPEN",
+					created_at: "2026-01-31T00:01:00Z",
+					last_seen: "2026-01-31T00:04:00Z",
+				},
+			],
+		},
+	],
+};
+
 describe("AvailabilityDashboard", () => {
 	beforeEach(() => {
 		mockUseAvailabilityReportQuery.mockReturnValue({
 			data: report,
+			isLoading: false,
+			error: null,
+		});
+		mockUseAvailabilitySnmpNoResponseQuery.mockReturnValue({
+			data: undefined,
 			isLoading: false,
 			error: null,
 		});
@@ -103,6 +149,53 @@ describe("AvailabilityDashboard", () => {
 		expect(screen.getByText("1/2 (50.00%)")).toBeInTheDocument();
 		expect(screen.getByText("SNMP no-response")).toBeInTheDocument();
 		expect(screen.getByText("1 CIs / 2 events")).toBeInTheDocument();
+	});
+
+	it("loads SNMP no-response affected CIs only after the card action", () => {
+		mockUseAvailabilitySnmpNoResponseQuery.mockReturnValue({
+			data: snmpNoResponseReport,
+			isLoading: false,
+			error: null,
+		});
+
+		render(<AvailabilityDashboard />);
+
+		expect(mockUseAvailabilitySnmpNoResponseQuery).toHaveBeenCalledWith({ enabled: false });
+		fireEvent.click(screen.getByRole("button", { name: /review affected cis/i }));
+
+		expect(mockUseAvailabilitySnmpNoResponseQuery).toHaveBeenLastCalledWith({ enabled: true });
+		expect(screen.getByLabelText("SNMP no-response affected CIs")).toBeInTheDocument();
+		expect(screen.getByText("Affected CIs")).toBeInTheDocument();
+		expect(screen.getAllByText("Core Router").length).toBeGreaterThan(0);
+		expect(screen.getByText("SNMP no response from Core Router")).toBeInTheDocument();
+		expect(screen.getByText("DEGRADED")).toBeInTheDocument();
+	});
+
+	it("shows SNMP drilldown loading, error, and empty states", () => {
+		mockUseAvailabilitySnmpNoResponseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			error: null,
+		});
+		const { rerender } = render(<AvailabilityDashboard />);
+		fireEvent.click(screen.getByRole("button", { name: /review affected cis/i }));
+		expect(screen.getByText(/loading affected cis/i)).toBeInTheDocument();
+
+		mockUseAvailabilitySnmpNoResponseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			error: new Error("boom"),
+		});
+		rerender(<AvailabilityDashboard />);
+		expect(screen.getByText(/could not load snmp no-response details/i)).toBeInTheDocument();
+
+		mockUseAvailabilitySnmpNoResponseQuery.mockReturnValue({
+			data: { ...snmpNoResponseReport, rows: [] },
+			isLoading: false,
+			error: null,
+		});
+		rerender(<AvailabilityDashboard />);
+		expect(screen.getByText(/no active snmp no-response cis/i)).toBeInTheDocument();
 	});
 
 	it("handles older availability responses without SNMP coverage", () => {

--- a/frontend/components/AvailabilityDashboard.tsx
+++ b/frontend/components/AvailabilityDashboard.tsx
@@ -1,7 +1,12 @@
 import type React from "react";
 import { Fragment, useMemo, useState } from "react";
 import { useAvailabilityReportQuery } from "../hooks/queries/useAvailabilityReportQuery";
-import type { AvailabilityReportRow, SnmpCoverageSummary } from "../types";
+import { useAvailabilitySnmpNoResponseQuery } from "../hooks/queries/useAvailabilitySnmpNoResponseQuery";
+import type {
+	AvailabilityReportRow,
+	AvailabilitySnmpNoResponseResponse,
+	SnmpCoverageSummary,
+} from "../types";
 import {
 	averageSeconds,
 	availabilityRowsToCsv,
@@ -51,6 +56,10 @@ const AvailabilityDashboard: React.FC = () => {
 	const [searchTerm, setSearchTerm] = useState("");
 	const [category, setCategory] = useState("ALL");
 	const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+	const [isSnmpDrilldownOpen, setIsSnmpDrilldownOpen] = useState(false);
+	const snmpDrilldown = useAvailabilitySnmpNoResponseQuery({
+		enabled: isSnmpDrilldownOpen,
+	});
 
 	const categories = useMemo(
 		() => Array.from(new Set(rows.map(getAvailabilityCategory))).sort(),
@@ -101,8 +110,21 @@ const AvailabilityDashboard: React.FC = () => {
 				<SummaryCard label="Active events" value={String(activeEvents)} />
 				<SummaryCard label="Worst availability" value={formatPercent(worstAvailability)} />
 				<SummaryCard label="SNMP functional" value={formatSnmpFunctional(snmpCoverage)} />
-				<SummaryCard label="SNMP no-response" value={formatSnmpNoResponse(snmpCoverage)} />
+				<SummaryCard
+					label="SNMP no-response"
+					value={formatSnmpNoResponse(snmpCoverage)}
+					actionLabel={isSnmpDrilldownOpen ? "Hide affected CIs" : "Review affected CIs"}
+					onAction={() => setIsSnmpDrilldownOpen((current) => !current)}
+				/>
 			</div>
+
+			{isSnmpDrilldownOpen && (
+				<SnmpNoResponseDrilldown
+					data={snmpDrilldown.data}
+					isLoading={snmpDrilldown.isLoading}
+					error={snmpDrilldown.error}
+				/>
+			)}
 
 			<div className="rounded-2xl border border-white/5 bg-surface-900 p-5">
 				<div className="mb-5 grid grid-cols-1 gap-4 md:grid-cols-[1fr_240px]">
@@ -198,10 +220,86 @@ const AvailabilityDashboard: React.FC = () => {
 	);
 };
 
-const SummaryCard: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+const SnmpNoResponseDrilldown: React.FC<{
+	data?: AvailabilitySnmpNoResponseResponse;
+	isLoading: boolean;
+	error: unknown;
+}> = ({ data, isLoading, error }) => (
+	<div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-5" aria-label="SNMP no-response affected CIs">
+		<div className="mb-4 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+			<div>
+				<p className="text-xs font-bold uppercase tracking-widest text-amber-300">SNMP no-response drilldown</p>
+				<h3 className="text-lg font-black uppercase tracking-tight text-white">Affected CIs</h3>
+				<p className="text-sm text-amber-100/70">Active or acknowledged SNMP collection failures with no response.</p>
+			</div>
+			{data && (
+				<p className="text-xs text-amber-100/70">
+					{data.summary.total_ci_with_no_response} CIs / {data.summary.total_events_with_no_response} events
+				</p>
+			)}
+		</div>
+
+		{isLoading ? (
+			<div className="rounded-xl border border-white/10 bg-black/20 p-4 text-sm text-amber-100">Loading affected CIs...</div>
+		) : error ? (
+			<div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">Could not load SNMP no-response details.</div>
+		) : !data || data.rows.length === 0 ? (
+			<div className="rounded-xl border border-dashed border-white/10 p-6 text-center text-sm text-amber-100/70">No active SNMP no-response CIs were found.</div>
+		) : (
+			<div className="overflow-x-auto">
+				<table className="w-full min-w-[760px] text-left text-sm">
+					<thead className="text-xs uppercase tracking-widest text-amber-100/60">
+						<tr className="border-b border-white/10">
+							<th className="p-3">CI</th>
+							<th className="p-3">Category</th>
+							<th className="p-3">Status</th>
+							<th className="p-3">IP</th>
+							<th className="p-3">Owner</th>
+							<th className="p-3">Events</th>
+							<th className="p-3">Latest</th>
+						</tr>
+					</thead>
+					<tbody className="divide-y divide-white/10">
+						{data.rows.map((row) => (
+							<tr key={row.ci_id} className="text-amber-50/90">
+								<td className="p-3">
+									<p className="font-bold text-white">{row.ci_name || row.ci_id}</p>
+									<p className="font-mono text-xs text-amber-100/50">{row.ci_id}</p>
+									{row.events[0]?.message && <p className="mt-1 text-xs text-amber-100/70">{row.events[0].message}</p>}
+								</td>
+								<td className="p-3">{row.category || "—"}</td>
+								<td className="p-3">{row.status || "—"}</td>
+								<td className="p-3 font-mono text-xs">{row.ip || "—"}</td>
+								<td className="p-3">{row.owner || "—"}</td>
+								<td className="p-3">{row.event_count}</td>
+								<td className="p-3">{row.latest_event_at ? new Date(row.latest_event_at).toLocaleString() : "—"}</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		)}
+	</div>
+);
+
+const SummaryCard: React.FC<{
+	label: string;
+	value: string;
+	actionLabel?: string;
+	onAction?: () => void;
+}> = ({ label, value, actionLabel, onAction }) => (
 	<div className="rounded-xl border border-white/5 bg-surface-900 p-5">
 		<p className="text-xs font-bold uppercase tracking-widest text-neutral-500">{label}</p>
 		<p className="mt-2 text-2xl font-black text-white">{value}</p>
+		{actionLabel && onAction && (
+			<button
+				type="button"
+				onClick={onAction}
+				className="mt-3 rounded-lg border border-white/10 px-3 py-1 text-xs font-bold uppercase text-neutral-300 hover:border-brand-500 hover:text-white"
+			>
+				{actionLabel}
+			</button>
+		)}
 	</div>
 );
 

--- a/frontend/hooks/queries/useAvailabilitySnmpNoResponseQuery.ts
+++ b/frontend/hooks/queries/useAvailabilitySnmpNoResponseQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "../../services/queryKeys";
+import { fetchAvailabilitySnmpNoResponse } from "../../services/queryResources";
+
+interface UseAvailabilitySnmpNoResponseQueryOptions {
+	enabled?: boolean;
+	limit?: number;
+	offset?: number;
+}
+
+export const useAvailabilitySnmpNoResponseQuery = ({
+	enabled = false,
+	limit = 25,
+	offset = 0,
+}: UseAvailabilitySnmpNoResponseQueryOptions = {}) =>
+	useQuery({
+		queryKey: queryKeys.availabilitySnmpNoResponse({ limit, offset }),
+		queryFn: ({ signal }) =>
+			fetchAvailabilitySnmpNoResponse({ limit, offset, signal }),
+		enabled,
+		refetchOnWindowFocus: false,
+		staleTime: 30000,
+	});

--- a/frontend/services/queryKeys.test.ts
+++ b/frontend/services/queryKeys.test.ts
@@ -25,6 +25,21 @@ describe("queryKeys", () => {
 		]);
 	});
 
+	it("scopes SNMP no-response drilldown by pagination", () => {
+		expect(queryKeys.availabilitySnmpNoResponse()).toEqual([
+			"events",
+			"availability-report",
+			"snmp-no-response",
+			{},
+		]);
+		expect(queryKeys.availabilitySnmpNoResponse({ limit: 25, offset: 0 })).toEqual([
+			"events",
+			"availability-report",
+			"snmp-no-response",
+			{ limit: 25, offset: 0 },
+		]);
+	});
+
 	it("scopes related events by ci id", () => {
 		expect(queryKeys.relatedEvents("ci-1")).toEqual([
 			"events",

--- a/frontend/services/queryKeys.ts
+++ b/frontend/services/queryKeys.ts
@@ -6,6 +6,8 @@ export const queryKeys = {
 	owners: () => ["owners"] as const,
 	activeEvents: () => ["events", "CONSOLE"] as const,
 	availabilityReport: () => ["events", "availability-report"] as const,
+	availabilitySnmpNoResponse: (params?: { limit?: number; offset?: number }) =>
+		["events", "availability-report", "snmp-no-response", params ?? {}] as const,
 	eventDetail: (eventId: string) => ["events", "detail", eventId] as const,
 	graphTopologyRoot: () => ["graph-topology"] as const,
 	graphTopology: (filters?: {

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -1,6 +1,7 @@
 import { api } from "./api";
 import type {
 	AvailabilityReportResponse,
+	AvailabilitySnmpNoResponseResponse,
 	EventDetail,
 	EventSummary,
 	GraphLink,
@@ -72,6 +73,26 @@ export const fetchAvailabilityReport = ({
 	const query = params.toString();
 	return api.get<AvailabilityReportResponse>(
 		`/events/availability-report${query ? `?${query}` : ""}`,
+		{ signal },
+	);
+};
+
+export interface FetchSnmpNoResponseOptions {
+	limit?: number;
+	offset?: number;
+	signal?: AbortSignal;
+}
+
+export const fetchAvailabilitySnmpNoResponse = ({
+	limit = 25,
+	offset = 0,
+	signal,
+}: FetchSnmpNoResponseOptions = {}) => {
+	const params = new URLSearchParams();
+	params.set("limit", String(limit));
+	params.set("offset", String(offset));
+	return api.get<AvailabilitySnmpNoResponseResponse>(
+		`/events/availability-report/snmp-no-response?${params.toString()}`,
 		{ signal },
 	);
 };

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -126,6 +126,41 @@ export interface AvailabilityReportResponse {
 	rows: AvailabilityReportRow[];
 }
 
+export interface AvailabilitySnmpNoResponseSummary {
+	total_ci_with_no_response: number;
+	total_events_with_no_response: number;
+}
+
+export interface AvailabilitySnmpNoResponseEvent {
+	id?: string | null;
+	message?: string | null;
+	status?: string | null;
+	created_at?: string | null;
+	last_seen?: string | null;
+}
+
+export interface AvailabilitySnmpNoResponseCI {
+	ci_id: string;
+	ci_name?: string | null;
+	category?: string | null;
+	status?: string | null;
+	ip?: string | null;
+	owner?: string | null;
+	brand?: string | null;
+	model?: string | null;
+	event_count: number;
+	latest_event_at?: string | null;
+	events: AvailabilitySnmpNoResponseEvent[];
+}
+
+export interface AvailabilitySnmpNoResponseResponse {
+	generated_at: string;
+	limit: number;
+	offset: number;
+	summary: AvailabilitySnmpNoResponseSummary;
+	rows: AvailabilitySnmpNoResponseCI[];
+}
+
 export interface EventSummary {
 	id: string;
 	ci_id: string;


### PR DESCRIPTION
Continues #226

## Descripción del Cambio
Agrega el segundo slice encadenado de KPIs SNMP: un drilldown lazy para revisar CIs afectados por fallas activas de SNMP no-response.

> Chained PR: este PR debe compararse contra `feat/issue-226-kpi-performance` / PR #254, no contra `main`.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Agrega endpoint autenticado `GET /api/events/availability-report/snmp-no-response` para listar CIs con fallas activas SNMP no-response.
- Mantiene intacto el payload always-on de `/availability-report` y la semántica MTTR/MTBF ICMP/PING.
- Hace accionable el card `SNMP no-response` y carga el drilldown bajo demanda.
- Protege el endpoint con permiso `EVENT_VIEW` porque expone detalles de CIs/eventos.

## Cambios
| File | Change |
|------|--------|
| `backend/services/event_service.py` | Agrega query paginada y bounded para CIs afectados por SNMP no-response. |
| `backend/routers/events.py` | Agrega endpoint `/availability-report/snmp-no-response` con auth `EVENT_VIEW`. |
| `backend/models/core.py` | Agrega modelos de respuesta del drilldown. |
| `frontend/components/AvailabilityDashboard.tsx` | Agrega acción y panel inline para revisar CIs afectados. |
| `frontend/hooks/queries/useAvailabilitySnmpNoResponseQuery.ts` | Nuevo hook lazy para el drilldown. |
| `frontend/services/queryResources.ts` | Agrega fetcher del endpoint de drilldown. |
| `frontend/services/queryKeys.ts` | Agrega key de React Query para drilldown. |
| Tests | Agrega cobertura backend, router/auth, query key y UI lazy states. |

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_event_service_smoke.py backend/tests/test_routers_metrics_events.py`
- [x] `corepack pnpm --dir frontend exec vitest run components/AvailabilityDashboard.test.tsx services/queryKeys.test.ts`
- [x] `corepack pnpm --dir frontend run build`
- [x] `git diff --check`
- [x] Shellcheck no aplica: no se modificaron scripts shell.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notas de alcance
- Este PR no agrega paginación UI todavía; el endpoint ya soporta `limit/offset` para follow-up.
- El endpoint devuelve hasta cinco eventos mínimos por CI afectado para mantener payload bounded.
- Siguiente slice recomendado: KPIs CPU/RAM/disco/I/O como PR separado.

---
*Generado por Alex*
