### PR TITLE
feat(system): add operational status history

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -9,7 +9,7 @@ import re
 import shutil
 import platform
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 from database import get_db, verify_connection
 
 # Global start time to track system reboots/restarts
@@ -17,6 +17,9 @@ STARTUP_TIME = datetime.now().isoformat()
 _DISK_SECTOR_SIZE_BYTES = 512
 _DISK_IO_PREVIOUS_SAMPLE = None
 _DISK_IO_SAMPLE_LOCK = threading.Lock()
+_SYSTEM_STATUS_HISTORY_RETENTION_DAYS = 7
+_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS = 300
+_SYSTEM_STATUS_HISTORY_LOCK = threading.Lock()
 from services.snmp_service import snmp_collector_loop, get_collector_status
 from seed_admin import seed_admin
 from seed_roles import seed_roles
@@ -167,8 +170,9 @@ async def startup_event():
         from repositories.metric_repo import create_hypertable
         from models.timescale_models import MetricValue  # Import to register model
         from models.rate_limit_attempt import RateLimitAttempt  # Import to register model
+        from models.system_status_history import SystemStatusSnapshot  # Import to register model
 
-        # Create Tables (includes backup_config, backup_history, and rate_limit_attempts)
+        # Create Tables (includes backup_config, backup_history, rate_limit_attempts, and system status history)
         Base.metadata.create_all(bind=engine)
 
         # Inline migration: add 'tier' column if it doesn't exist (safe for existing DBs)
@@ -355,6 +359,137 @@ def _get_disk_io_status():
         return status
 
 
+def _safe_float(value):
+    return None if value is None else float(value)
+
+
+def _safe_int(value):
+    return None if value is None else int(value)
+
+
+def _should_record_system_status_snapshot(latest_snapshot, now: datetime) -> bool:
+    """Return true when the latest persisted snapshot is outside the throttle window."""
+    if latest_snapshot is None or latest_snapshot.recorded_at is None:
+        return True
+    return (
+        now - latest_snapshot.recorded_at
+    ).total_seconds() >= _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS
+
+
+def _build_system_status_snapshot(status: dict, recorded_at: datetime):
+    """Convert the live `/api/system/status` payload into a compact persisted row."""
+    from models.system_status_history import SystemStatusSnapshot
+
+    collector = status.get("collector") or {}
+    collector_stats = collector.get("stats") or {}
+    disk_io = status.get("disk_io") or {}
+    return SystemStatusSnapshot(
+        recorded_at=recorded_at,
+        cpu=_safe_float(status.get("cpu")),
+        ram=_safe_float(status.get("ram")),
+        disk=_safe_float(status.get("disk")),
+        disk_io_supported=bool(disk_io.get("supported")),
+        disk_read_bytes_per_sec=_safe_float(disk_io.get("read_bytes_per_sec")),
+        disk_write_bytes_per_sec=_safe_float(disk_io.get("write_bytes_per_sec")),
+        disk_busy_percentage=_safe_float(disk_io.get("busy_percentage")),
+        neo4j_status=status.get("neo4j"),
+        postgres_status=status.get("postgres"),
+        collector_status=collector.get("status"),
+        collector_cis_monitored=_safe_int(collector_stats.get("cis_monitored")),
+        collector_metrics_collected=_safe_int(collector_stats.get("metrics_collected")),
+        collector_metrics_failed=_safe_int(collector_stats.get("metrics_failed")),
+        collector_jobs_per_min=_safe_float(collector_stats.get("jobs_per_min")),
+        collector_cycle_duration=_safe_float(collector_stats.get("cycle_duration")),
+    )
+
+
+def _serialize_system_status_snapshot(snapshot):
+    """Serialize a persisted status snapshot into the history API row contract."""
+    return {
+        "recorded_at": snapshot.recorded_at.isoformat(),
+        "cpu": snapshot.cpu,
+        "ram": snapshot.ram,
+        "disk": snapshot.disk,
+        "disk_io": {
+            "supported": snapshot.disk_io_supported,
+            "read_bytes_per_sec": snapshot.disk_read_bytes_per_sec,
+            "write_bytes_per_sec": snapshot.disk_write_bytes_per_sec,
+            "busy_percentage": snapshot.disk_busy_percentage,
+        },
+        "neo4j": snapshot.neo4j_status,
+        "postgres": snapshot.postgres_status,
+        "collector": {
+            "status": snapshot.collector_status,
+            "stats": {
+                "cis_monitored": snapshot.collector_cis_monitored,
+                "metrics_collected": snapshot.collector_metrics_collected,
+                "metrics_failed": snapshot.collector_metrics_failed,
+                "jobs_per_min": snapshot.collector_jobs_per_min,
+                "cycle_duration": snapshot.collector_cycle_duration,
+            },
+        },
+    }
+
+
+def _record_system_status_snapshot(status: dict, now: datetime | None = None) -> bool:
+    """Persist a throttled operational snapshot and prune data older than 7 days."""
+    from postgres_db import SessionLocal
+    from models.system_status_history import SystemStatusSnapshot
+
+    recorded_at = now or datetime.utcnow()
+    with _SYSTEM_STATUS_HISTORY_LOCK:
+        db = SessionLocal()
+        try:
+            latest = (
+                db.query(SystemStatusSnapshot)
+                .order_by(SystemStatusSnapshot.recorded_at.desc())
+                .first()
+            )
+            if not _should_record_system_status_snapshot(latest, recorded_at):
+                return False
+
+            db.add(_build_system_status_snapshot(status, recorded_at))
+            cutoff = recorded_at - timedelta(days=_SYSTEM_STATUS_HISTORY_RETENTION_DAYS)
+            db.query(SystemStatusSnapshot).filter(
+                SystemStatusSnapshot.recorded_at < cutoff
+            ).delete(synchronize_session=False)
+            db.commit()
+            return True
+        except Exception as exc:
+            db.rollback()
+            logger.warning("Failed to record system status snapshot: %s", exc)
+            return False
+        finally:
+            db.close()
+
+
+def _fetch_system_status_history(hours: int, limit: int, now: datetime | None = None):
+    """Read compact system status history rows newest-first."""
+    from postgres_db import SessionLocal
+    from models.system_status_history import SystemStatusSnapshot
+
+    generated_at = now or datetime.utcnow()
+    cutoff = generated_at - timedelta(hours=hours)
+    db = SessionLocal()
+    try:
+        snapshots = (
+            db.query(SystemStatusSnapshot)
+            .filter(SystemStatusSnapshot.recorded_at >= cutoff)
+            .order_by(SystemStatusSnapshot.recorded_at.desc())
+            .limit(limit)
+            .all()
+        )
+        return {
+            "generated_at": generated_at.isoformat(),
+            "hours": hours,
+            "limit": limit,
+            "retention_days": _SYSTEM_STATUS_HISTORY_RETENTION_DAYS,
+            "rows": [_serialize_system_status_snapshot(row) for row in snapshots],
+        }
+    finally:
+        db.close()
+
+
 @app.get("/api/system/status")
 def get_system_status():
     """
@@ -413,7 +548,7 @@ def get_system_status():
 
     collector = get_collector_status()
 
-    return {
+    payload = {
         "cpu": round(cpu_percent, 1),
         "ram": round(ram_percent, 1),
         "disk": round(disk_percent, 1),
@@ -421,5 +556,20 @@ def get_system_status():
         "neo4j": neo4j_status,
         "postgres": postgres_status,
         "collector": collector,
-        "startup_time": STARTUP_TIME
+        "startup_time": STARTUP_TIME,
     }
+    _record_system_status_snapshot(payload)
+    return payload
+
+
+@app.get("/api/system/status/history")
+def get_system_status_history(
+    hours: int = Query(168, ge=1, le=168, description="History window in hours"),
+    limit: int = Query(100, ge=1, le=500, description="Maximum snapshots to return"),
+):
+    """Fetch persisted operational system status snapshots, newest first."""
+    try:
+        return _fetch_system_status_history(hours=hours, limit=limit)
+    except Exception as exc:
+        logger.error("Failed to fetch system status history: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail="System status history unavailable") from exc

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,5 +1,12 @@
 from models.backup_config import BackupConfig, BackupHistory
 from models.prune_lock import PruneLock
 from models.rate_limit_attempt import RateLimitAttempt
+from models.system_status_history import SystemStatusSnapshot
 
-__all__ = ["BackupConfig", "BackupHistory", "PruneLock", "RateLimitAttempt"]
+__all__ = [
+    "BackupConfig",
+    "BackupHistory",
+    "PruneLock",
+    "RateLimitAttempt",
+    "SystemStatusSnapshot",
+]

--- a/backend/models/system_status_history.py
+++ b/backend/models/system_status_history.py
@@ -1,0 +1,32 @@
+"""SQLAlchemy model for compact operational system status history."""
+
+from datetime import datetime
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, String
+from postgres_db import Base
+
+
+class SystemStatusSnapshot(Base):
+    """Stores throttled `/api/system/status` snapshots for recent operations history."""
+
+    __tablename__ = "system_status_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    recorded_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+    cpu = Column(Float, nullable=True)
+    ram = Column(Float, nullable=True)
+    disk = Column(Float, nullable=True)
+
+    disk_io_supported = Column(Boolean, default=False, nullable=False)
+    disk_read_bytes_per_sec = Column(Float, nullable=True)
+    disk_write_bytes_per_sec = Column(Float, nullable=True)
+    disk_busy_percentage = Column(Float, nullable=True)
+
+    neo4j_status = Column(String, nullable=True)
+    postgres_status = Column(String, nullable=True)
+    collector_status = Column(String, nullable=True)
+    collector_cis_monitored = Column(Integer, nullable=True)
+    collector_metrics_collected = Column(Integer, nullable=True)
+    collector_metrics_failed = Column(Integer, nullable=True)
+    collector_jobs_per_min = Column(Float, nullable=True)
+    collector_cycle_duration = Column(Float, nullable=True)

--- a/backend/tests/test_system_status.py
+++ b/backend/tests/test_system_status.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timedelta
 
-from main import _build_disk_io_status, _collect_disk_io_sample, _is_diskstats_device
+from main import (
+    _build_disk_io_status,
+    _build_system_status_snapshot,
+    _collect_disk_io_sample,
+    _serialize_system_status_snapshot,
+    _should_record_system_status_snapshot,
+    _is_diskstats_device,
+)
 
 
 def test_collect_disk_io_sample_aggregates_supported_devices_only(tmp_path):
@@ -74,3 +81,68 @@ def test_build_disk_io_status_returns_unsupported_payload_without_sample():
         "busy_percentage": None,
         "sampled_at": None,
     }
+
+
+def test_system_status_snapshot_serializes_compact_operational_history_row():
+    recorded_at = datetime(2026, 1, 1, 12, 5, 0)
+    status = {
+        "cpu": 24.5,
+        "ram": 61.2,
+        "disk": 40.0,
+        "disk_io": {
+            "supported": True,
+            "read_bytes_per_sec": 1024.0,
+            "write_bytes_per_sec": 2048.0,
+            "busy_percentage": 12.5,
+        },
+        "neo4j": "CONNECTED",
+        "postgres": "CONNECTED",
+        "collector": {
+            "status": "RUNNING",
+            "stats": {
+                "cis_monitored": 8,
+                "metrics_collected": 120,
+                "metrics_failed": 1,
+                "jobs_per_min": 44,
+                "cycle_duration": 3,
+            },
+        },
+    }
+
+    snapshot = _build_system_status_snapshot(status, recorded_at)
+    row = _serialize_system_status_snapshot(snapshot)
+
+    assert row == {
+        "recorded_at": recorded_at.isoformat(),
+        "cpu": 24.5,
+        "ram": 61.2,
+        "disk": 40.0,
+        "disk_io": {
+            "supported": True,
+            "read_bytes_per_sec": 1024.0,
+            "write_bytes_per_sec": 2048.0,
+            "busy_percentage": 12.5,
+        },
+        "neo4j": "CONNECTED",
+        "postgres": "CONNECTED",
+        "collector": {
+            "status": "RUNNING",
+            "stats": {
+                "cis_monitored": 8,
+                "metrics_collected": 120,
+                "metrics_failed": 1,
+                "jobs_per_min": 44.0,
+                "cycle_duration": 3.0,
+            },
+        },
+    }
+
+
+def test_should_record_system_status_snapshot_honors_five_minute_throttle():
+    now = datetime(2026, 1, 1, 12, 5, 0)
+    latest = type("Snapshot", (), {"recorded_at": now - timedelta(minutes=4)})()
+    stale = type("Snapshot", (), {"recorded_at": now - timedelta(minutes=5)})()
+
+    assert _should_record_system_status_snapshot(None, now) is True
+    assert _should_record_system_status_snapshot(latest, now) is False
+    assert _should_record_system_status_snapshot(stale, now) is True

--- a/frontend/components/SystemDashboard.test.tsx
+++ b/frontend/components/SystemDashboard.test.tsx
@@ -1,14 +1,56 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SystemDashboard from './SystemDashboard';
 
 const mockUseSystemStatusQuery = vi.fn();
+const mockUseSystemStatusHistoryQuery = vi.fn();
 
 vi.mock('../hooks/queries/useSystemStatusQuery', () => ({
   useSystemStatusQuery: () => mockUseSystemStatusQuery(),
 }));
 
+vi.mock('../hooks/queries/useSystemStatusHistoryQuery', () => ({
+  useSystemStatusHistoryQuery: () => mockUseSystemStatusHistoryQuery(),
+}));
+
+const historyResponse = {
+  generated_at: '2026-04-04T10:05:00.000Z',
+  hours: 168,
+  limit: 24,
+  retention_days: 7,
+  rows: [
+    {
+      recorded_at: '2026-04-04T10:05:00.000Z',
+      cpu: 24,
+      ram: 61,
+      disk: 40,
+      disk_io: {
+        supported: true,
+        read_bytes_per_sec: 1048576,
+        write_bytes_per_sec: 524288,
+        busy_percentage: 12.5,
+      },
+      neo4j: 'CONNECTED',
+      postgres: 'CONNECTED',
+      collector: {
+        status: 'RUNNING',
+        stats: {
+          cis_monitored: 8,
+          metrics_collected: 120,
+          metrics_failed: 1,
+          cycle_duration: 3,
+          jobs_per_min: 44,
+        },
+      },
+    },
+  ],
+};
+
 describe('SystemDashboard', () => {
+  beforeEach(() => {
+    mockUseSystemStatusHistoryQuery.mockReturnValue({ data: historyResponse, isLoading: false, error: null });
+  });
+
   it('shows the loading state while the shared status query is pending', () => {
     mockUseSystemStatusQuery.mockReturnValue({ data: null, isLoading: true });
 
@@ -58,12 +100,51 @@ describe('SystemDashboard', () => {
     expect(screen.getByText('40%')).toBeInTheDocument();
     expect(screen.getByText('Disk I/O Throughput')).toBeInTheDocument();
     expect(screen.getByText('12.5%')).toBeInTheDocument();
-    expect(screen.getByText('1.0 MB/s read / 512.0 KB/s write')).toBeInTheDocument();
+    expect(screen.getAllByText('1.0 MB/s read / 512.0 KB/s write').length).toBeGreaterThan(0);
     expect(screen.getAllByText('CONNECTED').length).toBeGreaterThan(0);
-    expect(screen.getByText('RUNNING')).toBeInTheDocument();
+    expect(screen.getAllByText('RUNNING').length).toBeGreaterThan(0);
+    expect(screen.getByText('7-Day Operational History')).toBeInTheDocument();
+    expect(screen.getByText(/Persisted system health snapshots/i)).toBeInTheDocument();
+    expect(screen.getAllByText('1.0 MB/s read / 512.0 KB/s write').length).toBeGreaterThan(0);
+    expect(screen.getByText(/120 metrics · 1 failed/i)).toBeInTheDocument();
     expect(screen.getByText('Active Monitored CIs')).toBeInTheDocument();
     expect(screen.getByText('8')).toBeInTheDocument();
     expect(screen.queryByText('173')).not.toBeInTheDocument();
+  });
+
+  it('shows persisted history empty and error states', () => {
+    const statusData = {
+      cpu: 24,
+      ram: 61,
+      disk: 40,
+      disk_io: null,
+      neo4j: 'CONNECTED',
+      postgres: 'CONNECTED',
+      collector: {
+        status: 'RUNNING',
+        last_run: null,
+        stats: {
+          cis_monitored: 8,
+          metrics_collected: 120,
+          metrics_failed: 1,
+          cycle_duration: 3,
+          jobs_per_min: 44,
+        },
+      },
+    };
+
+    mockUseSystemStatusQuery.mockReturnValue({ data: statusData, isLoading: false });
+    mockUseSystemStatusHistoryQuery.mockReturnValueOnce({
+      data: { ...historyResponse, rows: [] },
+      isLoading: false,
+      error: null,
+    });
+    const { rerender } = render(<SystemDashboard />);
+    expect(screen.getByText(/No persisted operational snapshots yet/i)).toBeInTheDocument();
+
+    mockUseSystemStatusHistoryQuery.mockReturnValueOnce({ data: undefined, isLoading: false, error: new Error('boom') });
+    rerender(<SystemDashboard />);
+    expect(screen.getByText(/Operational history unavailable/i)).toBeInTheDocument();
   });
 
   it('shows a graceful fallback when disk I/O is unsupported', () => {

--- a/frontend/components/SystemDashboard.tsx
+++ b/frontend/components/SystemDashboard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Tooltip from './Tooltip';
 import { useSystemStatusQuery } from '../hooks/queries/useSystemStatusQuery';
+import { useSystemStatusHistoryQuery } from '../hooks/queries/useSystemStatusHistoryQuery';
 import type { DiskIoStatus } from '../services/queryResources';
 
 const formatBytesPerSecond = (value?: number | null) => {
@@ -23,8 +24,19 @@ const formatDiskIoRates = (diskIo?: DiskIoStatus | null) => {
     return `${formatBytesPerSecond(diskIo.read_bytes_per_sec)} read / ${formatBytesPerSecond(diskIo.write_bytes_per_sec)} write`;
 };
 
+const formatMetricPercent = (value?: number | null) => value == null ? '—' : `${value.toFixed(1)}%`;
+
+const formatHistoryTimestamp = (value: string) => new Date(value).toLocaleString();
+
+const getServiceBadgeClass = (status?: string | null) => {
+    if (status === 'CONNECTED' || status === 'RUNNING') return 'text-emerald-400';
+    if (status === 'UNKNOWN') return 'text-amber-400';
+    return 'text-red-500';
+};
+
 const SystemDashboard: React.FC = () => {
     const { data: status, isLoading: loading } = useSystemStatusQuery();
+    const { data: history, isLoading: historyLoading, error: historyError } = useSystemStatusHistoryQuery({ hours: 168, limit: 24 });
 
     const getStatusColor = (val: number) => {
         if (val >= 90) return 'text-red-500';
@@ -194,91 +206,58 @@ const SystemDashboard: React.FC = () => {
                 </div>
             </section>
 
-            {/* System Details / Logs */}
+            {/* Operational History */}
             <section className="flex-1 glass rounded-3xl p-8 border border-white/5 flex flex-col">
-                <h3 className="text-sm font-black text-white uppercase tracking-widest mb-6 flex items-center gap-2">
-                    <span className="material-symbols-outlined text-lg text-brand-400">terminal</span>
-                    System Messages & Logs
-                </h3>
-
-                <div className="flex-1 bg-black/40 rounded-xl p-4 font-mono text-xs overflow-y-auto custom-scrollbar border border-white/5">
-                    <div className="space-y-2">
-                        {/* System Reboot / Startup Event */}
-                        {status.startup_time && (
-                            <div className="flex gap-4 border-b border-white/5 pb-2 mb-2">
-                                <span className="text-neutral-500">{new Date(status.startup_time).toLocaleTimeString()}</span>
-                                <span className="text-blue-400 font-bold">SYSTEM_REBOOT</span>
-                                <span>Platform Engine Started (v3.2)</span>
-                            </div>
-                        )}
-
-                        <div className="flex gap-4 opacity-50">
-                            <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                            <span className="text-blue-400">INFO</span>
-                            <span>System Dashboard Initialized.</span>
-                        </div>
-
-                        {/* SNMP Collector Status */}
-                        {status.collector.last_run ? (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date(status.collector.last_run).toLocaleTimeString()}</span>
-                                <span className="text-emerald-400">SUCCESS</span>
-                                <span>SNMP Collector Cycle Completed.</span>
-                            </div>
-                        ) : status.collector.status === 'ERROR' && (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-red-500 font-bold">CRITICAL</span>
-                                <span>SNMP Collector Loop Error.</span>
-                            </div>
-                        )}
-
-                        {/* Neo4j Status */}
-                        {status.neo4j === 'CONNECTED' ? (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-emerald-400">SUCCESS</span>
-                                <span>Neo4j Graph Database Connected.</span>
-                            </div>
-                        ) : (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-red-500 font-bold">CRITICAL</span>
-                                <span>Neo4j Graph Database Connection Failed.</span>
-                            </div>
-                        )}
-
-                        {/* PostgreSQL / TimescaleDB Status */}
-                        {status.postgres === 'CONNECTED' ? (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-emerald-400">SUCCESS</span>
-                                <span>PostgreSQL/TimescaleDB Connected.</span>
-                            </div>
-                        ) : (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-red-500 font-bold">CRITICAL</span>
-                                <span>PostgreSQL/TimescaleDB Connection Failed.</span>
-                            </div>
-                        )}
-
-                        {/* Resource Alerts */}
-                        {status.cpu > 80 && (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-orange-500 font-bold">WARNING</span>
-                                <span>High CPU Usage Detected ({status.cpu}%).</span>
-                            </div>
-                        )}
-                        {status.ram > 85 && (
-                            <div className="flex gap-4">
-                                <span className="text-neutral-500">{new Date().toLocaleTimeString()}</span>
-                                <span className="text-orange-500 font-bold">WARNING</span>
-                                <span>High Memory Usage Detected ({status.ram}%).</span>
-                            </div>
-                        )}
+                <div className="mb-6 flex items-start justify-between gap-4">
+                    <div>
+                        <h3 className="text-sm font-black text-white uppercase tracking-widest flex items-center gap-2">
+                            <span className="material-symbols-outlined text-lg text-brand-400">history</span>
+                            7-Day Operational History
+                        </h3>
+                        <p className="mt-1 text-xs text-neutral-500">Persisted system health snapshots, newest first.</p>
                     </div>
+                    <span className="rounded-full border border-white/10 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-neutral-500">
+                        {history?.rows.length ?? 0} snapshots
+                    </span>
+                </div>
+
+                <div className="flex-1 overflow-y-auto rounded-xl border border-white/5 bg-black/40 custom-scrollbar">
+                    {historyLoading && !history ? (
+                        <div className="p-4 font-mono text-xs text-neutral-500">Loading operational history...</div>
+                    ) : historyError ? (
+                        <div className="p-4 font-mono text-xs text-red-300">Operational history unavailable.</div>
+                    ) : !history?.rows.length ? (
+                        <div className="p-4 font-mono text-xs text-neutral-500">No persisted operational snapshots yet. A snapshot is recorded at most every five minutes.</div>
+                    ) : (
+                        <div className="divide-y divide-white/5 font-mono text-xs">
+                            {history.rows.map((row) => (
+                                <div key={row.recorded_at} className="grid gap-3 p-4 text-neutral-300 md:grid-cols-[190px_1fr]">
+                                    <div>
+                                        <p className="font-bold text-neutral-100">{formatHistoryTimestamp(row.recorded_at)}</p>
+                                        <p className="mt-1 text-[10px] uppercase tracking-widest text-neutral-600">Snapshot</p>
+                                    </div>
+                                    <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+                                        <div>
+                                            <p className="text-[10px] uppercase tracking-widest text-neutral-600">Resources</p>
+                                            <p>CPU {formatMetricPercent(row.cpu)} / RAM {formatMetricPercent(row.ram)} / Disk {formatMetricPercent(row.disk)}</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-[10px] uppercase tracking-widest text-neutral-600">Disk I/O</p>
+                                            <p>{formatDiskIoRates(row.disk_io)}</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-[10px] uppercase tracking-widest text-neutral-600">Services</p>
+                                            <p><span className={getServiceBadgeClass(row.neo4j)}>Neo4j {row.neo4j ?? 'UNKNOWN'}</span> / <span className={getServiceBadgeClass(row.postgres)}>PG {row.postgres ?? 'UNKNOWN'}</span></p>
+                                        </div>
+                                        <div>
+                                            <p className="text-[10px] uppercase tracking-widest text-neutral-600">Collector</p>
+                                            <p><span className={getServiceBadgeClass(row.collector.status)}>{row.collector.status ?? 'UNKNOWN'}</span> · {row.collector.stats.metrics_collected ?? 0} metrics · {row.collector.stats.metrics_failed ?? 0} failed</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </div>
             </section>
         </div>

--- a/frontend/hooks/queries/useSystemStatusHistoryQuery.ts
+++ b/frontend/hooks/queries/useSystemStatusHistoryQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '../../services/queryKeys';
+import { fetchSystemStatusHistory } from '../../services/queryResources';
+
+export const useSystemStatusHistoryQuery = (options: { hours?: number; limit?: number } = {}) => {
+  const { hours = 168, limit = 24 } = options;
+
+  return useQuery({
+    queryKey: queryKeys.systemStatusHistory({ hours, limit }),
+    queryFn: ({ signal }) => fetchSystemStatusHistory({ hours, limit, signal }),
+    refetchInterval: 60000,
+  });
+};

--- a/frontend/services/queryKeys.test.ts
+++ b/frontend/services/queryKeys.test.ts
@@ -4,6 +4,16 @@ import { queryKeys } from "./queryKeys";
 describe("queryKeys", () => {
 	it("returns stable keys for shared polled resources", () => {
 		expect(queryKeys.systemStatus()).toEqual(["system-status"]);
+		expect(queryKeys.systemStatusHistory()).toEqual([
+			"system-status",
+			"history",
+			{ hours: 168, limit: 24 },
+		]);
+		expect(queryKeys.systemStatusHistory({ hours: 168, limit: 24 })).toEqual([
+			"system-status",
+			"history",
+			{ hours: 168, limit: 24 },
+		]);
 		expect(queryKeys.nodes()).toEqual(["nodes"]);
 		expect(queryKeys.links()).toEqual(["links"]);
 		expect(queryKeys.categories()).toEqual(["categories"]);

--- a/frontend/services/queryKeys.ts
+++ b/frontend/services/queryKeys.ts
@@ -1,5 +1,7 @@
 export const queryKeys = {
 	systemStatus: () => ["system-status"] as const,
+	systemStatusHistory: (params: { hours?: number; limit?: number } = {}) =>
+		["system-status", "history", { hours: params.hours ?? 168, limit: params.limit ?? 24 }] as const,
 	nodes: () => ["nodes"] as const,
 	links: () => ["links"] as const,
 	categories: () => ["categories"] as const,

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -41,6 +41,34 @@ export interface SystemStatus {
 	};
 }
 
+export interface SystemStatusHistoryRow {
+	recorded_at: string;
+	cpu?: number | null;
+	ram?: number | null;
+	disk?: number | null;
+	disk_io?: Pick<DiskIoStatus, "supported" | "read_bytes_per_sec" | "write_bytes_per_sec" | "busy_percentage"> | null;
+	neo4j?: "CONNECTED" | "DISCONNECTED" | "UNKNOWN" | string | null;
+	postgres?: "CONNECTED" | "DISCONNECTED" | "UNKNOWN" | string | null;
+	collector: {
+		status?: string | null;
+		stats: {
+			cis_monitored?: number | null;
+			metrics_collected?: number | null;
+			metrics_failed?: number | null;
+			cycle_duration?: number | null;
+			jobs_per_min?: number | null;
+		};
+	};
+}
+
+export interface SystemStatusHistoryResponse {
+	generated_at: string;
+	hours: number;
+	limit: number;
+	retention_days: number;
+	rows: SystemStatusHistoryRow[];
+}
+
 export interface OwnerRecord {
 	name: string;
 }
@@ -56,6 +84,22 @@ export interface GraphTopologyResponse {
 
 export const fetchSystemStatus = ({ signal }: { signal?: AbortSignal } = {}) =>
 	api.get<SystemStatus>("/system/status", { signal });
+
+export interface FetchSystemStatusHistoryOptions {
+	hours?: number;
+	limit?: number;
+	signal?: AbortSignal;
+}
+
+export const fetchSystemStatusHistory = ({
+	hours = 168,
+	limit = 24,
+	signal,
+}: FetchSystemStatusHistoryOptions = {}) =>
+	api.get<SystemStatusHistoryResponse>("/system/status/history", {
+		params: { hours, limit },
+		signal,
+	});
 
 export const fetchNodes = ({ signal }: { signal?: AbortSignal } = {}) =>
 	api.get<GraphNode[]>("/nodes", { signal });


### PR DESCRIPTION
Continues #226

## Descripción del Cambio
Agrega el cuarto slice encadenado de KPIs de desempeño: historial operativo persistido de estado del sistema con retención de 7 días.

> Chained PR: este PR debe compararse contra `feat/issue-226-kpi-health-cards` / PR #258, no contra `main`.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Agrega tabla PostgreSQL `system_status_snapshots` para snapshots compactos de `/api/system/status`.
- Registra snapshots de forma oportunista y throttled, máximo una vez cada 5 minutos.
- Aplica retención de 7 días durante el camino de escritura.
- Agrega `GET /api/system/status/history?hours=168&limit=100` para leer historial reciente.
- Reemplaza el log sintético de `SystemDashboard` por un panel `7-Day Operational History` alimentado por snapshots persistidos.
- No implementa auditoría de usuarios; eso queda como slice separado.

## Cambios
| File | Change |
|------|--------|
| `backend/models/system_status_history.py` | Nuevo modelo SQLAlchemy `SystemStatusSnapshot`. |
| `backend/models/__init__.py` | Registra/exporta el nuevo modelo. |
| `backend/main.py` | Agrega snapshot builder, throttled writer, history reader y endpoint de historial. |
| `backend/tests/test_system_status.py` | Cubre serialización de snapshots y throttle de 5 minutos. |
| `frontend/services/queryResources.ts` | Agrega tipos/fetcher para historial operativo. |
| `frontend/services/queryKeys.ts` | Agrega key estable con defaults para historial. |
| `frontend/hooks/queries/useSystemStatusHistoryQuery.ts` | Nuevo hook de historial con refetch cada 60s. |
| `frontend/components/SystemDashboard.tsx` | Renderiza historial operativo persistido. |
| `frontend/components/SystemDashboard.test.tsx` | Cubre render/loading/error/empty del historial. |

## ¿Cómo se probó?
- [x] `python -m pytest backend/tests/test_system_status.py backend/tests/test_routers_metrics_events.py::TestMetricsHistory::test_history_with_hours_param backend/tests/test_routers_nodes.py::TestGetNodes::test_list_nodes_with_metrics`
- [x] `corepack pnpm --dir frontend exec vitest run components/SystemDashboard.test.tsx services/queryKeys.test.ts`
- [x] `corepack pnpm --dir frontend run build`
- [x] `git diff --check`
- [x] Shellcheck no aplica: no se modificaron scripts shell.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notas de alcance
- El historial empieza vacío después del deploy y se llena gradualmente.
- La escritura usa un lock local para evitar duplicados concurrentes dentro del proceso; clusters multi-proceso pueden requerir control DB-level futuro si se necesita estricto 1 snapshot/5min global.
- La lectura se mantiene pública por paridad con `/api/system/status`; si se decide proteger datos operativos, conviene hacerlo en un PR de seguridad separado.

---
*Generado por Alex*
