### PR TITLE
feat(ai): add LM Studio chat integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,15 @@ POLLING_BENCHMARK_DURATION_SECONDS=0
 POLLING_BENCHMARK_PROTOCOL_MIX=ICMP:0.15,SNMP:0.55,CLI:0.15,REST:0.10,MQTT_STUB:0.05
 POLLING_BENCHMARK_SINK=synthetic
 
+# --- LM STUDIO AI CHAT ---
+# Enable only when LM Studio local server is running.
+LM_STUDIO_ENABLED=false
+# Use http://localhost:1234/v1 outside Docker. Inside Docker, prefer
+# http://host.docker.internal:1234/v1 or a LAN IP for the host running LM Studio.
+LM_STUDIO_BASE_URL=http://host.docker.internal:1234/v1
+LM_STUDIO_MODEL=local-model
+LM_STUDIO_TIMEOUT_SECONDS=15
+
 # --- CLI CREDENTIALS ---
 # Default credentials for CLI polling (SSH/Telnet to network devices)
 CLI_DEFAULT_USER=

--- a/backend/ai/README.md
+++ b/backend/ai/README.md
@@ -1,0 +1,25 @@
+# Backend AI prompt sources
+
+This folder contains NEX-GEN-owned prompt and harness documentation for the backend AI chat path. LM Studio does not load these Markdown files directly.
+
+## Load model
+
+1. Backend reads the prompt sources server-side.
+2. Backend composes a compact `system` message for `/v1/chat/completions`.
+3. Backend pre-resolves explicit allowed intents, such as `availability_check`, when authorized.
+4. Backend includes the harness result in the final chat completion request.
+
+The current runtime does not send an OpenAI-compatible `tools` array or execute an LM Studio tool-call loop. That is reserved for a future slice.
+
+The frontend cannot choose identity files, tool definitions, LM Studio URL, or model.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `identity/Soul.md` | Base read-only NEX-GEN assistant identity. |
+| `identity/scope.md` | Permissions and safety boundaries. |
+| `identity/context-policy.md` | Context budget and ordering rules. |
+| `identity/session-bootstrap.md` | First interaction flow. |
+| `tools/README.md` | Tool catalog summary. |
+| `tools/availability_check.md` | Bounded ping harness contract. |

--- a/backend/ai/identity/Soul.md
+++ b/backend/ai/identity/Soul.md
@@ -1,0 +1,22 @@
+# NEX-GEN Assistant identity
+
+You are NEX-GEN Assistant, a concise technical assistant for CMDB, monitoring, ITSM, and AIOps operations.
+
+## Operating rules
+
+- Use only the user question, selected operational context, and backend-provided harness results.
+- Be direct, practical, and explicit about uncertainty.
+- Do not mutate CIs, events, users, roles, or configuration.
+- Do not invent tool results.
+- Do not claim a tool was executed unless a backend harness result is present.
+- If a tool is unavailable or blocked, explain the limitation and answer from available context only.
+
+## Backend harnesses
+
+The backend may pre-resolve small allow-listed intents before the final LM Studio request.
+
+Current tool family:
+
+- `availability_check`: bounded read-only CI reachability check.
+
+Detailed harness contracts live under `../tools/`. Do not embed long harness instructions in this identity prompt.

--- a/backend/ai/identity/context-policy.md
+++ b/backend/ai/identity/context-policy.md
@@ -1,0 +1,24 @@
+# Context policy
+
+Keep incident context small. The assistant should receive only the facts needed for the current question.
+
+## Prompt ordering
+
+Use this order when composing the request:
+
+1. User question.
+2. Selected CI or event facts needed to answer.
+3. Recent relevant state, not full history.
+4. Harness result, if one exists.
+5. Omit broad capability docs and unrelated records.
+
+## Budget strategy
+
+- Prefer summarized fields over raw object dumps.
+- Include IDs, names, status, severity, timestamps, and the few metrics relevant to the question.
+- Trim long notes, logs, and histories unless the user asks about them directly.
+- Do not include the full tool catalog in every prompt.
+
+## Why tools stay compact
+
+Large tool catalogs waste context, dilute the incident facts, and increase the chance that the model focuses on unused capabilities instead of the operator's question. The backend should keep harness context limited to the current request.

--- a/backend/ai/identity/scope.md
+++ b/backend/ai/identity/scope.md
@@ -1,0 +1,20 @@
+# Assistant scope and permissions
+
+The first assistant slice is read-only.
+
+## Allowed
+
+- Explain stored CI, event, monitoring, ITSM, and AIOps context provided by the backend.
+- Interpret a backend-provided harness result.
+- Answer from the backend-provided context and any pre-resolved harness result.
+
+## Not allowed
+
+- Create, update, delete, acknowledge, suppress, or close CIs, events, users, roles, or configuration.
+- Run arbitrary shell commands.
+- Perform broad network scanning or target discovery.
+- Accept user-provided hostnames, IPs, shell flags, LM Studio URLs, or model names as execution authority.
+
+## Authority model
+
+Backend code decides whether an explicit diagnostic intent is authorized, resolves targets from stored NEX-GEN data, executes the harness, and returns the result.

--- a/backend/ai/identity/session-bootstrap.md
+++ b/backend/ai/identity/session-bootstrap.md
@@ -1,0 +1,15 @@
+# Session bootstrap
+
+This is the first interaction flow for backend-owned AI chat sessions.
+
+1. Frontend sends the user question and allowed UI context to `/api/ai/chat`.
+2. Backend loads identity docs server-side and builds a compact system prompt.
+3. Backend selects a small incident context for the user message.
+4. Backend pre-resolves explicit allowed intents, such as `availability_check`, when authorized.
+5. Backend sends the OpenAI-compatible request to LM Studio with `messages` and any backend harness result.
+6. LM Studio returns the assistant answer.
+7. Backend persists the exchange and harness metadata.
+
+The current slice does not send an OpenAI-compatible `tools` array or execute an LM Studio tool-call loop.
+
+The frontend cannot control assistant identity, prompt files, tool definitions, LM Studio base URL, or selected model.

--- a/backend/ai/tools/README.md
+++ b/backend/ai/tools/README.md
@@ -1,0 +1,11 @@
+# AI harness tools
+
+Tools are backend-owned, allow-listed harnesses. The current runtime pre-resolves explicit backend intents before the final LM Studio request; it does not yet accept model-initiated tool calls.
+
+## Current tools
+
+| Tool | Purpose | Mutates data? |
+|---|---|---:|
+| `availability_check` | Resolve one stored CI and run one bounded ping to its stored IP or hostname. | No |
+
+See `availability_check.md` for the exact contract.

--- a/backend/ai/tools/availability_check.md
+++ b/backend/ai/tools/availability_check.md
@@ -1,0 +1,52 @@
+# `availability_check` harness
+
+Bounded read-only ping check for one stored CI.
+
+## Purpose
+
+Answer a narrow operator question: "is this known CI reachable right now?"
+
+## Inputs
+
+| Field | Source | Notes |
+|---|---|---|
+| `ci_ref` | User request or UI context | CI id or CI name only. |
+
+The browser cannot provide shell commands, ping flags, raw targets, LM Studio settings, or model names.
+
+## Permission
+
+Requires backend diagnostic authorization for the current user and request. Tool execution is backend-authorized, not model-authorized.
+
+## Target resolution
+
+1. Resolve `ci_ref` against stored CMDB data.
+2. Use the CI's stored `ip` first, then stored `hostname`.
+3. Reject empty targets, unsafe hostnames, option-like values, and arbitrary user-supplied targets.
+
+## Guardrails
+
+- Executes one Linux-focused command: `ping -c 1 -W 2 <target>`.
+- Backend subprocess timeout is bounded.
+- No network scanning.
+- No shell interpolation.
+- No data mutation.
+
+## Output metadata
+
+| Field | Meaning |
+|---|---|
+| `type` | Always `availability_check`. |
+| `ci_id`, `ci_name` | Resolved CI identity when available. |
+| `target` | Stored IP or hostname used by the backend. |
+| `status` | `reachable`, `unreachable`, `ci_not_found`, `invalid_target`, or `error`. |
+| `latency_ms` | Parsed ping latency when available. |
+| `detail` | Short diagnostic summary safe for the UI. |
+
+## Failure modes
+
+- CI reference does not match stored data.
+- CI has no stored IP or hostname.
+- Stored target fails safety validation.
+- Ping command is unavailable, times out, or fails.
+- Backend authorization denies the request.

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,6 +20,20 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _env_float_bounded(name: str, default: float, *, minimum: float, maximum: float) -> float:
+    """Parse a bounded float environment variable with a safe fallback."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if minimum <= value <= maximum:
+        return value
+    return default
+
+
 # ---------------------------------------------------------------------------
 # Event Batch Pruner Settings
 # ---------------------------------------------------------------------------
@@ -246,3 +260,37 @@ def get_icmp_settings() -> ICMPSettings:
     if _icmp_settings is None:
         _icmp_settings = ICMPSettings.from_env()
     return _icmp_settings
+
+
+# ---------------------------------------------------------------------------
+# LM Studio AI Chat Settings
+# ---------------------------------------------------------------------------
+
+
+class LMStudioSettings(BaseModel):
+    """Server-side LM Studio proxy settings."""
+
+    enabled: bool = False
+    base_url: str = "http://localhost:1234/v1"
+    model: str = "local-model"
+    timeout_seconds: float = Field(default=15.0, gt=0, le=120)
+
+    @classmethod
+    def from_env(cls) -> "LMStudioSettings":
+        """Load LM Studio settings from environment variables."""
+        return cls(
+            enabled=_env_bool("LM_STUDIO_ENABLED", default=False),
+            base_url=os.getenv("LM_STUDIO_BASE_URL", "http://localhost:1234/v1").rstrip("/"),
+            model=os.getenv("LM_STUDIO_MODEL", "local-model"),
+            timeout_seconds=_env_float_bounded(
+                "LM_STUDIO_TIMEOUT_SECONDS",
+                15.0,
+                minimum=0.000001,
+                maximum=120.0,
+            ),
+        )
+
+
+def get_lm_studio_settings() -> LMStudioSettings:
+    """Return fresh LM Studio settings so tests and env changes are respected."""
+    return LMStudioSettings.from_env()

--- a/backend/main.py
+++ b/backend/main.py
@@ -141,7 +141,7 @@ def schedule_daily_backup() -> None:
 
 
 # Router Imports
-from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli
+from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai
 
 app = FastAPI(
     title="NEX-GEN API",
@@ -212,6 +212,7 @@ app.include_router(backup.router, prefix="/api")
 app.include_router(dictionaries.router, prefix="/api")
 app.include_router(cis.router, prefix="/api")
 app.include_router(cli.router, prefix="/api")
+app.include_router(ai.router, prefix="/api")
 
 
 @app.exception_handler(Exception)
@@ -246,6 +247,7 @@ async def startup_event():
         from models.audit_event import AuditEvent  # Import to register model
         from models.rate_limit_attempt import RateLimitAttempt  # Import to register model
         from models.system_status_history import SystemStatusSnapshot  # Import to register model
+        from models.ai_chat import AIChatMessage  # Import to register model
 
         # Create Tables (includes backup_config, backup_history, rate_limit_attempts, system status history, and audit events)
         Base.metadata.create_all(bind=engine)

--- a/backend/models/ai_chat.py
+++ b/backend/models/ai_chat.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Integer, JSON, String, Text
+
+from postgres_db import Base
+
+
+class AIChatMessage(Base):
+    """Persist one bounded AI chat exchange and optional harness metadata."""
+
+    __tablename__ = "ai_chat_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, index=True, nullable=False)
+    user_message = Column(Text, nullable=False)
+    assistant_response = Column(Text, nullable=False)
+    context = Column(Text, nullable=True)
+    harness_result = Column(JSON, nullable=True)
+    model = Column(String, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from config import get_lm_studio_settings
+from database import get_db
+from postgres_db import get_pg_db
+from models.user import AIPermission, User, UserPermission
+from services.auth_service import check_permission, get_current_active_user
+from services.ai_chat_service import (
+    LMStudioError,
+    LMStudioTimeoutError,
+    complete_chat,
+    maybe_run_harness,
+    save_chat_exchange,
+)
+
+
+router = APIRouter(prefix="/ai", tags=["AI Chat"])
+
+
+class AvailabilityIntent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["availability_check"]
+    ci_ref: str = Field(min_length=1, max_length=120)
+
+
+class AIChatRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query: str = Field(min_length=1, max_length=2_000)
+    context: str | None = Field(default=None, max_length=4_000)
+    intent: AvailabilityIntent | None = None
+
+
+class AIChatResponse(BaseModel):
+    answer: str
+    model: str | None = None
+    message_id: int | None = None
+    harness_result: dict[str, Any] | None = None
+
+
+def _can_run_availability_harness(user: User) -> bool:
+    can_run_diagnostics = check_permission(UserPermission.RUN_DIAGNOSTICS, user) or (
+        AIPermission.AI_RUN_DIAGNOSTIC.value in user.permissions
+    )
+    can_view_all_cmdb = AIPermission.AI_VIEW_ALL.value in user.permissions
+    return can_run_diagnostics and can_view_all_cmdb
+
+
+@router.post("/chat", response_model=AIChatResponse)
+async def chat_with_ai(
+    body: AIChatRequest,
+    current_user: User = Depends(get_current_active_user),
+    db=Depends(get_pg_db),
+    neo4j_driver=Depends(get_db),
+) -> AIChatResponse:
+    if not get_lm_studio_settings().enabled:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="LM Studio is unavailable",
+        )
+
+    if body.intent is not None and not _can_run_availability_harness(current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to run diagnostics")
+
+    harness_result = maybe_run_harness(body.intent, neo4j_driver)
+    try:
+        completion = complete_chat(body.query, body.context, harness_result)
+    except LMStudioTimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail="LM Studio request timed out",
+        )
+    except LMStudioError:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="LM Studio is unavailable",
+        )
+
+    row = save_chat_exchange(
+        db,
+        username=current_user.username,
+        user_message=body.query,
+        assistant_response=completion["content"],
+        context=body.context,
+        harness_result=harness_result,
+        model=completion.get("model"),
+    )
+    return AIChatResponse(
+        answer=completion["content"],
+        model=completion.get("model"),
+        message_id=getattr(row, "id", None),
+        harness_result=harness_result,
+    )

--- a/backend/services/ai_chat_service.py
+++ b/backend/services/ai_chat_service.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from config import LMStudioSettings, get_lm_studio_settings
+from models.ai_chat import AIChatMessage
+
+
+FALLBACK_SYSTEM_PROMPT = (
+    "You are NEX-GEN Assistant, a concise and technical assistant for CMDB, "
+    "monitoring, ITSM, and AIOps operations. Use only provided operational "
+    "context. Do not invent tool results."
+)
+AI_IDENTITY_DIR = Path(__file__).resolve().parents[1] / "ai" / "identity"
+PROMPT_SOURCE_FILES = ("Soul.md", "scope.md", "context-policy.md")
+MAX_SYSTEM_PROMPT_CHARS = 6_000
+
+MAX_QUERY_CHARS = 2_000
+MAX_CONTEXT_CHARS = 4_000
+_SAFE_HOST_RE = re.compile(r"^[A-Za-z0-9.-]{1,253}$")
+
+
+class LMStudioError(Exception):
+    """LM Studio returned an unusable response or could not be reached."""
+
+
+class LMStudioTimeoutError(LMStudioError):
+    """LM Studio did not answer within the configured timeout."""
+
+
+def load_system_prompt() -> str:
+    """Compose the bounded runtime system prompt from backend-owned sources."""
+    sections: list[str] = []
+    try:
+        for filename in PROMPT_SOURCE_FILES:
+            source = AI_IDENTITY_DIR / filename
+            text = source.read_text(encoding="utf-8").strip()
+            if not text:
+                return FALLBACK_SYSTEM_PROMPT
+            sections.append(f"## {filename}\n{text}")
+    except OSError:
+        return FALLBACK_SYSTEM_PROMPT
+
+    prompt = "\n\n".join(sections)
+    if len(prompt) > MAX_SYSTEM_PROMPT_CHARS:
+        return prompt[:MAX_SYSTEM_PROMPT_CHARS].rstrip()
+    return prompt
+
+
+@dataclass(frozen=True)
+class PingResult:
+    status: str
+    target: str
+    latency_ms: float | None
+    detail: str
+
+    def to_metadata(self, ci: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "type": "availability_check",
+            "ci_id": ci.get("id"),
+            "ci_name": ci.get("name"),
+            "target": self.target,
+            "status": self.status,
+            "latency_ms": self.latency_ms,
+            "detail": self.detail,
+        }
+
+
+def build_lm_studio_payload(
+    query: str,
+    context: str | None,
+    harness_result: dict[str, Any] | None,
+    settings: LMStudioSettings,
+) -> dict[str, Any]:
+    """Build a bounded OpenAI-compatible chat completion payload."""
+    trimmed_query = query[:MAX_QUERY_CHARS]
+    trimmed_context = (context or "")[:MAX_CONTEXT_CHARS]
+    user_content = f"User question:\n{trimmed_query}"
+    if trimmed_context:
+        user_content = f"{user_content}\n\nOperational context:\n{trimmed_context}"
+    if harness_result:
+        user_content += "\n\nHarness result:\n" + json.dumps(harness_result, sort_keys=True)
+
+    return {
+        "model": settings.model,
+        "messages": [
+            {"role": "system", "content": load_system_prompt()},
+            {"role": "user", "content": user_content},
+        ],
+        "temperature": 0.2,
+        "stream": False,
+    }
+
+
+def _post_lm_studio_chat_completion(payload: dict[str, Any], settings: LMStudioSettings) -> dict[str, str]:
+    url = f"{settings.base_url}/chat/completions"
+    body = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=settings.timeout_seconds) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except TimeoutError as exc:
+        raise LMStudioTimeoutError("LM Studio request timed out") from exc
+    except urllib.error.URLError as exc:
+        if isinstance(getattr(exc, "reason", None), TimeoutError):
+            raise LMStudioTimeoutError("LM Studio request timed out") from exc
+        raise LMStudioError("LM Studio is unavailable") from exc
+    except Exception as exc:
+        raise LMStudioError("LM Studio response could not be parsed") from exc
+
+    try:
+        message = data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise LMStudioError("LM Studio response did not contain a chat message") from exc
+    return {"content": str(message), "model": str(data.get("model") or settings.model)}
+
+
+def resolve_ci_for_harness(neo4j_driver, ci_ref: str) -> dict[str, Any] | None:
+    """Resolve a CI by id or name using stored CMDB data only."""
+    with neo4j_driver.session() as session:
+        record = session.run(
+            """
+            MATCH (ci:CI)
+            WHERE ci.id = $ci_ref OR toLower(ci.name) = toLower($ci_ref)
+            RETURN ci { .id, .name, .ip, .hostname } AS ci
+            LIMIT 1
+            """,
+            ci_ref=ci_ref,
+        ).single()
+    return record["ci"] if record else None
+
+
+def resolve_ping_target(ci: dict[str, Any]) -> str:
+    """Return a safe stored IP/hostname target for a bounded ping."""
+    target = str(ci.get("ip") or ci.get("hostname") or "").strip()
+    if not target:
+        raise ValueError("CI has no stored IP or hostname")
+    try:
+        ipaddress.ip_address(target)
+        return target
+    except ValueError:
+        if _SAFE_HOST_RE.fullmatch(target) and ".." not in target and not target.startswith("-"):
+            return target
+    raise ValueError("CI has an unsafe ping target")
+
+
+def run_bounded_ping(target: str) -> PingResult:
+    """Run one Linux-focused ping with bounded count and timeout."""
+    try:
+        completed = subprocess.run(
+            ["ping", "-c", "1", "-W", "2", target],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return PingResult(
+            status="error",
+            target=target,
+            latency_ms=None,
+            detail="ping command timed out",
+        )
+    except FileNotFoundError:
+        return PingResult(
+            status="error",
+            target=target,
+            latency_ms=None,
+            detail="ping command not found",
+        )
+    except (PermissionError, OSError, subprocess.SubprocessError):
+        return PingResult(
+            status="error",
+            target=target,
+            latency_ms=None,
+            detail="ping command failed",
+        )
+    output = f"{completed.stdout}\n{completed.stderr}".strip()
+    latency_match = re.search(r"time=([0-9.]+)\s*ms", output)
+    latency_ms = float(latency_match.group(1)) if latency_match else None
+    status = "reachable" if completed.returncode == 0 else "unreachable"
+    detail = "1 packet received" if status == "reachable" else "no response to one bounded ping"
+    return PingResult(status=status, target=target, latency_ms=latency_ms, detail=detail)
+
+
+def maybe_run_harness(intent: Any, neo4j_driver) -> dict[str, Any] | None:
+    if not intent or getattr(intent, "type", None) != "availability_check":
+        return None
+
+    ci_ref = str(getattr(intent, "ci_ref", "")).strip()
+    ci = resolve_ci_for_harness(neo4j_driver, ci_ref)
+    if ci is None:
+        return {"type": "availability_check", "ci_ref": ci_ref, "status": "ci_not_found"}
+
+    try:
+        target = resolve_ping_target(ci)
+        return run_bounded_ping(target).to_metadata(ci)
+    except ValueError as exc:
+        return {
+            "type": "availability_check",
+            "ci_id": ci.get("id"),
+            "ci_name": ci.get("name"),
+            "status": "invalid_target",
+            "detail": str(exc),
+        }
+
+
+def save_chat_exchange(
+    db,
+    *,
+    username: str,
+    user_message: str,
+    assistant_response: str,
+    context: str | None,
+    harness_result: dict[str, Any] | None,
+    model: str | None,
+) -> AIChatMessage:
+    row = AIChatMessage(
+        username=username,
+        user_message=user_message[:MAX_QUERY_CHARS],
+        assistant_response=assistant_response,
+        context=(context or "")[:MAX_CONTEXT_CHARS] or None,
+        harness_result=harness_result,
+        model=model,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def complete_chat(query: str, context: str | None, harness_result: dict[str, Any] | None) -> dict[str, str]:
+    settings = get_lm_studio_settings()
+    if not settings.enabled:
+        raise LMStudioError("LM Studio chat is disabled")
+    payload = build_lm_studio_payload(query, context, harness_result, settings)
+    return _post_lm_studio_chat_completion(payload, settings)

--- a/backend/tests/test_ai_chat_service.py
+++ b/backend/tests/test_ai_chat_service.py
@@ -1,0 +1,420 @@
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from models.user import User
+
+
+def _operator_user() -> User:
+    return User(username="operator", role="OPERATOR", permissions=["CI_VIEW"], allowed_locations=[])
+
+
+def _diagnostic_user() -> User:
+    return User(
+        username="diagnostic-operator",
+        role="OPERATOR",
+        permissions=["CI_VIEW", "RUN_DIAGNOSTICS"],
+        allowed_locations=[],
+    )
+
+
+def _ai_cmdb_diagnostic_user() -> User:
+    return User(
+        username="ai-cmdb-diagnostic-operator",
+        role="OPERATOR",
+        permissions=["CI_VIEW", "RUN_DIAGNOSTICS", "AI_VIEW_ALL"],
+        allowed_locations=[],
+    )
+
+
+class _FakeDb:
+    def __init__(self):
+        self.added = []
+        self.committed = False
+        self.refreshed = []
+
+    def add(self, model):
+        self.added.append(model)
+
+    def commit(self):
+        self.committed = True
+
+    def refresh(self, model):
+        model.id = 42
+        self.refreshed.append(model)
+
+
+def _make_client(db=None, user=None):
+    from routers.ai import router, get_pg_db, get_current_active_user, get_db
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    fake_db = db or _FakeDb()
+
+    def override_pg_db():
+        yield fake_db
+
+    app.dependency_overrides[get_pg_db] = override_pg_db
+    app.dependency_overrides[get_current_active_user] = lambda: user or _operator_user()
+    app.dependency_overrides[get_db] = lambda: MagicMock()
+    return TestClient(app), fake_db
+
+
+def test_ai_chat_requires_authentication():
+    from routers.ai import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    client = TestClient(app)
+
+    response = client.post("/api/ai/chat", json={"query": "hello"})
+
+    assert response.status_code == 401
+
+
+def test_ai_chat_success_uses_server_config_and_persists_history(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+
+    client, db = _make_client()
+
+    captured_payloads = []
+
+    def fake_completion(payload, settings):
+        captured_payloads.append(payload)
+        return {"content": "Use the incident timeline first.", "model": settings.model}
+
+    with patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=fake_completion):
+        response = client.post(
+            "/api/ai/chat",
+            json={"query": "What should I check?", "context": "Two Redis alerts"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["answer"] == "Use the incident timeline first."
+    assert response.json()["model"] == "local-model"
+    assert captured_payloads[0]["model"] == "local-model"
+    assert "http://lmstudio.local" not in json.dumps(captured_payloads[0])
+    assert db.committed is True
+    assert db.added[0].username == "operator"
+    assert db.added[0].user_message == "What should I check?"
+    assert db.added[0].assistant_response == "Use the incident timeline first."
+
+
+def test_payload_system_prompt_uses_backend_identity_sources(tmp_path, monkeypatch):
+    from config import LMStudioSettings
+    from services import ai_chat_service
+
+    identity_dir = tmp_path / "identity"
+    identity_dir.mkdir()
+    (identity_dir / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    (identity_dir / "scope.md").write_text("# Scope\n\nRead-only diagnostics.", encoding="utf-8")
+    (identity_dir / "context-policy.md").write_text("# Context\n\nUse compact context.", encoding="utf-8")
+    monkeypatch.setattr(ai_chat_service, "AI_IDENTITY_DIR", identity_dir)
+
+    payload = ai_chat_service.build_lm_studio_payload(
+        "What changed?",
+        None,
+        None,
+        LMStudioSettings(enabled=True, model="local-model"),
+    )
+
+    system_prompt = payload["messages"][0]["content"]
+    assert "Unique runtime identity." in system_prompt
+    assert "Read-only diagnostics." in system_prompt
+    assert "Use compact context." in system_prompt
+
+
+def test_payload_places_user_question_before_operational_context():
+    from config import LMStudioSettings
+    from services import ai_chat_service
+
+    payload = ai_chat_service.build_lm_studio_payload(
+        "What changed?",
+        "Router-01 alert context",
+        None,
+        LMStudioSettings(enabled=True, model="local-model"),
+    )
+
+    user_content = payload["messages"][1]["content"]
+    assert user_content.startswith("User question:\nWhat changed?")
+    assert user_content.index("User question:") < user_content.index("Operational context:")
+
+
+def test_payload_system_prompt_falls_back_when_identity_source_missing(tmp_path, monkeypatch):
+    from config import LMStudioSettings
+    from services import ai_chat_service
+
+    identity_dir = tmp_path / "identity"
+    identity_dir.mkdir()
+    (identity_dir / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    monkeypatch.setattr(ai_chat_service, "AI_IDENTITY_DIR", identity_dir)
+
+    payload = ai_chat_service.build_lm_studio_payload(
+        "What changed?",
+        None,
+        None,
+        LMStudioSettings(enabled=True, model="local-model"),
+    )
+
+    system_prompt = payload["messages"][0]["content"]
+    assert system_prompt == ai_chat_service.FALLBACK_SYSTEM_PROMPT
+
+
+def test_ai_chat_rejects_request_supplied_url_and_model(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "safe-model")
+    client, _ = _make_client()
+
+    response = client.post(
+        "/api/ai/chat",
+        json={
+            "query": "hello",
+            "base_url": "http://attacker.example/v1",
+            "model": "attacker-model",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_ai_chat_maps_lm_studio_timeout(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client()
+
+    from services.ai_chat_service import LMStudioTimeoutError
+
+    with patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=LMStudioTimeoutError("timeout")):
+        response = client.post("/api/ai/chat", json={"query": "hello"})
+
+    assert response.status_code == 504
+    assert response.json()["detail"] == "LM Studio request timed out"
+
+
+def test_ai_chat_maps_lm_studio_error_without_traceback(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client()
+
+    from services.ai_chat_service import LMStudioError
+
+    with patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=LMStudioError("Connection refused: stack")):
+        response = client.post("/api/ai/chat", json={"query": "hello"})
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "LM Studio is unavailable"
+
+
+def test_availability_check_resolves_ci_and_persists_ping_metadata(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, db = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    ci = {"id": "ci-1", "name": "Router-01", "ip": "192.168.1.10"}
+    from services.ai_chat_service import PingResult
+
+    ping_result = PingResult(
+        status="reachable",
+        target="192.168.1.10",
+        latency_ms=12.3,
+        detail="1 packet received",
+    )
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci), \
+         patch("services.ai_chat_service.run_bounded_ping", return_value=ping_result), \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion", return_value={"content": "Router-01 is reachable.", "model": "local-model"}):
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-01 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-01"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "reachable"
+    assert db.added[0].harness_result["ci_id"] == "ci-1"
+    assert db.added[0].harness_result["target"] == "192.168.1.10"
+
+
+def test_availability_check_requires_diagnostic_permission(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client()
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-01 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-01"},
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized to run diagnostics"
+    resolve_ci.assert_not_called()
+    run_ping.assert_not_called()
+    complete.assert_not_called()
+
+
+def test_availability_check_requires_ai_view_all_before_ci_resolution(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_diagnostic_user())
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-01 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-01"},
+            },
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Not authorized to run diagnostics"
+    resolve_ci.assert_not_called()
+    run_ping.assert_not_called()
+    complete.assert_not_called()
+
+
+def test_disabled_lm_studio_blocks_harness_side_effects(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "false")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_diagnostic_user())
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-01 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-01"},
+            },
+        )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "LM Studio is unavailable"
+    resolve_ci.assert_not_called()
+    run_ping.assert_not_called()
+    complete.assert_not_called()
+
+
+def test_ping_harness_rejects_invalid_stored_target():
+    from services.ai_chat_service import resolve_ping_target
+
+    with pytest.raises(ValueError, match="unsafe"):
+        resolve_ping_target({"id": "ci-1", "name": "Router", "ip": "8.8.8.8; rm -rf /"})
+
+
+def test_bounded_ping_maps_command_timeout():
+    from services.ai_chat_service import run_bounded_ping
+
+    with patch("services.ai_chat_service.subprocess.run", side_effect=subprocess.TimeoutExpired(["ping"], 3)):
+        result = run_bounded_ping("192.168.1.10")
+
+    assert result.status == "error"
+    assert result.target == "192.168.1.10"
+    assert result.latency_ms is None
+    assert result.detail == "ping command timed out"
+
+
+def test_bounded_ping_invokes_exact_bounded_subprocess_command():
+    from services.ai_chat_service import run_bounded_ping
+
+    completed = subprocess.CompletedProcess(
+        ["ping", "-c", "1", "-W", "2", "router-01.example"],
+        0,
+        stdout="64 bytes from router-01.example: icmp_seq=1 ttl=64 time=7.42 ms\n",
+        stderr="",
+    )
+
+    with patch("services.ai_chat_service.subprocess.run", return_value=completed) as run:
+        result = run_bounded_ping("router-01.example")
+
+    run.assert_called_once_with(
+        ["ping", "-c", "1", "-W", "2", "router-01.example"],
+        capture_output=True,
+        text=True,
+        timeout=3,
+        check=False,
+    )
+    assert result.status == "reachable"
+    assert result.target == "router-01.example"
+    assert result.latency_ms == 7.42
+    assert result.detail == "1 packet received"
+
+
+def test_bounded_ping_parses_success_without_latency():
+    from services.ai_chat_service import run_bounded_ping
+
+    completed = subprocess.CompletedProcess(
+        ["ping", "-c", "1", "-W", "2", "192.168.1.10"],
+        0,
+        stdout="1 packets transmitted, 1 received, 0% packet loss\n",
+        stderr="",
+    )
+
+    with patch("services.ai_chat_service.subprocess.run", return_value=completed):
+        result = run_bounded_ping("192.168.1.10")
+
+    assert result.status == "reachable"
+    assert result.latency_ms is None
+    assert result.detail == "1 packet received"
+
+
+def test_bounded_ping_maps_missing_command():
+    from services.ai_chat_service import run_bounded_ping
+
+    with patch("services.ai_chat_service.subprocess.run", side_effect=FileNotFoundError()):
+        result = run_bounded_ping("192.168.1.10")
+
+    assert result.status == "error"
+    assert result.target == "192.168.1.10"
+    assert result.latency_ms is None
+    assert result.detail == "ping command not found"
+
+
+def test_bounded_ping_maps_execution_failure_without_exception_details():
+    from services.ai_chat_service import run_bounded_ping
+
+    with patch("services.ai_chat_service.subprocess.run", side_effect=PermissionError("secret path")):
+        result = run_bounded_ping("192.168.1.10")
+
+    assert result.status == "error"
+    assert result.target == "192.168.1.10"
+    assert result.latency_ms is None
+    assert result.detail == "ping command failed"
+    assert "secret path" not in result.detail
+
+
+def test_bounded_ping_maps_subprocess_failure_without_exception_details():
+    from services.ai_chat_service import run_bounded_ping
+
+    with patch("services.ai_chat_service.subprocess.run", side_effect=subprocess.SubprocessError("secret detail")):
+        result = run_bounded_ping("192.168.1.10")
+
+    assert result.status == "error"
+    assert result.target == "192.168.1.10"
+    assert result.latency_ms is None
+    assert result.detail == "ping command failed"
+    assert "secret detail" not in result.detail

--- a/backend/tests/test_lm_studio_config.py
+++ b/backend/tests/test_lm_studio_config.py
@@ -1,0 +1,25 @@
+from config import get_lm_studio_settings
+
+
+def test_lm_studio_timeout_uses_fallback_for_invalid_env(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_TIMEOUT_SECONDS", "not-a-number")
+
+    settings = get_lm_studio_settings()
+
+    assert settings.timeout_seconds == 15.0
+
+
+def test_lm_studio_timeout_uses_fallback_for_out_of_bounds_env(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_TIMEOUT_SECONDS", "0")
+
+    settings = get_lm_studio_settings()
+
+    assert settings.timeout_seconds == 15.0
+
+
+def test_lm_studio_timeout_accepts_valid_env(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_TIMEOUT_SECONDS", "30.5")
+
+    settings = get_lm_studio_settings()
+
+    assert settings.timeout_seconds == 30.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,12 @@ services:
       - FRONTEND_ORIGIN=${FRONTEND_ORIGIN:-http://10.53.1.22:3010}
       - DISABLE_BACKEND_COLLECTOR=true
       - COOKIE_DOMAIN=${COOKIE_DOMAIN}
+      - LM_STUDIO_ENABLED=${LM_STUDIO_ENABLED:-false}
+      - LM_STUDIO_BASE_URL=${LM_STUDIO_BASE_URL:-http://host.docker.internal:1234/v1}
+      - LM_STUDIO_MODEL=${LM_STUDIO_MODEL:-local-model}
+      - LM_STUDIO_TIMEOUT_SECONDS=${LM_STUDIO_TIMEOUT_SECONDS:-15}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ${BACKUP_DIR:-.docker/backups}:/backups
     healthcheck:

--- a/docs/lm-studio-ai-chat.md
+++ b/docs/lm-studio-ai-chat.md
@@ -1,0 +1,79 @@
+# LM Studio AI Chat Integration
+
+NEX-GEN AI chat now uses a backend proxy to talk to LM Studio's OpenAI-compatible local API. The browser only calls `/api/ai/chat`; it never receives or controls the LM Studio base URL or model.
+
+## Quick path
+
+1. Start LM Studio and enable the local server.
+2. Configure the backend environment variables below.
+3. Send chat from the NEX-GEN AI console; the backend posts to `/v1/chat/completions`.
+
+## Environment
+
+| Variable | Required | Example | Notes |
+|---|---:|---|---|
+| `LM_STUDIO_ENABLED` | Yes | `true` | Keeps the proxy opt-in. |
+| `LM_STUDIO_BASE_URL` | Yes | `http://localhost:1234/v1` | Use `host.docker.internal` or a LAN IP from Docker. |
+| `LM_STUDIO_MODEL` | Yes | `qwen2.5-coder-7b-instruct` | Must match a model loaded in LM Studio. |
+| `LM_STUDIO_TIMEOUT_SECONDS` | No | `15` | Bounded backend request timeout. |
+
+## Docker networking
+
+Inside the backend container, `localhost` is the container itself, not your host machine. Use one of these instead:
+
+```env
+LM_STUDIO_BASE_URL=http://host.docker.internal:1234/v1
+# or
+LM_STUDIO_BASE_URL=http://192.168.1.50:1234/v1
+```
+
+The Compose backend service maps `host.docker.internal` to the Linux Docker host gateway so the default URL works on Linux as well as Docker Desktop environments.
+
+## Endpoint flow
+
+| Step | Component | Action |
+|---:|---|---|
+| 1 | Frontend | `chatWithAIAgent(query, context)` posts to `/api/ai/chat`. |
+| 2 | Backend | Auth validates the current user cookie/session. |
+| 3 | Harness | Optional `availability_check` first requires diagnostic permission, then resolves a stored CI and runs one bounded ping. |
+| 4 | LM Studio proxy | Backend sends a non-streaming OpenAI-compatible chat completion request. |
+| 5 | Persistence | Backend stores the user message, assistant answer, timestamp, model, context, and harness metadata. |
+
+## Safe harness behavior
+
+The first harness is intentionally small: CI availability check by ping. The browser may request an `availability_check` intent with a CI id/name, but it cannot provide a shell command, host target, base URL, or model. The backend resolves the CI from stored CMDB data and validates the stored IP/hostname before running `ping -c 1 -W 2`.
+
+Persisted chat history is stored server-side for authenticated application users who already have backend data access. This slice does not add a separate retention policy or encryption layer for AI chat records; deployers should treat chat history as operational data and align database access, backups, and cleanup with their existing operational data retention controls.
+
+## Assistant identity and harness files
+
+LM Studio does not consume Markdown prompt files directly. The backend reads the identity Markdown files, composes a bounded `system` message, and sends that through the OpenAI-compatible `messages` array.
+
+NEX-GEN-owned prompt and harness source files live under `backend/ai/`:
+
+| File | Purpose |
+|---|---|
+| [`backend/ai/README.md`](../backend/ai/README.md) | Load model and file map. |
+| [`backend/ai/identity/Soul.md`](../backend/ai/identity/Soul.md) | Base read-only assistant identity. |
+| [`backend/ai/identity/scope.md`](../backend/ai/identity/scope.md) | Permissions and mutation boundaries. |
+| [`backend/ai/identity/context-policy.md`](../backend/ai/identity/context-policy.md) | Compact incident context strategy. |
+| [`backend/ai/identity/session-bootstrap.md`](../backend/ai/identity/session-bootstrap.md) | First interaction flow. |
+| [`backend/ai/tools/README.md`](../backend/ai/tools/README.md) | Current backend-owned tool catalog. |
+| [`backend/ai/tools/availability_check.md`](../backend/ai/tools/availability_check.md) | Bounded ping harness contract. |
+
+At runtime, backend code loads `Soul.md`, `scope.md`, and `context-policy.md` for the system prompt. The current first slice pre-resolves explicit backend intents such as `availability_check`, authorizes them server-side, and includes the harness result in the prompt. It does not yet run an LM Studio tool-call loop or send an OpenAI `tools` array.
+
+## Known limitations
+
+- Chat is non-streaming for this first slice.
+- History is persisted server-side, but the current UI only displays the active browser session.
+- LM Studio errors are mapped to safe frontend messages; backend logs should be used for operator diagnostics.
+- The ping harness is Linux-focused and isolated in `services/ai_chat_service.py` for tests and future portability work.
+- LM Studio tool calls are not enabled yet; explicit backend intents are pre-resolved before the final chat completion request.
+
+## Future improvements
+
+- Add streaming responses once the proxy contract is stable.
+- Add an LM Studio tool-call loop with OpenAI-compatible `tools` payloads once the intent pre-resolution path is stable.
+- Add a conversation history endpoint for UI reloads.
+- Add more bounded, allow-listed harness tools with per-action audit and authorization checks.

--- a/frontend/services/geminiService.test.ts
+++ b/frontend/services/geminiService.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chatWithAIAgent } from './geminiService';
+import { api } from './api';
+
+vi.mock('./api', () => ({
+  api: {
+    post: vi.fn(),
+  },
+}));
+
+describe('chatWithAIAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('posts chat requests to the backend AI endpoint and returns the answer', async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({
+      answer: 'Check the active Redis incident first.',
+      model: 'local-model',
+    });
+
+    const answer = await chatWithAIAgent('What should I check?', 'Incident console context');
+
+    expect(api.post).toHaveBeenCalledWith('/ai/chat', {
+      query: 'What should I check?',
+      context: 'Incident console context',
+    });
+    expect(answer).toBe('Check the active Redis incident first.');
+  });
+
+  it('returns an empty string when the backend answer is empty', async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({ answer: '', model: 'local-model' });
+
+    const answer = await chatWithAIAgent('Hello', '');
+
+    expect(answer).toBe('');
+  });
+});

--- a/frontend/services/geminiService.ts
+++ b/frontend/services/geminiService.ts
@@ -1,6 +1,7 @@
 
 import { GoogleGenAI, Type } from "@google/genai";
 import { IncidentEvent, AIAction } from "../types";
+import { api } from "./api";
 
 const ai = new GoogleGenAI({ apiKey: process.env.API_KEY || '' });
 
@@ -37,12 +38,6 @@ export const analyzeIncident = async (incident: IncidentEvent): Promise<AIAction
 };
 
 export const chatWithAIAgent = async (query: string, context: string) => {
-  const response = await ai.models.generateContent({
-    model: 'gemini-3-flash-preview',
-    contents: `Context: ${context}\n\nUser Question: ${query}`,
-    config: {
-      systemInstruction: "You are NEX-GEN Assistant. Be concise, technical, and helpful. Use the graph CMDB context provided.",
-    }
-  });
-  return response.text;
+  const response = await api.post<{ answer: string }>('/ai/chat', { query, context });
+  return response.answer;
 };


### PR DESCRIPTION
## Descripción del Cambio
Closes #272

Adds the first safe LM Studio-backed AI chat slice for NEX-GEN:

- Backend `/api/ai/chat` proxy to LM Studio's OpenAI-compatible chat completions endpoint.
- Server-side LM Studio configuration, prompt loading, chat persistence, and actor attribution.
- Read-only CI availability harness with diagnostic + `AI_VIEW_ALL` authorization.
- Frontend chat service routed through the backend instead of browser-side LLM chat.
- Dedicated `backend/ai/` identity/tool prompt source docs and LM Studio integration documentation.

Review note: maintainer-approved `size:exception` for this PR (~1,169 changed lines) to keep the LM Studio chat, docs, harness, and tests together as one releaseable feature slice.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios principales
| File | Change |
|------|--------|
| `backend/routers/ai.py` | Adds authenticated AI chat endpoint and permission-gated harness execution. |
| `backend/services/ai_chat_service.py` | Adds prompt loading, LM Studio proxy, persistence helper, and bounded ping harness. |
| `backend/models/ai_chat.py` | Adds persisted AI chat exchange model. |
| `backend/ai/` | Adds server-owned assistant identity, context policy, and tool docs. |
| `frontend/services/geminiService.ts` | Routes chat through backend `/ai/chat`. |
| `docs/lm-studio-ai-chat.md` | Documents setup, Docker networking, prompt sources, and limitations. |

## ¿Cómo se probó?
- [x] `git diff --check`
- [x] `backend/.venv/bin/python -m pytest backend/tests/test_ai_chat_service.py backend/tests/test_lm_studio_config.py` — 22 passed, 1 warning
- [x] `backend/.venv/bin/python -m py_compile backend/config.py backend/main.py backend/models/ai_chat.py backend/routers/ai.py backend/services/ai_chat_service.py backend/tests/test_ai_chat_service.py backend/tests/test_lm_studio_config.py`
- [x] `pnpm test:run services/geminiService.test.ts` — 2 passed
- [x] Full frontend test run during final verification — 464 passed
- [x] `docker compose config` — passed with expected local unset-env warnings
- [x] Fresh pre-PR risk/reliability reviews: no CRITICAL blocker remains

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Notes / follow-up
- AI chat history is persisted as operational data; retention/redaction/encryption policy remains future hardening.
- Legacy `analyzeIncident` still uses the existing browser-side Gemini path and is intentionally out of scope.
- LM Studio tool-call loop is documented as future work; current slice pre-resolves explicit backend intents.
