### PR TITLE
fix(kpi): persist snapshots in background

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,25 +12,101 @@ import threading
 from datetime import datetime, timedelta, timezone
 from database import get_db, verify_connection
 
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+# Configure Logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 # Global start time to track system reboots/restarts
 STARTUP_TIME = datetime.now().isoformat()
 _DISK_SECTOR_SIZE_BYTES = 512
 _DISK_IO_PREVIOUS_SAMPLE = None
 _DISK_IO_SAMPLE_LOCK = threading.Lock()
-_SYSTEM_STATUS_HISTORY_RETENTION_DAYS = 7
-_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS = 300
 _SYSTEM_STATUS_HISTORY_LOCK = threading.Lock()
+
+
+_SYSTEM_STATUS_SNAPSHOTS_ENABLED = True
+_SYSTEM_STATUS_HISTORY_RETENTION_DAYS = 7
+_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS = 900
+_SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS = 1800
+
+
+def _parse_system_status_bool(value: str) -> bool | None:
+    if value.strip().lower() in ("1", "true", "yes", "on", "enabled", "enable"):
+        return True
+    if value.strip().lower() in ("0", "false", "no", "off", "disabled", "disable"):
+        return False
+    return None
+
+
+def _parse_system_status_int(env_var: str, default_value: int, minimum: int | None = None) -> int:
+    raw_value = os.getenv(env_var)
+    if raw_value is None:
+        return default_value
+
+    try:
+        parsed_value = int(raw_value.strip())
+        if minimum is not None and parsed_value < minimum:
+            raise ValueError(f"{env_var} cannot be lower than {minimum}: {parsed_value}")
+        return parsed_value
+    except Exception as exc:
+        logger.warning(
+            "Invalid value for %s=%r, using default %s: %s",
+            env_var,
+            raw_value,
+            default_value,
+            exc,
+        )
+        return default_value
+
+
+def _reload_system_status_env_settings() -> None:
+    """Load system-status snapshot behavior from environment with safe defaults."""
+    global _SYSTEM_STATUS_SNAPSHOTS_ENABLED
+    global _SYSTEM_STATUS_HISTORY_RETENTION_DAYS
+    global _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS
+    global _SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS
+
+    enabled = os.getenv("SYSTEM_STATUS_SNAPSHOTS_ENABLED", "true")
+    parsed_enabled = _parse_system_status_bool(enabled)
+    if parsed_enabled is None:
+        logger.warning(
+            "Invalid value for SYSTEM_STATUS_SNAPSHOTS_ENABLED=%r, using default true",
+            enabled,
+        )
+        parsed_enabled = True
+    _SYSTEM_STATUS_SNAPSHOTS_ENABLED = parsed_enabled
+
+    _SYSTEM_STATUS_HISTORY_RETENTION_DAYS = _parse_system_status_int(
+        "SYSTEM_STATUS_HISTORY_RETENTION_DAYS",
+        default_value=7,
+        minimum=1,
+    )
+    _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS = _parse_system_status_int(
+        "SYSTEM_STATUS_SNAPSHOT_INTERVAL_SECONDS",
+        default_value=900,
+        minimum=60,
+    )
+    _SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS = _parse_system_status_int(
+        "SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS",
+        default_value=1800,
+        minimum=60,
+    )
+
 from services.snmp_service import snmp_collector_loop, get_collector_status
 from seed_admin import seed_admin
 from seed_roles import seed_roles
 from middleware.rate_limit import RateLimitMiddleware
 
-# APScheduler for backup scheduling
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from apscheduler.triggers.cron import CronTrigger
-
 # Global scheduler instance
 backup_scheduler = AsyncIOScheduler()
+
+
+# Initialize system-status snapshot settings from environment now and again during startup.
+_reload_system_status_env_settings()
 
 
 def schedule_daily_backup() -> None:
@@ -66,10 +142,6 @@ def schedule_daily_backup() -> None:
 
 # Router Imports
 from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli
-
-# Configure Logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="NEX-GEN API",
@@ -199,7 +271,7 @@ async def startup_event():
         logger.error(f"Failed to initialize TimescaleDB: {e}")
 
     # Ensure Defaults
-    pass
+    _reload_system_status_env_settings()
 
     # Seed Admin
     try:
@@ -236,6 +308,14 @@ async def startup_event():
         logger.info("Scheduled audit retention cleanup at 03:30")
     except Exception as e:
         logger.error(f"Failed to schedule audit retention cleanup: {e}")
+
+    # Start System Status Snapshot Scheduler (background ownership for persisted history)
+    if _SYSTEM_STATUS_SNAPSHOTS_ENABLED:
+        try:
+            _register_system_status_snapshot_job()
+        except Exception as e:
+            logger.error("Failed to schedule system status snapshot job: %s", e)
+
     backup_scheduler.start()
     logger.info("Backup scheduler started")
 
@@ -392,6 +472,18 @@ def _should_record_system_status_snapshot(latest_snapshot, now: datetime) -> boo
     ).total_seconds() >= _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS
 
 
+def _is_system_status_history_stale(
+    latest_recorded_at: datetime | None,
+    generated_at: datetime,
+    stale_threshold_seconds: int | None = None,
+) -> bool:
+    """Return whether persisted history is stale."""
+    threshold = stale_threshold_seconds or _SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS
+    if latest_recorded_at is None:
+        return True
+    return (generated_at - latest_recorded_at).total_seconds() > threshold
+
+
 def _build_system_status_snapshot(status: dict, recorded_at: datetime):
     """Convert the live `/api/system/status` payload into a compact persisted row."""
     from models.system_status_history import SystemStatusSnapshot
@@ -454,8 +546,104 @@ def _serialize_system_status_snapshot(snapshot):
     }
 
 
+def _build_system_status_payload() -> dict:
+    """Build live system telemetry payload for dashboard cards."""
+    # 1. System Resources (OS Independent if possible, or Linux specific)
+    cpu_percent = 0.0
+    ram_percent = 0.0
+    disk_percent = 0.0
+
+    try:
+        # Load Average (Unix)
+        if hasattr(os, "getloadavg"):
+            load = os.getloadavg()
+            # Approximation: Load / Cores * 100 (Simplified)
+            cpu_percent = min((load[0] / os.cpu_count()) * 100, 100)
+    except:
+        pass
+
+    try:
+        # Disk Usage
+        total, used, free = shutil.disk_usage("/")
+        disk_percent = (used / total) * 100
+    except:
+        pass
+
+    # RAM (Linux /proc/meminfo parsing)
+    if platform.system() == "Linux":
+        try:
+            with open("/proc/meminfo", "r") as f:
+                lines = f.readlines()
+                mem_total = int(lines[0].split()[1])
+                mem_available = int(lines[2].split()[1])  # MemAvailable usually
+                ram_percent = ((mem_total - mem_available) / mem_total) * 100
+        except:
+            pass
+
+    # 2. Service Status
+    neo4j_status = "UNKNOWN"
+    try:
+        verify_connection(max_retries=1, retry_delay=0)
+        neo4j_status = "CONNECTED"
+    except:
+        neo4j_status = "DISCONNECTED"
+
+    postgres_status = "UNKNOWN"
+    try:
+        from postgres_db import engine
+        from sqlalchemy import text
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        postgres_status = "CONNECTED"
+    except:
+        postgres_status = "DISCONNECTED"
+
+    collector = get_collector_status()
+
+    return {
+        "cpu": round(cpu_percent, 1),
+        "ram": round(ram_percent, 1),
+        "disk": round(disk_percent, 1),
+        "disk_io": _get_disk_io_status(),
+        "neo4j": neo4j_status,
+        "postgres": postgres_status,
+        "collector": collector,
+        "startup_time": STARTUP_TIME,
+    }
+
+
+def _record_system_status_snapshot_job() -> bool:
+    try:
+        payload = _build_system_status_payload()
+        return _record_system_status_snapshot(payload)
+    except Exception as exc:
+        logger.warning("Failed to run system status snapshot job: %s", exc)
+        return False
+
+
+def _register_system_status_snapshot_job() -> bool:
+    if not _SYSTEM_STATUS_SNAPSHOTS_ENABLED:
+        logger.info("System status snapshot scheduler is disabled")
+        return False
+
+    backup_scheduler.add_job(
+        _record_system_status_snapshot_job,
+        trigger=IntervalTrigger(seconds=_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS),
+        id="system_status_snapshot",
+        name="System Status Snapshot",
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    logger.info(
+        "Scheduled system status snapshot job every %ss",
+        _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS,
+    )
+    return True
+
+
 def _record_system_status_snapshot(status: dict, now: datetime | None = None) -> bool:
-    """Persist a throttled operational snapshot and prune data older than 7 days."""
+    """Persist a throttled operational snapshot and prune data older than configured retention."""
     from postgres_db import SessionLocal
     from models.system_status_history import SystemStatusSnapshot
 
@@ -506,11 +694,21 @@ def _fetch_system_status_history(hours: int, limit: int, now: datetime | None = 
             .limit(limit)
             .all()
         )
+        latest_recorded_at = snapshots[0].recorded_at if snapshots else None
+        is_stale = _is_system_status_history_stale(
+            latest_recorded_at=latest_recorded_at,
+            generated_at=generated_at,
+        )
+
         return {
             "generated_at": _utc_isoformat(generated_at),
             "hours": hours,
             "limit": limit,
             "retention_days": _SYSTEM_STATUS_HISTORY_RETENTION_DAYS,
+            "snapshot_interval_seconds": _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS,
+            "stale_threshold_seconds": _SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS,
+            "latest_recorded_at": _utc_isoformat(latest_recorded_at) if latest_recorded_at else None,
+            "is_stale": is_stale,
             "rows": [_serialize_system_status_snapshot(row) for row in snapshots],
         }
     finally:
@@ -522,71 +720,7 @@ def get_system_status():
     """
     Get internal system health metrics (CPU, RAM, Disk, Services).
     """
-    # 1. System Resources (OS Independent if possible, or Linux specific)
-    cpu_percent = 0.0
-    ram_percent = 0.0
-    disk_percent = 0.0
-
-    try:
-        # Load Average (Unix)
-        if hasattr(os, "getloadavg"):
-            load = os.getloadavg()
-            # Approximation: Load / Cores * 100 (Simplified)
-            cpu_percent = min((load[0] / os.cpu_count()) * 100, 100)
-    except:
-        pass
-
-    try:
-        # Disk Usage
-        total, used, free = shutil.disk_usage("/")
-        disk_percent = (used / total) * 100
-    except:
-        pass
-
-    # RAM (Linux /proc/meminfo parsing)
-    if platform.system() == "Linux":
-        try:
-            with open("/proc/meminfo", "r") as f:
-                lines = f.readlines()
-                mem_total = int(lines[0].split()[1])
-                mem_free = int(lines[1].split()[1])  # MemFree
-                mem_available = int(lines[2].split()[1])  # MemAvailable usually
-                ram_percent = ((mem_total - mem_available) / mem_total) * 100
-        except:
-            pass
-
-    # 2. Service Status
-    neo4j_status = "UNKNOWN"
-    try:
-        verify_connection(max_retries=1, retry_delay=0)
-        neo4j_status = "CONNECTED"
-    except:
-        neo4j_status = "DISCONNECTED"
-
-    postgres_status = "UNKNOWN"
-    try:
-        from postgres_db import engine
-        from sqlalchemy import text
-        with engine.connect() as conn:
-            conn.execute(text("SELECT 1"))
-        postgres_status = "CONNECTED"
-    except:
-        postgres_status = "DISCONNECTED"
-
-    collector = get_collector_status()
-
-    payload = {
-        "cpu": round(cpu_percent, 1),
-        "ram": round(ram_percent, 1),
-        "disk": round(disk_percent, 1),
-        "disk_io": _get_disk_io_status(),
-        "neo4j": neo4j_status,
-        "postgres": postgres_status,
-        "collector": collector,
-        "startup_time": STARTUP_TIME,
-    }
-    _record_system_status_snapshot(payload)
-    return payload
+    return _build_system_status_payload()
 
 
 @app.get("/api/system/status/history")

--- a/backend/tests/test_system_status.py
+++ b/backend/tests/test_system_status.py
@@ -1,12 +1,18 @@
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
+import main
 from main import (
     _build_disk_io_status,
     _build_system_status_snapshot,
     _collect_disk_io_sample,
+    _fetch_system_status_history,
+    _is_diskstats_device,
+    _is_system_status_history_stale,
+    _register_system_status_snapshot_job,
+    _reload_system_status_env_settings,
     _serialize_system_status_snapshot,
     _should_record_system_status_snapshot,
-    _is_diskstats_device,
 )
 
 
@@ -138,11 +144,149 @@ def test_system_status_snapshot_serializes_compact_operational_history_row():
     }
 
 
-def test_should_record_system_status_snapshot_honors_five_minute_throttle():
-    now = datetime(2026, 1, 1, 12, 5, 0)
-    latest = type("Snapshot", (), {"recorded_at": now - timedelta(minutes=4)})()
-    stale = type("Snapshot", (), {"recorded_at": now - timedelta(minutes=5)})()
+def test_should_record_system_status_snapshot_honors_fifteen_minute_throttle():
+    now = datetime(2026, 1, 1, 12, 15, 0)
+    latest = type("Snapshot", (), {"recorded_at": now - timedelta(minutes=14)})()
+    stale = type("Snapshot", (), {"recorded_at": now - timedelta(minutes=15)})()
 
     assert _should_record_system_status_snapshot(None, now) is True
     assert _should_record_system_status_snapshot(latest, now) is False
     assert _should_record_system_status_snapshot(stale, now) is True
+
+
+def test_system_status_history_staleness_calculation():
+    now = datetime(2026, 1, 1, 12, 0, 0)
+
+    assert _is_system_status_history_stale(now - timedelta(minutes=29), now, stale_threshold_seconds=1800) is False
+    assert _is_system_status_history_stale(now - timedelta(minutes=31), now, stale_threshold_seconds=1800) is True
+    assert _is_system_status_history_stale(None, now, stale_threshold_seconds=1800) is True
+
+
+def test_get_system_status_does_not_record_snapshot_on_request(monkeypatch):
+    payload = {
+        "cpu": 1.1,
+        "ram": 2.2,
+        "disk": 3.3,
+        "disk_io": {"supported": False},
+        "neo4j": "CONNECTED",
+        "postgres": "CONNECTED",
+        "collector": {"status": "RUNNING", "stats": {}},
+        "startup_time": "startup",
+    }
+    record_calls = []
+
+    monkeypatch.setattr(main, "_build_system_status_payload", lambda: payload)
+    monkeypatch.setattr(main, "_record_system_status_snapshot", lambda *args, **kwargs: record_calls.append((args, kwargs)))
+
+    status = main.get_system_status()
+
+    assert status == payload
+    assert len(record_calls) == 0
+
+
+def _patch_status_history_rows(monkeypatch, rows):
+    class FakeQuery:
+        def filter(self, *_args, **_kwargs): return self
+        def order_by(self, *_args, **_kwargs): return self
+        def limit(self, *_args, **_kwargs): return self
+        def all(self): return rows
+
+    class FakeDb:
+        def query(self, *_args, **_kwargs): return FakeQuery()
+        def close(self): pass
+
+    monkeypatch.setattr("postgres_db.SessionLocal", lambda: FakeDb())
+
+
+def test_fetch_system_status_history_includes_freshness_metadata(monkeypatch):
+    snapshot = type("Snapshot", (), {
+        "recorded_at": datetime(2026, 1, 1, 11, 31, 0),
+        "cpu": 24.5, "ram": 61.2, "disk": 40.0,
+        "disk_io_supported": True,
+        "disk_read_bytes_per_sec": 1024.0,
+        "disk_write_bytes_per_sec": 2048.0,
+        "disk_busy_percentage": 12.5,
+        "neo4j_status": "CONNECTED", "postgres_status": "CONNECTED",
+        "collector_status": "RUNNING", "collector_cis_monitored": 8,
+        "collector_metrics_collected": 120, "collector_metrics_failed": 1,
+        "collector_jobs_per_min": 44.0, "collector_cycle_duration": 3.0,
+    })()
+    _patch_status_history_rows(monkeypatch, [snapshot])
+    monkeypatch.setattr(main, "_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS", 900)
+    monkeypatch.setattr(main, "_SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS", 1800)
+
+    history = _fetch_system_status_history(
+        hours=168,
+        limit=500,
+        now=datetime(2026, 1, 1, 12, 0, 0),
+    )
+
+    assert history["snapshot_interval_seconds"] == 900
+    assert history["stale_threshold_seconds"] == 1800
+    assert history["latest_recorded_at"] == "2026-01-01T11:31:00Z"
+    assert history["is_stale"] is False
+    assert history["rows"][0]["recorded_at"] == "2026-01-01T11:31:00Z"
+
+
+def test_fetch_system_status_history_marks_missing_rows_stale(monkeypatch):
+    _patch_status_history_rows(monkeypatch, [])
+
+    history = _fetch_system_status_history(
+        hours=168,
+        limit=500,
+        now=datetime(2026, 1, 1, 12, 0, 0),
+    )
+
+    assert history["latest_recorded_at"] is None
+    assert history["is_stale"] is True
+    assert history["rows"] == []
+
+
+def test_reload_system_status_env_settings_uses_safe_defaults(monkeypatch):
+    monkeypatch.setenv("SYSTEM_STATUS_SNAPSHOTS_ENABLED", "off")
+    monkeypatch.setenv("SYSTEM_STATUS_SNAPSHOT_INTERVAL_SECONDS", "30")
+    monkeypatch.setenv("SYSTEM_STATUS_HISTORY_RETENTION_DAYS", "invalid")
+    monkeypatch.setenv("SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS", "1801")
+
+    _reload_system_status_env_settings()
+
+    assert main._SYSTEM_STATUS_SNAPSHOTS_ENABLED is False
+    assert main._SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS == 900
+    assert main._SYSTEM_STATUS_HISTORY_RETENTION_DAYS == 7
+    assert main._SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS == 1801
+
+    monkeypatch.setenv("SYSTEM_STATUS_SNAPSHOTS_ENABLED", "true")
+    monkeypatch.setenv("SYSTEM_STATUS_SNAPSHOT_INTERVAL_SECONDS", "900")
+    monkeypatch.setenv("SYSTEM_STATUS_HISTORY_RETENTION_DAYS", "7")
+    monkeypatch.setenv("SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS", "1800")
+    _reload_system_status_env_settings()
+
+
+def test_register_system_status_snapshot_job_is_noop_when_disabled(monkeypatch):
+    fake_scheduler = MagicMock()
+    monkeypatch.setattr(main, "backup_scheduler", fake_scheduler)
+    monkeypatch.setattr(main, "_SYSTEM_STATUS_SNAPSHOTS_ENABLED", False)
+
+    result = _register_system_status_snapshot_job()
+
+    assert result is False
+    fake_scheduler.add_job.assert_not_called()
+
+
+def test_register_system_status_snapshot_job_registers_interval_job(monkeypatch):
+    fake_scheduler = MagicMock()
+    monkeypatch.setattr(main, "backup_scheduler", fake_scheduler)
+    monkeypatch.setattr(main, "_SYSTEM_STATUS_SNAPSHOTS_ENABLED", True)
+    monkeypatch.setattr(main, "_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS", 900)
+
+    result = _register_system_status_snapshot_job()
+
+    assert result is True
+    fake_scheduler.add_job.assert_called_once()
+    _, kwargs = fake_scheduler.add_job.call_args
+    assert kwargs["id"] == "system_status_snapshot"
+    assert kwargs["replace_existing"] is True
+    assert kwargs["max_instances"] == 1
+    assert kwargs["coalesce"] is True
+    trigger = kwargs["trigger"]
+    assert trigger.interval.total_seconds() == 900


### PR DESCRIPTION
## Descripción del Cambio
Closes #262

Backend slice for server KPI operational history snapshots.

- Moves snapshot persistence out of `GET /api/system/status` and into a backend-owned scheduler.
- Adds env-backed defaults for 15-minute snapshot cadence, 7-day retention, 30-minute stale threshold, and a scheduler kill switch.
- Extends `/api/system/status/history` with freshness metadata for the UI.

Chain context:

```text
main
└── 📍 PR 1: backend scheduler + history metadata
    └── PR 2: frontend stale warning + patch changelog (follow-up PR)
```

Out of scope for this PR:
- Frontend stale warning UI.
- CI/SNMP/ICMP collector changes.
- Merging/releasing; this PR is for review only.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && python -m pytest tests/test_system_status.py` — 13 passed, 5 warnings
- [x] `cd backend && python -m pytest` — baseline has unrelated failures; targeted system-status suite passes
- [x] LSP diagnostics clean for changed backend files
- [x] Judgment Day dual review — both judges clean

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
