### PR TITLE
feat(monitoring): add ICMP latency warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,8 @@ FRONTEND_ORIGIN=http://localhost:5173
 # --- ENGINE CONFIG ---
 SNMP_DEFAULT_COMMUNITY=public
 POLLING_CYCLE_SECONDS=10
+ICMP_LATENCY_WARNING_MS=100
+ICMP_LATENCY_CRITICAL_MS=500
 
 # Scalable polling pipeline PR1 flags/defaults (all behavior-changing flags default off)
 POLLING_PIPELINE_OBSERVE_ONLY=false

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -211,11 +211,19 @@ def get_polling_pipeline_settings() -> PollingPipelineSettings:
 
 
 class ICMPSettings(BaseModel):
-    """ICMP polling settings for timeout, retry, and debounce behavior."""
+    """ICMP polling settings for timeout, retry, debounce, and latency thresholds."""
 
     timeout_ms: int = Field(default=3000, ge=1)
     retries: int = Field(default=2, ge=0)
     debounce_count: int = Field(default=3, ge=1)
+    latency_warning_ms: float = Field(default=100.0, ge=0)
+    latency_critical_ms: float = Field(default=500.0, gt=0)
+
+    @model_validator(mode="after")
+    def validate_latency_thresholds(self) -> "ICMPSettings":
+        if self.latency_warning_ms >= self.latency_critical_ms:
+            raise ValueError("ICMP_LATENCY_WARNING_MS must be less than ICMP_LATENCY_CRITICAL_MS")
+        return self
 
     @classmethod
     def from_env(cls) -> "ICMPSettings":
@@ -224,6 +232,8 @@ class ICMPSettings(BaseModel):
             timeout_ms=int(os.getenv("ICMP_TIMEOUT_MS", "3000")),
             retries=int(os.getenv("ICMP_RETRIES", "2")),
             debounce_count=int(os.getenv("ICMP_DEBOUNCE_COUNT", "3")),
+            latency_warning_ms=float(os.getenv("ICMP_LATENCY_WARNING_MS", "100")),
+            latency_critical_ms=float(os.getenv("ICMP_LATENCY_CRITICAL_MS", "500")),
         )
 
 

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -27,14 +27,17 @@ from polling.icmp_measurements import (
     ICMP_LATENCY_METRIC_ID,
     build_icmp_sidecar_samples,
     coerce_ping_measurement,
+    evaluate_latency_status,
     is_icmp_availability_metric,
     is_icmp_telemetry_metric,
+    latency_threshold_metadata,
     PingMeasurement,
     parse_ping_latency_ms,
 )
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
+    EVENT_TYPE_THRESHOLD_BREACH,
     FAILURE_FAMILY_SNMP_NO_RESPONSE,
     SOURCE_PROTOCOL_ICMP,
     SOURCE_PROTOCOL_SNMP,
@@ -309,6 +312,7 @@ def _refresh_icmp_availability_events(session, updates):
         OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
         WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
           AND existing.event_type = 'AVAILABILITY'
+          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
           AND existing.availability_source IN ['PING', 'ICMP']
           AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
         WITH row, n, m, head(collect(existing)) AS existing
@@ -351,12 +355,94 @@ def _recover_icmp_availability_events(session, updates):
         UNWIND $recoveries AS row
         MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
         WHERE e.status IN ['OPEN', 'ACK']
+          AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
           AND e.event_type = 'AVAILABILITY'
           AND e.availability_source IN ['PING', 'ICMP']
           AND (e.source_protocol IS NULL OR toUpper(e.source_protocol) = row.protocol)
         SET e.status = 'RECOVERED',
             e.recovered_at = datetime(),
             e.message = 'Metric ICMP availability recovered. Latest sample collected by legacy SNMP worker'
+        WITH e
+        CALL {
+            WITH e
+            MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+            WHERE pe.propagated_from = e.id
+              AND pe.root_cause_ci_id = e.ci_id
+              AND pe.correlation_type = 'PROPAGATED'
+              AND pe.status IN ['OPEN', 'ACK']
+              AND coalesce(m.can_propagate, true) = true
+            SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
+            RETURN count(pe) AS propagated_recovered
+        }
+        RETURN e
+    """, recoveries=recoveries)
+
+
+def _refresh_icmp_latency_events(session, updates):
+    breaches = [
+        u
+        for u in updates
+        if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
+        and u.get("metric_id") == ICMP_LATENCY_METRIC_ID
+        and u.get("event_type") == EVENT_TYPE_THRESHOLD_BREACH
+        and u.get("status") in {"WARNING", "CRITICAL"}
+    ]
+    if not breaches:
+        return
+    session.run("""
+        UNWIND $breaches AS row
+        MATCH (n:CI {id: row.node_id})
+        MATCH (m:MetricDef {id: row.metric_id})
+        OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH'})
+        WHERE existing.status IN ['OPEN', 'ACK']
+          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+        WITH row, n, m, head(collect(existing)) AS existing
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+            CREATE (created:Event {
+                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
+                message: row.message, source_protocol: row.source_protocol,
+                last_seen: datetime(), ack: false, correlation_type: 'ROOT',
+                root_cause_ci_id: row.node_id
+            })
+            MERGE (n)-[:HAS_EVENT]->(created)
+            MERGE (created)-[:TRIGGERED_BY]->(m)
+        )
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+            SET existing.severity = row.status,
+                existing.message = row.message,
+                existing.source_protocol = row.source_protocol,
+                existing.last_seen = datetime(),
+                existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
+                existing.recovered_at = NULL,
+                existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
+                existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id)
+            MERGE (n)-[:HAS_EVENT]->(existing)
+            MERGE (existing)-[:TRIGGERED_BY]->(m)
+        )
+    """, breaches=breaches)
+
+
+def _recover_icmp_latency_events(session, updates):
+    recoveries = [
+        u
+        for u in updates
+        if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
+        and u.get("metric_id") == ICMP_LATENCY_METRIC_ID
+        and u.get("status") == "OK"
+    ]
+    if not recoveries:
+        return
+    session.run("""
+        UNWIND $recoveries AS row
+        MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
+        WHERE e.status IN ['OPEN', 'ACK']
+          AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
+          AND e.event_type = 'THRESHOLD_BREACH'
+          AND (e.source_protocol IS NULL OR toUpper(e.source_protocol) = row.source_protocol)
+        SET e.status = 'RECOVERED',
+            e.recovered_at = datetime(),
+            e.message = row.message
         WITH e
         CALL {
             WITH e
@@ -559,18 +645,41 @@ def poll_snmp():
                             "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP and availability_source else "telemetry",
                         })
                     for sample in sidecar_samples:
+                        latency_thresholds = latency_threshold_metadata(
+                            warning_ms=icmp_settings.latency_warning_ms,
+                            critical_ms=icmp_settings.latency_critical_ms,
+                        )
+                        sample_status = "OK"
+                        sample_message = "Latest ICMP telemetry sample collected by legacy SNMP worker"
+                        sample_event_type = None
+                        sample_severity = "INFO"
+                        if sample["metric_id"] == ICMP_LATENCY_METRIC_ID:
+                            sample_status = evaluate_latency_status(
+                                sample.get("value"),
+                                warning_ms=icmp_settings.latency_warning_ms,
+                                critical_ms=icmp_settings.latency_critical_ms,
+                            )
+                            sample_severity = sample_status if sample_status in {"WARNING", "CRITICAL"} else "INFO"
+                            if sample_status == "CRITICAL":
+                                sample_message = f"Critical Threshold Breached: {sample['value']} >= {icmp_settings.latency_critical_ms}"
+                                sample_event_type = EVENT_TYPE_THRESHOLD_BREACH
+                            elif sample_status == "WARNING":
+                                sample_message = f"Warning Threshold Breached: {sample['value']} >= {icmp_settings.latency_warning_ms}"
+                                sample_event_type = EVENT_TYPE_THRESHOLD_BREACH
+                            else:
+                                sample_message = f"Metric ICMP Latency is OK. Value: {sample['value']}"
                         latest_updates.append({
                             "node_id": node_id,
                             "metric_id": sample["metric_id"],
                             "value": sample["value"],
                             "protocol": protocol,
                             "metric_name": sample["metric_id"],
-                            "criticality": record["criticality"],
-                            "status": "OK",
-                            "message": "Latest ICMP telemetry sample collected by legacy SNMP worker",
-                            "event_type": None,
+                            "criticality": latency_thresholds["criticality"] if sample["metric_id"] == ICMP_LATENCY_METRIC_ID else record["criticality"],
+                            "status": sample_status,
+                            "message": sample_message,
+                            "event_type": sample_event_type,
                             "source_protocol": SOURCE_PROTOCOL_ICMP,
-                            "severity": "INFO",
+                            "severity": sample_severity,
                             "metric_kind": "telemetry",
                         })
                 else:
@@ -639,6 +748,9 @@ def poll_snmp():
                 availability_updates = [u for u in latest_updates if u.get("metric_kind") == "availability"]
                 _refresh_icmp_availability_events(session, availability_updates)
                 _recover_icmp_availability_events(session, availability_updates)
+                latency_updates = [u for u in latest_updates if u.get("metric_id") == ICMP_LATENCY_METRIC_ID]
+                _refresh_icmp_latency_events(session, latency_updates)
+                _recover_icmp_latency_events(session, latency_updates)
                 _recover_snmp_collection_failures(session, latest_updates)
                 print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")
 

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Iterable, Mapping
 from uuid import UUID
@@ -66,6 +66,73 @@ def _collection_failure_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[
         key = (row.get("ci_id"), row.get("metric_id"), row.get("event_type"), row.get("failure_family"))
         deduped[key] = row
     return list(deduped.values())
+
+
+def _observed_at_order(value: Any) -> float | None:
+    if isinstance(value, datetime):
+        observed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            observed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if observed.tzinfo is None:
+        observed = observed.replace(tzinfo=timezone.utc)
+    return observed.timestamp()
+
+
+def _non_collection_target_event_type(row: Mapping[str, Any]) -> str | None:
+    event_type = row.get("event_type")
+    if event_type and event_type != EVENT_TYPE_COLLECTION_FAILURE:
+        return str(event_type)
+    if not row.get("recover_non_collection_event"):
+        return None
+    if row.get("source_protocol") == "ICMP" and row.get("availability_source") in {"PING", "ICMP"}:
+        return EVENT_TYPE_AVAILABILITY
+    return EVENT_TYPE_THRESHOLD_BREACH
+
+
+def _dedupe_non_collection_latest_state(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: dict[tuple[Any, Any, Any], tuple[bool, float, int, dict[str, Any]]] = {}
+    for index, row in enumerate(rows):
+        event_type = _non_collection_target_event_type(row)
+        if event_type is None:
+            continue
+        key = (
+            row.get("ci_id"),
+            row.get("metric_id"),
+            event_type,
+            row.get("correlation_type") or "ROOT",
+            row.get("propagated_from"),
+            row.get("root_cause_event_id"),
+            row.get("root_cause_ci_id"),
+        )
+        observed_order = _observed_at_order(row.get("observed_at"))
+        order = (observed_order is not None, observed_order or 0.0, index)
+        existing = deduped.get(key)
+        if existing is None or order >= (existing[0], existing[1], existing[2]):
+            deduped[key] = (*order, row)
+    return [item[3] for item in deduped.values()]
+
+
+def _non_collection_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in _dedupe_non_collection_latest_state(rows)
+        if row.get("is_breach") and row.get("event_type") and row.get("event_type") != EVENT_TYPE_COLLECTION_FAILURE
+    ]
+
+
+def _latest_metric_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    row_list = list(rows)
+    non_collection_latest_ids = {id(row) for row in _dedupe_non_collection_latest_state(row_list)}
+    return [
+        row
+        for row in row_list
+        if _non_collection_target_event_type(row) is None or id(row) in non_collection_latest_ids
+    ]
 
 
 def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
@@ -143,6 +210,7 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
             "observed_at": _value(envelope.get("observed_at")),
             "correlation_type": metadata.get("correlation_type") or "ROOT",
             "propagated_from": metadata.get("propagated_from"),
+            "root_cause_event_id": metadata.get("root_cause_event_id"),
             "root_cause_ci_id": metadata.get("root_cause_ci_id") or envelope.get("ci_id"),
             "business_service_id": metadata.get("business_service_id"),
             "business_service_name": metadata.get("business_service_name"),
@@ -165,7 +233,10 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
     rows = build_event_rows(envelopes)
     if not rows:
         return 0
+    latest_metric_rows = _latest_metric_rows(rows)
     collection_failure_rows = _collection_failure_event_rows(rows)
+    non_collection_state_rows = _dedupe_non_collection_latest_state(rows)
+    non_collection_event_rows = _non_collection_event_rows(non_collection_state_rows)
     with driver.session() as session:
         session.run(
             """
@@ -178,7 +249,7 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
             CREATE (n)-[:HAS_RESULT]->(res)
             CREATE (res)-[:FOR_METRIC]->(m)
             """,
-            rows=rows,
+            rows=latest_metric_rows,
         )
         session.run(
             """
@@ -232,33 +303,63 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
             WITH row WHERE row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'
             MATCH (n:CI {id: row.ci_id})
             MATCH (m:MetricDef {id: row.metric_id})
-            MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN'})
-            SET e.id = coalesce(e.id, randomUUID()),
-                e.severity = row.severity,
-                e.message = row.message,
-                e.source_protocol = row.source_protocol,
-                e.availability_source = row.availability_source,
-                e.last_seen = datetime(),
-                e.ack = false,
-                e.correlation_type = coalesce(e.correlation_type, row.correlation_type),
-                e.propagated_from = coalesce(e.propagated_from, row.propagated_from),
-                e.root_cause_ci_id = coalesce(e.root_cause_ci_id, row.root_cause_ci_id),
-                e.business_service_id = coalesce(e.business_service_id, row.business_service_id),
-                e.business_service_name = coalesce(e.business_service_name, row.business_service_name),
-                e.business_service_tier = coalesce(e.business_service_tier, row.business_service_tier),
-                e.owner_t1 = coalesce(e.owner_t1, row.owner_t1),
-                e.owner_t2 = coalesce(e.owner_t2, row.owner_t2),
-                e.owner_t3 = coalesce(e.owner_t3, row.owner_t3),
-                e.impacted_users = coalesce(e.impacted_users, row.impacted_users),
-                e.site = coalesce(e.site, row.site),
-                e.service_catalog_id = coalesce(e.service_catalog_id, row.service_catalog_id),
-                e.service_category = coalesce(e.service_category, row.service_category),
-                e.service_tier = coalesce(e.service_tier, row.service_tier),
-                e.sla_minutes = coalesce(e.sla_minutes, row.sla_minutes)
-            MERGE (n)-[:HAS_EVENT]->(e)
-            MERGE (e)-[:TRIGGERED_BY]->(m)
+            OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: row.event_type})
+            WHERE existing.status IN ['OPEN', 'ACK']
+              AND coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')
+              AND (
+                coalesce(row.correlation_type, 'ROOT') <> 'PROPAGATED'
+                OR (
+                  (row.propagated_from IS NULL OR existing.propagated_from = row.propagated_from)
+                  AND (row.root_cause_event_id IS NULL OR existing.root_cause_event_id = row.root_cause_event_id)
+                  AND (row.root_cause_ci_id IS NULL OR existing.root_cause_ci_id = row.root_cause_ci_id)
+                )
+              )
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN',
+                    severity: row.severity, message: row.message, source_protocol: row.source_protocol,
+                    availability_source: row.availability_source, last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type, propagated_from: row.propagated_from,
+                    root_cause_event_id: row.root_cause_event_id, root_cause_ci_id: row.root_cause_ci_id,
+                    business_service_id: row.business_service_id,
+                    business_service_name: row.business_service_name, business_service_tier: row.business_service_tier,
+                    owner_t1: row.owner_t1, owner_t2: row.owner_t2, owner_t3: row.owner_t3,
+                    impacted_users: row.impacted_users, site: row.site, service_catalog_id: row.service_catalog_id,
+                    service_category: row.service_category, service_tier: row.service_tier, sla_minutes: row.sla_minutes
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.severity = row.severity,
+                    existing.message = row.message,
+                    existing.source_protocol = row.source_protocol,
+                    existing.availability_source = row.availability_source,
+                    existing.last_seen = datetime(),
+                    existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
+                    existing.recovered_at = NULL,
+                    existing.correlation_type = coalesce(existing.correlation_type, row.correlation_type),
+                    existing.propagated_from = coalesce(existing.propagated_from, row.propagated_from),
+                    existing.root_cause_event_id = coalesce(existing.root_cause_event_id, row.root_cause_event_id),
+                    existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.root_cause_ci_id),
+                    existing.business_service_id = coalesce(existing.business_service_id, row.business_service_id),
+                    existing.business_service_name = coalesce(existing.business_service_name, row.business_service_name),
+                    existing.business_service_tier = coalesce(existing.business_service_tier, row.business_service_tier),
+                    existing.owner_t1 = coalesce(existing.owner_t1, row.owner_t1),
+                    existing.owner_t2 = coalesce(existing.owner_t2, row.owner_t2),
+                    existing.owner_t3 = coalesce(existing.owner_t3, row.owner_t3),
+                    existing.impacted_users = coalesce(existing.impacted_users, row.impacted_users),
+                    existing.site = coalesce(existing.site, row.site),
+                    existing.service_catalog_id = coalesce(existing.service_catalog_id, row.service_catalog_id),
+                    existing.service_category = coalesce(existing.service_category, row.service_category),
+                    existing.service_tier = coalesce(existing.service_tier, row.service_tier),
+                    existing.sla_minutes = coalesce(existing.sla_minutes, row.sla_minutes)
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
             """,
-            rows=rows,
+            rows=non_collection_event_rows,
         )
         session.run(
             """
@@ -298,10 +399,14 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
             WITH row WHERE row.recover_non_collection_event
             MATCH (:CI {id: row.ci_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
             WHERE e.status IN ['OPEN', 'ACK']
+              AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
               AND (
                 (
                   row.source_protocol = 'ICMP'
-                  AND e.event_type = 'AVAILABILITY'
+                  AND (
+                    e.event_type = 'AVAILABILITY'
+                    OR (e.event_type = 'THRESHOLD_BREACH' AND row.metric_id = e.metric_id)
+                  )
                   AND (e.source_protocol IS NULL OR toUpper(e.source_protocol) = row.source_protocol)
                 )
                 OR (
@@ -325,6 +430,6 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
             }
             RETURN e
             """,
-            rows=rows,
+            rows=non_collection_state_rows,
         )
     return len(rows)

--- a/backend/polling/icmp_measurements.py
+++ b/backend/polling/icmp_measurements.py
@@ -101,6 +101,30 @@ def icmp_metadata(measurement: PingMeasurement) -> dict[str, Any]:
     return metadata
 
 
+def latency_threshold_metadata(*, warning_ms: float, critical_ms: float) -> dict[str, Any]:
+    """Build MetricDef-compatible threshold metadata for ICMP latency."""
+    return {
+        "warning": float(warning_ms),
+        "critical": float(critical_ms),
+        "operator": ">=",
+        "criticality": 3,
+        "metric_kind": "telemetry",
+        "name": "ICMP Latency",
+    }
+
+
+def evaluate_latency_status(latency_ms: float | None, *, warning_ms: float, critical_ms: float) -> str:
+    """Evaluate ICMP latency against warning/critical thresholds."""
+    if latency_ms is None:
+        return "OK"
+    latency = float(latency_ms)
+    if latency >= float(critical_ms):
+        return "CRITICAL"
+    if latency >= float(warning_ms):
+        return "WARNING"
+    return "OK"
+
+
 def is_icmp_telemetry_metric(metric_id: str, metadata: dict[str, Any] | None = None) -> bool:
     """Return true for ICMP sidecar telemetry metrics that are derived, not polled."""
     value = str(metric_id or "")

--- a/backend/polling/writer_pool.py
+++ b/backend/polling/writer_pool.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from sqlalchemy import text
 
+from config import get_icmp_settings
 from models.timescale_models import MetricValue
 from polling import event_writer, pg_queue
 from polling.icmp_measurements import (
@@ -17,6 +18,8 @@ from polling.icmp_measurements import (
     ICMP_JITTER_METRIC_ID,
     ICMP_LATENCY_METRIC_ID,
     ICMP_PACKET_LOSS_METRIC_ID,
+    evaluate_latency_status,
+    latency_threshold_metadata,
 )
 
 
@@ -122,6 +125,30 @@ def _sidecar_samples(db, envelope: Mapping[str, Any]) -> list[dict[str, Any]]:
         packet_loss = 0.0 if numeric > 0 else 100.0
         samples.append({"node_id": envelope["ci_id"], "metric_id": ICMP_PACKET_LOSS_METRIC_ID, "value": packet_loss, "time": observed})
     return samples
+
+
+def _icmp_latency_event_envelope(envelope: Mapping[str, Any]) -> dict[str, Any] | None:
+    icmp = ((envelope.get("metadata") or {}).get("icmp") or {})
+    if "latency_ms" not in icmp:
+        return None
+    latency = float(icmp["latency_ms"])
+    settings = get_icmp_settings()
+    metadata = latency_threshold_metadata(
+        warning_ms=settings.latency_warning_ms,
+        critical_ms=settings.latency_critical_ms,
+    )
+    status = evaluate_latency_status(
+        latency,
+        warning_ms=settings.latency_warning_ms,
+        critical_ms=settings.latency_critical_ms,
+    )
+    return {
+        **dict(envelope),
+        "metric_id": ICMP_LATENCY_METRIC_ID,
+        "status": status,
+        "value": {"numeric": latency, "raw": latency},
+        "metadata": metadata,
+    }
 
 
 def receipt_exists(db, idempotency_key: str) -> bool:
@@ -253,15 +280,22 @@ def run_writer_once(
             stats["retried"] += 1
         return stats
 
-    event_payloads = [
-        item for item in new_payloads + pending_payloads
-        if not _is_internal_icmp_availability(item["envelope"])
-    ]
+    event_payloads = []
+    for item in new_payloads + pending_payloads:
+        if not _is_internal_icmp_availability(item["envelope"]):
+            event_payloads.append(item)
+        latency_envelope = _icmp_latency_event_envelope(item["envelope"])
+        if latency_envelope is not None:
+            event_payloads.append({**item, "envelope": latency_envelope})
     try:
         event_writer.batch_update_events(neo4j_driver, [item["envelope"] for item in event_payloads])
     except Exception as exc:
         retry_at = (now or _utc_now()) + timedelta(seconds=30)
+        retried_result_ids = set()
         for item in event_payloads:
+            if item["result_id"] in retried_result_ids:
+                continue
+            retried_result_ids.add(item["result_id"])
             pg_queue.retry_result(queue_db, item["result_id"], next_eligible_at=retry_at, error_code="neo4j_pending", error_message=str(exc))
             stats["retried"] += 1
         return stats

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import List, Dict, Any, Optional, Set
 import importlib
 import json
+from config import get_icmp_settings
 from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
 import re
 from neo4j import Driver
@@ -442,6 +443,7 @@ def find_open_parent_event(ci_id: str, max_depth: int = 3) -> Optional[Dict[str,
 
 
 def ensure_icmp_sidecar_metric_defs(session) -> None:
+    icmp_settings = get_icmp_settings()
     session.run("""
         MERGE (latency:MetricDef {id: $latency_id})
         SET latency.name = 'ICMP Latency',
@@ -450,7 +452,9 @@ def ensure_icmp_sidecar_metric_defs(session) -> None:
             latency.dataType = 'FLOAT',
             latency.unit = 'ms',
             latency.operator = '>=',
-            latency.criticality = coalesce(latency.criticality, 1),
+            latency.warning = $latency_warning_ms,
+            latency.critical = $latency_critical_ms,
+            latency.criticality = coalesce(latency.criticality, 3),
             latency.metric_kind = 'telemetry'
         MERGE (jitter:MetricDef {id: $jitter_id})
         SET jitter.name = 'ICMP Jitter',
@@ -461,7 +465,9 @@ def ensure_icmp_sidecar_metric_defs(session) -> None:
             jitter.operator = '>=',
             jitter.criticality = coalesce(jitter.criticality, 1),
             jitter.metric_kind = 'telemetry'
-    """, latency_id=ICMP_LATENCY_METRIC_ID, jitter_id=ICMP_JITTER_METRIC_ID)
+    """, latency_id=ICMP_LATENCY_METRIC_ID, jitter_id=ICMP_JITTER_METRIC_ID,
+        latency_warning_ms=icmp_settings.latency_warning_ms,
+        latency_critical_ms=icmp_settings.latency_critical_ms)
 
 
 def migrate_icmp_sidecar_metrics() -> None:

--- a/backend/tests/test_icmp_metric_migration.py
+++ b/backend/tests/test_icmp_metric_migration.py
@@ -49,6 +49,8 @@ def test_migrate_icmp_sidecar_metrics_is_idempotent_for_existing_cis_with_ips(mo
     params = [q["params"] for q in driver.mock_session.queries]
     assert "MERGE (latency:MetricDef {id: $latency_id})" in queries
     assert "MERGE (jitter:MetricDef {id: $jitter_id})" in queries
+    assert "latency.warning = $latency_warning_ms" in queries
+    assert "latency.critical = $latency_critical_ms" in queries
     assert "MATCH (n:CI)" in queries
     assert "n.ip IS NOT NULL" in queries
     assert "trim(toString(n.ip)) <> ''" in queries
@@ -56,7 +58,12 @@ def test_migrate_icmp_sidecar_metrics_is_idempotent_for_existing_cis_with_ips(mo
     assert "availability.id STARTS WITH 'PING-'" not in queries
     assert "MERGE (n)-[:HAS_METRIC]->(latency)" in queries
     assert "MERGE (n)-[:HAS_METRIC]->(jitter)" in queries
-    assert {"latency_id": "icmp_latency_ms", "jitter_id": "icmp_jitter_ms"} in params
+    assert {
+        "latency_id": "icmp_latency_ms",
+        "jitter_id": "icmp_jitter_ms",
+        "latency_warning_ms": 100.0,
+        "latency_critical_ms": 500.0,
+    } in params
 
 
 def test_migrate_icmp_sidecar_metrics_script_entrypoint_invokes_repository(monkeypatch):

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -78,6 +78,34 @@ def test_event_writer_derives_threshold_breach_and_availability_recovery_rows():
     assert "Service/Host Down" in rows[2]["message"]
 
 
+def test_event_writer_derives_icmp_latency_warning_and_critical_threshold_rows():
+    from polling.event_writer import build_event_rows
+
+    base = {
+        **_event_row(99.9),
+        "protocol": "ICMP",
+        "metric_id": "icmp_latency_ms",
+        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+    }
+
+    rows = build_event_rows([
+        base,
+        {**base, "value": {"numeric": 100.0, "raw": 100.0}},
+        {**base, "value": {"numeric": 499.9, "raw": 499.9}},
+        {**base, "value": {"numeric": 500.0, "raw": 500.0}},
+        {**base, "value": {"numeric": None, "raw": None}},
+    ])
+
+    assert rows[0]["is_breach"] is False
+    assert rows[0]["recover_non_collection_event"] is True
+    assert rows[1]["severity"] == "WARNING"
+    assert rows[1]["event_type"] == "THRESHOLD_BREACH"
+    assert rows[2]["severity"] == "WARNING"
+    assert rows[3]["severity"] == "CRITICAL"
+    assert rows[4]["is_breach"] is False
+    assert rows[4]["recover_non_collection_event"] is False
+
+
 def test_event_writer_uses_unwind_for_latest_breach_and_recovery_updates():
     from polling.event_writer import batch_update_events
 
@@ -89,7 +117,8 @@ def test_event_writer_uses_unwind_for_latest_breach_and_recovery_updates():
     assert "MERGE (n)-[r:HAS_METRIC]->(m)" in queries
     assert "CREATE (res:MetricResult" in queries
     assert "status: 'OPEN'" in queries
-    assert "e.id = coalesce(e.id, randomUUID())" in queries
+    assert "id: randomUUID()" in queries
+    assert "e.id = coalesce(e.id, randomUUID())" not in queries
     assert "RECOVERED" in queries
     assert "correlation_type" in queries
     assert "root_cause_ci_id" in queries
@@ -115,6 +144,250 @@ def test_event_writer_icmp_success_recovers_only_icmp_availability_events():
     assert "pe.propagated_from = e.id" in recovery_query
 
 
+def test_event_writer_icmp_latency_ok_recovers_threshold_breach_events():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [{
+        **_event_row(42.0),
+        "protocol": "ICMP",
+        "metric_id": "icmp_latency_ms",
+        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+    }])
+
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    assert "e.event_type = 'THRESHOLD_BREACH'" in recovery_query["query"]
+    assert "row.metric_id = e.metric_id" in recovery_query["query"]
+
+
+def test_event_writer_direct_latency_recovery_excludes_propagated_events():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [{
+        **_event_row(42.0),
+        "protocol": "ICMP",
+        "metric_id": "icmp_latency_ms",
+        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+    }])
+
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])["query"]
+    assert "coalesce(e.correlation_type, 'ROOT') = 'ROOT'" in recovery_query
+    assert "pe.root_cause_ci_id = e.ci_id" in recovery_query
+    assert "pe.correlation_type = 'PROPAGATED'" in recovery_query
+
+
+def test_event_writer_threshold_breach_refresh_updates_open_or_ack_events_without_merge_duplicate():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [{
+        **_event_row(500.0),
+        "protocol": "ICMP",
+        "metric_id": "icmp_latency_ms",
+        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+    }])
+
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    assert "existing.status IN ['OPEN', 'ACK']" in breach_query["query"]
+    assert "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')" in breach_query["query"]
+    assert "coalesce(row.correlation_type, 'ROOT') <> 'PROPAGATED'" in breach_query["query"]
+    assert "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN'})" not in breach_query["query"]
+    assert "SET existing.severity = row.severity" in breach_query["query"]
+    assert "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END" in breach_query["query"]
+
+
+def test_event_writer_propagated_breach_refresh_matches_correlation_and_root_identifiers():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [{
+        **_event_row(500.0),
+        "protocol": "ICMP",
+        "metric_id": "icmp_latency_ms",
+        "metadata": {
+            "name": "ICMP Latency",
+            "warning": 100,
+            "critical": 500,
+            "operator": ">=",
+            "metric_kind": "telemetry",
+            "criticality": 3,
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "event-parent",
+            "root_cause_event_id": "event-root",
+            "root_cause_ci_id": "ci-root",
+        },
+    }])
+
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    query = breach_query["query"]
+    assert "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')" in query
+    assert "row.propagated_from IS NULL OR existing.propagated_from = row.propagated_from" in query
+    assert "row.root_cause_event_id IS NULL OR existing.root_cause_event_id = row.root_cause_event_id" in query
+    assert "row.root_cause_ci_id IS NULL OR existing.root_cause_ci_id = row.root_cause_ci_id" in query
+    assert breach_query["params"]["rows"][0]["correlation_type"] == "PROPAGATED"
+    assert breach_query["params"]["rows"][0]["root_cause_event_id"] == "event-root"
+
+
+def test_event_writer_deduplicates_non_collection_breaches_before_create_query():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        {
+            **_event_row(100.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+        {
+            **_event_row(500.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+    ])
+
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    assert len(breach_query["params"]["rows"]) == 1
+    assert breach_query["params"]["rows"][0]["severity"] == "CRITICAL"
+    assert breach_query["params"]["rows"][0]["value"] == "500.0"
+
+
+def test_event_writer_keeps_distinct_propagated_roots_in_non_collection_batch():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        {
+            **_event_row(500.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "metadata": {
+                "name": "ICMP Latency",
+                "critical": 500,
+                "operator": ">=",
+                "metric_kind": "telemetry",
+                "criticality": 3,
+                "correlation_type": "PROPAGATED",
+                "propagated_from": "event-parent-a",
+                "root_cause_event_id": "event-root-a",
+                "root_cause_ci_id": "ci-root-a",
+            },
+        },
+        {
+            **_event_row(500.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "metadata": {
+                "name": "ICMP Latency",
+                "critical": 500,
+                "operator": ">=",
+                "metric_kind": "telemetry",
+                "criticality": 3,
+                "correlation_type": "PROPAGATED",
+                "propagated_from": "event-parent-b",
+                "root_cause_event_id": "event-root-b",
+                "root_cause_ci_id": "ci-root-b",
+            },
+        },
+    ])
+
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    assert len(breach_query["params"]["rows"]) == 2
+
+
+def test_event_writer_uses_latest_non_collection_state_for_ok_then_warning_batch():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        {
+            **_event_row(42.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "observed_at": datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+        {
+            **_event_row(100.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+    ])
+
+    latest_query = driver.mock_session.queries[0]
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    assert len(latest_query["params"]["rows"]) == 1
+    assert latest_query["params"]["rows"][0]["status"] == "WARNING"
+    assert len(breach_query["params"]["rows"]) == 1
+    assert breach_query["params"]["rows"][0]["severity"] == "WARNING"
+    assert recovery_query["params"]["rows"][0]["recover_non_collection_event"] is False
+
+
+def test_event_writer_uses_latest_non_collection_state_for_warning_then_ok_batch():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        {
+            **_event_row(100.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "observed_at": datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+        {
+            **_event_row(42.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+    ])
+
+    latest_query = driver.mock_session.queries[0]
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    assert len(latest_query["params"]["rows"]) == 1
+    assert latest_query["params"]["rows"][0]["status"] == "OK"
+    assert breach_query["params"]["rows"] == []
+    assert len(recovery_query["params"]["rows"]) == 1
+    assert recovery_query["params"]["rows"][0]["recover_non_collection_event"] is True
+
+
+def test_event_writer_prefers_latest_observed_timestamp_over_last_duplicate_order():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    batch_update_events(driver, [
+        {
+            **_event_row(42.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "observed_at": datetime(2026, 1, 1, 12, 2, tzinfo=timezone.utc),
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+        {
+            **_event_row(500.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        },
+    ])
+
+    latest_query = driver.mock_session.queries[0]
+    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    assert latest_query["params"]["rows"][0]["status"] == "OK"
+    assert breach_query["params"]["rows"] == []
+    assert recovery_query["params"]["rows"][0]["value"] == "42.0"
+
+
 def test_event_writer_preserves_propagated_correlation_metadata():
     from polling.event_writer import build_event_rows
 
@@ -135,6 +408,7 @@ def test_event_writer_preserves_propagated_correlation_metadata():
 
     assert rows[0]["correlation_type"] == "PROPAGATED"
     assert rows[0]["propagated_from"] == "event-root"
+    assert rows[0]["root_cause_event_id"] is None
     assert rows[0]["root_cause_ci_id"] == "ci-root"
     assert rows[0]["business_service_id"] == "bs-1"
 

--- a/backend/tests/test_polling_writer_pool.py
+++ b/backend/tests/test_polling_writer_pool.py
@@ -86,7 +86,10 @@ def test_writer_expands_icmp_sidecar_samples_and_keeps_events_primary_only(monke
         {"node_id": "ci-1", "metric_id": "icmp_jitter_ms", "value": 7.5, "time": row.observed_at},
         {"node_id": "ci-1", "metric_id": "packet_loss_pct", "value": 0.0, "time": row.observed_at},
     ]
-    assert [event["metric_id"] for event in event_rows] == ["PING-CHECK"]
+    assert [event["metric_id"] for event in event_rows] == ["PING-CHECK", "icmp_latency_ms"]
+    assert event_rows[1]["status"] == "OK"
+    assert event_rows[1]["metadata"]["warning"] == 100.0
+    assert event_rows[1]["metadata"]["critical"] == 500.0
 
 
 def test_writer_expands_failed_icmp_availability_to_packet_loss_sidecar(monkeypatch):
@@ -152,8 +155,41 @@ def test_writer_persists_only_sidecars_for_internal_icmp_availability(monkeypatc
         {"node_id": "ci-1", "metric_id": "icmp_jitter_ms", "value": 7.5, "time": row.observed_at},
         {"node_id": "ci-1", "metric_id": "packet_loss_pct", "value": 0.0, "time": row.observed_at},
     ]
-    assert event_rows == []
+    assert [event["metric_id"] for event in event_rows] == ["icmp_latency_ms"]
+    assert event_rows[0]["status"] == "OK"
     assert completed == [row.result_id]
+
+
+def test_writer_emits_warning_latency_event_from_icmp_sidecar(monkeypatch):
+    from polling import writer_pool
+
+    persisted = []
+    event_rows = []
+    row = _row(key="icmp-warning", numeric=1.0)
+    row.protocol = "ICMP"
+    row.metric_id = "icmp_availability"
+    row.envelope.update({
+        "protocol": "ICMP",
+        "metric_id": "icmp_availability",
+        "metadata": {
+            "metric_kind": "availability",
+            "internal": True,
+            "icmp": {"latency_ms": 150.0, "sidecar_metric_ids": ["icmp_latency_ms"]},
+        },
+    })
+    monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
+    monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
+    monkeypatch.setattr(writer_pool, "previous_metric_value", lambda db, node_id, metric_id, before: None)
+    monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: None)
+
+    stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
+
+    assert stats["inserted"] == 1
+    assert event_rows[0]["metric_id"] == "icmp_latency_ms"
+    assert event_rows[0]["status"] == "WARNING"
+    assert event_rows[0]["value"]["numeric"] == 150.0
 
 
 def test_writer_batches_timescale_inserts_receipts_and_neo4j_updates(monkeypatch):

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -26,6 +26,8 @@ class TestICMPSettings:
         assert settings.timeout_ms == 3000
         assert settings.retries == 2
         assert settings.debounce_count == 3
+        assert settings.latency_warning_ms == 100
+        assert settings.latency_critical_ms == 500
 
     def test_icmp_settings_from_env_override(self):
         """ICMPSettings.from_env reads env vars correctly."""
@@ -33,12 +35,24 @@ class TestICMPSettings:
         with patch.dict(os.environ, {
             "ICMP_TIMEOUT_MS": "5000",
             "ICMP_RETRIES": "5",
-            "ICMP_DEBOUNCE_COUNT": "7"
+            "ICMP_DEBOUNCE_COUNT": "7",
+            "ICMP_LATENCY_WARNING_MS": "150",
+            "ICMP_LATENCY_CRITICAL_MS": "600",
         }, clear=True):
             settings = ICMPSettings.from_env()
             assert settings.timeout_ms == 5000
             assert settings.retries == 5
             assert settings.debounce_count == 7
+            assert settings.latency_warning_ms == 150
+            assert settings.latency_critical_ms == 600
+
+    def test_icmp_latency_thresholds_must_be_ordered(self):
+        """ICMP latency warning threshold must remain below critical."""
+        from pydantic import ValidationError
+        from config import ICMPSettings
+
+        with pytest.raises(ValidationError, match="ICMP_LATENCY_WARNING_MS"):
+            ICMPSettings(latency_warning_ms=500, latency_critical_ms=500)
 
     def test_get_icmp_settings_singleton(self):
         """get_icmp_settings returns cached singleton."""
@@ -830,6 +844,89 @@ def test_poll_snmp_prefers_legacy_availability_when_sidecars_return_first():
     mock_fetch_icmp.assert_called_once()
     rows = mock_bulk_insert.call_args.args[1]
     assert any(row["metric_id"] == "PING-CHECK" and row["value"] == 1.0 for row in rows)
+
+
+def test_refresh_icmp_latency_events_updates_open_or_ack_events_without_merge_duplicate():
+    from engines.snmp_worker import _refresh_icmp_latency_events
+
+    session = MockNeo4jSession()
+    _refresh_icmp_latency_events(session, [{
+        "node_id": "ci-001",
+        "metric_id": "icmp_latency_ms",
+        "protocol": "ICMP",
+        "source_protocol": "ICMP",
+        "event_type": "THRESHOLD_BREACH",
+        "status": "WARNING",
+        "message": "Latency warning",
+    }])
+
+    query = session.queries[0]["query"]
+    assert "existing.status IN ['OPEN', 'ACK']" in query
+    assert "coalesce(existing.correlation_type, 'ROOT') = 'ROOT'" in query
+    assert "MERGE (e:Event {ci_id: row.node_id, metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH', status: 'OPEN'})" not in query
+    assert "SET existing.severity = row.status" in query
+    assert "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END" in query
+
+
+def test_recover_icmp_availability_events_excludes_propagated_direct_match_and_recovers_descendants():
+    from engines.snmp_worker import _recover_icmp_availability_events
+
+    session = MockNeo4jSession()
+    _recover_icmp_availability_events(session, [{
+        "node_id": "ci-001",
+        "metric_id": "PING-CHECK",
+        "protocol": "ICMP",
+        "source_protocol": "ICMP",
+        "availability_source": "PING",
+        "value": 1.0,
+    }])
+
+    query = session.queries[0]["query"]
+    assert "coalesce(e.correlation_type, 'ROOT') = 'ROOT'" in query
+    assert "pe.propagated_from = e.id" in query
+    assert "pe.root_cause_ci_id = e.ci_id" in query
+    assert "pe.correlation_type = 'PROPAGATED'" in query
+
+
+def test_refresh_icmp_availability_events_excludes_propagated_direct_match():
+    from engines.snmp_worker import _refresh_icmp_availability_events
+
+    session = MockNeo4jSession()
+    _refresh_icmp_availability_events(session, [{
+        "node_id": "ci-001",
+        "metric_id": "PING-CHECK",
+        "protocol": "ICMP",
+        "source_protocol": "ICMP",
+        "availability_source": "PING",
+        "event_type": "AVAILABILITY",
+        "severity": "CRITICAL",
+        "message": "Service/Host Down: PING-CHECK",
+        "value": 0.0,
+    }])
+
+    query = session.queries[0]["query"]
+    assert "coalesce(existing.correlation_type, 'ROOT') = 'ROOT'" in query
+
+
+def test_recover_icmp_latency_events_excludes_propagated_direct_match_and_recovers_descendants():
+    from engines.snmp_worker import _recover_icmp_latency_events
+
+    session = MockNeo4jSession()
+    _recover_icmp_latency_events(session, [{
+        "node_id": "ci-001",
+        "metric_id": "icmp_latency_ms",
+        "protocol": "ICMP",
+        "source_protocol": "ICMP",
+        "status": "OK",
+        "message": "Metric ICMP Latency is OK. Value: 42.0",
+    }])
+
+    query = session.queries[0]["query"]
+    assert "coalesce(e.correlation_type, 'ROOT') = 'ROOT'" in query
+    assert "pe.propagated_from = e.id" in query
+    assert "pe.root_cause_ci_id = e.ci_id" in query
+    assert "pe.correlation_type = 'PROPAGATED'" in query
+    assert "SET pe.status = 'RECOVERED'" in query
 
 
 def test_poll_snmp_skips_icmp_sidecar_metrics_as_primary_poll_targets():

--- a/frontend/components/GlobalInventory.test.tsx
+++ b/frontend/components/GlobalInventory.test.tsx
@@ -100,6 +100,23 @@ describe('GlobalInventory', () => {
     expect(screen.getByText('warning')).toBeInTheDocument();
   });
 
+  it('surfaces warning metrics as degraded in the inventory and detail views', () => {
+    nodes = [makeNode({
+      id: 'router-warning',
+      label: 'Latency Router',
+      metrics: [{ name: 'icmp_latency_ms', protocol: 'ICMP', oid: '', value: '150', status: 'WARNING', last_updated: '2026-04-04T10:05:00.000Z' }],
+    })];
+
+    const { container } = render(<GlobalInventory />);
+
+    expect(container.querySelector('.bg-yellow-500.animate-pulse')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Latency Router'));
+
+    expect(screen.getByText('warning')).toBeInTheDocument();
+    expect(screen.getByText('150.00')).toBeInTheDocument();
+  });
+
   it('falls back to a category-name technology icon when icon metadata is missing', () => {
     nodes = [makeNode({
       id: 'switch-1',

--- a/frontend/components/GlobalInventory.tsx
+++ b/frontend/components/GlobalInventory.tsx
@@ -8,6 +8,12 @@ import { useNodesQuery } from '../hooks/queries/useNodesQuery';
 import { formatMetricValue } from '../utils/metricFormatting';
 import CategoryIcon from './CategoryIcon';
 
+const getWorstMetricStatus = (metrics: GraphNode['metrics'] = []) => {
+    if (metrics.some((metric) => metric.status === 'CRITICAL')) return 'CRITICAL';
+    if (metrics.some((metric) => metric.status === 'WARNING')) return 'WARNING';
+    return 'OK';
+};
+
 /**
  * GlobalInventory Component
  * 
@@ -81,7 +87,14 @@ const GlobalInventory: React.FC = () => {
             <div className="flex-1 flex gap-6 overflow-hidden">
                 {/* List Column */}
                 <div className="w-1/3 flex flex-col gap-3 overflow-y-auto custom-scrollbar pr-2">
-                    {filteredInventory.map(item => (
+                    {filteredInventory.map(item => {
+                        const worstStatus = getWorstMetricStatus(item.metrics);
+                        const statusDotClass = worstStatus === 'CRITICAL'
+                            ? 'bg-red-500 animate-pulse'
+                            : worstStatus === 'WARNING'
+                                ? 'bg-yellow-500 animate-pulse'
+                                : 'bg-emerald-500';
+                        return (
                         <div
                             key={item.id}
                             onClick={() => setSelectedId(item.id)}
@@ -93,7 +106,7 @@ const GlobalInventory: React.FC = () => {
                             <div className="flex justify-between items-start">
                                 <div>
                                     <div className="flex items-center gap-2">
-                                        <span className={`w-2 h-2 rounded-full ${item.metrics?.some(m => m.status === 'CRITICAL') ? 'bg-red-500 animate-pulse' : 'bg-emerald-500'}`}></span>
+                                        <span className={`w-2 h-2 rounded-full ${statusDotClass}`}></span>
                                         <h3 className={`text-sm font-black ${selectedId === item.id ? 'text-brand-400' : 'text-white'}`}>{item.label || item.id}</h3>
                                     </div>
                                     <div className="flex gap-2 mt-1">
@@ -109,7 +122,7 @@ const GlobalInventory: React.FC = () => {
                                 <span className="material-symbols-outlined text-neutral-600 text-lg group-hover:text-white transition-colors">chevron_right</span>
                             </div>
                         </div>
-                    ))}
+                    )})}
                 </div>
 
                 {/* Detail Column */}
@@ -141,7 +154,7 @@ const GlobalInventory: React.FC = () => {
                                     <div key={idx} className={`p-4 rounded-xl border ${getStatusClasses(metric.status)} flex flex-col gap-2 transition-all hover:scale-[1.02]`}>
                                         <div className="flex justify-between items-start">
                                             <span className="text-[10px] font-black uppercase opacity-70 tracking-wider">{metric.protocol}</span>
-                                            {metric.status === 'CRITICAL' && <span className="material-symbols-outlined text-sm animate-pulse">warning</span>}
+                                            {(metric.status === 'CRITICAL' || metric.status === 'WARNING') && <span className="material-symbols-outlined text-sm animate-pulse">warning</span>}
                                         </div>
                                         <h4 className="text-center font-black text-sm uppercase opacity-90">{metric.name}</h4>
                                         <div className="text-center py-2">


### PR DESCRIPTION
## Descripción del Cambio
Closes #270

Agrega thresholds configurables para clasificar latencia ICMP en `OK`, `WARNING` y `CRITICAL`, conectando el sidecar `icmp_latency_ms` con el flujo existente de eventos y la visualización de inventario.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios principales
| File | Change |
|------|--------|
| `.env.example` / `backend/config.py` | Adds `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS`. |
| `backend/polling/icmp_measurements.py` | Adds ICMP latency threshold metadata and status evaluation helpers. |
| `backend/polling/writer_pool.py` | Emits latency threshold event envelopes from ICMP sidecar samples. |
| `backend/polling/event_writer.py` | Handles latency threshold event lifecycle, dedupe, ACK updates, and root/propagated separation. |
| `backend/engines/snmp_worker.py` | Aligns legacy ICMP latency threshold refresh/recovery behavior. |
| `backend/repositories/topology_repo.py` | Applies env-backed defaults to the global `icmp_latency_ms` MetricDef. |
| `frontend/components/GlobalInventory.tsx` | Surfaces warning metrics as degraded in inventory/detail views. |

## Size Exception
- [x] Maintainer-approved `size:exception`: this PR is ~841 changed lines because backend lifecycle behavior, migration/defaults, focused tests, and minimal frontend visibility need to land together to avoid partial event semantics.

## ¿Cómo se probó?
- [x] `backend/.venv/bin/python -m pytest backend/tests/test_polling_event_writer.py backend/tests/test_snmp_worker.py backend/tests/test_polling_writer_pool.py backend/tests/test_icmp_metric_migration.py -q` → 72 passed
- [x] `pnpm test:run GlobalInventory.test.tsx` → 6 passed
- [x] `git diff --check`
- [x] Fresh reliability review completed with no blockers.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Tests were run for touched backend/frontend behavior.
- [x] Docs/config example updated for behavior change.
- [x] Conventional commit format used.
- [x] No attribution trailers added.