### PR TITLE
feat(system): add disk I/O health KPI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,13 +5,18 @@ from starlette.middleware.base import BaseHTTPMiddleware
 import logging
 import asyncio
 import os
+import re
 import shutil
 import platform
+import threading
 from datetime import datetime
 from database import get_db, verify_connection
 
 # Global start time to track system reboots/restarts
 STARTUP_TIME = datetime.now().isoformat()
+_DISK_SECTOR_SIZE_BYTES = 512
+_DISK_IO_PREVIOUS_SAMPLE = None
+_DISK_IO_SAMPLE_LOCK = threading.Lock()
 from services.snmp_service import snmp_collector_loop, get_collector_status
 from seed_admin import seed_admin
 from seed_roles import seed_roles
@@ -234,6 +239,122 @@ def read_root():
     return {"status": "System Operational", "module": "Backend API v1.4 (Refactored)"}
 
 
+def _is_diskstats_device(device_name: str) -> bool:
+    """Return true for base disk devices while excluding common partitions."""
+    if device_name.startswith(("loop", "ram", "fd", "sr")):
+        return False
+    if re.fullmatch(r"sd[a-z]+|vd[a-z]+|xvd[a-z]+|hd[a-z]+", device_name):
+        return True
+    if re.fullmatch(r"nvme\d+n\d+", device_name):
+        return True
+    if re.fullmatch(r"mmcblk\d+", device_name):
+        return True
+    return False
+
+
+def _collect_disk_io_sample(path: str = "/proc/diskstats", sampled_at: datetime | None = None):
+    """Collect a lightweight aggregate disk I/O sample from Linux /proc/diskstats."""
+    read_bytes = 0
+    write_bytes = 0
+    busy_ms = 0
+
+    try:
+        with open(path, "r", encoding="utf-8") as diskstats:
+            lines = diskstats.readlines()
+    except OSError:
+        return None
+
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 14:
+            continue
+        device_name = parts[2]
+        if not _is_diskstats_device(device_name):
+            continue
+        try:
+            read_bytes += int(parts[5]) * _DISK_SECTOR_SIZE_BYTES
+            write_bytes += int(parts[9]) * _DISK_SECTOR_SIZE_BYTES
+            busy_ms += int(parts[12])
+        except ValueError:
+            continue
+
+    if read_bytes == 0 and write_bytes == 0 and busy_ms == 0:
+        return None
+
+    return {
+        "read_bytes": read_bytes,
+        "write_bytes": write_bytes,
+        "busy_ms": busy_ms,
+        "sampled_at": sampled_at or datetime.now(),
+    }
+
+
+def _empty_disk_io_status(supported: bool = False):
+    return {
+        "supported": supported,
+        "read_bytes_total": None,
+        "write_bytes_total": None,
+        "read_bytes_per_sec": None,
+        "write_bytes_per_sec": None,
+        "busy_percentage": None,
+        "sampled_at": None,
+    }
+
+
+def _build_disk_io_status(current, previous=None):
+    """Build the API disk I/O payload, including rates when a previous sample exists."""
+    if current is None:
+        return _empty_disk_io_status(supported=False)
+
+    sampled_at = current["sampled_at"]
+    status = {
+        "supported": True,
+        "read_bytes_total": current["read_bytes"],
+        "write_bytes_total": current["write_bytes"],
+        "read_bytes_per_sec": None,
+        "write_bytes_per_sec": None,
+        "busy_percentage": None,
+        "sampled_at": sampled_at.isoformat(),
+    }
+
+    if previous is None:
+        return status
+
+    elapsed_seconds = (sampled_at - previous["sampled_at"]).total_seconds()
+    if elapsed_seconds <= 0:
+        return status
+
+    read_delta = current["read_bytes"] - previous["read_bytes"]
+    write_delta = current["write_bytes"] - previous["write_bytes"]
+    busy_delta = current["busy_ms"] - previous["busy_ms"]
+    if read_delta < 0 or write_delta < 0 or busy_delta < 0:
+        return status
+
+    status["read_bytes_per_sec"] = round(read_delta / elapsed_seconds, 2)
+    status["write_bytes_per_sec"] = round(write_delta / elapsed_seconds, 2)
+    status["busy_percentage"] = round(
+        min((busy_delta / (elapsed_seconds * 1000)) * 100, 100), 1
+    )
+    return status
+
+
+def _get_disk_io_status():
+    """Return disk I/O health with graceful unsupported/null behavior."""
+    global _DISK_IO_PREVIOUS_SAMPLE
+    if platform.system() != "Linux":
+        _DISK_IO_PREVIOUS_SAMPLE = None
+        return _empty_disk_io_status(supported=False)
+
+    with _DISK_IO_SAMPLE_LOCK:
+        current = _collect_disk_io_sample()
+        if current is None:
+            _DISK_IO_PREVIOUS_SAMPLE = None
+            return _empty_disk_io_status(supported=False)
+        status = _build_disk_io_status(current, _DISK_IO_PREVIOUS_SAMPLE)
+        _DISK_IO_PREVIOUS_SAMPLE = current
+        return status
+
+
 @app.get("/api/system/status")
 def get_system_status():
     """
@@ -296,6 +417,7 @@ def get_system_status():
         "cpu": round(cpu_percent, 1),
         "ram": round(ram_percent, 1),
         "disk": round(disk_percent, 1),
+        "disk_io": _get_disk_io_status(),
         "neo4j": neo4j_status,
         "postgres": postgres_status,
         "collector": collector,

--- a/backend/tests/test_system_status.py
+++ b/backend/tests/test_system_status.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timedelta
+
+from main import _build_disk_io_status, _collect_disk_io_sample, _is_diskstats_device
+
+
+def test_collect_disk_io_sample_aggregates_supported_devices_only(tmp_path):
+    diskstats = tmp_path / "diskstats"
+    diskstats.write_text(
+        "   8       0 sda 10 0 20 0 5 0 8 0 0 30 0 0\n"
+        "   8       1 sda1 10 0 200 0 5 0 80 0 0 300 0 0\n"
+        "   7       0 loop0 10 0 200 0 5 0 80 0 0 300 0 0\n"
+        " 253       0 dm-0 10 0 200 0 5 0 80 0 0 300 0 0\n"
+        " 259       0 nvme0n1 1 0 4 0 1 0 6 0 0 10 0 0\n",
+        encoding="utf-8",
+    )
+
+    sampled_at = datetime(2026, 1, 1, 12, 0, 0)
+    sample = _collect_disk_io_sample(str(diskstats), sampled_at=sampled_at)
+
+    assert sample == {
+        "read_bytes": (20 + 4) * 512,
+        "write_bytes": (8 + 6) * 512,
+        "busy_ms": 40,
+        "sampled_at": sampled_at,
+    }
+
+
+def test_is_diskstats_device_supports_common_base_disk_names():
+    assert _is_diskstats_device("sda") is True
+    assert _is_diskstats_device("nvme0n1") is True
+    assert _is_diskstats_device("mmcblk0") is True
+    assert _is_diskstats_device("sda1") is False
+    assert _is_diskstats_device("nvme0n1p1") is False
+    assert _is_diskstats_device("mmcblk0p1") is False
+    assert _is_diskstats_device("dm-0") is False
+
+
+def test_build_disk_io_status_computes_rates_from_previous_sample():
+    previous_time = datetime(2026, 1, 1, 12, 0, 0)
+    current_time = previous_time + timedelta(seconds=2)
+    previous = {
+        "read_bytes": 1024,
+        "write_bytes": 2048,
+        "busy_ms": 100,
+        "sampled_at": previous_time,
+    }
+    current = {
+        "read_bytes": 3072,
+        "write_bytes": 4096,
+        "busy_ms": 300,
+        "sampled_at": current_time,
+    }
+
+    status = _build_disk_io_status(current, previous)
+
+    assert status["supported"] is True
+    assert status["read_bytes_total"] == 3072
+    assert status["write_bytes_total"] == 4096
+    assert status["read_bytes_per_sec"] == 1024.0
+    assert status["write_bytes_per_sec"] == 1024.0
+    assert status["busy_percentage"] == 10.0
+    assert status["sampled_at"] == current_time.isoformat()
+
+
+def test_build_disk_io_status_returns_unsupported_payload_without_sample():
+    status = _build_disk_io_status(None)
+
+    assert status == {
+        "supported": False,
+        "read_bytes_total": None,
+        "write_bytes_total": None,
+        "read_bytes_per_sec": None,
+        "write_bytes_per_sec": None,
+        "busy_percentage": None,
+        "sampled_at": None,
+    }

--- a/frontend/components/SystemDashboard.test.tsx
+++ b/frontend/components/SystemDashboard.test.tsx
@@ -23,7 +23,18 @@ describe('SystemDashboard', () => {
         cpu: 24,
         ram: 61,
         disk: 40,
+        disk_io: {
+          supported: true,
+          read_bytes_total: 10485760,
+          write_bytes_total: 5242880,
+          read_bytes_per_sec: 1048576,
+          write_bytes_per_sec: 524288,
+          busy_percentage: 12.5,
+          sampled_at: '2026-04-04T10:00:03.000Z',
+        },
         neo4j: 'CONNECTED',
+        postgres: 'CONNECTED',
+        startup_time: '2026-04-04T09:00:00.000Z',
         collector: {
           status: 'RUNNING',
           last_run: '2026-04-04T10:00:00.000Z',
@@ -45,10 +56,52 @@ describe('SystemDashboard', () => {
     expect(screen.getByText('24%')).toBeInTheDocument();
     expect(screen.getByText('61%')).toBeInTheDocument();
     expect(screen.getByText('40%')).toBeInTheDocument();
-    expect(screen.getByText('CONNECTED')).toBeInTheDocument();
+    expect(screen.getByText('Disk I/O Throughput')).toBeInTheDocument();
+    expect(screen.getByText('12.5%')).toBeInTheDocument();
+    expect(screen.getByText('1.0 MB/s read / 512.0 KB/s write')).toBeInTheDocument();
+    expect(screen.getAllByText('CONNECTED').length).toBeGreaterThan(0);
     expect(screen.getByText('RUNNING')).toBeInTheDocument();
     expect(screen.getByText('Active Monitored CIs')).toBeInTheDocument();
     expect(screen.getByText('8')).toBeInTheDocument();
     expect(screen.queryByText('173')).not.toBeInTheDocument();
+  });
+
+  it('shows a graceful fallback when disk I/O is unsupported', () => {
+    mockUseSystemStatusQuery.mockReturnValue({
+      data: {
+        cpu: 24,
+        ram: 61,
+        disk: 40,
+        disk_io: {
+          supported: false,
+          read_bytes_total: null,
+          write_bytes_total: null,
+          read_bytes_per_sec: null,
+          write_bytes_per_sec: null,
+          busy_percentage: null,
+          sampled_at: null,
+        },
+        neo4j: 'CONNECTED',
+        postgres: 'CONNECTED',
+        collector: {
+          status: 'RUNNING',
+          last_run: null,
+          stats: {
+            cis_monitored: 8,
+            metrics_collected: 120,
+            metrics_failed: 1,
+            cycle_duration: 3,
+            jobs_per_min: 44,
+          },
+        },
+      },
+      isLoading: false,
+    });
+
+    render(<SystemDashboard />);
+
+    expect(screen.getByText('Disk I/O Throughput')).toBeInTheDocument();
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+    expect(screen.getByText('Disk I/O unsupported on this host')).toBeInTheDocument();
   });
 });

--- a/frontend/components/SystemDashboard.tsx
+++ b/frontend/components/SystemDashboard.tsx
@@ -1,6 +1,27 @@
 import React from 'react';
 import Tooltip from './Tooltip';
 import { useSystemStatusQuery } from '../hooks/queries/useSystemStatusQuery';
+import type { DiskIoStatus } from '../services/queryResources';
+
+const formatBytesPerSecond = (value?: number | null) => {
+    if (value == null) return '—';
+    if (value >= 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(1)} MB/s`;
+    if (value >= 1024) return `${(value / 1024).toFixed(1)} KB/s`;
+    return `${value.toFixed(0)} B/s`;
+};
+
+const formatDiskIoBusy = (diskIo?: DiskIoStatus | null) => {
+    if (!diskIo?.supported) return 'N/A';
+    return diskIo.busy_percentage == null ? 'Sampling' : `${diskIo.busy_percentage}%`;
+};
+
+const formatDiskIoRates = (diskIo?: DiskIoStatus | null) => {
+    if (!diskIo?.supported) return 'Disk I/O unsupported on this host';
+    if (diskIo.read_bytes_per_sec == null || diskIo.write_bytes_per_sec == null) {
+        return 'Collecting baseline sample';
+    }
+    return `${formatBytesPerSecond(diskIo.read_bytes_per_sec)} read / ${formatBytesPerSecond(diskIo.write_bytes_per_sec)} write`;
+};
 
 const SystemDashboard: React.FC = () => {
     const { data: status, isLoading: loading } = useSystemStatusQuery();
@@ -48,7 +69,7 @@ const SystemDashboard: React.FC = () => {
             </header>
 
             {/* Resources Grid */}
-            <section className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
 
                 {/* CPU Card */}
                 <div className="glass p-8 rounded-3xl relative group">
@@ -112,6 +133,29 @@ const SystemDashboard: React.FC = () => {
                         </div>
                         <div className="w-full bg-black/40 h-2 rounded-full overflow-hidden">
                             <div className={`h-full rounded-full transition-all duration-1000 ${getBarColor(status.disk)}`} style={{ width: `${status.disk}%` }}></div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Disk I/O Card */}
+                <div className="glass p-8 rounded-3xl relative group">
+                    <div className="absolute inset-0 rounded-3xl overflow-hidden pointer-events-none">
+                        <div className="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity">
+                            <span className="material-symbols-outlined text-9xl">speed</span>
+                        </div>
+                    </div>
+                    <div className="relative z-10">
+                        <div className="flex items-center mb-4">
+                            <h3 className="text-sm font-black text-neutral-400 uppercase tracking-widest">Disk I/O Throughput</h3>
+                            <Tooltip text="Read/write throughput and busy time sampled from the backend host diskstats." />
+                        </div>
+                        <div className="flex items-end gap-2 mb-2">
+                            <span className={`text-4xl font-black tracking-tighter ${status.disk_io?.busy_percentage == null ? 'text-neutral-400' : getStatusColor(status.disk_io.busy_percentage)}`}>{formatDiskIoBusy(status.disk_io)}</span>
+                            <span className="text-xs font-bold text-neutral-500 mb-2">BUSY</span>
+                        </div>
+                        <p className="mb-3 min-h-5 text-xs font-bold uppercase tracking-wide text-neutral-500">{formatDiskIoRates(status.disk_io)}</p>
+                        <div className="w-full bg-black/40 h-2 rounded-full overflow-hidden">
+                            <div className={`h-full rounded-full transition-all duration-1000 ${getBarColor(status.disk_io?.busy_percentage ?? 0)}`} style={{ width: `${status.disk_io?.busy_percentage ?? 0}%` }}></div>
                         </div>
                     </div>
                 </div>
@@ -205,7 +249,7 @@ const SystemDashboard: React.FC = () => {
                         )}
 
                         {/* PostgreSQL / TimescaleDB Status */}
-                        {(status as any).postgres === 'CONNECTED' ? (
+                        {status.postgres === 'CONNECTED' ? (
                             <div className="flex gap-4">
                                 <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
                                 <span className="text-emerald-400">SUCCESS</span>

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -9,11 +9,24 @@ import type {
 	MultiMetricHistoryResponse,
 } from "../types";
 
+export interface DiskIoStatus {
+	supported: boolean;
+	read_bytes_total?: number | null;
+	write_bytes_total?: number | null;
+	read_bytes_per_sec?: number | null;
+	write_bytes_per_sec?: number | null;
+	busy_percentage?: number | null;
+	sampled_at?: string | null;
+}
+
 export interface SystemStatus {
 	cpu: number;
 	ram: number;
 	disk: number;
+	disk_io?: DiskIoStatus | null;
 	neo4j: "CONNECTED" | "DISCONNECTED" | "UNKNOWN";
+	postgres?: "CONNECTED" | "DISCONNECTED" | "UNKNOWN";
+	startup_time?: string | null;
 	collector: {
 		status: string;
 		last_run: string | null;


### PR DESCRIPTION
Continues #226

## Descripción del Cambio
Agrega el tercer slice encadenado de KPIs de desempeño: una tarjeta de Disk I/O Throughput en el dashboard de salud del sistema, reutilizando `/api/system/status`.

> Chained PR: este PR debe compararse contra `feat/issue-226-kpi-snmp-drilldown` / PR #256, no contra `main`.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Agrega `disk_io` a `GET /api/system/status` usando `/proc/diskstats` en Linux.
- Mantiene intactas las métricas existentes de CPU, RAM, disk usage, Neo4j, Postgres, collector y startup time.
- Calcula throughput read/write y busy percentage desde la muestra anterior del proceso.
- Muestra una cuarta tarjeta `Disk I/O Throughput` en `SystemDashboard` con fallback para hosts no soportados o primera muestra.

## Cambios
| File | Change |
|------|--------|
| `backend/main.py` | Agrega helpers de diskstats, sampling thread-safe y campo `disk_io` en system status. |
| `backend/tests/test_system_status.py` | Cubre filtros de dispositivos, agregado de diskstats y cálculo de tasas. |
| `frontend/services/queryResources.ts` | Extiende `SystemStatus` con `postgres`, `startup_time` y `disk_io`. |
| `frontend/components/SystemDashboard.tsx` | Agrega card de Disk I/O con fallback graceful. |
| `frontend/components/SystemDashboard.test.tsx` | Cubre render de Disk I/O y estado unsupported. |

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_system_status.py backend/tests/test_routers_metrics_events.py::TestMetricsHistory::test_history_with_hours_param backend/tests/test_routers_nodes.py::TestGetNodes::test_list_nodes_with_metrics`
- [x] `corepack pnpm --dir frontend exec vitest run components/SystemDashboard.test.tsx`
- [x] `corepack pnpm --dir frontend run build`
- [x] `git diff --check`
- [x] Shellcheck no aplica: no se modificaron scripts shell.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notas de alcance
- En la primera muestra del backend, las tasas pueden ser `null` hasta que exista una muestra previa.
- En hosts no Linux o sin `/proc/diskstats`, la tarjeta degrada a `Unsupported`.
- Siguiente slice recomendado: histórico operativo de 7 días como PR separado.

---
*Generado por Alex*
