### PR TITLE
feat(catalog): add category technology icons

### DIFF
--- a/backend/models/core.py
+++ b/backend/models/core.py
@@ -41,6 +41,7 @@ class Link(BaseModel):
 
 class Category(BaseModel):
     name: str
+    icon_key: Optional[str] = None
 
 
 class MetricDef(BaseModel):

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -1,4 +1,5 @@
 # pyright: reportArgumentType=false
+from __future__ import annotations
 from typing import List, Dict, Any, Optional, Set
 import importlib
 import json
@@ -6,7 +7,6 @@ from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC
 import re
 from neo4j import Driver
 from database import get_db
-from models.core import Node, Link
 _relationship_types = importlib.import_module("services.relationship_types")
 LISTABLE_RELATIONSHIP_TYPES = _relationship_types.LISTABLE_RELATIONSHIP_TYPES
 SUPPORTED_CI_RELATIONSHIP_TYPES = _relationship_types.SUPPORTED_CI_RELATIONSHIP_TYPES
@@ -24,13 +24,21 @@ def get_nodes(allowed_locations: Optional[List[str]] = None, is_admin: bool = Fa
     query += """
         OPTIONAL MATCH (n)-[:CATEGORIZED_AS]->(c:Category)
         OPTIONAL MATCH (n)-[r:HAS_METRIC]->(m:MetricDef)
-        RETURN n, c.name as category, collect({
+        RETURN n, c.name as category, c.icon_key as category_icon_key, collect({
             name: m.id, protocol: m.protocol, status: r.status, value: r.last_value, last_updated: r.last_updated
         }) as metrics
-    """
+        """
     with driver.session() as session:
         result = session.run(query, **params)
-        return [{"node": r["n"], "category": r["category"], "metrics": r["metrics"]} for r in result]
+    return [
+        {
+            "node": r["n"],
+            "category": r["category"],
+            "category_icon_key": r["category_icon_key"],
+            "metrics": r["metrics"],
+        }
+        for r in result
+    ]
 
 def upsert_node(node: Node) -> None:
     driver = get_db()

--- a/backend/routers/catalog.py
+++ b/backend/routers/catalog.py
@@ -16,10 +16,11 @@ router = APIRouter(
 
 
 class CategoryUpdate(BaseModel):
-    name: str
+    name: Optional[str] = None
+    icon_key: Optional[str] = None
 
 
-@router.get("/categories", response_model=List[Dict[str, str]])
+@router.get("/categories", response_model=List[Dict[str, Any]])
 async def get_categories(current_user: User = Depends(get_current_active_user)):
     """Fetch all available CI Categories."""
     return catalog_service.get_categories()
@@ -62,7 +63,8 @@ async def update_category(
         raise HTTPException(
             status_code=403, detail="Not authorized to update categories"
         )
-    return catalog_service.update_category(name, update.name)
+    new_name = update.name or name
+    return catalog_service.update_category(name, new_name, update.icon_key)
 
 
 @router.get("/categories/{name}/usage")

--- a/backend/services/catalog_service.py
+++ b/backend/services/catalog_service.py
@@ -2,17 +2,61 @@ import json
 from typing import List, Dict, Any, Optional
 from database import get_db
 from models.core import Category, HardwareModel, OwnerGroup
+from services.category_icons import (
+    get_default_category_icon,
+    normalize_icon_key,
+    is_valid_icon_key,
+    resolve_category_icon,
+)
+from fastapi import HTTPException
 
 def get_categories() -> List[Dict[str, str]]:
     driver = get_db()
     with driver.session() as session:
-        result = session.run("MATCH (c:Category) RETURN c.name as name")
-        return [{"name": record["name"]} for record in result]
+        result = session.run(
+            "MATCH (c:Category) RETURN c.name as name, c.icon_key as icon_key"
+        )
+        return [
+            {
+                "name": record["name"],
+                "icon_key": resolve_category_icon(record["name"], record.get("icon_key")),
+            }
+            for record in result
+        ]
 
 def create_category(category: Category) -> Dict[str, str]:
     driver = get_db()
+    if category.icon_key is not None and not is_valid_icon_key(category.icon_key):
+        # Unknown icon values are rejected at API level, but keep defense in depth.
+        raise HTTPException(status_code=400, detail="Invalid icon_key")
+
+    icon_key = normalize_icon_key(category.icon_key) or get_default_category_icon(category.name)
+
+    # Respect default catalog mapping for known technologies while avoiding overriding
+    # unknown/custom metadata.
+    default_icon = get_default_category_icon(category.name)
+
     with driver.session() as session:
-        session.run("MERGE (c:Category {name: $name})", name=category.name)
+        if icon_key is not None:
+            session.run(
+                """
+                MERGE (c:Category {name: $name})
+                ON CREATE SET c.icon_key = $icon_key
+                ON MATCH SET c.icon_key = COALESCE(c.icon_key, $default_icon_key)
+                """,
+                name=category.name,
+                icon_key=icon_key,
+                default_icon_key=default_icon,
+            )
+        else:
+            session.run(
+                """
+                MERGE (c:Category {name: $name})
+                ON MATCH SET c.icon_key = COALESCE(c.icon_key, $default_icon_key)
+                """,
+                name=category.name,
+                default_icon_key=default_icon,
+            )
     return {"message": "Category created"}
 
 def delete_category(name: str) -> Dict[str, str]:
@@ -21,13 +65,43 @@ def delete_category(name: str) -> Dict[str, str]:
         session.run("MATCH (c:Category {name: $name}) DETACH DELETE c", name=name)
     return {"message": "Category deleted"}
 
-def update_category(name: str, new_name: str) -> Dict[str, str]:
+def update_category(
+    name: str,
+    new_name: str,
+    icon_key: Optional[str] = None,
+) -> Dict[str, str]:
+    if icon_key is not None and not is_valid_icon_key(icon_key):
+        raise HTTPException(status_code=400, detail="Invalid icon_key")
+
+    # Always keep legacy behavior even if icon_key is omitted.
+    default_icon = get_default_category_icon(new_name)
+
     driver = get_db()
     with driver.session() as session:
-        session.run("""
+        query = """
             MATCH (c:Category {name: $name})
             SET c.name = $new_name
-        """, name=name, new_name=new_name)
+            """
+
+        if icon_key is None:
+            # Preserve stored metadata for unknown categories; only set default for
+            # known technologies when absent.
+            if default_icon:
+                query += " SET c.icon_key = COALESCE(c.icon_key, $default_icon_key)"
+            session.run(
+                query,
+                name=name,
+                new_name=new_name,
+                default_icon_key=default_icon,
+            )
+            return {"message": "Category updated"}
+
+        session.run(
+            query + " SET c.icon_key = $icon_key",
+            name=name,
+            new_name=new_name,
+            icon_key=resolve_category_icon(new_name, icon_key),
+        )
     return {"message": "Category updated"}
 
 def get_category_usage(name: str) -> Dict[str, int]:

--- a/backend/services/category_icons.py
+++ b/backend/services/category_icons.py
@@ -1,0 +1,81 @@
+import re
+
+
+ALLOWED_CATEGORY_ICON_KEYS = {
+    "generic",
+    "switch_l2",
+    "switch_l3",
+    "router",
+    "server",
+    "saas",
+    "storage",
+    "camera",
+    "video_analytics",
+}
+
+
+_CATEGORY_DEFAULT_ICON_BY_NAME = {
+    "layer2switch": "switch_l2",
+    "l2switch": "switch_l2",
+    "switchlayer2": "switch_l2",
+    "layerswitch2": "switch_l2",
+    "switch2": "switch_l2",
+    "layer3switch": "switch_l3",
+    "l3switch": "switch_l3",
+    "switchlayer3": "switch_l3",
+    "layerswitch3": "switch_l3",
+    "switch3": "switch_l3",
+    "router": "router",
+    "server": "server",
+    "saas": "saas",
+    "softwareasaservice": "saas",
+    "storage": "storage",
+    "camera": "camera",
+    "cameras": "camera",
+    "videoanalytics": "video_analytics",
+    "video_analytics": "video_analytics",
+}
+
+
+def normalize_icon_key(icon_key: str | None) -> str | None:
+    if icon_key is None:
+        return None
+
+    normalized = re.sub(r"[^a-z0-9_]+", "", str(icon_key).strip().lower())
+    if not normalized:
+        return None
+
+    alias_map = {
+        "genericicon": "generic",
+        "default": "generic",
+    }
+    normalized = alias_map.get(normalized, normalized)
+    if normalized not in ALLOWED_CATEGORY_ICON_KEYS:
+        return None
+
+    return normalized
+
+
+def is_valid_icon_key(icon_key: str | None) -> bool:
+    return normalize_icon_key(icon_key) is not None
+
+
+def resolve_category_icon(category_name: str | None, icon_key: str | None) -> str:
+    icon = normalize_icon_key(icon_key)
+    if icon:
+        return icon
+
+    default_icon = get_default_category_icon(category_name)
+    if default_icon:
+        return default_icon
+
+    return "generic"
+
+
+def get_default_category_icon(category_name: str | None) -> str | None:
+    if not category_name:
+        return None
+
+    normalized = re.sub(r"[^a-z0-9]+", "", category_name.lower())
+    default_icon = _CATEGORY_DEFAULT_ICON_BY_NAME.get(normalized)
+    return default_icon

--- a/backend/services/node_service.py
+++ b/backend/services/node_service.py
@@ -13,6 +13,7 @@ from models.user import User, UserRole, UserPermission
 from models.core import Node
 from services.auth_service import check_permission
 from fastapi.responses import StreamingResponse, JSONResponse
+from services.category_icons import resolve_category_icon
 from repositories import topology_repo
 
 logger = logging.getLogger(__name__)
@@ -102,10 +103,15 @@ def get_nodes(current_user: User) -> List[Dict[str, Any]]:
                         pass
                 metrics.append(m_data)
 
+        category = record["category"]
         node_data = {
             "id": node.get("id"),
             "label": node.get("name"),
-            "type": record["category"] or node.get("layer", "Unknown"),
+            "type": category or node.get("layer", "Unknown"),
+            "category": category,
+            "category_icon_key": resolve_category_icon(
+                category, record.get("category_icon_key")
+            ),
             "status": node.get("status", "OK"),
             "ip": node.get("ip"),
             "owner": node.get("owner"),

--- a/backend/tests/test_category_icons.py
+++ b/backend/tests/test_category_icons.py
@@ -1,0 +1,31 @@
+"""Tests for category icon catalog normalization and defaults."""
+
+
+from services import category_icons
+
+
+def test_resolve_category_icon_prefers_stored_key():
+    assert (
+        category_icons.resolve_category_icon("Layer 2 switch", "router")
+        == "router"
+    )
+
+
+def test_resolve_category_icon_applies_default_for_known_category():
+    assert (
+        category_icons.resolve_category_icon("Layer 2 switch", None)
+        == "switch_l2"
+    )
+
+
+def test_resolve_category_icon_defaults_to_generic_when_unknown():
+    assert category_icons.resolve_category_icon("Legacy Blade", None) == "generic"
+
+
+def test_invalid_icon_key_normalization_returns_none():
+    assert category_icons.normalize_icon_key("  bad:key! ") is None
+
+
+def test_is_valid_icon_key_accepts_generic_aliases():
+    assert category_icons.is_valid_icon_key("Generic")
+    assert category_icons.is_valid_icon_key("default")

--- a/backend/tests/test_node_service.py
+++ b/backend/tests/test_node_service.py
@@ -366,6 +366,55 @@ class TestGetNodes:
 
             assert result[0]["type"] == "core-router"
 
+    def test_category_field_is_exposed_and_type_remains_compatible(self):
+        """Nodes must include category metadata while preserving type semantics."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(layer="router"),
+            category="Core Router",
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [
+                {
+                    **node_record,
+                    "category_icon_key": "router",
+                }
+            ]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["type"] == "Core Router"
+            assert result[0]["category"] == "Core Router"
+            assert result[0]["category_icon_key"] == "router"
+
+    def test_category_icon_key_defaults_to_generic_when_missing(self):
+        """Missing icon metadata should default to generic in node payloads."""
+        admin = _make_user(username="admin", role="ADMIN")
+        node_record = _make_full_record(
+            node_props=_make_node_record(layer="firewall"),
+            category="Legacy Device",
+            metrics=[],
+        )
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [
+                {
+                    **node_record,
+                    "category_icon_key": None,
+                }
+            ]
+
+            from services.node_service import get_nodes
+
+            result = get_nodes(admin)
+
+            assert result[0]["type"] == "Legacy Device"
+            assert result[0]["category"] == "Legacy Device"
+            assert result[0]["category_icon_key"] == "generic"
+
     def test_empty_nodes_list_returns_empty(self):
         """When repo returns no nodes, result should be empty list."""
         admin = _make_user(username="admin", role="ADMIN")

--- a/backend/tests/test_routers_catalog.py
+++ b/backend/tests/test_routers_catalog.py
@@ -98,6 +98,23 @@ class TestCategoriesRouter:
         assert len(data) == 2
         assert data[0]["name"] == "Router"
 
+    def test_get_categories_returns_icon_metadata_and_generic_default(self):
+        _override_current_user(_make_pydantic_user())
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.get_categories.return_value = [
+                {"name": "Layer 2 switch", "icon_key": "switch_l2"},
+                {"name": "Legacy Device", "icon_key": "generic"},
+            ]
+
+            response = client.get("/api/categories")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data[0]["name"] == "Layer 2 switch"
+        assert data[0]["icon_key"] == "switch_l2"
+        assert data[1]["name"] == "Legacy Device"
+        assert data[1]["icon_key"] == "generic"
+
     def test_get_categories_requires_authentication(self):
         # Clear any global overrides to simulate no-token/invalid-token
         app.dependency_overrides.clear()
@@ -168,6 +185,22 @@ class TestCategoriesRouter:
         sent_category = mock_service.create_category.call_args.args[0]
         assert sent_category.name == "Router"
 
+    def test_create_category_saves_icon_key_when_provided(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_category.return_value = {"message": "Category created"}
+
+            response = client.post(
+                "/api/categories",
+                json={"name": "Router", "icon_key": "router"},
+            )
+
+        assert response.status_code == 200
+        sent_category = mock_service.create_category.call_args.args[0]
+        assert sent_category.icon_key == "router"
+
     def test_create_category_conflict(self):
         _override_current_user(
             _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
@@ -190,6 +223,23 @@ class TestCategoriesRouter:
         response = client.post("/api/categories", json={})
 
         assert response.status_code == 422
+
+    def test_create_category_rejects_invalid_icon_key(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.create_category.side_effect = HTTPException(
+                status_code=400, detail="Invalid icon_key"
+            )
+
+            response = client.post(
+                "/api/categories",
+                json={"name": "Router", "icon_key": "not-a-key"},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid icon_key"
 
     def test_delete_category_success(self):
         _override_current_user(
@@ -218,7 +268,39 @@ class TestCategoriesRouter:
 
         assert response.status_code == 200
         assert response.json()["message"] == "Category updated"
-        mock_service.update_category.assert_called_once_with("Router", "Edge Router")
+        mock_service.update_category.assert_called_once_with("Router", "Edge Router", None)
+
+    def test_update_category_accepts_icon_key(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_category.return_value = {"message": "Category updated"}
+
+            response = client.put(
+                "/api/categories/Router",
+                json={"icon_key": "router"},
+            )
+
+        assert response.status_code == 200
+        mock_service.update_category.assert_called_once_with("Router", "Router", "router")
+
+    def test_update_category_rejects_invalid_icon_key(self):
+        _override_current_user(
+            _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
+        )
+        with patch("routers.catalog.catalog_service") as mock_service:
+            mock_service.update_category.side_effect = HTTPException(
+                status_code=400, detail="Invalid icon_key"
+            )
+
+            response = client.put(
+                "/api/categories/Router",
+                json={"icon_key": "not-a-key"},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid icon_key"
 
     def test_get_category_usage_success(self):
         with patch("routers.catalog.catalog_service") as mock_service:

--- a/backend/tests/test_topology_repo_nodes.py
+++ b/backend/tests/test_topology_repo_nodes.py
@@ -37,3 +37,15 @@ def test_get_nodes_keeps_location_scope_for_non_admin(monkeypatch):
     params = session.run.call_args.kwargs
     assert "n.location_name IN $allowed_locations" in query
     assert params["allowed_locations"] == ["HQ-Madrid"]
+
+
+def test_get_nodes_returns_category_icon_key_field(monkeypatch):
+    from repositories import topology_repo
+
+    driver, session = _mock_driver()
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.get_nodes(allowed_locations=None, is_admin=True)
+
+    query = session.run.call_args.args[0]
+    assert "c.icon_key as category_icon_key" in query

--- a/frontend/components/CIDetailModal.test.tsx
+++ b/frontend/components/CIDetailModal.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CIDetailModal from './CIDetailModal';
+import type { GraphNode } from '../types';
+
+vi.mock('./MetricHistoryChart', () => ({
+    default: () => <div>Metric history chart</div>,
+}));
+
+const makeNode = (overrides: Partial<GraphNode> = {}): GraphNode => ({
+    id: overrides.id ?? 'ci-1',
+    label: overrides.label ?? 'Core Router',
+    type: overrides.type ?? 'Infrastructure',
+    status: overrides.status ?? 'ACTIVE',
+    metadata: overrides.metadata ?? {},
+    category: overrides.category ?? 'Network',
+    category_icon_key: overrides.category_icon_key,
+    ip: overrides.ip ?? '10.0.0.1',
+    metrics: overrides.metrics ?? [],
+    ...overrides,
+});
+
+describe('CIDetailModal technology icons', () => {
+    it('renders the explicit category technology icon while keeping operational status separate', () => {
+        render(
+            <CIDetailModal
+                node={makeNode({
+                    status: 'EXCEPTION',
+                    category: 'Network',
+                    category_icon_key: 'router',
+                })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('img', { name: 'Router technology icon' })).toBeInTheDocument();
+        expect(screen.getByText('EXCEPTION STATUS')).toBeInTheDocument();
+        expect(screen.getByText('Network')).toBeInTheDocument();
+    });
+
+    it('falls back to category-name icon resolution when icon metadata is missing', () => {
+        render(
+            <CIDetailModal
+                node={makeNode({
+                    label: 'Access Switch',
+                    category: 'Layer 2 Switch',
+                    category_icon_key: null,
+                })}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByRole('img', { name: 'Layer 2 Switch technology icon' })).toBeInTheDocument();
+        expect(screen.getByText('Layer 2 Switch')).toBeInTheDocument();
+    });
+});

--- a/frontend/components/CIDetailModal.tsx
+++ b/frontend/components/CIDetailModal.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { GraphNode } from '../types';
 import { getStatusClasses } from '../utils/status';
+import CategoryIcon from './CategoryIcon';
 import MetricHistoryChart from './MetricHistoryChart';
 
 interface CIDetailModalProps {
@@ -36,7 +37,12 @@ const CIDetailModal: React.FC<CIDetailModalProps> = ({ node, onClose }) => {
                         <h2 className="text-4xl font-black text-white uppercase tracking-tighter">{node.label || node.id}</h2>
                         <div className="flex flex-wrap gap-3 mt-4">
                             <span className="text-xs font-mono text-neutral-400 bg-black/40 px-3 py-1.5 rounded-lg border border-white/5">ID: {node.id}</span>
-                            {(node.category || node.type) && <span className="text-xs font-bold text-brand-400 bg-brand-500/10 px-3 py-1.5 rounded-lg border border-brand-500/20">{node.category || node.type}</span>}
+                            {(node.category || node.type) && (
+                                <span className="inline-flex items-center gap-1 text-xs font-bold text-brand-400 bg-brand-500/10 px-3 py-1.5 rounded-lg border border-brand-500/20">
+                                    <CategoryIcon iconKey={node.category_icon_key} categoryName={node.category || node.type} className="text-sm" />
+                                    {node.category || node.type}
+                                </span>
+                            )}
                             <span className="text-xs font-mono text-accent-cyan bg-accent-cyan/10 px-3 py-1.5 rounded-lg border border-accent-cyan/20">{node.ip || 'NO IP'}</span>
                             {node.location_name && <span className="text-xs font-bold text-purple-400 bg-purple-500/10 px-3 py-1.5 rounded-lg border border-purple-500/20">{node.location_name}</span>}
                         </div>

--- a/frontend/components/CatalogManager.test.tsx
+++ b/frontend/components/CatalogManager.test.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import CatalogManager from './CatalogManager';
+
+type MockCategory = {
+	name: string;
+	icon_key?: string | null;
+};
+
+type MockHardware = {
+	brand: string;
+	model: string;
+	category?: string;
+	owner?: string;
+};
+
+type MockOwner = {
+	name: string;
+	users: [];
+};
+
+const mocks = vi.hoisted(() => ({
+	mockApiGet: vi.fn(),
+	mockApiPost: vi.fn(),
+	mockApiPut: vi.fn(),
+	mockApiDelete: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+	api: {
+		get: mocks.mockApiGet,
+		post: mocks.mockApiPost,
+		put: mocks.mockApiPut,
+		delete: mocks.mockApiDelete,
+	},
+}));
+
+const hardware: MockHardware[] = [];
+const owners: MockOwner[] = [];
+
+const categories: MockCategory[] = [
+	{ name: 'Layer 2 switch', icon_key: 'switch_l2' },
+	{ name: 'Video Analytics' },
+];
+
+const openCategoryEditor = async (name: string) => {
+	fireEvent.click(screen.getByRole('button', { name: 'CATEGORIES' }));
+
+	await waitFor(() => {
+		expect(screen.getByText(name)).toBeInTheDocument();
+	});
+
+	const editButton = screen.getByRole('button', { name: `edit category ${name}` });
+	fireEvent.click(editButton);
+	await waitFor(() => {
+		expect(screen.getByRole('heading', { name: /^Edit/i })).toBeInTheDocument();
+	});
+};
+
+const withinCategoryEditor = () => {
+	const editorPanel = screen.getByRole('heading', { name: /^(Edit|New)/i }).parentElement;
+	if (!editorPanel) {
+		throw new Error('Category editor panel not found');
+	}
+
+	return within(editorPanel);
+};
+
+describe('CatalogManager category icon selector', () => {
+	beforeEach(() => {
+		mocks.mockApiGet.mockReset();
+		mocks.mockApiPost.mockReset();
+		mocks.mockApiPut.mockReset();
+		mocks.mockApiDelete.mockReset();
+
+		mocks.mockApiGet.mockImplementation(async (endpoint: string) => {
+			if (endpoint === '/hardware') return hardware;
+			if (endpoint === '/categories') return categories;
+			if (endpoint === '/owners') return owners;
+			return Promise.resolve([]);
+		});
+
+		mocks.mockApiPut.mockResolvedValue(undefined);
+		mocks.mockApiPost.mockResolvedValue(undefined);
+		mocks.mockApiDelete.mockResolvedValue(undefined);
+	});
+
+	it('shows the current selected icon while editing a category', async () => {
+		render(<CatalogManager />);
+
+		await openCategoryEditor('Layer 2 switch');
+
+		const editor = withinCategoryEditor();
+		expect(editor.getAllByRole('img', { name: /layer 2 switch technology icon/i }).length).toBeGreaterThan(0);
+		expect(editor.getByRole('textbox', { name: /search icons/i })).toHaveValue('');
+	});
+
+	it('searches the icon catalog, updates the preview, and saves the selection', async () => {
+		render(<CatalogManager />);
+
+		await openCategoryEditor('Layer 2 switch');
+
+		const searchInput = screen.getByRole('textbox', { name: /search icons/i });
+		fireEvent.change(searchInput, { target: { value: 'router' } });
+
+		await waitFor(() => {
+			expect(screen.getByRole('button', { name: /select router icon/i })).toBeInTheDocument();
+			expect(screen.queryByRole('button', { name: /select layer 2 switch icon/i })).not.toBeInTheDocument();
+		});
+
+		fireEvent.click(screen.getByRole('button', { name: /select router icon/i }));
+		const editor = withinCategoryEditor();
+		expect(editor.getAllByRole('img', { name: /router technology icon/i }).length).toBeGreaterThan(0);
+
+		fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+		await waitFor(() => {
+			expect(mocks.mockApiPut).toHaveBeenCalledWith('/categories/Layer 2 switch', {
+				name: 'Layer 2 switch',
+				icon_key: 'router',
+			});
+		});
+	});
+
+	it('allows selecting the generic icon and sends the generic key', async () => {
+		render(<CatalogManager />);
+
+		await openCategoryEditor('Video Analytics');
+
+		fireEvent.click(screen.getByRole('button', { name: /select generic icon/i }));
+		const editor = withinCategoryEditor();
+		expect(editor.getAllByRole('img', { name: /generic technology icon/i }).length).toBeGreaterThan(0);
+
+		fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+		await waitFor(() => {
+			expect(mocks.mockApiPut).toHaveBeenCalledWith('/categories/Video Analytics', {
+				name: 'Video Analytics',
+				icon_key: 'generic',
+			});
+		});
+	});
+
+	it('keeps icon selector state scoped to the active edit session', async () => {
+		render(<CatalogManager />);
+
+		await openCategoryEditor('Layer 2 switch');
+		fireEvent.click(screen.getByRole('button', { name: /select router icon/i }));
+		fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+		fireEvent.click(screen.getByRole('button', { name: /add/i }));
+
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: /new/i })).toBeInTheDocument();
+		});
+
+		const editor = withinCategoryEditor();
+		expect(editor.getByRole('textbox', { name: /search icons/i })).toHaveValue('');
+		expect(editor.getAllByRole('img', { name: /generic technology icon/i }).length).toBeGreaterThan(0);
+	});
+});

--- a/frontend/components/CatalogManager.tsx
+++ b/frontend/components/CatalogManager.tsx
@@ -1,321 +1,465 @@
-
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { api } from '../services/api';
+import CategoryIcon from './CategoryIcon';
+import {
+	CategoryIconKey,
+	findCategoryIcons,
+	resolveCategoryIconKey,
+} from '../utils/categoryIcons';
 
 // Types
 interface HardwareModel {
-    brand: string;
-    model: string;
-    category?: string;
-    owner?: string;
+	brand: string;
+	model: string;
+	category?: string;
+	owner?: string;
 }
 
 interface Category {
-    name: string;
+	name: string;
+	icon_key?: string | null;
 }
 
 interface OwnerGroup {
-    name: string;
-    users: { name: string, email?: string, phone?: string }[];
+	name: string;
+	users: { name: string, email?: string, phone?: string }[];
 }
 
+const normalizeCategoryForIcon = (category?: Category | null): CategoryIconKey =>
+	resolveCategoryIconKey({
+		iconKey: category?.icon_key,
+		categoryName: category?.name,
+	});
+
 const CatalogManager: React.FC = () => {
-    type Tab = 'HARDWARE' | 'CATEGORIES' | 'OWNERS';
-    const [activeTab, setActiveTab] = useState<Tab>('HARDWARE');
+	type Tab = 'HARDWARE' | 'CATEGORIES' | 'OWNERS';
+	const [activeTab, setActiveTab] = useState<Tab>('HARDWARE');
 
-    // Data State
-    const [models, setModels] = useState<HardwareModel[]>([]);
-    const [categories, setCategories] = useState<Category[]>([]);
-    const [owners, setOwners] = useState<OwnerGroup[]>([]);
+	// Data State
+	const [models, setModels] = useState<HardwareModel[]>([]);
+	const [categories, setCategories] = useState<Category[]>([]);
+	const [owners, setOwners] = useState<OwnerGroup[]>([]);
 
-    // Editor State
-    const [isEditing, setIsEditing] = useState(false);
-    const [selectedItem, setSelectedItem] = useState<any>(null);
-    const [formData, setFormData] = useState<any>({});
+	// Editor State
+	const [isEditing, setIsEditing] = useState(false);
+	const [selectedItem, setSelectedItem] = useState<any>(null);
+	const [formData, setFormData] = useState<any>({});
+	const [iconSearchQuery, setIconSearchQuery] = useState('');
+	const [selectedIconKey, setSelectedIconKey] = useState<CategoryIconKey>('generic');
 
-    useEffect(() => {
-        fetchData();
-    }, []);
+	const visibleIcons = useMemo(
+		() => findCategoryIcons(iconSearchQuery),
+		[iconSearchQuery],
+	);
 
-    const fetchData = async () => {
-        try {
-            const [resModels, resCats, resOwners] = await Promise.all([
-                api.get<HardwareModel[]>('/hardware'),
-                api.get<Category[]>('/categories'),
-                api.get<OwnerGroup[]>('/owners')
-            ]);
-            setModels(Array.isArray(resModels) ? resModels : []);
-            setCategories(Array.isArray(resCats) ? resCats : []);
-            setOwners(Array.isArray(resOwners) ? resOwners : []);
-        } catch (e) {
-            console.error("Error fetching catalog data", e);
-        }
-    };
+	useEffect(() => {
+		fetchData();
+	}, []);
 
-    // --- Actions ---
+	const clearEditorState = () => {
+		setSelectedItem(null);
+		setFormData({});
+		setIconSearchQuery('');
+		setSelectedIconKey('generic');
+	};
 
-    const handleEdit = (item: any) => {
-        setSelectedItem(item);
-        setFormData({ ...item }); // Clone
-        setIsEditing(true);
-    };
+	const fetchData = async () => {
+		try {
+			const [resModels, resCats, resOwners] = await Promise.all([
+				api.get<HardwareModel[]>('/hardware'),
+				api.get<Category[]>('/categories'),
+				api.get<OwnerGroup[]>('/owners'),
+			]);
+			setModels(Array.isArray(resModels) ? resModels : []);
+			setCategories(Array.isArray(resCats) ? resCats : []);
+			setOwners(Array.isArray(resOwners) ? resOwners : []);
+		} catch (e) {
+			console.error('Error fetching catalog data', e);
+		}
+	};
 
-    const handleCreate = () => {
-        setSelectedItem(null);
-        setFormData({});
-        setIsEditing(true);
-    };
+	// --- Actions ---
 
-    const handleSave = async () => {
-        let url = '';
-        let method = 'POST';
-        let body = { ...formData }; // Clone to avoid mutation
+	const handleEdit = (item: any) => {
+		setSelectedItem(item);
+		setFormData({ ...item });
+		if (activeTab === 'CATEGORIES') {
+			setIconSearchQuery('');
+			setSelectedIconKey(normalizeCategoryForIcon(item));
+		}
+		setIsEditing(true);
+	};
 
-        try {
-            if (activeTab === 'HARDWARE') {
-                if (selectedItem) {
-                    // Update
-                    url = `/hardware/${selectedItem.brand}/${selectedItem.model}`;
-                    method = 'PUT';
-                    // Body matches HardwareModelUpdate
-                    body = {
-                        brand: formData.brand, // Allow rename
-                        model: formData.model,
-                        category: formData.category,
-                        owner: formData.owner
-                    };
-                } else {
-                    // Create
-                    url = '/hardware';
-                }
-            } else if (activeTab === 'CATEGORIES') {
-                if (selectedItem) {
-                    url = `/categories/${selectedItem.name}`;
-                    method = 'PUT';
-                    body = { name: formData.name };
-                } else {
-                    url = '/categories';
-                }
-            } else if (activeTab === 'OWNERS') {
-                if (selectedItem) {
-                    url = `/owners/${selectedItem.name}`;
-                    method = 'PUT';
-                    // Ensure users is a list if present
-                    if (formData.users && typeof formData.users === 'string') {
-                        // Parse or handle string? Assuming basic object here.
-                        // For now, let's keep it simple: we primarily edit Name. 
-                        // Advanced User editing can stay in Users tab if needed? 
-                        // Or we implement basic user list editing here.
-                    }
-                } else {
-                    url = '/owners';
-                }
-            }
+	const handleCreate = () => {
+		clearEditorState();
+		setIsEditing(true);
+	};
 
-            if (method === 'POST') {
-                await api.post(url, body);
-            } else {
-                await api.put(url, body);
-            }
+	const closeEditor = () => {
+		setIsEditing(false);
+		clearEditorState();
+	};
 
+	const handleSave = async () => {
+		let url = '';
+		let method = 'POST';
+		let body = { ...formData }; // Clone to avoid mutation
 
+		try {
+			if (activeTab === 'HARDWARE') {
+				if (selectedItem) {
+					// Update
+					url = `/hardware/${selectedItem.brand}/${selectedItem.model}`;
+					method = 'PUT';
+					// Body matches HardwareModelUpdate
+					body = {
+						brand: formData.brand, // Allow rename
+						model: formData.model,
+						category: formData.category,
+						owner: formData.owner,
+					};
+				} else {
+					// Create
+					url = '/hardware';
+				}
+			} else if (activeTab === 'CATEGORIES') {
+				if (selectedItem) {
+					url = `/categories/${selectedItem.name}`;
+					method = 'PUT';
+					body = {
+						name: formData.name,
+						icon_key: selectedIconKey,
+					};
+				} else {
+					url = '/categories';
+					body = {
+						name: formData.name,
+						icon_key: selectedIconKey,
+					};
+				}
+			} else if (activeTab === 'OWNERS') {
+				if (selectedItem) {
+					url = `/owners/${selectedItem.name}`;
+					method = 'PUT';
+					// Ensure users is a list if present
+					if (formData.users && typeof formData.users === 'string') {
+						// Parse or handle string? Assuming basic object here.
+					}
+				} else {
+					url = '/owners';
+				}
+			}
 
-            setIsEditing(false);
-            setFormData({});
-            setSelectedItem(null);
-            fetchData();
-        } catch (e) {
-            alert("Error saving: " + e);
-        }
-    };
+			if (method === 'POST') {
+				await api.post(url, body);
+			} else {
+				await api.put(url, body);
+			}
 
-    const handleDelete = async (item: any) => {
-        if (!confirm(`Are you sure you want to delete ${item.name || (item.brand + ' ' + item.model)}?`)) return;
+			setIsEditing(false);
+			clearEditorState();
+			fetchData();
+		} catch (e) {
+			alert('Error saving: ' + e);
+		}
+	};
 
-        let url = '';
-        if (activeTab === 'HARDWARE') url = `/hardware/${item.brand}/${item.model}`;
-        else if (activeTab === 'CATEGORIES') url = `/categories/${item.name}`;
-        else if (activeTab === 'OWNERS') url = `/owners/${item.name}`;
+	const handleDelete = async (item: any) => {
+		if (!confirm(`Are you sure you want to delete ${item.name || (item.brand + ' ' + item.model)}?`)) return;
 
-        try {
-            await api.delete(url);
-            fetchData();
-        } catch (e) {
-            alert("Error deleting: " + e);
-        }
-    };
+		let url = '';
+		if (activeTab === 'HARDWARE') url = `/hardware/${item.brand}/${item.model}`;
+		else if (activeTab === 'CATEGORIES') url = `/categories/${item.name}`;
+		else if (activeTab === 'OWNERS') url = `/owners/${item.name}`;
 
-    // --- Render Helpers ---
+		try {
+			await api.delete(url);
+			fetchData();
+		} catch (e) {
+			alert('Error deleting: ' + e);
+		}
+	};
 
-    return (
-        <div className="h-full flex flex-col p-6">
-            <div className="flex justify-between items-center mb-6">
-                <h2 className="text-3xl font-black text-white tracking-tighter uppercase">Catalog Manager</h2>
-                <div className="flex gap-2">
-                    {(['HARDWARE', 'CATEGORIES', 'OWNERS'] as Tab[]).map(tab => (
-                        <button
-                            key={tab}
-                            onClick={() => { setActiveTab(tab); setIsEditing(false); }}
-                            className={`px-4 py-2 rounded-lg font-bold text-sm tracking-wider transition-colors ${activeTab === tab ? 'bg-brand-500 text-white' : 'bg-white/5 text-neutral-400 hover:bg-white/10'
-                                }`}
-                        >
-                            {tab}
-                        </button>
-                    ))}
-                </div>
-            </div>
+	const renderCategoryIconSelector = () => (
+		<div className="space-y-3">
+			<label className="text-xs font-bold text-neutral-500 uppercase">Current icon</label>
+			<div className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 bg-black/40">
+				<CategoryIcon
+					iconKey={selectedIconKey}
+					categoryName={formData.name}
+					className="text-2xl"
+					iconClassName="text-brand-200"
+				/>
+				<span className="text-sm text-neutral-300">
+					{selectedIconKey === 'generic' ? 'Generic/default' : selectedIconKey.replace('_', ' ')}
+				</span>
+			</div>
 
-            <div className={`flex-1 glass rounded-2xl border border-white/5 overflow-hidden flex flex-col`}>
-                {/* Toolbar */}
-                <div className="p-4 border-b border-white/5 bg-black/20 flex justify-end">
-                    <button onClick={handleCreate} className="bg-brand-600 hover:bg-brand-500 text-white px-4 py-2 rounded-lg font-bold text-sm flex items-center gap-2">
-                        <span className="material-symbols-outlined text-sm">add</span>
-                        NEW {activeTab.slice(0, -1)}
-                    </button>
-                </div>
+			<div className="space-y-2">
+				<label className="text-xs font-bold text-neutral-500 uppercase" htmlFor="icon-search">
+					Search icons
+				</label>
+				<input
+					id="icon-search"
+					type="text"
+					className="w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+					placeholder="Search icon names..."
+					value={iconSearchQuery}
+					onChange={(event) => setIconSearchQuery(event.target.value)}
+				/>
+			</div>
 
-                {/* List Content */}
-                <div className="flex-1 overflow-y-auto custom-scrollbar p-2 space-y-2">
-                    {/* HARDWARE LIST */}
-                    {activeTab === 'HARDWARE' && models.map((m, i) => (
-                        <div key={i} className="p-4 rounded-xl border border-white/5 bg-white/5 flex justify-between items-center hover:bg-white/10 transition-colors">
-                            <div>
-                                <div className="font-bold text-white">{m.brand} <span className="text-neutral-400 font-normal">{m.model}</span></div>
-                                <div className="flex gap-2 mt-1">
-                                    <span className="text-xs bg-white/10 px-2 py-0.5 rounded text-neutral-300">{m.category || 'No Category'}</span>
-                                    <span className="text-xs bg-white/10 px-2 py-0.5 rounded text-neutral-300">{m.owner || 'No Owner'}</span>
-                                </div>
-                            </div>
-                            <div className="flex gap-2">
-                                <button onClick={() => handleEdit(m)} className="text-neutral-500 hover:text-white"><span className="material-symbols-outlined">edit</span></button>
-                                <button onClick={() => handleDelete(m)} className="text-neutral-500 hover:text-red-500"><span className="material-symbols-outlined">delete</span></button>
-                            </div>
-                        </div>
-                    ))}
+			<div className="grid grid-cols-3 gap-2 max-h-56 overflow-y-auto pr-1">
+				{visibleIcons.map((icon) => (
+					<button
+						type="button"
+						key={icon.key}
+						className={`rounded-lg border p-2 text-left transition ${selectedIconKey === icon.key ? 'border-brand-400 bg-brand-500/20' : 'border-white/10 bg-white/5 hover:bg-white/10'}`}
+						onClick={() => setSelectedIconKey(icon.key)}
+						aria-label={`Select ${icon.label} icon`}
+					>
+						<div className="flex items-center gap-2">
+							<CategoryIcon iconKey={icon.key} className="text-xl" />
+							<span className="text-xs text-neutral-300">{icon.label}</span>
+						</div>
+					</button>
+				))}
+			</div>
+		</div>
+	);
 
-                    {/* CATEGORIES LIST */}
-                    {activeTab === 'CATEGORIES' && categories.map((c, i) => (
-                        <div key={i} className="p-4 rounded-xl border border-white/5 bg-white/5 flex justify-between items-center hover:bg-white/10 transition-colors">
-                            <span className="font-bold text-white">{c.name}</span>
-                            <div className="flex gap-2">
-                                <button onClick={() => handleEdit(c)} className="text-neutral-500 hover:text-white"><span className="material-symbols-outlined">edit</span></button>
-                                <button onClick={() => handleDelete(c)} className="text-neutral-500 hover:text-red-500"><span className="material-symbols-outlined">delete</span></button>
-                            </div>
-                        </div>
-                    ))}
+	const categoryEditHeader = selectedItem ? 'Edit' : 'New';
 
-                    {/* OWNERS LIST */}
-                    {activeTab === 'OWNERS' && owners.map((o, i) => (
-                        <div key={i} className="p-4 rounded-xl border border-white/5 bg-white/5 flex justify-between items-center hover:bg-white/10 transition-colors">
-                            <div>
-                                <div className="font-bold text-white">{o.name}</div>
-                                <div className="text-xs text-neutral-500 mt-1">{o.users?.length || 0} users</div>
-                            </div>
-                            <div className="flex gap-2">
-                                <button onClick={() => handleEdit(o)} className="text-neutral-500 hover:text-white"><span className="material-symbols-outlined">edit</span></button>
-                                <button onClick={() => handleDelete(o)} className="text-neutral-500 hover:text-red-500"><span className="material-symbols-outlined">delete</span></button>
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </div>
+	return (
+		<div className="h-full flex flex-col p-6">
+			<div className="flex justify-between items-center mb-6">
+				<h2 className="text-3xl font-black text-white tracking-tighter uppercase">Catalog Manager</h2>
+				<div className="flex gap-2">
+					{(['HARDWARE', 'CATEGORIES', 'OWNERS'] as Tab[]).map((tab) => (
+						<button
+							key={tab}
+							onClick={() => {
+								setActiveTab(tab);
+								setIsEditing(false);
+								clearEditorState();
+							}}
+							className={`px-4 py-2 rounded-lg font-bold text-sm tracking-wider transition-colors ${activeTab === tab ? 'bg-brand-500 text-white' : 'bg-white/5 text-neutral-400 hover:bg-white/10'
+								}`}
+						>
+							{tab}
+						</button>
+					))}
+				</div>
+			</div>
 
-            {/* Edit Modal (Simple Inline Overlay for speed) */}
-            {isEditing && (
-                <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
-                    <div className="bg-[#0a0a0a] border border-white/10 rounded-2xl p-6 w-[500px]">
-                        <h3 className="text-xl font-bold text-white mb-6 uppercase">
-                            {selectedItem ? 'Edit' : 'New'} {activeTab.slice(0, -1)}
-                        </h3>
+			<div className={`flex-1 glass rounded-2xl border border-white/5 overflow-hidden flex flex-col`}>
+				{/* Toolbar */}
+				<div className="p-4 border-b border-white/5 bg-black/20 flex justify-end">
+					<button
+						onClick={handleCreate}
+						className="bg-brand-600 hover:bg-brand-500 text-white px-4 py-2 rounded-lg font-bold text-sm flex items-center gap-2"
+					>
+						<span className="material-symbols-outlined text-sm">add</span>
+						NEW {activeTab.slice(0, -1)}
+					</button>
+				</div>
 
-                        <div className="space-y-4">
-                            {/* Hardware Form */}
-                            {activeTab === 'HARDWARE' && (
-                                <>
-                                    <div className="grid grid-cols-2 gap-4">
-                                        <div className="space-y-2">
-                                            <label className="text-xs font-bold text-neutral-500 uppercase">Brand</label>
-                                            <input
-                                                className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
-                                                value={formData.brand || ''}
-                                                onChange={e => setFormData({ ...formData, brand: e.target.value })}
-                                            />
-                                        </div>
-                                        <div className="space-y-2">
-                                            <label className="text-xs font-bold text-neutral-500 uppercase">Model</label>
-                                            <input
-                                                className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
-                                                value={formData.model || ''}
-                                                onChange={e => setFormData({ ...formData, model: e.target.value })}
-                                            />
-                                        </div>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <label className="text-xs font-bold text-neutral-500 uppercase">Category</label>
-                                        <select
-                                            className="w-full bg-black/40 border border-white/10 p-2 rounded text-white"
-                                            value={formData.category || ''}
-                                            onChange={e => setFormData({ ...formData, category: e.target.value })}
-                                        >
-                                            <option value="">Select...</option>
-                                            {categories.map(c => <option key={c.name} value={c.name}>{c.name}</option>)}
-                                        </select>
-                                    </div>
-                                    <div className="space-y-2">
-                                        <label className="text-xs font-bold text-neutral-500 uppercase">Default Owner</label>
-                                        <select
-                                            className="w-full bg-black/40 border border-white/10 p-2 rounded text-white"
-                                            value={formData.owner || ''}
-                                            onChange={e => setFormData({ ...formData, owner: e.target.value })}
-                                        >
-                                            <option value="">Select...</option>
-                                            {owners.map(o => <option key={o.name} value={o.name}>{o.name}</option>)}
-                                        </select>
-                                    </div>
-                                </>
-                            )}
+				{/* List Content */}
+				<div className="flex-1 overflow-y-auto custom-scrollbar p-2 space-y-2">
+					{/* HARDWARE LIST */}
+					{activeTab === 'HARDWARE' &&
+						models.map((m, i) => (
+							<div key={i} className="p-4 rounded-xl border border-white/5 bg-white/5 flex justify-between items-center hover:bg-white/10 transition-colors">
+								<div>
+									<div className="font-bold text-white">{m.brand} <span className="text-neutral-400 font-normal">{m.model}</span></div>
+									<div className="flex gap-2 mt-1">
+										<span className="text-xs bg-white/10 px-2 py-0.5 rounded text-neutral-300">{m.category || 'No Category'}</span>
+										<span className="text-xs bg-white/10 px-2 py-0.5 rounded text-neutral-300">{m.owner || 'No Owner'}</span>
+									</div>
+								</div>
+								<div className="flex gap-2">
+							<button
+								onClick={() => handleEdit(m)}
+								className="text-neutral-500 hover:text-white"
+								aria-label="edit"
+							>
+										<span className="material-symbols-outlined">edit</span>
+									</button>
+									<button
+										onClick={() => handleDelete(m)}
+										className="text-neutral-500 hover:text-red-500"
+										aria-label={`delete hardware ${m.brand} ${m.model}`}
+									>
+										<span className="material-symbols-outlined">delete</span>
+									</button>
+								</div>
+							</div>
+						))}
 
-                            {/* Category Form */}
-                            {activeTab === 'CATEGORIES' && (
-                                <div className="space-y-2">
-                                    <label className="text-xs font-bold text-neutral-500 uppercase">Name</label>
-                                    <input
-                                        className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
-                                        value={formData.name || ''}
-                                        onChange={e => setFormData({ ...formData, name: e.target.value })}
-                                    />
-                                </div>
-                            )}
+					{/* CATEGORIES LIST */}
+					{activeTab === 'CATEGORIES' &&
+						categories.map((c, i) => (
+							<div key={i} className="p-4 rounded-xl border border-white/5 bg-white/5 flex justify-between items-center hover:bg-white/10 transition-colors">
+								<div className="flex items-center gap-3">
+									<CategoryIcon
+										iconKey={c.icon_key}
+										categoryName={c.name}
+										className="text-xl"
+									/>
+									<span className="font-bold text-white">{c.name}</span>
+								</div>
+								<div className="flex gap-2">
+										<button
+											onClick={() => handleEdit(c)}
+											className="text-neutral-500 hover:text-white"
+											aria-label={`edit category ${c.name}`}
+										>
+										<span className="material-symbols-outlined">edit</span>
+									</button>
+									<button
+										onClick={() => handleDelete(c)}
+										className="text-neutral-500 hover:text-red-500"
+										aria-label={`delete category ${c.name}`}
+									>
+										<span className="material-symbols-outlined">delete</span>
+									</button>
+								</div>
+							</div>
+						))}
 
-                            {/* Owner Form */}
-                            {activeTab === 'OWNERS' && (
-                                <div className="space-y-2">
-                                    <label className="text-xs font-bold text-neutral-500 uppercase">Name</label>
-                                    <input
-                                        className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
-                                        value={formData.name || ''}
-                                        onChange={e => setFormData({ ...formData, name: e.target.value })}
-                                    />
-                                    <div className="text-xs text-brand-400 mt-2">
-                                        * To manage users, please use the User Management tab (future feature).
-                                    </div>
-                                </div>
-                            )}
+					{/* OWNERS LIST */}
+					{activeTab === 'OWNERS' &&
+						owners.map((o, i) => (
+							<div key={i} className="p-4 rounded-xl border border-white/5 bg-white/5 flex justify-between items-center hover:bg-white/10 transition-colors">
+								<div>
+									<div className="font-bold text-white">{o.name}</div>
+									<div className="text-xs text-neutral-500 mt-1">{o.users?.length || 0} users</div>
+								</div>
+								<div className="flex gap-2">
+							<button
+								onClick={() => handleEdit(o)}
+								className="text-neutral-500 hover:text-white"
+								aria-label="edit"
+							>
+										<span className="material-symbols-outlined">edit</span>
+									</button>
+									<button
+										onClick={() => handleDelete(o)}
+										className="text-neutral-500 hover:text-red-500"
+										aria-label={`delete owner ${o.name}`}
+									>
+										<span className="material-symbols-outlined">delete</span>
+									</button>
+								</div>
+							</div>
+						))}
+				</div>
+			</div>
 
-                            <div className="flex gap-4 mt-6">
-                                <button onClick={() => setIsEditing(false)} className="flex-1 bg-white/5 hover:bg-white/10 text-white font-bold py-3 rounded-xl transition-colors">
-                                    CANCEL
-                                </button>
-                                <button onClick={handleSave} className="flex-1 bg-brand-600 hover:bg-brand-500 text-white font-bold py-3 rounded-xl transition-colors">
-                                    SAVE
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            )}
-        </div>
-    );
+			{/* Edit Modal (Simple Inline Overlay for speed) */}
+			{isEditing && (
+				<div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
+					<div className="bg-[#0a0a0a] border border-white/10 rounded-2xl p-6 w-[620px] max-h-[80vh] overflow-y-auto">
+						<h3 className="text-xl font-bold text-white mb-6 uppercase">
+							{categoryEditHeader} {activeTab.slice(0, -1)}
+						</h3>
+
+						<div className="space-y-4">
+							{/* Hardware Form */}
+							{activeTab === 'HARDWARE' && (
+								<>
+									<div className="grid grid-cols-2 gap-4">
+										<div className="space-y-2">
+											<label className="text-xs font-bold text-neutral-500 uppercase">Brand</label>
+											<input
+												className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+												value={formData.brand || ''}
+												onChange={(e) => setFormData({ ...formData, brand: e.target.value })}
+										/>
+									</div>
+									<div className="space-y-2">
+										<label className="text-xs font-bold text-neutral-500 uppercase">Model</label>
+										<input
+											className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+											value={formData.model || ''}
+											onChange={(e) => setFormData({ ...formData, model: e.target.value })}
+										/>
+									</div>
+								</div>
+								<div className="space-y-2">
+									<label className="text-xs font-bold text-neutral-500 uppercase">Category</label>
+									<select
+										className="w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+										value={formData.category || ''}
+										onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+									>
+										<option value="">Select...</option>
+										{categories.map((c) => (
+											<option key={c.name} value={c.name}>{c.name}</option>
+										))}
+									</select>
+								</div>
+								<div className="space-y-2">
+									<label className="text-xs font-bold text-neutral-500 uppercase">Default Owner</label>
+									<select
+										className="w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+										value={formData.owner || ''}
+										onChange={(e) => setFormData({ ...formData, owner: e.target.value })}
+									>
+										<option value="">Select...</option>
+										{owners.map((o) => (
+											<option key={o.name} value={o.name}>{o.name}</option>
+										))}
+									</select>
+								</div>
+							</>
+							)}
+
+							{/* Category Form */}
+							{activeTab === 'CATEGORIES' && (
+								<div className="space-y-4">
+									<div className="space-y-2">
+										<label className="text-xs font-bold text-neutral-500 uppercase">Name</label>
+										<input
+											className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+											value={formData.name || ''}
+											onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+										/>
+									</div>
+
+									{renderCategoryIconSelector()}
+								</div>
+							)}
+
+							{/* Owner Form */}
+							{activeTab === 'OWNERS' && (
+								<div className="space-y-2">
+									<label className="text-xs font-bold text-neutral-500 uppercase">Name</label>
+									<input
+										className="input-field w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+										value={formData.name || ''}
+										onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+									/>
+									<div className="text-xs text-brand-400 mt-2">
+										* To manage users, please use the User Management tab (future feature).
+									</div>
+								</div>
+							)}
+
+							<div className="flex gap-4 mt-6">
+								<button onClick={closeEditor} className="flex-1 bg-white/5 hover:bg-white/10 text-white font-bold py-3 rounded-xl transition-colors">
+									CANCEL
+								</button>
+								<button onClick={handleSave} className="flex-1 bg-brand-600 hover:bg-brand-500 text-white font-bold py-3 rounded-xl transition-colors">
+									SAVE
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 };
 
 export default CatalogManager;

--- a/frontend/components/CategoryIcon.test.tsx
+++ b/frontend/components/CategoryIcon.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CategoryIcon from "./CategoryIcon";
+
+describe("CategoryIcon", () => {
+	it("renders explicit icon keys and exposes readable labels", () => {
+		render(<CategoryIcon iconKey="router" />);
+
+		const icon = screen.getByRole("img", { name: /router technology icon/i });
+
+		expect(icon).toBeInTheDocument();
+		expect(icon).toHaveTextContent("router");
+	});
+
+	it("falls back to generic icon for unknown keys", () => {
+		render(<CategoryIcon iconKey="not-a-key" />);
+
+		const icon = screen.getByRole("img", { name: /generic technology icon/i });
+
+		expect(icon).toBeInTheDocument();
+		expect(icon).toHaveTextContent("category");
+	});
+
+	it("falls back to category-derived icon", () => {
+		render(<CategoryIcon categoryName="Layer 3 switch" />);
+
+		const icon = screen.getByRole("img", { name: /layer 3 switch technology icon/i });
+
+		expect(icon).toBeInTheDocument();
+		expect(icon).toHaveTextContent("hub");
+	});
+});

--- a/frontend/components/CategoryIcon.tsx
+++ b/frontend/components/CategoryIcon.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import {
+	getCategoryIconEntry,
+	resolveCategoryIconKey,
+	type CategoryIconEntry,
+	type ResolveCategoryIconArgs,
+} from "../utils/categoryIcons";
+
+export interface CategoryIconProps extends ResolveCategoryIconArgs {
+	className?: string;
+	iconClassName?: string;
+}
+
+const buildTitle = (entry: CategoryIconEntry): string => `${entry.label} technology icon`;
+
+export const CategoryIcon: React.FC<CategoryIconProps> = ({
+	iconKey,
+	categoryName,
+	className,
+	iconClassName,
+}) => {
+	const resolvedKey = resolveCategoryIconKey({ iconKey, categoryName });
+	const entry = getCategoryIconEntry(resolvedKey);
+
+	return (
+		<span
+			role="img"
+			aria-label={buildTitle(entry)}
+			className={`material-symbols-outlined ${className ?? "text-[1.25rem]"} ${iconClassName ?? ""}`.trim()}
+			title={buildTitle(entry)}
+		>
+			{entry.materialSymbol}
+		</span>
+	);
+};
+
+export default CategoryIcon;

--- a/frontend/components/DependencyMiniMap.test.tsx
+++ b/frontend/components/DependencyMiniMap.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import DependencyMiniMap from './DependencyMiniMap';
+import type { Event, GraphLink, GraphNode } from '../types';
+
+const baseEvent: Event = {
+    id: 'event-1',
+    ci_id: 'router-1',
+    ci_name: 'Router 1',
+    metric_id: 'metric-1',
+    metric_name: 'Ping',
+    status: 'OPEN',
+    severity: 'CRITICAL',
+    message: 'PING Down',
+    created_at: '2026-06-14T00:00:00Z',
+    last_seen: '2026-06-14T00:00:00Z',
+    ack: false,
+};
+
+const renderMiniMap = (nodes: GraphNode[], links: GraphLink[] = [], event = baseEvent) =>
+    render(<DependencyMiniMap ciId={nodes[0].id} nodes={nodes} links={links} event={event} />);
+
+describe('DependencyMiniMap technology icons', () => {
+    it('renders the shared technology icon from category_icon_key while keeping status separate', async () => {
+        renderMiniMap([
+            {
+                id: 'router-1',
+                label: 'Router 1',
+                type: 'INFRASTRUCTURE',
+                status: 'ACTIVE',
+                metadata: {},
+                category: 'Network',
+                category_icon_key: 'router',
+                hasCritical: true,
+            },
+        ]);
+
+        const icon = await screen.findByRole('img', { name: 'Router technology icon' });
+
+        expect(icon).toHaveTextContent('router');
+        expect(screen.getByText('CAÍDO')).toBeInTheDocument();
+        expect(icon).not.toHaveTextContent('CAÍDO');
+    });
+
+    it('falls back to category-derived technology icon when no explicit icon key exists', async () => {
+        renderMiniMap([
+            {
+                id: 'switch-1',
+                label: 'Switch 1',
+                type: 'INFRASTRUCTURE',
+                status: 'ACTIVE',
+                metadata: {},
+                category: 'Layer 2 switch',
+                hasWarning: true,
+            },
+        ], [], { ...baseEvent, ci_id: 'switch-1', severity: 'WARNING', message: 'CPU Threshold' });
+
+        await waitFor(() => {
+            expect(screen.getByRole('img', { name: 'Layer 2 Switch technology icon' })).toHaveTextContent('lan');
+        });
+        expect(screen.getByText('WARNING')).toBeInTheDocument();
+    });
+});

--- a/frontend/components/DependencyMiniMap.tsx
+++ b/frontend/components/DependencyMiniMap.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { GraphNode, Event } from '../types';
+import CategoryIcon from './CategoryIcon';
 
 interface DependencyMiniMapProps {
     ciId?: string;
@@ -182,14 +183,6 @@ const DependencyMiniMap: React.FC<DependencyMiniMapProps> = ({ ciId, nodes, link
 
 
     if (!ciId) return null;
-
-    const getIcon = (type: string) => {
-        if (type === 'SERVER') return 'dns';
-        if (type === 'DATABASE') return 'database';
-        if (type === 'APPLICATION') return 'apps';
-        if (type === 'ROUTER' || type === 'SWITCH') return 'router';
-        return 'circle';
-    };
 
     // Determine Alarm Type Details
     const isPingFailure = event?.message.includes("Unreachable") || event?.message.includes("PING") || event?.message.includes("Down");
@@ -427,7 +420,15 @@ const DependencyMiniMap: React.FC<DependencyMiniMapProps> = ({ ciId, nodes, link
                                     )}
 
                                     <circle r={size} fill={fillColor} stroke={strokeColor} strokeWidth={isAlarmSource ? 3 : 2} className="shadow-2xl" />
-                                    <text x="0" y={isRoot ? 11 : 8} textAnchor="middle" className="material-symbols-outlined text-white pointer-events-none select-none" style={{ fontSize: fontSize + 'px' }}>{getIcon(n.type)}</text>
+                                    <foreignObject x={-size} y={-size} width={size * 2} height={size * 2} className="pointer-events-none">
+                                        <div className="flex h-full w-full items-center justify-center">
+                                            <CategoryIcon
+                                                iconKey={n.category_icon_key}
+                                                categoryName={n.category ?? n.type}
+                                                className={`text-white pointer-events-none select-none leading-none ${isRoot ? 'text-[28px]' : 'text-[22px]'}`}
+                                            />
+                                        </div>
+                                    </foreignObject>
                                 </g>
                             </g>
                         );

--- a/frontend/components/GlobalInventory.test.tsx
+++ b/frontend/components/GlobalInventory.test.tsx
@@ -80,4 +80,40 @@ describe('GlobalInventory', () => {
     expect(screen.queryByText('ID: node-1')).not.toBeInTheDocument();
     expect(screen.getByText('Select a CI to view telemetry')).toBeInTheDocument();
   });
+
+  it('renders explicit category technology icons while keeping critical status separate', () => {
+    nodes = [makeNode({
+      id: 'router-1',
+      label: 'Edge Router',
+      category: 'Network',
+      category_icon_key: 'router',
+      metrics: [{ name: 'CPU Load', protocol: 'SNMP', oid: '1', value: '95', status: 'CRITICAL', last_updated: '2026-04-04T10:05:00.000Z' }],
+    })];
+
+    render(<GlobalInventory />);
+
+    expect(screen.getByRole('img', { name: 'Router technology icon' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Edge Router'));
+
+    expect(screen.getAllByRole('img', { name: 'Router technology icon' })).toHaveLength(2);
+    expect(screen.getByText('warning')).toBeInTheDocument();
+  });
+
+  it('falls back to a category-name technology icon when icon metadata is missing', () => {
+    nodes = [makeNode({
+      id: 'switch-1',
+      label: 'Access Switch',
+      category: 'Layer 2 Switch',
+      category_icon_key: null,
+    })];
+
+    render(<GlobalInventory />);
+
+    expect(screen.getByRole('img', { name: 'Layer 2 Switch technology icon' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Access Switch'));
+
+    expect(screen.getAllByRole('img', { name: 'Layer 2 Switch technology icon' })).toHaveLength(2);
+  });
 });

--- a/frontend/components/GlobalInventory.tsx
+++ b/frontend/components/GlobalInventory.tsx
@@ -6,6 +6,7 @@ import { getStatusClasses } from '../utils/status';
 import { useCategoriesQuery } from '../hooks/queries/useCategoriesQuery';
 import { useNodesQuery } from '../hooks/queries/useNodesQuery';
 import { formatMetricValue } from '../utils/metricFormatting';
+import CategoryIcon from './CategoryIcon';
 
 /**
  * GlobalInventory Component
@@ -97,7 +98,12 @@ const GlobalInventory: React.FC = () => {
                                     </div>
                                     <div className="flex gap-2 mt-1">
                                         <span className="text-[10px] font-mono text-neutral-500">{item.ip || 'NO IP'}</span>
-                                        {item.category && <span className="text-[10px] font-bold text-brand-400 bg-brand-500/10 px-1.5 rounded">{item.category}</span>}
+                                        {(item.category || item.type) && (
+                                            <span className="inline-flex items-center gap-1 text-[10px] font-bold text-brand-400 bg-brand-500/10 px-1.5 rounded">
+                                                <CategoryIcon iconKey={item.category_icon_key} categoryName={item.category || item.type} className="text-[0.75rem]" />
+                                                {item.category || item.type}
+                                            </span>
+                                        )}
                                     </div>
                                 </div>
                                 <span className="material-symbols-outlined text-neutral-600 text-lg group-hover:text-white transition-colors">chevron_right</span>
@@ -115,7 +121,12 @@ const GlobalInventory: React.FC = () => {
                                     <h2 className="text-3xl font-black text-white uppercase">{selectedItem.label || selectedItem.id}</h2>
                                     <div className="flex gap-4 mt-2">
                                         <span className="text-xs font-mono text-neutral-400 bg-black/20 px-2 py-1 rounded">ID: {selectedItem.id}</span>
-                                        {(selectedItem.category || selectedItem.type) && <span className="text-xs font-bold text-brand-400 bg-brand-500/10 px-2 py-1 rounded">{selectedItem.category || selectedItem.type}</span>}
+                                        {(selectedItem.category || selectedItem.type) && (
+                                            <span className="inline-flex items-center gap-1 text-xs font-bold text-brand-400 bg-brand-500/10 px-2 py-1 rounded">
+                                                <CategoryIcon iconKey={selectedItem.category_icon_key} categoryName={selectedItem.category || selectedItem.type} className="text-sm" />
+                                                {selectedItem.category || selectedItem.type}
+                                            </span>
+                                        )}
                                         <span className="text-xs font-mono text-accent-cyan bg-accent-cyan/10 px-2 py-1 rounded">{selectedItem.ip}</span>
                                     </div>
                                 </div>

--- a/frontend/components/HardwareCatalog.tsx
+++ b/frontend/components/HardwareCatalog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { MetricDef } from '../types';
+import CategoryIcon from './CategoryIcon';
 
 interface HardwareModel {
     brand: string;
@@ -10,7 +11,7 @@ interface HardwareModel {
 
 const HardwareCatalog: React.FC = () => {
     const [models, setModels] = useState<HardwareModel[]>([]);
-    const [categories, setCategories] = useState<{ name: string }[]>([]);
+    const [categories, setCategories] = useState<{ name: string; icon_key?: string | null }[]>([]);
     const [owners, setOwners] = useState<{ name: string }[]>([]);
 
     // Form State
@@ -136,7 +137,16 @@ const HardwareCatalog: React.FC = () => {
                                         <span className="text-neutral-400">{m.model}</span>
                                     </div>
                                     <div className="flex gap-2 mt-2">
-                                        {m.category && <span className="text-[10px] bg-brand-500/20 text-brand-300 px-2 py-0.5 rounded uppercase tracking-wider">{m.category}</span>}
+                                        {m.category && (
+                                            <span className="text-[10px] bg-brand-500/20 text-brand-300 px-2 py-0.5 rounded uppercase tracking-wider inline-flex items-center gap-1">
+                                                <CategoryIcon
+                                                    className="text-[11px]"
+                                                    iconKey={categories.find((c) => c.name === m.category)?.icon_key}
+                                                    categoryName={m.category}
+                                                />
+                                                {m.category}
+                                            </span>
+                                        )}
                                         {m.owner && <span className="text-[10px] bg-neutral-700 text-neutral-300 px-2 py-0.5 rounded uppercase tracking-wider">{m.owner}</span>}
                                     </div>
                                 </div>

--- a/frontend/components/MassLinkEditor.test.tsx
+++ b/frontend/components/MassLinkEditor.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MassLinkEditor from './MassLinkEditor';
+
+const mocks = vi.hoisted(() => ({
+    mockUseCategoriesQuery: vi.fn(),
+    mockUseQuery: vi.fn(),
+}));
+
+vi.mock('../hooks/queries/useCategoriesQuery', () => ({
+    useCategoriesQuery: mocks.mockUseCategoriesQuery,
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+    useQuery: mocks.mockUseQuery,
+}));
+
+vi.mock('./RelationshipTooltip', () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./RelationshipBadge', () => ({
+    default: () => null,
+}));
+
+const nodes = [
+    {
+        id: 'router-1',
+        label: 'Router 1',
+        type: 'INFRASTRUCTURE',
+        status: 'ACTIVE',
+        metadata: {},
+        ip: '10.0.0.1',
+        location_name: 'MDF',
+        category: 'Network',
+        category_icon_key: 'router',
+    },
+    {
+        id: 'switch-1',
+        label: 'Switch 1',
+        type: 'INFRASTRUCTURE',
+        status: 'ACTIVE',
+        metadata: {},
+        ip: '10.0.0.2',
+        location_name: 'IDF',
+        category: 'Layer 2 switch',
+    },
+];
+
+describe('MassLinkEditor technology icons', () => {
+    beforeEach(() => {
+        mocks.mockUseCategoriesQuery.mockReset();
+        mocks.mockUseQuery.mockReset();
+
+        mocks.mockUseCategoriesQuery.mockReturnValue({
+            data: [
+                { name: 'Network', icon_key: 'router' },
+                { name: 'Layer 2 switch', icon_key: 'switch_l2' },
+            ],
+        });
+        mocks.mockUseQuery.mockImplementation(({ queryKey }: { queryKey: string[] }) => {
+            if (queryKey[0] === 'nodes') return { data: nodes };
+            if (queryKey[0] === 'metrics') return { data: [] };
+            return { data: undefined };
+        });
+    });
+
+    it('renders shared technology icons for CI candidates without using status as the icon', () => {
+        render(<MassLinkEditor />);
+
+        expect(screen.getAllByRole('img', { name: 'Router technology icon' })).toHaveLength(2);
+        expect(screen.getAllByText('router')).toHaveLength(2);
+        expect(screen.queryByText('ACTIVE')).not.toBeInTheDocument();
+    });
+
+    it('falls back to category name resolution when a candidate has no explicit icon key', () => {
+        render(<MassLinkEditor />);
+
+        expect(screen.getAllByRole('img', { name: 'Layer 2 Switch technology icon' })).toHaveLength(2);
+        expect(screen.getAllByText('lan')).toHaveLength(2);
+    });
+});

--- a/frontend/components/MassLinkEditor.tsx
+++ b/frontend/components/MassLinkEditor.tsx
@@ -4,6 +4,7 @@ import { useCategoriesQuery } from '../hooks/queries/useCategoriesQuery';
 import { useQuery } from '@tanstack/react-query';
 import RelationshipTooltip from './RelationshipTooltip';
 import RelationshipBadge from './RelationshipBadge';
+import CategoryIcon from './CategoryIcon';
 
 interface FilterState {
     label: 'CI' | 'MetricDef';
@@ -129,10 +130,17 @@ const FilterPanel: React.FC<FilterPanelProps> = ({ title, filter, setFilter, cat
                                     onChange={() => toggleId(node.id)}
                                 />
                                 <div className="flex flex-col min-w-0">
-                                    {/* T6: Wrap node label in RelationshipTooltip */}
-                                    <RelationshipTooltip ciId={node.id} relationships={relationshipMap || new Map()}>
-                                        <span className="text-[11px] font-bold text-white truncate">{node.label}</span>
-                                    </RelationshipTooltip>
+                                    <div className="flex items-center gap-2 min-w-0">
+                                        <CategoryIcon
+                                            iconKey={node.category_icon_key}
+                                            categoryName={node.category || node.type}
+                                            className="text-sm text-brand-300 shrink-0"
+                                        />
+                                        {/* T6: Wrap node label in RelationshipTooltip */}
+                                        <RelationshipTooltip ciId={node.id} relationships={relationshipMap || new Map()}>
+                                            <span className="text-[11px] font-bold text-white truncate">{node.label}</span>
+                                        </RelationshipTooltip>
+                                    </div>
                                     {/* T7: Add RelationshipBadge */}
                                     <RelationshipBadge ciId={node.id} relationships={relationshipMap || new Map()} />
                                     <span className="text-[9px] text-neutral-500 font-mono truncate">{node.id} • {node.ip || 'No IP'} • {node.location_name}</span>

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -27,6 +27,7 @@ import { useEventMutations } from "../hooks/queries/useEventMutations";
 import { useEventDetailQuery } from "../hooks/queries/useEventDetailQuery";
 import { useMonitoringConsoleData } from "../hooks/queries/useMonitoringConsoleData";
 import { useRelatedEventsQuery } from "../hooks/queries/useRelatedEventsQuery";
+import CategoryIcon from "./CategoryIcon";
 
 /**
  * Configure Leaflet Default Icon
@@ -1056,6 +1057,10 @@ const MonitoringConsole: React.FC = () => {
 			}),
 		[nodes, events, filterCategory],
 	);
+	const nodeById = useMemo(
+		() => new Map(nodesWithEvents.map((node) => [node.id, node])),
+		[nodesWithEvents],
+	);
 
 	// Smart culling hook — returns top-n nodes when threshold exceeded
 	const { culledNodes, isActive: isSmartMode } = useSmartCulling(
@@ -1400,7 +1405,11 @@ const MonitoringConsole: React.FC = () => {
 												</td>
 											</tr>
 										) : (
-											filteredEventStream.map((evt) => (
+											filteredEventStream.map((evt) => {
+												const eventNode = nodeById.get(evt.ci_id);
+												const categoryName = eventNode?.category ?? eventNode?.type ?? null;
+
+												return (
 												<tr
 													key={evt.id}
 													className="hover:bg-white/5 transition-colors group"
@@ -1430,7 +1439,14 @@ const MonitoringConsole: React.FC = () => {
 														{formatOpenAge(evt)}
 													</td>
 													<td className="p-3 font-bold text-white">
-														{evt.ci_name || evt.ci_id}
+														<div className="flex items-center gap-2">
+															<CategoryIcon
+																iconKey={eventNode?.category_icon_key}
+																categoryName={categoryName}
+																className="text-base text-brand-300 shrink-0"
+															/>
+															<span>{evt.ci_name || evt.ci_id}</span>
+														</div>
 													</td>
 													<td className="p-3 text-neutral-300">
 														<div className="flex flex-col">
@@ -1480,7 +1496,8 @@ const MonitoringConsole: React.FC = () => {
 														</div>
 													</td>
 												</tr>
-											))
+												);
+											})
 										)}
 									</tbody>
 								</table>
@@ -2019,7 +2036,14 @@ const MonitoringConsole: React.FC = () => {
 											<div className="text-neutral-500 uppercase font-bold tracking-wider mb-0.5">
 												Categoría CI
 											</div>
-											<div className="text-white font-semibold">
+											<div className="text-white font-semibold flex items-center gap-2">
+												{category && (
+													<CategoryIcon
+														iconKey={node?.category_icon_key}
+														categoryName={category}
+														className="text-base text-brand-300 shrink-0"
+													/>
+												)}
 												{category || (
 													<span className="text-neutral-600 italic">
 														No configurado

--- a/frontend/components/NetworkVisualizer.test.tsx
+++ b/frontend/components/NetworkVisualizer.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import NetworkVisualizer from './NetworkVisualizer';
+
+vi.mock('react-force-graph-3d', async () => {
+    const React = await vi.importActual<typeof import('react')>('react');
+
+    return {
+        default: React.forwardRef((props: any, ref) => {
+            React.useImperativeHandle(ref, () => ({
+                d3Force: () => ({
+                    strength: vi.fn(),
+                    distance: vi.fn(),
+                }),
+                zoomToFit: vi.fn(),
+            }));
+
+            return (
+                <div data-testid="force-graph">
+                    {props.graphData.nodes.map((node: any) => (
+                        <div key={node.id} data-testid={`node-color-${node.id}`}>
+                            {props.nodeColor(node)}
+                        </div>
+                    ))}
+                </div>
+            );
+        }),
+    };
+});
+
+const graphPayload = {
+    nodes: [
+        {
+            id: 'router-1',
+            label: 'Router 1',
+            type: 'CI',
+            status: 'CRITICAL',
+            category: 'Network',
+            category_icon_key: 'router',
+        },
+        {
+            id: 'switch-1',
+            label: 'Switch 1',
+            type: 'CI',
+            status: 'ACTIVE',
+            category: 'Layer 2 switch',
+        },
+    ],
+    links: [],
+};
+
+describe('NetworkVisualizer technology icons', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            json: async () => graphPayload,
+        }));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('renders the shared technology icon from category_icon_key while keeping status color separate', async () => {
+        render(<NetworkVisualizer />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/graph/full'));
+        fireEvent.click(screen.getByRole('button', { name: 'SHOW INFRASTRUCTURE (CIs)' }));
+
+        const icon = await screen.findByRole('img', { name: 'Router technology icon' });
+
+        expect(icon).toHaveTextContent('router');
+        expect(icon).not.toHaveTextContent('CRITICAL');
+        expect(screen.getByTestId('node-color-router-1')).toHaveTextContent('#ff0055');
+    });
+
+    it('falls back to category-derived technology icon when no explicit icon key exists', async () => {
+        render(<NetworkVisualizer />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/graph/full'));
+        fireEvent.click(screen.getByRole('button', { name: 'SHOW INFRASTRUCTURE (CIs)' }));
+
+        const icon = await screen.findByRole('img', { name: 'Layer 2 Switch technology icon' });
+
+        expect(icon).toHaveTextContent('lan');
+        expect(screen.getByText('Switch 1')).toBeInTheDocument();
+    });
+});

--- a/frontend/components/NetworkVisualizer.tsx
+++ b/frontend/components/NetworkVisualizer.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import ForceGraph3D from 'react-force-graph-3d';
 import { GraphNode, GraphLink } from '../types';
+import CategoryIcon from './CategoryIcon';
 // import SpriteText from 'three-spritetext'; // Optional for text labels if needed
 
 
@@ -49,6 +50,16 @@ const NetworkVisualizer: React.FC = () => {
 
         return { nodes: activeNodes, links: activeLinks };
     }, [nodes, links, showCIs]);
+
+    const technologyNodes = useMemo(() => {
+        return graphData.nodes.filter(node => node.category_icon_key || node.category || node.type === 'Category' || node.type === 'CI');
+    }, [graphData.nodes]);
+
+    const getTechnologyCategoryName = (node: any) => {
+        if (node.category) return node.category;
+        if (node.type === 'Category') return node.label;
+        return node.type;
+    };
 
     // Apply custom forces when graph loads
     useEffect(() => {
@@ -171,6 +182,26 @@ const NetworkVisualizer: React.FC = () => {
                         <span className="w-3 h-3 rounded-full bg-[#ff00aa] shadow-[0_0_10px_#ff00aa]"></span>
                         <span className="text-[10px] font-bold text-neutral-300 uppercase">Metric Def</span>
                     </div>
+
+                    {technologyNodes.length > 0 && (
+                        <div className="mt-3 border-t border-white/10 pt-2">
+                            <h5 className="mb-2 text-[10px] font-bold uppercase text-cyan-300">Technology Icons</h5>
+                            <div className="flex max-h-32 flex-col gap-1 overflow-hidden">
+                                {technologyNodes.map((node) => (
+                                    <div key={`technology-${node.id}`} className="flex items-center justify-end gap-2">
+                                        <span className="max-w-28 truncate text-[10px] font-bold uppercase text-neutral-300">
+                                            {node.label}
+                                        </span>
+                                        <CategoryIcon
+                                            iconKey={node.category_icon_key}
+                                            categoryName={getTechnologyCategoryName(node)}
+                                            className="text-[16px] leading-none text-cyan-300"
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -405,6 +405,56 @@ describe("VisualRelationshipEditor", () => {
 		expect(appNodeButton).not.toHaveClass("w-36", "rounded-2xl");
 	});
 
+	it("renders shared technology icons from category_icon_key while keeping status separate", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={[
+					{
+						...nodes[0],
+						category: "Network",
+						category_icon_key: "router",
+					},
+					nodes[1],
+				]}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		const icon = await screen.findByRole("img", {
+			name: "Router technology icon",
+		});
+
+		expect(icon).toHaveTextContent("router");
+		expect(icon).not.toHaveTextContent("ACTIVE");
+		expect(screen.getByLabelText("CI status")).toHaveValue("OK");
+	});
+
+	it("falls back to category-derived technology icons for visual graph nodes", async () => {
+		render(
+			<VisualRelationshipEditor
+				nodes={[
+					{
+						...nodes[0],
+						category: "Layer 2 switch",
+						category_icon_key: null,
+					},
+					nodes[1],
+				]}
+				links={links}
+				onClose={vi.fn()}
+				onMutated={onMutated}
+			/>,
+		);
+
+		const icon = await screen.findByRole("img", {
+			name: "Layer 2 Switch technology icon",
+		});
+
+		expect(icon).toHaveTextContent("lan");
+	});
+
 	it("fades unrelated nodes and links while keeping related graph items prominent on hover", () => {
 		render(
 			<VisualRelationshipEditor

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -1,8 +1,10 @@
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import * as d3 from "d3";
 import type { GraphNode } from "../types";
 import { api } from "../services/api";
+import CategoryIcon from "./CategoryIcon";
 import type { LinkData } from "./RelationshipManager";
 import {
 	canDeleteRelationship,
@@ -706,11 +708,34 @@ const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
 			.attr("class", "node-circle transition-all duration-300");
 
 		nodeSelection
+			.append("foreignObject")
+			.attr("x", (node) => -((statusVisualMap.get(node.id)?.radius ?? 24) - 7))
+			.attr("y", (node) => -((statusVisualMap.get(node.id)?.radius ?? 24) - 7))
+			.attr(
+				"width",
+				(node) => ((statusVisualMap.get(node.id)?.radius ?? 24) - 7) * 2,
+			)
+			.attr(
+				"height",
+				(node) => ((statusVisualMap.get(node.id)?.radius ?? 24) - 7) * 2,
+			)
+			.attr("class", "pointer-events-none")
+			.each(function (node) {
+				this.innerHTML = `<div class="flex h-full w-full items-center justify-center">${renderToStaticMarkup(
+					<CategoryIcon
+						iconKey={node.sourceNode.category_icon_key}
+						categoryName={node.sourceNode.category ?? node.sourceNode.type}
+						className="text-[18px] leading-none text-white pointer-events-none select-none"
+					/>,
+				)}</div>`;
+			});
+
+		nodeSelection
 			.append("text")
-			.attr("dy", "0.35em")
+			.attr("dy", "-1.8em")
 			.attr("text-anchor", "middle")
 			.attr("fill", "#f5f5f5")
-			.attr("font-size", 11)
+			.attr("font-size", 9)
 			.attr("font-weight", 900)
 			.attr("pointer-events", "none")
 			.text((node) => node.label.slice(0, 2).toUpperCase());

--- a/frontend/components/__tests__/MonitoringConsole.smoke.test.tsx
+++ b/frontend/components/__tests__/MonitoringConsole.smoke.test.tsx
@@ -14,6 +14,7 @@ import {
 	fireEvent,
 	render,
 	screen,
+	within,
 	waitFor,
 } from "@testing-library/react";
 import type React from "react";
@@ -232,6 +233,258 @@ describe("MonitoringConsole smoke tests", () => {
 		expect(endpointCalls["/categories"]).toBe(1);
 		expect(endpointCalls["/events?status=CONSOLE"]).toBe(2);
 		expect(endpointCalls["/events/availability-report"]).toBeUndefined();
+	});
+
+	it("GIVEN an event CI has category_icon_key WHEN the stream renders THEN it shows the shared technology icon separate from status", async () => {
+		const { default: MonitoringConsole } = await import("../MonitoringConsole");
+
+		mockApiGet.mockImplementation((url: string) => {
+			if (url === "/nodes") {
+				return Promise.resolve([
+					{
+						id: "ci-router",
+						label: "Router-01",
+						type: "Network",
+						status: "OK",
+						metadata: {},
+						category: "Router",
+						category_icon_key: "router",
+						ip: "10.0.0.1",
+						location: { lat: 40.4, long: -3.7 },
+					},
+				]);
+			}
+			if (url === "/links") return Promise.resolve([]);
+			if (url === "/categories") return Promise.resolve([{ name: "Router", icon_key: "router" }]);
+			if (url === "/events?status=CONSOLE") {
+				return Promise.resolve([
+					{
+						id: "evt-router",
+						ci_id: "ci-router",
+						ci_name: "Router-01",
+						metric_id: "metric-cpu",
+						metric_name: "CPU",
+						metric_protocol: "SNMP",
+						status: "OPEN",
+						severity: "CRITICAL",
+						message: "CPU over threshold",
+						created_at: "2026-04-04T20:00:00.000Z",
+						last_seen: "2026-04-04T20:00:00.000Z",
+						ack: false,
+						comments: [],
+					},
+				]);
+			}
+			return Promise.resolve([]);
+		});
+
+		renderWithQueryClient(<MonitoringConsole />);
+
+		expect(await screen.findByLabelText("Router technology icon")).toHaveTextContent("router");
+		expect(screen.getByText("Router-01")).toBeInTheDocument();
+		expect(screen.getByText("OPEN")).toBeInTheDocument();
+	});
+
+	it("GIVEN an event CI lacks category_icon_key WHEN the stream renders THEN it falls back by category name", async () => {
+		const { default: MonitoringConsole } = await import("../MonitoringConsole");
+
+		mockApiGet.mockImplementation((url: string) => {
+			if (url === "/nodes") {
+				return Promise.resolve([
+					{
+						id: "ci-switch",
+						label: "Access-SW-01",
+						type: "Layer 2 Switch",
+						status: "OK",
+						metadata: {},
+						category: "Layer 2 Switch",
+						category_icon_key: null,
+						ip: "10.0.0.2",
+						location: { lat: 40.4, long: -3.7 },
+					},
+				]);
+			}
+			if (url === "/links") return Promise.resolve([]);
+			if (url === "/categories") return Promise.resolve([{ name: "Layer 2 Switch" }]);
+			if (url === "/events?status=CONSOLE") {
+				return Promise.resolve([
+					{
+						id: "evt-switch",
+						ci_id: "ci-switch",
+						ci_name: "Access-SW-01",
+						metric_id: "metric-latency",
+						metric_name: "Latency",
+						metric_protocol: "SNMP",
+						status: "ACK",
+						severity: "WARNING",
+						message: "Latency over threshold",
+						created_at: "2026-04-04T20:00:00.000Z",
+						last_seen: "2026-04-04T20:00:00.000Z",
+						ack: true,
+						comments: [],
+					},
+				]);
+			}
+			return Promise.resolve([]);
+		});
+
+		renderWithQueryClient(<MonitoringConsole />);
+
+		expect(await screen.findByLabelText("Layer 2 Switch technology icon")).toHaveTextContent("lan");
+		expect(screen.getByText("Access-SW-01")).toBeInTheDocument();
+		expect(screen.getByText("ACK")).toBeInTheDocument();
+	});
+
+	it("GIVEN event detail opens for a CI with category_icon_key WHEN the category strip renders THEN it shows the shared technology icon separate from severity", async () => {
+		const { default: MonitoringConsole } = await import("../MonitoringConsole");
+
+		mockApiGet.mockImplementation((url: string) => {
+			if (url === "/nodes") {
+				return Promise.resolve([
+					{
+						id: "ci-detail-router",
+						label: "Edge-Router-01",
+						type: "Network",
+						status: "OK",
+						metadata: {},
+						category: "Router",
+						category_icon_key: "router",
+						ip: "10.0.0.1",
+						location: { lat: 40.4, long: -3.7 },
+					},
+				]);
+			}
+			if (url === "/links") return Promise.resolve([]);
+			if (url === "/categories") return Promise.resolve([{ name: "Router", icon_key: "router" }]);
+			if (url === "/events?status=CONSOLE") {
+				return Promise.resolve([
+					{
+						id: "evt-detail-router",
+						ci_id: "ci-detail-router",
+						ci_name: "Edge-Router-01",
+						metric_id: "metric-cpu",
+						metric_name: "CPU",
+						metric_protocol: "SNMP",
+						status: "OPEN",
+						severity: "CRITICAL",
+						message: "CPU over threshold",
+						created_at: "2026-04-04T20:00:00.000Z",
+						last_seen: "2026-04-04T20:00:00.000Z",
+						ack: false,
+						comments: [],
+					},
+				]);
+			}
+			if (url === "/events/evt-detail-router") {
+				return Promise.resolve({
+					event: {
+						id: "evt-detail-router",
+						ci_ref: { id: "ci-detail-router", label: "Edge-Router-01" },
+						metric_name: "CPU",
+						metric_protocol: "SNMP",
+						status: "OPEN",
+						severity: "CRITICAL",
+						message: "CPU over threshold",
+						created_at: "2026-04-04T20:00:00.000Z",
+						comments: [],
+					},
+					business_context: {
+						source: "catalog",
+						service_catalog: { category: "Router" },
+					},
+					itsm_context: {},
+				});
+			}
+			return Promise.resolve([]);
+		});
+
+		renderWithQueryClient(<MonitoringConsole />);
+
+		expect(await screen.findByText("CPU over threshold")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /Details/ }));
+
+		const categoryLabel = await screen.findByText("Categoría CI");
+		const categoryStrip = categoryLabel.closest("div")?.parentElement;
+		expect(categoryStrip).not.toBeNull();
+		expect(within(categoryStrip as HTMLElement).getByLabelText("Router technology icon")).toHaveTextContent("router");
+		expect(within(categoryStrip as HTMLElement).getByText("Router")).toBeInTheDocument();
+		expect(screen.getAllByText("CRITICAL").length).toBeGreaterThan(0);
+	});
+
+	it("GIVEN event detail opens for a CI without category_icon_key WHEN the category strip renders THEN it falls back by category name", async () => {
+		const { default: MonitoringConsole } = await import("../MonitoringConsole");
+
+		mockApiGet.mockImplementation((url: string) => {
+			if (url === "/nodes") {
+				return Promise.resolve([
+					{
+						id: "ci-detail-switch",
+						label: "Access-SW-01",
+						type: "Layer 2 Switch",
+						status: "OK",
+						metadata: {},
+						category: "Layer 2 Switch",
+						category_icon_key: null,
+						ip: "10.0.0.2",
+						location: { lat: 40.4, long: -3.7 },
+					},
+				]);
+			}
+			if (url === "/links") return Promise.resolve([]);
+			if (url === "/categories") return Promise.resolve([{ name: "Layer 2 Switch" }]);
+			if (url === "/events?status=CONSOLE") {
+				return Promise.resolve([
+					{
+						id: "evt-detail-switch",
+						ci_id: "ci-detail-switch",
+						ci_name: "Access-SW-01",
+						metric_id: "metric-latency",
+						metric_name: "Latency",
+						metric_protocol: "SNMP",
+						status: "ACK",
+						severity: "WARNING",
+						message: "Latency over threshold",
+						created_at: "2026-04-04T20:00:00.000Z",
+						last_seen: "2026-04-04T20:00:00.000Z",
+						ack: true,
+						comments: [],
+					},
+				]);
+			}
+			if (url === "/events/evt-detail-switch") {
+				return Promise.resolve({
+					event: {
+						id: "evt-detail-switch",
+						ci_ref: { id: "ci-detail-switch", label: "Access-SW-01" },
+						metric_name: "Latency",
+						metric_protocol: "SNMP",
+						status: "ACK",
+						severity: "WARNING",
+						message: "Latency over threshold",
+						created_at: "2026-04-04T20:00:00.000Z",
+						comments: [],
+					},
+					business_context: {
+						source: "catalog",
+						service_catalog: { category: "Layer 2 Switch" },
+					},
+					itsm_context: {},
+				});
+			}
+			return Promise.resolve([]);
+		});
+
+		renderWithQueryClient(<MonitoringConsole />);
+
+		expect(await screen.findByText("Latency over threshold")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: /Details/ }));
+
+		const categoryLabel = await screen.findByText("Categoría CI");
+		const categoryStrip = categoryLabel.closest("div")?.parentElement;
+		expect(categoryStrip).not.toBeNull();
+		expect(within(categoryStrip as HTMLElement).getByLabelText("Layer 2 Switch technology icon")).toHaveTextContent("lan");
+		expect(within(categoryStrip as HTMLElement).getByText("Layer 2 Switch")).toBeInTheDocument();
+		expect(screen.getAllByText("ACK").length).toBeGreaterThan(0);
 	});
 
 	it("GIVEN monitoring dashboard renders THEN it does not fetch or show the full availability report", async () => {

--- a/frontend/services/queryResources.test.ts
+++ b/frontend/services/queryResources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { fetchActiveEvents, fetchNodeMetricHistory, fetchNodesSearch } from "./queryResources";
+import { fetchActiveEvents, fetchCategories, fetchNodeMetricHistory, fetchNodesSearch } from "./queryResources";
 
 const { mockApiGet } = vi.hoisted(() => ({
 	mockApiGet: vi.fn(),
@@ -25,6 +25,39 @@ describe("fetchActiveEvents", () => {
 		expect(mockApiGet).toHaveBeenCalledWith("/events?status=CONSOLE", {
 			signal,
 		});
+	});
+});
+
+describe("fetchCategories", () => {
+	beforeEach(() => {
+		mockApiGet.mockReset();
+	});
+
+	it("fetches categories with icon metadata", async () => {
+		const signal = new AbortController().signal;
+		const mockCategories = [
+			{ name: "Router", icon_key: "router" },
+			{ name: "Storage", icon_key: "storage" },
+		];
+		mockApiGet.mockResolvedValue(mockCategories);
+
+		const result = await fetchCategories({ signal });
+
+		expect(mockApiGet).toHaveBeenCalledWith("/categories", {
+			signal,
+		});
+		expect(result).toEqual(mockCategories);
+		expect(result[0].icon_key).toBe("router");
+	});
+
+	it("supports missing icon metadata from older API responses", async () => {
+		const mockCategories = [{ name: "Network" }];
+		mockApiGet.mockResolvedValue(mockCategories);
+
+		const result = await fetchCategories({});
+
+		expect(mockApiGet).toHaveBeenCalledWith("/categories", { signal: undefined });
+		expect(result).toEqual(mockCategories);
 	});
 });
 

--- a/frontend/services/queryResources.ts
+++ b/frontend/services/queryResources.ts
@@ -4,6 +4,7 @@ import type {
 	AvailabilitySnmpNoResponseResponse,
 	EventDetail,
 	EventSummary,
+	CategoryIconKey,
 	GraphLink,
 	GraphNode,
 	MultiMetricHistoryResponse,
@@ -79,6 +80,7 @@ export interface OwnerRecord {
 
 export interface CategoryRecord {
 	name: string;
+	icon_key?: CategoryIconKey | null;
 }
 
 export interface GraphTopologyResponse {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -5,6 +5,17 @@ export type NodeType =
 	| "USER"
 	| "CLOUD_RESOURCE";
 
+export type CategoryIconKey =
+	| "generic"
+	| "switch_l2"
+	| "switch_l3"
+	| "router"
+	| "server"
+	| "saas"
+	| "storage"
+	| "camera"
+	| "video_analytics";
+
 export interface SNMPConfig {
 	version: "v2c" | "v3";
 	readCommunity?: string;
@@ -33,9 +44,10 @@ export interface MetricValue {
 export interface GraphNode {
 	id: string;
 	label: string;
-	type: NodeType;
+	type: NodeType | string;
 	status: "ACTIVE" | "EXCEPTION" | "MAINTENANCE" | "OK";
 	metadata: Record<string, any>;
+	category_icon_key?: CategoryIconKey | null;
 	snmp?: SNMPConfig;
 	pollingInterval?: number; // seconds
 	thresholds?: MonitoringThresholds;

--- a/frontend/utils/categoryIcons.test.ts
+++ b/frontend/utils/categoryIcons.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+	CATEGORY_ICON_CATALOG,
+	findCategoryIcons,
+	getCategoryIconEntry,
+	normalizeCategoryName,
+	isCategoryIconKey,
+	resolveCategoryIconKey,
+} from "./categoryIcons";
+
+describe("categoryIcons utility", () => {
+	it("resolves known icon keys to catalog entries", () => {
+		const routerEntry = getCategoryIconEntry("router");
+		const serverEntry = getCategoryIconEntry("server");
+
+		expect(routerEntry.key).toBe("router");
+		expect(routerEntry.label).toBe("Router");
+		expect(routerEntry.materialSymbol).toBe("router");
+		expect(routerEntry.materialSymbol).not.toBe("");
+
+		expect(serverEntry.key).toBe("server");
+		expect(serverEntry.label).toBe("Server");
+		expect(serverEntry.materialSymbol).not.toBe("");
+	});
+
+	it("searches catalog entries by query", () => {
+		const switches = findCategoryIcons("switch");
+		const results = switches.map((entry) => entry.key);
+
+		expect(results).toEqual(expect.arrayContaining(["switch_l2", "switch_l3"]));
+		expect(switches).toHaveLength(2);
+
+	const none = findCategoryIcons("non-existent-technology");
+		expect(none).toHaveLength(0);
+	});
+
+	it("falls back to generic icon for invalid icon keys", () => {
+		expect(resolveCategoryIconKey({ iconKey: "bad-key" })).toBe("generic");
+		expect(resolveCategoryIconKey({ iconKey: "bad-key", categoryName: "Router" })).toBe("router");
+		expect(resolveCategoryIconKey({ categoryName: "Unknown Category" })).toBe("generic");
+		expect(isCategoryIconKey("bad-key")).toBe(false);
+	});
+
+	it("infers initial default icon by category name", () => {
+		expect(resolveCategoryIconKey({ categoryName: "Layer 2 switch" })).toBe("switch_l2");
+		expect(resolveCategoryIconKey({ categoryName: "Layer 3 switch" })).toBe("switch_l3");
+		expect(resolveCategoryIconKey({ categoryName: "Video Analytics" })).toBe("video_analytics");
+		expect(resolveCategoryIconKey({ categoryName: "", iconKey: "camera" })).toBe("camera");
+	});
+
+	it("normalizes category names consistently", () => {
+		expect(normalizeCategoryName(" Layer-2 SWITCH  ")).toBe("layer2 switch");
+		expect(normalizeCategoryName("Layer   3   switch")).toBe("layer3 switch");
+		expect(normalizeCategoryName("Cameras")).toBe("cameras");
+		expect(CATEGORY_ICON_CATALOG).toBeInstanceOf(Array);
+		expect(CATEGORY_ICON_CATALOG.length).toBeGreaterThan(0);
+	});
+
+	it("guarantees no blank symbol for unknown lookup", () => {
+		const unknownEntry = getCategoryIconEntry("mystery");
+		expect(unknownEntry.key).toBe("generic");
+		expect(unknownEntry.materialSymbol).toBe("category");
+		expect(unknownEntry.materialSymbol).not.toBe("");
+	});
+});

--- a/frontend/utils/categoryIcons.ts
+++ b/frontend/utils/categoryIcons.ts
@@ -1,0 +1,175 @@
+import type { CategoryIconKey } from "../types";
+
+export type CategoryIconEntry = {
+	key: CategoryIconKey;
+	label: string;
+	materialSymbol: string;
+	aliases?: string[];
+};
+
+const CATEGORY_ICON_KEY_SET = new Set<string>([
+	"generic",
+	"switch_l2",
+	"switch_l3",
+	"router",
+	"server",
+	"saas",
+	"storage",
+	"camera",
+	"video_analytics",
+]);
+
+export const CATEGORY_ICON_CATALOG: CategoryIconEntry[] = [
+	{
+		key: "generic",
+		label: "Generic",
+		materialSymbol: "category",
+		aliases: ["default", "default icon", "general"],
+	},
+	{
+		key: "switch_l2",
+		label: "Layer 2 Switch",
+		materialSymbol: "lan",
+		aliases: ["l2", "layer 2", "switch"],
+	},
+	{
+		key: "switch_l3",
+		label: "Layer 3 Switch",
+		materialSymbol: "hub",
+		aliases: ["l3", "layer 3", "router switch", "layer3"],
+	},
+	{
+		key: "router",
+		label: "Router",
+		materialSymbol: "router",
+		aliases: ["gateway", "routing"],
+	},
+	{
+		key: "server",
+		label: "Server",
+		materialSymbol: "dns",
+		aliases: ["compute", "host"],
+	},
+	{
+		key: "saas",
+		label: "SaaS",
+		materialSymbol: "cloud",
+		aliases: ["software as a service", "managed service"],
+	},
+	{
+		key: "storage",
+		label: "Storage",
+		materialSymbol: "storage",
+		aliases: ["nas", "san", "backup"],
+	},
+	{
+		key: "camera",
+		label: "Cameras",
+		materialSymbol: "videocam",
+		aliases: ["cctv", "video"],
+	},
+	{
+		key: "video_analytics",
+		label: "Video Analytics",
+		materialSymbol: "analytics",
+		aliases: ["analytics", "video analysis", "ai video"],
+	},
+];
+
+const DEFAULT_ICON_KEY: CategoryIconKey = "generic";
+
+const CATEGORY_NAME_TO_ICON: Record<string, CategoryIconKey> = {
+	"layer2 switch": "switch_l2",
+	"l2 switch": "switch_l2",
+	"switch l2": "switch_l2",
+	"layer3 switch": "switch_l3",
+	"l3 switch": "switch_l3",
+	"switch l3": "switch_l3",
+	"router": "router",
+	"server": "server",
+	"saas": "saas",
+	"storage": "storage",
+	"camera": "camera",
+	"cameras": "camera",
+	"video analytics": "video_analytics",
+	"video_analytics": "video_analytics",
+};
+
+const INDEXED_CATALOG = new Map<string, CategoryIconEntry>(
+	CATEGORY_ICON_CATALOG.map((entry) => [entry.key, entry]),
+);
+
+export const isCategoryIconKey = (value?: string | null): value is CategoryIconKey =>
+	typeof value === "string" && CATEGORY_ICON_KEY_SET.has(value);
+
+export const getCategoryIconEntry = (iconKey: string): CategoryIconEntry => {
+	if (isCategoryIconKey(iconKey)) {
+		return INDEXED_CATALOG.get(iconKey) ?? INDEXED_CATALOG.get(DEFAULT_ICON_KEY)!;
+	}
+	return INDEXED_CATALOG.get(DEFAULT_ICON_KEY)!;
+};
+
+export const normalizeCategoryName = (categoryName: string): string => {
+	return categoryName
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.replace(/\blayer\s+2\b/g, "layer2")
+		.replace(/\blayer\s+3\b/g, "layer3")
+		.replace(/\s+/g, " ")
+		.trim();
+};
+
+export const resolveCategoryIconKey = ({
+	iconKey,
+	categoryName,
+}: {
+	iconKey?: string | null;
+	categoryName?: string | null;
+}): CategoryIconKey => {
+	if (isCategoryIconKey(iconKey)) {
+		return iconKey;
+	}
+
+	if (categoryName) {
+		const normalized = normalizeCategoryName(categoryName);
+		if (CATEGORY_NAME_TO_ICON[normalized]) {
+			return CATEGORY_NAME_TO_ICON[normalized];
+		}
+
+		for (const [name, key] of Object.entries(CATEGORY_NAME_TO_ICON)) {
+			if (name.includes(normalized) || normalized.includes(name)) {
+				return key;
+			}
+		}
+	}
+
+	return DEFAULT_ICON_KEY;
+};
+
+const includesQuery = (value: string, query: string): boolean => {
+	const normalizedValue = normalizeCategoryName(value);
+	const normalizedQuery = normalizeCategoryName(query);
+	return normalizedValue.includes(normalizedQuery);
+};
+
+export const findCategoryIcons = (query: string): CategoryIconEntry[] => {
+	const normalizedQuery = normalizeCategoryName(query);
+	if (!normalizedQuery) {
+		return CATEGORY_ICON_CATALOG;
+	}
+
+	return CATEGORY_ICON_CATALOG.filter((entry) => {
+		const aliasText = (entry.aliases ?? []).join(" ");
+		return (
+			includesQuery(entry.label, normalizedQuery) ||
+			includesQuery(entry.key, normalizedQuery) ||
+			includesQuery(aliasText, normalizedQuery)
+		);
+	});
+};
+
+export type ResolveCategoryIconArgs = {
+	iconKey?: string | null;
+	categoryName?: string | null;
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     test: {
+      forbidOnly: true,
       globals: true,
       environment: 'jsdom',
       setupFiles: ['./test/setup.ts'],

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/apply-progress.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/apply-progress.md
@@ -1,0 +1,178 @@
+# Apply Progress — category-technology-icons
+
+## Scope
+
+Feature slice PR 4 surface migration is complete on top of PR 1 + PR 2 + PR 3. Prior runs migrated `MassLinkEditor` CI candidate rows, `DependencyMiniMap` node rendering, `VisualRelationshipEditor` graph node rendering, `GlobalInventory` list/detail category chips, `CIDetailModal` header category rendering, `NetworkVisualizer` technology legend rendering, and `MonitoringConsole` event-stream/detail rendering to the shared `CategoryIcon` renderer. This verification/refactor run created an ignored local `.env` with mock-only values adapted from `.env.example`, started Neo4j/PostgreSQL/backend through Docker Compose, installed backend test dependencies only inside the running backend container, and completed task 1.5 focused backend verification. Full frontend verification passed again. Full backend verification executed in the container but failed on unrelated existing suites outside category technology icons. Task 4.3 is now complete under a maintainer-approved scoped verification exception for this category-icons PR slice; this is not a claim that the full backend suite is green.
+
+## Changed files (cumulative):
+
+- `backend/tests/test_routers_catalog.py`
+- `backend/tests/test_node_service.py`
+- `backend/tests/test_topology_repo_nodes.py`
+- `backend/services/category_icons.py`
+- `backend/models/core.py`
+- `backend/services/catalog_service.py`
+- `backend/routers/catalog.py`
+- `backend/repositories/topology_repo.py`
+- `backend/services/node_service.py`
+- `frontend/types.ts`
+- `frontend/services/queryResources.ts`
+- `frontend/utils/categoryIcons.ts`
+- `frontend/components/CategoryIcon.tsx`
+- `frontend/utils/categoryIcons.test.ts`
+- `frontend/components/CategoryIcon.test.tsx`
+- `frontend/services/queryResources.test.ts`
+- `frontend/components/CatalogManager.test.tsx`
+- `frontend/components/CatalogManager.tsx`
+- `frontend/components/HardwareCatalog.tsx`
+- `frontend/components/MassLinkEditor.test.tsx`
+- `frontend/components/MassLinkEditor.tsx`
+- `frontend/components/DependencyMiniMap.test.tsx`
+- `frontend/components/DependencyMiniMap.tsx`
+- `frontend/components/VisualRelationshipEditor.test.tsx`
+- `frontend/components/VisualRelationshipEditor.tsx`
+- `frontend/components/GlobalInventory.test.tsx`
+- `frontend/components/GlobalInventory.tsx`
+- `frontend/components/CIDetailModal.test.tsx`
+- `frontend/components/CIDetailModal.tsx`
+- `frontend/components/NetworkVisualizer.test.tsx`
+- `frontend/components/NetworkVisualizer.tsx`
+- `frontend/components/__tests__/MonitoringConsole.smoke.test.tsx`
+- `frontend/components/MonitoringConsole.tsx`
+- `frontend/vite.config.ts`
+
+## TDD Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 2.1 | `frontend/utils/categoryIcons.test.ts`<br>`frontend/components/CategoryIcon.test.tsx` | Unit | N/A (new) | ✅ Written | ✅ Passed in this environment via `npm exec -- pnpm run test:run CategoryIcon.test.tsx categoryIcons.test.ts` | ✅ Covered multiple cases | ✅ Clean |
+| 2.2 | `frontend/types.ts`, `frontend/services/queryResources.ts` | Unit | N/A (typing/API contract refactor) | N/A (typing/API contract refactor) | ✅ Passed in this environment via `npm exec -- pnpm run test:run categoryIcons CategoryIcon queryResources` | ➖ Not structurally branching | ➖ N/A |
+| 2.3 | `frontend/utils/categoryIcons.ts`, `frontend/components/CategoryIcon.tsx` | Unit | N/A (new) | ✅ Written by 2.1 tests | ✅ Passed in this environment via focused icon tests | ✅ Behavior covered in `2.1` tests | ✅ Clean |
+| 2.4 | `frontend/services/queryResources.test.ts` | Unit | ✅ Focused frontend primitive/queryResources suite passed before checklist update (17 tests) | ✅ Existing API contract tests cover `CategoryRecord.icon_key` parsing | ✅ Passed `npm exec -- pnpm run test:run categoryIcons CategoryIcon queryResources` (3 files, 17 tests) | ✅ Resolver/component/queryResources cases cover explicit keys, fallback, search, and API contract | ✅ No local duplicate category technology icon mappings found outside shared `frontend/utils/categoryIcons.ts` |
+| 3.1 | `frontend/components/CatalogManager.test.tsx` | Integration/UI | Existing catalog tests available | ✅ Written before code | ✅ Passed previously via targeted `CatalogManager.test.tsx` | ✅ Covers current icon, searchable grid, preview, generic option, save payload | ✅ Clean |
+| 3.2 | `frontend/components/CatalogManager.tsx`, `frontend/components/HardwareCatalog.tsx` | UI | Existing catalog tests available | ✅ Covered by 3.1 tests | ✅ Passed previously via targeted catalog tests | ✅ Uses shared `CategoryIcon` + icon catalog search utility | ✅ Clean |
+| 3.3 | `frontend/components/CatalogManager.test.tsx` | Integration/UI | Existing catalog tests available | ✅ Selector state scope covered in 3.1 test additions | ✅ Passed `CatalogManager.test.tsx` (4 tests) | ✅ Selector state reset path verified | ✅ Clean |
+| 4.1/4.2 partial — `MassLinkEditor` CI candidate rows | `frontend/components/MassLinkEditor.test.tsx` | Integration/UI | N/A — no existing focused `MassLinkEditor` test file before this slice | ✅ Two failing tests written first for explicit `category_icon_key` rendering, category-name fallback, and status separation | ✅ Passed `MassLinkEditor.test.tsx` (2 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused icon tests passed with `CategoryIcon`/resolver coverage |
+| 4.1/4.2 partial — `DependencyMiniMap` nodes | `frontend/components/DependencyMiniMap.test.tsx` | Integration/UI | ✅ Existing related `EventDetailModal.acceptance.test.tsx` passed before changes (41 tests) | ✅ Two failing tests written first for explicit `category_icon_key`, category-name fallback, and status separation | ✅ Passed `DependencyMiniMap.test.tsx` (2 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused DependencyMiniMap + icon regression passed (52 tests) |
+| 4.1/4.2 partial — `VisualRelationshipEditor` graph nodes | `frontend/components/VisualRelationshipEditor.test.tsx` | Integration/UI | ✅ Existing `VisualRelationshipEditor.test.tsx` passed before changes (30 tests) | ✅ Two failing tests written first for explicit `category_icon_key`, category-name fallback, and status separation | ✅ Passed `VisualRelationshipEditor.test.tsx` (32 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused VisualRelationshipEditor + icon regression passed (41 tests) |
+| 4.1/4.2 partial — `GlobalInventory` list/detail chips | `frontend/components/GlobalInventory.test.tsx` | Integration/UI | ✅ Existing `GlobalInventory.test.tsx` passed before changes (3 tests) | ✅ Two failing tests written first for explicit `category_icon_key`, category-name fallback, and status separation | ✅ Passed `GlobalInventory.test.tsx` (5 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused GlobalInventory + icon regression passed (14 tests) |
+| 4.1/4.2 completion — `CIDetailModal` header category chip | `frontend/components/CIDetailModal.test.tsx` | Integration/UI | N/A — no existing focused `CIDetailModal` test file before this slice | ✅ Two failing tests written first for explicit `category_icon_key`, category-name fallback, and status separation | ✅ Passed `CIDetailModal.test.tsx` (2 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused CIDetailModal + icon regression passed (11 tests) |
+| 4.1/4.2 partial — `NetworkVisualizer` technology legend | `frontend/components/NetworkVisualizer.test.tsx` | Integration/UI | N/A — no existing focused `NetworkVisualizer` test file before this slice | ✅ Two failing tests written first for explicit `category_icon_key`, category-name fallback, and status color separation | ✅ Passed `NetworkVisualizer.test.tsx` (2 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused NetworkVisualizer + icon regression passed (11 tests) |
+| 4.1/4.2 completion — `MonitoringConsole` event stream | `frontend/components/__tests__/MonitoringConsole.smoke.test.tsx` | Integration/UI | ✅ Existing `MonitoringConsole.smoke.test.tsx` passed before changes in prior slice (8 tests) | ✅ Two failing tests written first for explicit `category_icon_key`, category-name fallback, and status separation | ✅ Passed `MonitoringConsole.smoke.test.tsx` (10 tests) after minimal implementation | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name | ✅ Focused MonitoringConsole + icon regression passed (19 tests) |
+| 4.1 audit fix — `MonitoringConsole` event-detail category strip | `frontend/components/__tests__/MonitoringConsole.smoke.test.tsx` | Integration/UI | ✅ Existing `MonitoringConsole.smoke.test.tsx` passed before changes (10 tests) | ✅ Two event-detail tests written first and failed before selector correction (Details accessible name mismatch), proving the missing path was not covered | ✅ Passed focused MonitoringConsole + icon regression (21 tests) with existing implementation; no production change required | ✅ Two cases: explicit router icon and Layer 2 switch fallback by category name; severity/status assertions stay separate | ✅ No implementation refactor needed; corrected test query to match actual accessible name |
+| Test-only guard audit fix | `frontend/vite.config.ts` | Config | N/A — config guard only | ✅ Audit check identified missing explicit guard | ✅ Added `test.forbidOnly: true`; Vitest config accepted by focused run | ➖ Triangulation skipped: single structural guard option | ✅ No package script change needed |
+| 1.5 | `backend/tests/test_routers_catalog.py`<br>`backend/tests/test_node_service.py`<br>`backend/tests/test_topology_repo_nodes.py` | Backend verification/refactor | ✅ Docker Compose backend environment created with mock `.env`; backend dev dependencies installed only inside the running backend container | N/A — verification/refactor task only | ✅ Passed `docker compose exec -T backend python -m pytest tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py` (117 tests) | ✅ Focused backend coverage includes catalog icon metadata/defaults/invalid rejection and `/nodes.type` compatibility with `category_icon_key` | ✅ No tracked backend refactor required; fallback behavior is centralized through `services.category_icons.resolve_category_icon` in the verified paths |
+| 4.3 | Full frontend/backend verification with scoped backend exception | Full suite / scoped backend slice | ✅ Frontend full suite passed again (53 files, 461 tests); category-icons focused backend Docker verification passed (117 tests); backend full suite was runnable but not green | N/A — verification/refactor task only | ✅ Completed under maintainer-approved scoped verification exception: frontend passed and focused backend passed; full backend failed (101 failed, 947 passed, 1 skipped) in predominantly out-of-scope auth/events/RTU/dictionary/CLI suites | ✅ Backend failure triage recorded below; follow-up stabilization issue opened as #267 | ✅ Exception documented; no tracked code/test refactor required in this artifact-only update |
+
+## Scoped Verification Exception — Task 4.3
+
+Maintainer approval: The maintainer explicitly approved a scoped verification exception for task 4.3 on this category-icons PR slice.
+
+This exception closes task 4.3 based on focused slice evidence while preserving that the full backend suite remains red. It is not a claim that backend full-suite verification is green.
+
+Accepted verification evidence:
+- Focused category-icons backend verification passed in Docker: `117 passed` for `tests/test_routers_catalog.py`, `tests/test_node_service.py`, and `tests/test_topology_repo_nodes.py`.
+- Full frontend suite passed: `53 files / 461 tests`.
+- Full backend suite remains red: `101 failed, 947 passed, 1 skipped`.
+- Backend full-suite failures were triaged and are predominantly out-of-scope for category technology icons.
+- One `test_routers_nodes.py` authentication-policy failure remains uncertain but unlikely related because this change touched node payload/icon metadata, not unauthenticated route policy, and focused node compatibility tests pass.
+
+Follow-up stabilization tracking:
+- GitHub issue #267: https://github.com/alexandervazquez98/next-gen/issues/267
+
+## Issues / Deviations
+- `corepack` is still unavailable in this environment, but `pnpm` is runnable through `npm exec -- pnpm`; focused frontend tests and the full frontend suite passed.
+- Host Python still lacks `pytest`/`pip`; backend verification is now runnable through Docker Compose using mock-only `.env` values and container-local dev dependency installation.
+- Full backend pytest is not green in this environment: `docker compose exec -T backend python -m pytest` failed with 101 failed, 947 passed, and 1 skipped. Failures are outside the category technology icon focused tests and include existing auth/events permission expectations, RTU/router 404s, dictionary service/repository mocks, CLI worker tests, and `HTTPException(..., code=...)` misuse in `routers/cis.py`. Task 4.3 is complete only under the maintainer-approved scoped verification exception tracked above.
+- Triage rerun on 2026-06-14 reproduced the same full backend result with concise output: 101 failed, 947 passed, 1 skipped. The category-icons focused backend suite still passes in Docker: 117 passed for `tests/test_routers_catalog.py`, `tests/test_node_service.py`, and `tests/test_topology_repo_nodes.py`.
+- Phase 4 task 4.1 is now checked accurately because `MonitoringConsole` covers both live event stream and event-detail category strip technology icon behavior.
+- Phase 4 task 4.2 remains checked because `MonitoringConsole.tsx` already rendered `CategoryIcon` in both required places; this audit fix did not need production code changes.
+- `frontend/vite.config.ts` now sets `test.forbidOnly: true` so focused tests cannot pass with committed `test.only`/`describe.only`.
+- `DependencyMiniMap` renders the shared HTML `CategoryIcon` inside SVG via `foreignObject`; operational status text and colors remain separate from the technology icon.
+- `VisualRelationshipEditor` uses `CategoryIcon` rendered to static markup inside SVG `foreignObject` nodes; operational status radius/stroke/fill remains separate from the technology icon.
+- `GlobalInventory` renders technology icons in list/detail category chips while leaving critical/healthy metric indicators and warning symbols separate.
+- `CIDetailModal` renders technology icons in the header category chip while leaving the operational status dot/text and metric warning/check indicators separate.
+- `NetworkVisualizer` renders shared technology icons in a graph legend/list derived from visible graph nodes while keeping 3D node color/status handling separate.
+- `MonitoringConsole` renders shared technology icons in the live event stream CI column and event-detail category strip while leaving severity/status badges and KPI status icons separate.
+
+## Remaining
+- No category-technology-icons apply tasks remain. Backend full-suite stabilization remains out of scope for this PR slice and is tracked in GitHub issue #267.
+
+## Full Backend Failure Triage — 2026-06-14
+
+Docker environment status: `neo4j`, `postgres`, and `backend` were running and healthy via `docker compose ps`; no containers were stopped. Full backend pytest was rerun inside the backend container with concise traceback output. `pytest-json-report` is not installed in the container, so `--json-report` was unavailable and no tracked artifacts were created.
+
+| Test file/module | Failures | Likely cause | Category-icons assessment |
+|---|---:|---|---|
+| `tests/test_auth_extended.py` | 1 | Permission enum completeness drift. | Unrelated. |
+| `tests/test_auth_router_refresh.py` | 2 | Cookie domain / secure flag expectations. | Unrelated. |
+| `tests/test_cli_worker.py` | 34 | CLI worker helper expectations for regex extraction, credential fallback, escalation, and NaN rate limiting. | Unrelated. |
+| `tests/test_dictionary_service.py` | 8 | Dictionary service mocked repository/CRUD contract mismatches. | Unrelated. |
+| `tests/test_event_correlation.py` | 4 | Event correlation and recovery propagation expectations. | Unrelated. |
+| `tests/test_polling_docs_links.py` | 2 | Polling documentation/link coverage expectations. | Unrelated. |
+| `tests/test_routers_auth_users_roles.py` | 2 | Audit request context lacks `request.client` in TestClient scope for these cases. | Unrelated. |
+| `tests/test_routers_dictionaries.py` | 1 | `routers/cis.py` raises `HTTPException(..., code=...)`, which FastAPI does not accept. | Unrelated. |
+| `tests/test_routers_events.py` | 13 | Auth/guard behavior drift: expected 401/200/guard messages, got 403; some mocks patch missing `set_cooldown`. | Unrelated. |
+| `tests/test_routers_links.py` | 4 | Link create/delete endpoints returning 403 where tests expect success/no auth block. | Unrelated. |
+| `tests/test_routers_metrics_events.py` | 10 | Auth expectation drift on metrics/events routes: tests expect 401 for unauthenticated, got 403. | Unrelated. |
+| `tests/test_routers_nodes.py` | 1 | Node list unauthenticated expectation drift: test expects 401, route returned 200. | Uncertain but unlikely related; category-icons changed node payload metadata, not router authentication policy. Focused `/nodes` compatibility tests pass. |
+| `tests/test_rtu_integration.py` | 2 | RTU repository conversion error: `dict(record)` fails on mocked/driver record shape. | Unrelated. |
+| `tests/test_rtu_sensor_repo.py` | 5 | Same RTU/sensor repository record conversion issue. | Unrelated. |
+| `tests/test_rtus_router.py` | 12 | RTU/sensor router endpoints return 404 where tests expect mounted CRUD routes. | Unrelated. |
+
+Changed backend paths comparison:
+- Related changed paths (`backend/services/category_icons.py`, `backend/models/core.py`, `backend/services/catalog_service.py`, `backend/routers/catalog.py`, `backend/repositories/topology_repo.py`, `backend/services/node_service.py`) are covered by the focused Docker run and pass: 117 tests.
+- No failures appear in `tests/test_routers_catalog.py`, `tests/test_node_service.py`, `tests/test_topology_repo_nodes.py`, or `tests/test_category_icons.py` in the full-suite summary.
+- The only nearby full-suite failure is `tests/test_routers_nodes.py::TestGetNodes::test_list_nodes_unauthenticated`, but the observed failure is authentication policy (`200` vs expected `401`), not category/icon payload behavior.
+
+Assessment: full backend failures are predominantly unrelated to category technology icons. One `/nodes` router authentication failure is classified as uncertain-but-unlikely-related because this change touched node payload metadata, while the failure concerns unauthenticated access behavior and focused node compatibility tests pass. Task 4.3 is complete under the maintainer-approved scoped verification exception documented above; backend full-suite stabilization remains tracked separately in GitHub issue #267.
+
+## Test Commands Run
+- `corepack --version` → failed (`corepack: command not found`).
+- `npm exec -- pnpm --version` → passed (`10.12.1`).
+- RED: `cd frontend && npm exec -- pnpm run test:run MassLinkEditor.test.tsx` → failed as expected before implementation (2 missing technology icon assertions).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run MassLinkEditor.test.tsx` → passed (2 tests).
+- Focused icon regression: `cd frontend && npm exec -- pnpm run test:run MassLinkEditor.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 11 tests).
+- Safety net: `cd frontend && npm exec -- pnpm run test:run components/__tests__/EventDetailModal.acceptance.test.tsx` → passed (41 tests) before modifying `DependencyMiniMap.tsx`.
+- RED: `cd frontend && npm exec -- pnpm run test:run DependencyMiniMap.test.tsx` → failed as expected before implementation (2 missing technology icon assertions).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run DependencyMiniMap.test.tsx` → passed (2 tests).
+- Focused DependencyMiniMap regression: `cd frontend && npm exec -- pnpm run test:run DependencyMiniMap.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts components/__tests__/EventDetailModal.acceptance.test.tsx` → passed (4 files, 52 tests).
+- Safety net: `cd frontend && npm exec -- pnpm run test:run VisualRelationshipEditor.test.tsx` → passed before changes (30 tests).
+- RED: `cd frontend && npm exec -- pnpm run test:run VisualRelationshipEditor.test.tsx` → failed as expected before implementation (2 missing technology icon assertions; 30 existing tests passed).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run VisualRelationshipEditor.test.tsx` → passed (32 tests).
+- Focused VisualRelationshipEditor regression: `cd frontend && npm exec -- pnpm run test:run VisualRelationshipEditor.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 41 tests).
+- Safety net: `cd frontend && npm exec -- pnpm run test:run GlobalInventory.test.tsx` → passed before changes (3 tests).
+- RED: `cd frontend && npm exec -- pnpm run test:run GlobalInventory.test.tsx` → failed as expected before implementation (2 missing technology icon assertions; 3 existing tests passed).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run GlobalInventory.test.tsx` → passed (5 tests).
+- Focused GlobalInventory regression: `cd frontend && npm exec -- pnpm run test:run GlobalInventory.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 14 tests).
+- RED: `cd frontend && npm exec -- pnpm run test:run CIDetailModal.test.tsx` → failed as expected before implementation (2 missing technology icon assertions).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run CIDetailModal.test.tsx` → passed (2 tests).
+- Focused CIDetailModal regression: `cd frontend && npm exec -- pnpm run test:run CIDetailModal.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 11 tests).
+- RED: `cd frontend && npm exec -- pnpm run test:run NetworkVisualizer.test.tsx` → failed as expected before implementation (2 missing technology icon assertions).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run NetworkVisualizer.test.tsx` → passed (2 tests).
+- Focused NetworkVisualizer regression: `cd frontend && npm exec -- pnpm run test:run NetworkVisualizer.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 11 tests).
+- Safety net: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx` → passed before changes (8 tests).
+- RED: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx` → failed as expected before implementation (2 missing technology icon assertions).
+- GREEN: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx` → passed (10 tests).
+- Focused MonitoringConsole regression: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 19 tests).
+- Safety net: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx` → passed before audit-fix edits (10 tests).
+- RED: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx` → failed after adding event-detail tests because the tests could not open the detail modal via exact accessible name `Details`; this exposed that the new assertions were on a previously uncovered path and needed selector correction, not production changes.
+- GREEN: `cd frontend && npm exec -- pnpm run test:run components/__tests__/MonitoringConsole.smoke.test.tsx CategoryIcon.test.tsx categoryIcons.test.ts` → passed (3 files, 21 tests).
+- `cd backend && python -m pytest tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py` → blocked (`/usr/bin/python: No module named pytest`). This is the repo-root-adjusted equivalent of the task command because running from `backend/` requires `tests/...` paths, not `backend/tests/...`.
+- `cd frontend && npm exec -- pnpm run test:run categoryIcons CategoryIcon queryResources` → passed (3 files, 17 tests).
+- `cd frontend && npm exec -- pnpm run test:run` → passed (53 files, 461 tests).
+- `cd backend && python -m pip show pytest` → blocked (`/usr/bin/python: No module named pip`).
+- `cd backend && python3 -m pytest tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py` → blocked (`/usr/bin/python3: No module named pytest`).
+- `cd backend && python3 -m pip show pytest` → blocked (`/usr/bin/python3: No module named pip`).
+- Created ignored local `.env` with mock-only values adapted from `.env.example`; no real secrets used.
+- `docker compose ps` → initially no running services.
+- `docker compose up -d neo4j postgres backend` → built backend image and started Neo4j, PostgreSQL, and backend services; Neo4j/PostgreSQL became healthy and backend started.
+- `docker compose ps && docker compose exec -T backend python -m pip install -r requirements-dev.txt` → services running; installed `pytest`, `pytest-asyncio`, `httpx`, `pytest-cov`, and `factory-boy` only inside the running backend container.
+- `docker compose exec -T backend python -m pytest tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py` → passed (117 tests, 17 warnings).
+- `cd frontend && npm exec -- pnpm run test:run` → passed again (53 files, 461 tests).
+- `docker compose exec -T backend python -m pytest` → failed outside this slice (101 failed, 947 passed, 1 skipped, 43 warnings); task 4.3 remained unchecked until the maintainer-approved scoped verification exception was recorded.
+- `docker compose ps` → `neo4j`, `postgres`, and `backend` running and healthy.
+- `docker compose exec -T backend python -m pytest -q --tb=short --disable-warnings --json-report --json-report-file=/tmp/backend-full-pytest-report.json` → blocked because `pytest-json-report` is not installed (`unrecognized arguments`).
+- `docker compose exec -T backend python -m pytest -q --tb=short --disable-warnings` → reproduced full backend failure (101 failed, 947 passed, 1 skipped, 43 warnings); concise failure evidence captured in tool output, no tracked artifact created.
+- Parsed the full pytest short summary by test file: 101 failures across 15 files/modules; none in category-icons focused test files.
+- `docker compose exec -T backend python -m pytest -q --tb=short --disable-warnings tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py` → passed (117 tests, 17 warnings).

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/design.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/design.md
@@ -1,0 +1,75 @@
+# Design: Category Technology Icons
+
+## Technical Approach
+
+Add catalog-owned `icon_key` metadata to Neo4j `Category` nodes and expose it through existing catalog and node/category contracts. The backend validates icon keys against a controlled catalog, seeds/backfills defaults, and preserves `/nodes.type` as the existing category-as-type value. The frontend centralizes category icon lookup/rendering so catalog, inventory, monitoring map, topology, and detail views share one fallback-safe component while status indicators remain separate.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Store `icon_key` on `Category` nodes | One source of truth; requires API/test updates | Use `Category.icon_key` with generic fallback. |
+| Frontend-only mapping | Fast but not admin-editable or persisted | Reject except as client fallback for legacy/missing metadata. |
+| Custom uploads | Flexible but adds asset security/storage scope | Reject for v1; use controlled Material Symbols catalog. |
+| Put icon metadata directly on `/nodes` | Easy rendering but risks bloating node contract | Add optional `category_icon_key` while keeping `type` unchanged. |
+
+## Data Flow
+
+```text
+Admin selector -> PUT /categories/{name} -> catalog_service validates icon_key
+              -> (:Category {name, icon_key})
+
+/categories -> CategoryRecord[] -> useCategoriesQuery -> icon resolver/component
+/nodes      -> node_service keeps type=category and adds category/category_icon_key
+             -> maps/topology/inventory render technology icon + separate status
+```
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `backend/models/core.py` | Modify | Extend `Category` with optional `icon_key`. |
+| `backend/services/category_icons.py` | Create | Allowed icon catalog, defaults, normalization, validation, generic fallback. |
+| `backend/services/catalog_service.py` | Modify | Return/set `icon_key`, preserve it on rename, seed/backfill defaults on category create/read. |
+| `backend/routers/catalog.py` | Modify | Replace `List[Dict[str,str]]` contract with typed category response/update accepting optional `icon_key`. |
+| `backend/repositories/topology_repo.py` | Modify | Return `c.icon_key as category_icon_key` from `get_nodes`. |
+| `backend/services/node_service.py` | Modify | Keep `type = category or layer`; add `category` and `category_icon_key` fields without removing current keys. |
+| `frontend/types.ts` | Modify | Add `CategoryRecord.icon_key`, `GraphNode.category_icon_key`, and loosen runtime category/type expectations safely. |
+| `frontend/services/queryResources.ts` | Modify | Update category API types. |
+| `frontend/components/CategoryIcon.tsx` | Create | Shared Material Symbols renderer with default fallback and status-agnostic semantics. |
+| `frontend/utils/categoryIcons.ts` | Create | Controlled catalog, defaults, lookup by category/icon key, search helpers. |
+| `frontend/components/CatalogManager.tsx` | Modify | Add visual icon selector with current icon, search grid, preview, and generic option. |
+| `frontend/components/HardwareCatalog.tsx` | Modify | Display category icons next to category labels. |
+| `frontend/components/GlobalInventory.tsx` | Modify | Render category icons in list and detail chips. |
+| `frontend/components/MonitoringConsole.tsx` | Modify | Add technology icon overlays/markers while retaining `STATUS_COLORS` for health. |
+| `frontend/components/DependencyMiniMap.tsx`, `frontend/components/NetworkVisualizer.tsx`, `frontend/components/VisualRelationshipEditor.tsx`, `frontend/components/MassLinkEditor.tsx`, `frontend/components/CIDetailModal.tsx` | Modify | Replace scattered category/type visuals with shared renderer. |
+
+## Interfaces / Contracts
+
+```ts
+type CategoryIconKey = "generic" | "switch_l2" | "switch_l3" | "router" | "server" | "saas" | "storage" | "camera" | "video_analytics";
+interface CategoryRecord { name: string; icon_key?: CategoryIconKey | null; }
+interface GraphNode { type: string; category?: string; category_icon_key?: CategoryIconKey | null; }
+```
+
+Backend rejects unknown `icon_key` with 422/400 and leaves previous metadata unchanged. Missing/null resolves to `generic` on both backend responses and frontend rendering.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Backend unit | Icon validation/default resolution and generic fallback | Add tests for `category_icons.py` before implementation. |
+| Backend router/service | `/categories` returns/updates `icon_key`; invalid keys rejected; rename preserves metadata | Extend `backend/tests/test_routers_catalog.py`; add catalog service tests with mocked Neo4j. |
+| Backend node compatibility | `/nodes` keeps category-as-`type` and adds icon metadata | Extend `backend/tests/test_node_service.py` and `backend/tests/test_topology_repo_nodes.py`. |
+| Frontend unit | Resolver/component fallback, searchable selector, no blank icon | Add Vitest tests for `categoryIcons` and `CategoryIcon`. |
+| Frontend integration | Catalog save flow and key surfaces render icons separate from status | Extend `GlobalInventory`, `MonitoringConsole`, topology/detail tests. |
+
+Strict TDD applies: write failing tests for each slice before code, then implement and refactor.
+
+## Migration / Rollout
+
+No destructive migration. Add an idempotent Neo4j backfill in catalog service/startup or an explicit admin-safe script to set default `icon_key` for Layer 2 switch, Layer 3 switch, router, server, SaaS, storage, cameras, and video analytics by normalized category name. Existing categories without a match remain unset in storage but resolve to `generic` in API/UI. Roll out in chained PRs: backend contract/defaults first, shared frontend resolver second, admin selector third, surfaces fourth.
+
+## Open Questions
+
+- [ ] None blocking. Chained PR strategy is required later but not selected in this phase.

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/exploration.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/exploration.md
@@ -1,0 +1,49 @@
+## Exploration: Category Technology Icons
+
+### Current State
+Categories are Neo4j `Category` nodes identified only by `name`. CI creation/upsert stores both `CI.layer = node.type` and a `(:CI)-[:CATEGORIZED_AS]->(:Category)` relationship; `/nodes` returns the resolved category as `type` rather than a separate `category` field. Hardware catalog entries link to categories via `(:HardwareModel)-[:BELONGS_TO]->(:Category)`, but categories currently have no icon/color metadata. Frontend visuals use category/type strings inconsistently: some screens show text badges, some use hard-coded Material Symbols by broad node type, and map markers are status-colored circles without technology icons.
+
+### Affected Areas
+- `backend/models/core.py` — `Category` is `name` only; API schemas would need icon metadata if icons are catalog-driven.
+- `backend/services/catalog_service.py` — category CRUD and hardware catalog queries are the central place to read/write category metadata and migration defaults.
+- `backend/routers/catalog.py` — `/categories` response model currently exposes `List[Dict[str, str]]`; mutations accept only category names.
+- `backend/repositories/topology_repo.py` — CI upsert/bulk import creates categories from `node.type`; `/nodes` resolves `c.name as category` but `node_service` maps it into `type`.
+- `backend/services/node_service.py` — node payload normalization currently loses the separate `category` field; this affects all frontend consumers.
+- `backend/services/event_service.py` — availability and SNMP reports already include `category`; icon metadata could be enriched here or resolved on the client.
+- `frontend/types.ts` — `GraphNode` has optional `category`, but backend `/nodes` often returns category as `type`; `NodeType` is a narrow broad-type union while runtime categories include values like `NETWORK`.
+- `frontend/services/queryResources.ts` and `frontend/hooks/queries/useMonitoringConsoleData.ts` — category records and filter options are name-only today.
+- `frontend/components/CatalogManager.tsx` and `frontend/components/HardwareCatalog.tsx` — category management UI is the natural place to select/edit category icons.
+- `frontend/components/GlobalInventory.tsx`, `MonitoringConsole.tsx`, `CIDetailModal.tsx`, `DependencyMiniMap.tsx`, `NetworkVisualizer.tsx`, `VisualRelationshipEditor.tsx`, `MassLinkEditor.tsx` — visual category/type rendering is spread across badges, maps, SVG/D3, 3D graph, and filtering.
+- `frontend/constants.tsx` — contains a broad `ICONS` map for `SERVICE`, `INFRASTRUCTURE`, etc.; not connected to catalog categories.
+- Tests: `backend/tests/test_routers_catalog.py`, `backend/tests/test_node_service.py`, `backend/tests/test_topology_repo_nodes.py`, `frontend/components/__tests__/MonitoringConsole*.tsx`, `frontend/components/GlobalInventory.test.tsx`, `frontend/hooks/queries/useMonitoringConsoleData.test.tsx` — likely regression points under strict TDD.
+
+### Approaches
+1. **Catalog-owned category icon metadata** — Add icon fields to `Category` nodes and expose them through `/categories`; frontend resolves icons from category catalog with safe fallback icons.
+   - Pros: Single source of truth; supports migration defaults; allows admin-managed icons; avoids duplicating mappings in every UI.
+   - Cons: Requires backend schema/API changes, frontend type updates, migration/backfill, and UI changes.
+   - Effort: Medium
+
+2. **Frontend-only category-to-icon registry** — Keep backend categories name-only and add a client utility mapping known category strings to Material Symbols.
+   - Pros: Fast, minimal backend risk, easy to test in UI helpers.
+   - Cons: Not catalog-driven, no admin configurability, migration is just code defaults, and unknown categories degrade silently.
+   - Effort: Low
+
+3. **Hybrid default registry plus catalog override** — Seed default icon/color metadata for existing categories, expose/edit via catalog, and keep frontend fallback registry for legacy/unknown records.
+   - Pros: Best migration story; resilient during rollout; keeps icons reflected system-wide while preventing blank UI for old data.
+   - Cons: More moving parts and likely exceeds one reviewable PR, so chained delivery is required.
+   - Effort: Medium/High
+
+### Recommendation
+Use the hybrid approach. Store `icon` and optionally `color`/`description` on `Category` nodes, add a migration/backfill for existing categories, expose metadata through `/categories`, and centralize frontend icon resolution in one utility/component used across catalog, inventory, monitoring, detail, and graph views. Keep frontend fallbacks for categories without metadata and broad node types such as `SERVICE`/`INFRASTRUCTURE`.
+
+Product questions for proposal: Which icon source is allowed (Material Symbols only, custom SVGs, or both)? Should admins choose icons, or should the system assign fixed icons? Are icons by category only, or can hardware model/brand override the category icon? Is color part of the technology identity or status-only? What are the initial canonical categories and their default icons?
+
+### Risks
+- Existing `/nodes` maps category into `type`; changing this carelessly may break filters, tests, and visual layouts that expect `node.type`.
+- Category rename/delete currently changes/deletes `Category` nodes without explicit migration semantics for icon metadata and relationships.
+- Visual rendering is scattered; without a shared frontend resolver, behavior will remain inconsistent.
+- Backend tests currently assume category payloads are name-only; strict TDD requires contract tests before implementation.
+- Chained PRs are required later because backend schema/API, migration, and multiple UI surfaces likely exceed the 400 changed-line review budget.
+
+### Ready for Proposal
+Yes — proceed to proposal after the orchestrator confirms the product questions above, especially icon source, admin editability, and whether category is the only technology identity dimension.

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/proposal.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/proposal.md
@@ -1,0 +1,65 @@
+# Proposal: Category Technology Icons
+
+## Intent
+
+Create a catalog-owned icon system so operators recognize technology type across maps, topology, inventory, monitoring, detail, and catalog views. Icons represent technology type only, not operational status; unknown categories keep a generic fallback.
+
+## Scope
+
+### In Scope
+- Add icon metadata and defaults for Layer 2 switch, Layer 3 switch, router, server, SaaS, storage, cameras, and video analytics.
+- Allow admin users to edit category/icon association from the catalog UI.
+- Expose metadata through category APIs and a shared frontend resolver/component.
+- Preserve `/nodes` UI assumptions while improving category/type icon rendering.
+
+### Out of Scope
+- Operational status icons, severity indicators, or status color replacement.
+- Hardware model, vendor, or instance-level icon overrides.
+- Full visual redesign of topology, maps, or inventory screens.
+
+## Capabilities
+
+### New Capabilities
+- `category-technology-icons`: Category icon metadata, admin editing, fallback behavior, migration/backfill, and shared UI rendering.
+
+### Modified Capabilities
+- None. Existing `audit-logging` requirements remain unchanged.
+
+## Approach
+
+Use the exploration-recommended hybrid model: store icon metadata on catalog categories, seed/backfill defaults, expose metadata through category endpoints, and centralize frontend resolution with fallbacks. Keep status color/health separate from technology icons. Maintain compatibility with `/nodes` consumers that rely on category values mapped into `type`.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `backend/models/core.py` | Modified | Add category icon metadata fields. |
+| `backend/services/catalog_service.py` | Modified | Read/write icon associations and defaults. |
+| `backend/routers/catalog.py` | Modified | Extend category API contracts. |
+| `backend/repositories/topology_repo.py`, `backend/services/node_service.py` | Modified | Preserve category/type compatibility. |
+| `frontend/services/queryResources.ts`, `frontend/types.ts` | Modified | Type and fetch category icon metadata. |
+| `frontend/components/CatalogManager.tsx`, `HardwareCatalog.tsx` | Modified | Admin icon editing UI. |
+| `frontend/components/*map*`, `*Topology*`, `GlobalInventory.tsx`, `MonitoringConsole.tsx`, `CIDetailModal.tsx` | Modified | Use shared technology icon rendering. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Breaking `/nodes` category-as-`type` consumers | Med | Preserve payload compatibility and add regression tests first. |
+| Inconsistent visuals remain scattered | Med | Use one resolver/component and migrate surfaces through chained PRs. |
+| Unknown categories render blank | Low | Require generic fallback in backend/client contracts. |
+
+## Rollback Plan
+
+Revert API/schema/UI changes and seeded metadata; frontend generic fallbacks keep legacy category rendering usable.
+
+## Dependencies
+
+- Strict TDD is required.
+- Chained PRs are required later due to the 400-line review budget; strategy is not selected yet.
+
+## Success Criteria
+
+- [ ] Admins can assign/edit category icons from UI.
+- [ ] Initial technology types have defaults; unmapped categories show generic icons.
+- [ ] Maps, topology, inventory, monitoring, detail, and catalog use consistent technology icons without status/icon confusion.

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/specs/category-technology-icons/spec.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/specs/category-technology-icons/spec.md
@@ -1,0 +1,93 @@
+# Category Technology Icons Specification
+
+## Purpose
+
+Define category-owned technology icons so operators can recognize technology type consistently across catalog, inventory, monitoring, maps, topology, and detail views without confusing icons with operational status.
+
+## Requirements
+
+### Requirement: Category Icon Association
+
+The system MUST persist an `icon_key` association for catalog categories. The icon key MUST identify a controlled selectable icon, not an uploaded custom asset.
+
+#### Scenario: Category stores selected icon
+
+- GIVEN an admin selects an allowed icon for a category
+- WHEN the category is saved
+- THEN the category exposes the selected `icon_key`
+- AND future reads return the same association
+
+#### Scenario: Invalid icon is rejected
+
+- GIVEN a category update references an icon outside the allowed catalog
+- WHEN the update is submitted
+- THEN the system MUST reject the association
+- AND the previous category icon remains unchanged
+
+### Requirement: Initial Technology Defaults
+
+The system MUST provide default icon keys for Layer 2 switch, Layer 3 switch, router, server, SaaS, storage, cameras, and video analytics category types.
+
+#### Scenario: Known technology receives default icon
+
+- GIVEN a category matches an initial technology type
+- WHEN category icon metadata is initialized or read
+- THEN the category has the expected default `icon_key`
+
+#### Scenario: Existing category without mapping uses generic icon
+
+- GIVEN an existing category has no icon association
+- WHEN the category is displayed or returned to clients
+- THEN the system MUST use a generic/default technology icon
+
+### Requirement: Admin Icon Selection Experience
+
+Admin category management MUST expose a visual icon selector showing the current icon, searchable controlled icon grid, preview, and generic/default option.
+
+#### Scenario: Admin previews and saves icon
+
+- GIVEN an admin is editing a category
+- WHEN the admin searches the icon catalog and selects an icon
+- THEN the UI previews the selection before save
+- AND saving updates the category association
+
+#### Scenario: Admin selects generic/default icon
+
+- GIVEN an admin wants no specific technology icon
+- WHEN the admin chooses the generic/default option
+- THEN the category uses the generic/default technology icon
+
+### Requirement: System-Wide Technology Rendering
+
+The system MUST render category technology icons consistently anywhere category/type identity appears, especially maps and topology. Technology icons MUST NOT represent operational status, severity, or health.
+
+#### Scenario: Shared icon appears across surfaces
+
+- GIVEN a category has an `icon_key`
+- WHEN the category appears in catalog, inventory, monitoring, detail, map, or topology surfaces
+- THEN each surface renders the same technology icon for that category
+
+#### Scenario: Status remains visually separate
+
+- GIVEN a node has both a technology category and an operational status
+- WHEN the node is rendered on maps or topology
+- THEN the technology icon identifies category type only
+- AND status indicators remain separate from the technology icon
+
+### Requirement: Category Payload Compatibility
+
+The system MUST expose category icon metadata without breaking existing category/type consumers, including `/nodes` consumers that rely on category values mapped into `type`.
+
+#### Scenario: Existing type value remains compatible
+
+- GIVEN a client reads node data that previously used category as `type`
+- WHEN category icon metadata is added
+- THEN the existing category/type value remains available
+- AND icon metadata is available for rendering
+
+#### Scenario: Missing icon metadata remains safe
+
+- GIVEN a client receives a category without `icon_key`
+- WHEN the client renders the category
+- THEN it MUST display the generic/default icon
+- AND no surface renders a blank or broken icon

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/tasks.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: Category Technology Icons
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 900-1300 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 backend contract → PR 2 shared frontend primitives → PR 3 admin selector → PR 4 surfaces |
+| Delivery strategy | force-chained |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Persist and expose category icon metadata | PR 1 | Backend tests/code; preserves `/nodes.type`. |
+| 2 | Add shared frontend icon types/resolver/component | PR 2 | Depends on PR 1 API contract. |
+| 3 | Add admin visual icon selector | PR 3 | Depends on PR 2 primitives. |
+| 4 | Migrate inventory, monitoring, map, topology, and detail surfaces | PR 4 | Depends on PR 2; keep status separate. |
+
+## Phase 1: Backend Contract and Defaults
+
+- [x] 1.1 RED: Add tests in `backend/tests/test_routers_catalog.py` for `icon_key` reads, saves, invalid rejection, and generic/default behavior.
+- [x] 1.2 RED: Add tests in `backend/tests/test_node_service.py` and `backend/tests/test_topology_repo_nodes.py` proving `/nodes.type` remains compatible and `category_icon_key` is added.
+- [x] 1.3 GREEN: Create `backend/services/category_icons.py` with controlled keys, defaults, normalization, validation, and generic fallback.
+- [x] 1.4 GREEN: Update `backend/models/core.py`, `backend/services/catalog_service.py`, `backend/routers/catalog.py`, `backend/repositories/topology_repo.py`, and `backend/services/node_service.py` for persisted `icon_key` and node metadata.
+- [x] 1.5 REFACTOR: Run `cd backend && python -m pytest backend/tests/test_routers_catalog.py backend/tests/test_node_service.py backend/tests/test_topology_repo_nodes.py` and simplify duplicated fallback logic.
+
+## Phase 2: Shared Frontend Primitives
+
+- [x] 2.1 RED: Add Vitest coverage in `frontend/utils/categoryIcons.test.ts` and `frontend/components/CategoryIcon.test.tsx` for lookup, search, fallback, and no blank icon.
+- [x] 2.2 GREEN: Update `frontend/types.ts` and `frontend/services/queryResources.ts` for `CategoryRecord.icon_key` and `GraphNode.category_icon_key`.
+- [x] 2.3 GREEN: Create `frontend/utils/categoryIcons.ts` and `frontend/components/CategoryIcon.tsx` using controlled Material Symbols and status-agnostic semantics.
+- [x] 2.4 REFACTOR: Run `cd frontend && corepack pnpm test:run -- categoryIcons CategoryIcon queryResources` and remove local duplicate icon mappings.
+
+## Phase 3: Admin Selector
+
+- [x] 3.1 RED: Extend `frontend/components/CatalogManager.test.tsx` or nearest catalog test for current icon, search grid, preview, generic option, and save flow.
+- [x] 3.2 GREEN: Update `frontend/components/CatalogManager.tsx` and `frontend/components/HardwareCatalog.tsx` to show/edit category icons via the shared primitives.
+- [x] 3.3 REFACTOR: Run targeted catalog frontend tests and keep selector state isolated from category rename/edit state.
+
+## Phase 4: System-Wide Rendering
+
+- [x] 4.1 RED: Extend tests for `frontend/components/GlobalInventory.tsx`, `MonitoringConsole.tsx` live stream and event-detail category strip, topology/map/detail components to assert shared technology icons and separate status indicators.
+- [x] 4.2 GREEN: Migrate `GlobalInventory.tsx`, `MonitoringConsole.tsx`, `DependencyMiniMap.tsx`, `NetworkVisualizer.tsx`, `VisualRelationshipEditor.tsx`, `MassLinkEditor.tsx`, and `CIDetailModal.tsx` to `CategoryIcon`.
+- [x] 4.3 REFACTOR: Run `cd frontend && corepack pnpm test:run` plus `cd backend && python -m pytest`, then update this checklist with completed PR slice evidence (completed under maintainer-approved scoped verification exception; backend full suite remains red and is tracked in issue #267).

--- a/openspec/changes/archive/2026-06-14-category-technology-icons/verify-report.md
+++ b/openspec/changes/archive/2026-06-14-category-technology-icons/verify-report.md
@@ -1,0 +1,207 @@
+# Verification Report — category-technology-icons
+
+**Change**: category-technology-icons  
+**Version**: N/A  
+**Mode**: Strict TDD  
+**Artifact store**: Hybrid (OpenSpec + Engram)  
+**Verified at**: 2026-06-14
+
+## Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 15 |
+| Tasks complete | 15 |
+| Tasks incomplete | 0 |
+| Apply state | all_done |
+| Verification exception | Maintainer-approved scoped backend exception for task 4.3 |
+| Follow-up issue | https://github.com/alexandervazquez98/next-gen/issues/267 |
+
+Task completion is accurate. `tasks.md` marks 4.3 complete only under the scoped verification exception, and `apply-progress.md` explicitly states this is not a claim that the full backend suite is green. Issue #267 is documented as the follow-up for backend full-suite stabilization.
+
+## Archive Gate
+
+**Archive gate verdict: PASS**
+
+Archive may proceed with warnings under the maintainer-approved scoped verification exception. There are no CRITICAL verification issues for `category-technology-icons`. The backend full-suite stabilization work remains tracked separately in issue #267 and is not part of this archive gate.
+
+## Build & Tests Execution
+
+**Build**: ✅ Passed
+
+```text
+Command: npm exec -- pnpm run build
+Result: passed
+Evidence: Vite built successfully; 1208 modules transformed; production assets emitted.
+Warning: Vite reported a large JS chunk (>500 kB), unrelated to category technology icons.
+```
+
+**Tests**: ✅ Scoped verification passed with approved full-backend exception
+
+```text
+Command: docker compose exec -T backend python -m pytest -q --tb=short --disable-warnings tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py
+Result: 117 passed, 17 warnings
+
+Command: docker compose exec -T backend python -m pytest -q --tb=short --disable-warnings tests/test_category_icons.py tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py
+Result: 122 passed, 17 warnings
+
+Command: npm exec -- pnpm run test:run
+Result: 53 files passed, 461 tests passed
+
+Known exception from apply-progress:
+Command: docker compose exec -T backend python -m pytest
+Result: 101 non-passing, 947 passed, 1 skipped
+Disposition: accepted scoped exception; failures tracked in issue #267 and not treated as a category-icons verification failure.
+```
+
+**Coverage**: ⚠️ Available, informational only
+
+```text
+Backend focused coverage command passed with 122 tests.
+- services/category_icons.py: 97%
+- routers/catalog.py: 100%
+- services/node_service.py: 85%
+- services/catalog_service.py: 15% overall file coverage
+- repositories/topology_repo.py: 17% overall file coverage
+
+Frontend coverage command passed with 53 files / 461 tests.
+- CategoryIcon.tsx: 100%
+- categoryIcons.ts: 97.22%
+- GlobalInventory.tsx: 83.33% lines
+- Several broad UI files remain below 80% overall file coverage, but focused category-icon behavior is covered by passing tests.
+```
+
+## TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress.md` contains a TDD Evidence table. |
+| All tasks have tests/evidence | ✅ | 15/15 tasks complete; verification/refactor tasks include command evidence. |
+| RED confirmed (tests exist) | ✅ | Reported backend/frontend test files exist. |
+| GREEN confirmed (tests pass) | ✅ | Focused backend category-icon suites pass; full frontend suite passes. |
+| Triangulation adequate | ✅ | Explicit icon, category fallback, invalid key, generic fallback, status separation, and payload compatibility cases are covered. |
+| Safety net for modified files | ✅ | Apply-progress records safety-net runs; current verification re-ran focused backend and full frontend tests. |
+
+**TDD Compliance**: 6/6 checks passed, with the documented backend full-suite exception for task 4.3.
+
+## Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | Backend icon utilities; frontend resolver/component/query resource tests | `backend/tests/test_category_icons.py`, `frontend/utils/categoryIcons.test.ts`, `frontend/components/CategoryIcon.test.tsx`, `frontend/services/queryResources.test.ts` | Pytest, Vitest |
+| Integration/UI | Catalog selector and migrated rendering surfaces | Catalog, inventory, monitoring, topology/map/detail component tests | RTL/Vitest |
+| Backend contract/service/repository | Category API, node service compatibility, topology repository query shape | 4 backend test files, 122 passing tests | Pytest in Docker |
+| E2E | 0 | None | Not used for this change |
+
+## Changed File Coverage
+
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `backend/services/category_icons.py` | 97% | n/a | 46 | ✅ Excellent |
+| `backend/routers/catalog.py` | 100% | n/a | — | ✅ Excellent |
+| `backend/services/node_service.py` | 85% | n/a | broad non-icon paths | ⚠️ Acceptable |
+| `backend/services/catalog_service.py` | 15% | n/a | broad non-icon paths | ⚠️ Low overall file coverage |
+| `backend/repositories/topology_repo.py` | 17% | n/a | broad non-icon paths | ⚠️ Low overall file coverage |
+| `frontend/components/CategoryIcon.tsx` | 100% | 100% | — | ✅ Excellent |
+| `frontend/utils/categoryIcons.ts` | 97.22% | 86.95% | 142 | ✅ Excellent |
+| `frontend/components/GlobalInventory.tsx` | 83.33% | 63.79% | 32, 35-36, 67-72 | ⚠️ Acceptable |
+| Broad migrated UI components | Mixed | Mixed | Non-icon paths remain uncovered | ⚠️ Informational |
+
+Coverage is not used as a blocking gate here because focused category-icon behavior is covered by runtime tests and full frontend execution passed.
+
+## Assertion Quality
+
+| File | Line | Assertion | Issue | Severity |
+|------|------|-----------|-------|----------|
+| `frontend/components/VisualRelationshipEditor.test.tsx` | 401-405 | `querySelector("circle.node-circle")`, `not.toHaveClass(...)` | Existing implementation-detail assertions are present in a modified related test file. They do not cover category-icon behavior and did not block the verified scenarios. | WARNING |
+
+**Assertion quality**: 0 CRITICAL, 1 WARNING. Category-icon assertions verify accessible labels, rendered symbols, saved payloads, fallback behavior, and status separation; no tautologies or ghost loops found in the change-specific tests inspected.
+
+## Quality Metrics
+
+**Linter**: ➖ Backend Ruff unavailable in container (`No module named ruff`). No frontend lint script is configured in `frontend/package.json`.  
+**Type Checker / Build**: ✅ `npm exec -- pnpm run build` passed.  
+**Test-only guard**: ✅ `frontend/vite.config.ts` sets `test.forbidOnly: true`.
+
+## Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Category Icon Association | Category stores selected icon | `backend/tests/test_routers_catalog.py`, `frontend/components/CatalogManager.test.tsx` | ✅ COMPLIANT |
+| Category Icon Association | Invalid icon is rejected | `backend/tests/test_routers_catalog.py`, `backend/tests/test_category_icons.py` | ✅ COMPLIANT |
+| Initial Technology Defaults | Known technology receives default icon | `backend/tests/test_category_icons.py`, `frontend/utils/categoryIcons.test.ts`, focused backend suite | ✅ COMPLIANT |
+| Initial Technology Defaults | Existing category without mapping uses generic icon | `backend/tests/test_routers_catalog.py`, `backend/tests/test_node_service.py`, `frontend/components/CategoryIcon.test.tsx` | ✅ COMPLIANT |
+| Admin Icon Selection Experience | Admin previews and saves icon | `frontend/components/CatalogManager.test.tsx` | ✅ COMPLIANT |
+| Admin Icon Selection Experience | Admin selects generic/default icon | `frontend/components/CatalogManager.test.tsx` | ✅ COMPLIANT |
+| System-Wide Technology Rendering | Shared icon appears across surfaces | `GlobalInventory`, `MonitoringConsole`, `DependencyMiniMap`, `NetworkVisualizer`, `VisualRelationshipEditor`, `MassLinkEditor`, `CIDetailModal` tests | ✅ COMPLIANT |
+| System-Wide Technology Rendering | Status remains visually separate | Surface tests assert technology icons separately from status/severity/health indicators | ✅ COMPLIANT |
+| Category Payload Compatibility | Existing type value remains compatible | `backend/tests/test_node_service.py`, `backend/tests/test_topology_repo_nodes.py` | ✅ COMPLIANT |
+| Category Payload Compatibility | Missing icon metadata remains safe | Backend/frontend fallback tests and migrated surface fallback tests | ✅ COMPLIANT |
+
+**Compliance summary**: 10/10 scenarios compliant with runtime evidence.
+
+## Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Persist controlled icon metadata | ✅ Implemented | `Category.icon_key`, `category_icons.py`, catalog router/service validation. |
+| Default and generic fallback behavior | ✅ Implemented | Backend `resolve_category_icon`; frontend `resolveCategoryIconKey`; `CategoryIcon` never renders blank for unknown keys. |
+| Admin selector | ✅ Implemented | `CatalogManager` exposes searchable controlled icon selection, preview, save payload, and generic option. |
+| System-wide rendering | ✅ Implemented | Shared `CategoryIcon` is used across catalog, inventory, monitoring, maps/topology, detail, and mass link surfaces. |
+| `/nodes` compatibility | ✅ Implemented | `type` remains category-compatible; `category` and `category_icon_key` are additive. |
+
+## Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Store `icon_key` on catalog categories | ✅ Yes | Backend model/service/router paths support persisted controlled metadata. |
+| Reject frontend-only mapping as source of truth | ✅ Yes | Frontend mapping is used as fallback/resolver only; backend exposes metadata. |
+| Reject custom uploads for v1 | ✅ Yes | Controlled Material Symbols catalog is used. |
+| Add optional `category_icon_key` while keeping `type` unchanged | ✅ Yes | Node compatibility tests pass. |
+| Keep status/severity separate from technology icons | ✅ Yes | Surface tests and implementation keep operational status indicators separate. |
+
+## Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**:
+- Full backend pytest remains red: 101 non-passing, 947 passed, 1 skipped. This is accepted only under the maintainer-approved scoped verification exception and tracked by issue #267.
+- One full-suite `test_routers_nodes.py` auth-policy failure remains uncertain but unlikely related; focused node compatibility tests pass and the observed failure concerns authentication policy, not category icon payload behavior.
+- Overall coverage for broad backend/UI files is low even though focused category-icon behavior is covered.
+- Ruff is unavailable in the backend container and frontend has no configured lint script.
+- Existing implementation-detail assertions remain in `VisualRelationshipEditor.test.tsx`.
+
+**SUGGESTION**:
+- Stabilize backend full-suite failures under issue #267 before relying on full backend green as an archive gate.
+- Consider adding narrower coverage reporting for changed lines or icon-specific slices to avoid broad-file coverage noise.
+- Consider replacing implementation-detail assertions in `VisualRelationshipEditor.test.tsx` with user-visible behavior assertions when that area is next touched.
+
+## Artifacts
+
+- OpenSpec: `openspec/changes/category-technology-icons/verify-report.md`
+- Engram: `sdd/category-technology-icons/verify-report`
+
+## Next Recommended
+
+Archive may proceed with warnings because the maintainer approved the scoped verification exception. Backend full-suite stabilization remains tracked separately by issue #267: https://github.com/alexandervazquez98/next-gen/issues/267.
+
+## Risks
+
+- Backend full-suite failures remain outside this slice and can mask future regressions until issue #267 is resolved.
+- This is NOT a full backend green claim. The scoped exception must not be interpreted as a full backend pass.
+
+## Skill Resolution
+
+paths-injected — loaded `sdd-verify/SKILL.md`, `sdd-verify/strict-tdd-verify.md`, and `work-unit-commits/SKILL.md` from the orchestrator-provided paths.
+
+## Verdict
+
+Final verdict: PASS
+
+Warnings present: yes — accepted under maintainer-approved scoped verification exception.
+
+CRITICAL: None.
+
+Archive may proceed with warnings because the maintainer approved the scoped verification exception. This is NOT a full backend green claim: the backend full suite remains red under the explicit exception and is tracked by issue #267: https://github.com/alexandervazquez98/next-gen/issues/267.
+
+All category-technology-icons requirements have passing runtime coverage and all tasks are complete under the approved scoped verification exception.

--- a/openspec/specs/category-technology-icons/spec.md
+++ b/openspec/specs/category-technology-icons/spec.md
@@ -1,0 +1,93 @@
+# Category Technology Icons Specification
+
+## Purpose
+
+Define category-owned technology icons so operators can recognize technology type consistently across catalog, inventory, monitoring, maps, topology, and detail views without confusing icons with operational status.
+
+## Requirements
+
+### Requirement: Category Icon Association
+
+The system MUST persist an `icon_key` association for catalog categories. The icon key MUST identify a controlled selectable icon, not an uploaded custom asset.
+
+#### Scenario: Category stores selected icon
+
+- GIVEN an admin selects an allowed icon for a category
+- WHEN the category is saved
+- THEN the category exposes the selected `icon_key`
+- AND future reads return the same association
+
+#### Scenario: Invalid icon is rejected
+
+- GIVEN a category update references an icon outside the allowed catalog
+- WHEN the update is submitted
+- THEN the system MUST reject the association
+- AND the previous category icon remains unchanged
+
+### Requirement: Initial Technology Defaults
+
+The system MUST provide default icon keys for Layer 2 switch, Layer 3 switch, router, server, SaaS, storage, cameras, and video analytics category types.
+
+#### Scenario: Known technology receives default icon
+
+- GIVEN a category matches an initial technology type
+- WHEN category icon metadata is initialized or read
+- THEN the category has the expected default `icon_key`
+
+#### Scenario: Existing category without mapping uses generic icon
+
+- GIVEN an existing category has no icon association
+- WHEN the category is displayed or returned to clients
+- THEN the system MUST use a generic/default technology icon
+
+### Requirement: Admin Icon Selection Experience
+
+Admin category management MUST expose a visual icon selector showing the current icon, searchable controlled icon grid, preview, and generic/default option.
+
+#### Scenario: Admin previews and saves icon
+
+- GIVEN an admin is editing a category
+- WHEN the admin searches the icon catalog and selects an icon
+- THEN the UI previews the selection before save
+- AND saving updates the category association
+
+#### Scenario: Admin selects generic/default icon
+
+- GIVEN an admin wants no specific technology icon
+- WHEN the admin chooses the generic/default option
+- THEN the category uses the generic/default technology icon
+
+### Requirement: System-Wide Technology Rendering
+
+The system MUST render category technology icons consistently anywhere category/type identity appears, especially maps and topology. Technology icons MUST NOT represent operational status, severity, or health.
+
+#### Scenario: Shared icon appears across surfaces
+
+- GIVEN a category has an `icon_key`
+- WHEN the category appears in catalog, inventory, monitoring, detail, map, or topology surfaces
+- THEN each surface renders the same technology icon for that category
+
+#### Scenario: Status remains visually separate
+
+- GIVEN a node has both a technology category and an operational status
+- WHEN the node is rendered on maps or topology
+- THEN the technology icon identifies category type only
+- AND status indicators remain separate from the technology icon
+
+### Requirement: Category Payload Compatibility
+
+The system MUST expose category icon metadata without breaking existing category/type consumers, including `/nodes` consumers that rely on category values mapped into `type`.
+
+#### Scenario: Existing type value remains compatible
+
+- GIVEN a client reads node data that previously used category as `type`
+- WHEN category icon metadata is added
+- THEN the existing category/type value remains available
+- AND icon metadata is available for rendering
+
+#### Scenario: Missing icon metadata remains safe
+
+- GIVEN a client receives a category without `icon_key`
+- WHEN the client renders the category
+- THEN it MUST display the generic/default icon
+- AND no surface renders a blank or broken icon


### PR DESCRIPTION
Closes #268

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Add controlled `icon_key` category technology icons with backend validation/default fallback.
- Add admin category icon selector and shared frontend `CategoryIcon` renderer.
- Migrate catalog, inventory, monitoring, topology/map, detail, and mass-link surfaces to shared technology icons while keeping status indicators separate.

## Changes
| File/Area | Change |
|---|---|
| `backend/services/category_icons.py` | Controlled icon key catalog, normalization, validation, defaults, fallback. |
| `backend/models/core.py`, `backend/services/catalog_service.py`, `backend/routers/catalog.py` | Persist and expose category `icon_key`; reject invalid keys. |
| `backend/services/node_service.py`, `backend/repositories/topology_repo.py` | Add `category_icon_key` while preserving `/nodes.type` compatibility. |
| `frontend/utils/categoryIcons.ts`, `frontend/components/CategoryIcon.tsx` | Shared icon resolver/component. |
| Catalog/admin UI | Visual icon selection, preview, generic/default option. |
| Inventory/monitoring/topology/detail surfaces | Shared technology icon rendering with status kept separate. |
| `openspec/` | Archived SDD proposal/spec/design/tasks/verify trail and main spec. |

## Test Plan
- [x] Backend focused category-icons suite: `docker compose exec -T backend python -m pytest tests/test_routers_catalog.py tests/test_node_service.py tests/test_topology_repo_nodes.py` → 117 passed.
- [x] Expanded backend focused suite with icon utility tests → 122 passed.
- [x] Frontend full suite: `cd frontend && npm exec -- pnpm run test:run` → 461 passed.
- [x] Frontend build: `cd frontend && npm exec -- pnpm run build` → passed.
- [x] SDD verify: PASS under maintainer-approved scoped backend exception.

## Verification warning
The full backend suite is not green in the current Docker mock environment (`101 non-passing, 947 passed, 1 skipped`). This PR uses a maintainer-approved scoped verification exception for the category-icons slice. Backend full-suite stabilization is tracked separately in #267. This PR does **not** claim full backend green.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran relevant tests/builds or documented scoped exception.
- [x] Docs/specs updated for behavior change.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.