### PR TITLE
fix(metrics): derive packet loss from icmp polling

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -484,14 +484,6 @@ def poll_snmp():
                     ))
                     val = measurement.availability_value
                     sample_time = datetime.utcnow()
-                    if measurement.available:
-                        previous_latency = _previous_latency_ms(db, node_id, sample_time)
-                        sidecar_samples = build_icmp_sidecar_samples(
-                            node_id,
-                            measurement,
-                            previous_latency_ms=previous_latency,
-                            observed_at=sample_time,
-                        )
                     # Debounce logic: track consecutive failures per node
                     if val == 0:
                         _consecutive_failures[node_id] = _consecutive_failures.get(node_id, 0) + 1
@@ -508,6 +500,18 @@ def poll_snmp():
                     else:
                         # Success: reset counter and proceed normally
                         _consecutive_failures[node_id] = 0
+                    if val is not None:
+                        previous_latency = (
+                            _previous_latency_ms(db, node_id, sample_time)
+                            if measurement.available
+                            else None
+                        )
+                        sidecar_samples = build_icmp_sidecar_samples(
+                            node_id,
+                            measurement,
+                            previous_latency_ms=previous_latency,
+                            observed_at=sample_time,
+                        )
                 snmp_status = "OK"
                 snmp_error = None
                 if protocol == SOURCE_PROTOCOL_SNMP and record["oid"]:

--- a/backend/polling/icmp_measurements.py
+++ b/backend/polling/icmp_measurements.py
@@ -9,7 +9,8 @@ from typing import Any
 ICMP_AVAILABILITY_METRIC_ID = "icmp_availability"
 ICMP_LATENCY_METRIC_ID = "icmp_latency_ms"
 ICMP_JITTER_METRIC_ID = "icmp_jitter_ms"
-ICMP_SIDECAR_METRIC_IDS = [ICMP_LATENCY_METRIC_ID, ICMP_JITTER_METRIC_ID]
+ICMP_PACKET_LOSS_METRIC_ID = "packet_loss_pct"
+ICMP_SIDECAR_METRIC_IDS = [ICMP_LATENCY_METRIC_ID, ICMP_JITTER_METRIC_ID, ICMP_PACKET_LOSS_METRIC_ID]
 
 
 @dataclass(frozen=True)
@@ -63,9 +64,18 @@ def build_icmp_sidecar_samples(
     previous_latency_ms: float | None = None,
     observed_at: Any | None = None,
 ) -> list[dict[str, Any]]:
-    """Build latency and optional jitter sidecar samples for a successful ping."""
+    """Build derived ICMP telemetry samples from a recorded ping result."""
+    packet_loss = 0.0 if measurement.available else 100.0
+    packet_loss_sample = {
+        "node_id": node_id,
+        "metric_id": ICMP_PACKET_LOSS_METRIC_ID,
+        "value": packet_loss,
+    }
     if not measurement.available or measurement.latency_ms is None:
-        return []
+        samples = [packet_loss_sample]
+        if observed_at is not None:
+            samples[0]["time"] = observed_at
+        return samples
     samples: list[dict[str, Any]] = [{
         "node_id": node_id,
         "metric_id": ICMP_LATENCY_METRIC_ID,
@@ -77,6 +87,7 @@ def build_icmp_sidecar_samples(
             "metric_id": ICMP_JITTER_METRIC_ID,
             "value": abs(float(measurement.latency_ms) - float(previous_latency_ms)),
         })
+    samples.append(packet_loss_sample)
     if observed_at is not None:
         for sample in samples:
             sample["time"] = observed_at

--- a/backend/polling/writer_pool.py
+++ b/backend/polling/writer_pool.py
@@ -12,7 +12,12 @@ from sqlalchemy import text
 
 from models.timescale_models import MetricValue
 from polling import event_writer, pg_queue
-from polling.icmp_measurements import ICMP_AVAILABILITY_METRIC_ID, ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
+from polling.icmp_measurements import (
+    ICMP_AVAILABILITY_METRIC_ID,
+    ICMP_JITTER_METRIC_ID,
+    ICMP_LATENCY_METRIC_ID,
+    ICMP_PACKET_LOSS_METRIC_ID,
+)
 
 
 def _utc_now() -> datetime:
@@ -98,14 +103,24 @@ def previous_metric_value(db, node_id: str, metric_id: str, before: datetime) ->
 
 def _sidecar_samples(db, envelope: Mapping[str, Any]) -> list[dict[str, Any]]:
     icmp = ((envelope.get("metadata") or {}).get("icmp") or {})
-    if "latency_ms" not in icmp:
+    sidecar_ids = set(icmp.get("sidecar_metric_ids") or [])
+    if not sidecar_ids:
         return []
     observed = _timestamp(envelope["observed_at"])
-    latency = float(icmp["latency_ms"])
-    samples = [{"node_id": envelope["ci_id"], "metric_id": ICMP_LATENCY_METRIC_ID, "value": latency, "time": observed}]
-    previous = previous_metric_value(db, envelope["ci_id"], ICMP_LATENCY_METRIC_ID, observed)
-    if previous is not None:
+    samples = []
+    numeric = _numeric(envelope)
+    if ICMP_LATENCY_METRIC_ID in sidecar_ids and "latency_ms" in icmp:
+        latency = float(icmp["latency_ms"])
+        samples.append({"node_id": envelope["ci_id"], "metric_id": ICMP_LATENCY_METRIC_ID, "value": latency, "time": observed})
+        previous = previous_metric_value(db, envelope["ci_id"], ICMP_LATENCY_METRIC_ID, observed)
+    else:
+        latency = None
+        previous = None
+    if ICMP_JITTER_METRIC_ID in sidecar_ids and latency is not None and previous is not None:
         samples.append({"node_id": envelope["ci_id"], "metric_id": ICMP_JITTER_METRIC_ID, "value": abs(latency - previous), "time": observed})
+    if ICMP_PACKET_LOSS_METRIC_ID in sidecar_ids and numeric is not None:
+        packet_loss = 0.0 if numeric > 0 else 100.0
+        samples.append({"node_id": envelope["ci_id"], "metric_id": ICMP_PACKET_LOSS_METRIC_ID, "value": packet_loss, "time": observed})
     return samples
 
 

--- a/backend/tests/test_icmp_measurements.py
+++ b/backend/tests/test_icmp_measurements.py
@@ -1,6 +1,7 @@
 from polling.icmp_measurements import (
     ICMP_JITTER_METRIC_ID,
     ICMP_LATENCY_METRIC_ID,
+    ICMP_PACKET_LOSS_METRIC_ID,
     PingMeasurement,
     build_icmp_sidecar_samples,
     is_icmp_availability_metric,
@@ -25,16 +26,22 @@ def test_parse_ping_latency_ms_returns_none_for_failures():
 def test_build_icmp_sidecar_samples_success_failure_and_jitter():
     success = PingMeasurement(available=True, latency_ms=15.5, raw="ok")
     samples = build_icmp_sidecar_samples("ci-1", success, previous_latency_ms=None)
-    assert samples == [{"node_id": "ci-1", "metric_id": ICMP_LATENCY_METRIC_ID, "value": 15.5}]
+    assert samples == [
+        {"node_id": "ci-1", "metric_id": ICMP_LATENCY_METRIC_ID, "value": 15.5},
+        {"node_id": "ci-1", "metric_id": ICMP_PACKET_LOSS_METRIC_ID, "value": 0.0},
+    ]
 
     with_jitter = build_icmp_sidecar_samples("ci-1", success, previous_latency_ms=10.0)
     assert with_jitter == [
         {"node_id": "ci-1", "metric_id": ICMP_LATENCY_METRIC_ID, "value": 15.5},
         {"node_id": "ci-1", "metric_id": ICMP_JITTER_METRIC_ID, "value": 5.5},
+        {"node_id": "ci-1", "metric_id": ICMP_PACKET_LOSS_METRIC_ID, "value": 0.0},
     ]
 
     failure = PingMeasurement(available=False, latency_ms=None, raw="timeout")
-    assert build_icmp_sidecar_samples("ci-1", failure, previous_latency_ms=10.0) == []
+    assert build_icmp_sidecar_samples("ci-1", failure, previous_latency_ms=10.0) == [
+        {"node_id": "ci-1", "metric_id": ICMP_PACKET_LOSS_METRIC_ID, "value": 100.0},
+    ]
 
 
 def test_icmp_metric_kind_helpers_deny_sidecars_even_with_bad_availability_metadata():
@@ -42,6 +49,8 @@ def test_icmp_metric_kind_helpers_deny_sidecars_even_with_bad_availability_metad
     assert is_icmp_availability_metric("PING-router-a", {}) is True
     assert is_icmp_availability_metric("icmp_latency_ms", {"metric_kind": "availability"}) is False
     assert is_icmp_availability_metric("icmp_jitter_ms", {"metric_kind": "availability"}) is False
+    assert is_icmp_availability_metric("packet_loss_pct", {"metric_kind": "availability"}) is False
     assert is_icmp_telemetry_metric("icmp_latency_ms", {}) is True
     assert is_icmp_telemetry_metric("icmp_jitter_ms", {"metric_kind": "availability"}) is True
+    assert is_icmp_telemetry_metric("packet_loss_pct", {"metric_kind": "availability"}) is True
     assert is_icmp_telemetry_metric("PING-CHECK", {"metric_kind": "availability"}) is False

--- a/backend/tests/test_polling_snmp_executor.py
+++ b/backend/tests/test_polling_snmp_executor.py
@@ -95,7 +95,7 @@ def test_icmp_executor_maps_ping_success_and_failure_statuses():
     assert success.metric_id == "PING-CHECK"
     assert success.metadata["metric_kind"] == "availability"
     assert success.metadata["icmp"]["latency_ms"] == 18.25
-    assert success.metadata["icmp"]["sidecar_metric_ids"] == ["icmp_latency_ms", "icmp_jitter_ms"]
+    assert success.metadata["icmp"]["sidecar_metric_ids"] == ["icmp_latency_ms", "icmp_jitter_ms", "packet_loss_pct"]
     assert failure.status == PollingResultStatus.CRITICAL
     assert failure.value["numeric"] == 0.0
     assert "latency_ms" not in failure.metadata["icmp"]

--- a/backend/tests/test_polling_writer_pool.py
+++ b/backend/tests/test_polling_writer_pool.py
@@ -65,7 +65,10 @@ def test_writer_expands_icmp_sidecar_samples_and_keeps_events_primary_only(monke
     row.envelope.update({
         "protocol": "ICMP",
         "metric_id": "PING-CHECK",
-        "metadata": {"metric_kind": "availability", "icmp": {"latency_ms": 20.0, "sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms"]}},
+        "metadata": {
+            "metric_kind": "availability",
+            "icmp": {"latency_ms": 20.0, "sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms", "packet_loss_pct"]},
+        },
     })
     monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
@@ -76,11 +79,42 @@ def test_writer_expands_icmp_sidecar_samples_and_keeps_events_primary_only(monke
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
 
-    assert stats["inserted"] == 3
+    assert stats["inserted"] == 4
     assert persisted[0][1] == [
         {"node_id": "ci-1", "metric_id": "PING-CHECK", "value": 1.0, "time": row.observed_at},
         {"node_id": "ci-1", "metric_id": "icmp_latency_ms", "value": 20.0, "time": row.observed_at},
         {"node_id": "ci-1", "metric_id": "icmp_jitter_ms", "value": 7.5, "time": row.observed_at},
+        {"node_id": "ci-1", "metric_id": "packet_loss_pct", "value": 0.0, "time": row.observed_at},
+    ]
+    assert [event["metric_id"] for event in event_rows] == ["PING-CHECK"]
+
+
+def test_writer_expands_failed_icmp_availability_to_packet_loss_sidecar(monkeypatch):
+    from polling import writer_pool
+
+    persisted = []
+    event_rows = []
+    row = _row(key="icmp-failed", numeric=0.0)
+    row.protocol = "ICMP"
+    row.metric_id = "PING-CHECK"
+    row.envelope.update({
+        "protocol": "ICMP",
+        "metric_id": "PING-CHECK",
+        "metadata": {"metric_kind": "availability", "icmp": {"sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms", "packet_loss_pct"]}},
+    })
+    monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
+    monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
+    monkeypatch.setattr(writer_pool, "previous_metric_value", lambda *a, **k: (_ for _ in ()).throw(AssertionError("latency lookup not expected")))
+    monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: None)
+
+    stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
+
+    assert stats["inserted"] == 2
+    assert persisted[0][1] == [
+        {"node_id": "ci-1", "metric_id": "PING-CHECK", "value": 0.0, "time": row.observed_at},
+        {"node_id": "ci-1", "metric_id": "packet_loss_pct", "value": 100.0, "time": row.observed_at},
     ]
     assert [event["metric_id"] for event in event_rows] == ["PING-CHECK"]
 
@@ -97,7 +131,11 @@ def test_writer_persists_only_sidecars_for_internal_icmp_availability(monkeypatc
     row.envelope.update({
         "protocol": "ICMP",
         "metric_id": "icmp_availability",
-        "metadata": {"metric_kind": "availability", "internal": True, "icmp": {"latency_ms": 20.0, "sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms"]}},
+        "metadata": {
+            "metric_kind": "availability",
+            "internal": True,
+            "icmp": {"latency_ms": 20.0, "sidecar_metric_ids": ["icmp_latency_ms", "icmp_jitter_ms", "packet_loss_pct"]},
+        },
     })
     monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
@@ -108,10 +146,11 @@ def test_writer_persists_only_sidecars_for_internal_icmp_availability(monkeypatc
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
 
-    assert stats["inserted"] == 2
+    assert stats["inserted"] == 3
     assert persisted[0][1] == [
         {"node_id": "ci-1", "metric_id": "icmp_latency_ms", "value": 20.0, "time": row.observed_at},
         {"node_id": "ci-1", "metric_id": "icmp_jitter_ms", "value": 7.5, "time": row.observed_at},
+        {"node_id": "ci-1", "metric_id": "packet_loss_pct", "value": 0.0, "time": row.observed_at},
     ]
     assert event_rows == []
     assert completed == [row.result_id]


### PR DESCRIPTION
Closes #265

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Derives `packet_loss_pct` from ICMP ping measurements as sidecar telemetry.
- Preserves debounce suppression in the legacy worker path and expands packet loss in the queue writer path.
- Adds focused tests for ICMP sidecars, executor metadata, and writer expansion.

## Changes
| File | Change |
|------|--------|
| `backend/polling/icmp_measurements.py` | Adds `packet_loss_pct` as an ICMP sidecar and derives 0/100 packet loss samples. |
| `backend/engines/snmp_worker.py` | Builds ICMP sidecars after debounce so recorded failures persist packet loss. |
| `backend/polling/writer_pool.py` | Expands packet loss sidecars from ICMP result metadata in queue mode. |
| `backend/tests/*` | Updates and adds coverage for packet loss sidecar behavior. |

## Test Plan
- [x] `python -m pytest backend/tests/test_icmp_measurements.py`
- [x] `python -m pytest backend/tests/test_polling_snmp_executor.py`
- [x] `python -m pytest backend/tests/test_polling_writer_pool.py`
- [x] Fresh review: PASS WITH CONCERNS, concern resolved by runtime verification.
- [x] Runtime Docker/Neo4j validation: `packet_loss_pct` reached 25/25 relationships with `last_polled` after worker cycles.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Tests cover the changed behavior
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
