### PR TITLE
fix(cmdb): restore CI topology visibility

### DIFF
--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -6,8 +6,8 @@ import json
 from config import get_icmp_settings
 from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
 import re
-from neo4j import Driver
 from database import get_db
+from models.core import Node
 _relationship_types = importlib.import_module("services.relationship_types")
 LISTABLE_RELATIONSHIP_TYPES = _relationship_types.LISTABLE_RELATIONSHIP_TYPES
 SUPPORTED_CI_RELATIONSHIP_TYPES = _relationship_types.SUPPORTED_CI_RELATIONSHIP_TYPES
@@ -31,15 +31,15 @@ def get_nodes(allowed_locations: Optional[List[str]] = None, is_admin: bool = Fa
         """
     with driver.session() as session:
         result = session.run(query, **params)
-    return [
-        {
-            "node": r["n"],
-            "category": r["category"],
-            "category_icon_key": r["category_icon_key"],
-            "metrics": r["metrics"],
-        }
-        for r in result
-    ]
+        return [
+            {
+                "node": r["n"],
+                "category": r["category"],
+                "category_icon_key": r["category_icon_key"],
+                "metrics": r["metrics"],
+            }
+            for r in result
+        ]
 
 def upsert_node(node: Node) -> None:
     driver = get_db()
@@ -274,17 +274,17 @@ def get_filtered_graph_data(layer=None, location=None, owner=None, allowed_locat
     if locations: where.append("n.location_name IN $locations"); params["locations"] = locations
     if owners: where.append("n.owner IN $owners"); params["owners"] = owners
     if not is_admin and allowed_locations: where.append("n.location_name IN $allowed_locations"); params["allowed_locations"] = allowed_locations
-    w_str = (" AND " + " AND ".join(where)) if where else ""
+    w_str = ("WHERE " + " AND ".join(where)) if where else ""
     with driver.session() as session:
-        # Build the query: only CIs with valid location coordinates
+        # Build the query: include every scoped CI. Geographic coordinates are optional
+        # and are only reconstructed for frontend map placement when present.
         node_query = f"""
             MATCH (n:CI)
-            WHERE n.location IS NOT NULL AND n.location.latitude IS NOT NULL AND n.location.longitude IS NOT NULL
             {w_str}
             OPTIONAL MATCH (n)-[r:HAS_METRIC]->(m:MetricDef)
             RETURN n, 
-                   n.location.latitude as lat, 
-                   n.location.longitude as lng, 
+                   CASE WHEN n.location IS NULL THEN null ELSE n.location.latitude END as lat,
+                   CASE WHEN n.location IS NULL THEN null ELSE n.location.longitude END as lng,
                    labels(n) as labels,
                    collect({{
                        name: m.id, 

--- a/backend/tests/test_topology_repo_nodes.py
+++ b/backend/tests/test_topology_repo_nodes.py
@@ -1,6 +1,43 @@
 from unittest.mock import MagicMock
 
 
+class _SessionBoundResult:
+    def __init__(self, rows, is_session_open):
+        self._rows = rows
+        self._is_session_open = is_session_open
+
+    def __iter__(self):
+        if not self._is_session_open():
+            raise RuntimeError("Cannot consume Neo4j result after session is closed")
+        return iter(self._rows)
+
+
+class _SessionBoundDriver:
+    def __init__(self, rows):
+        self.session_instance = _SessionBoundSession(rows)
+
+    def session(self):
+        return self.session_instance
+
+
+class _SessionBoundSession:
+    def __init__(self, rows):
+        self._open = False
+        self._rows = rows
+        self.run = MagicMock(side_effect=self._run)
+
+    def __enter__(self):
+        self._open = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._open = False
+        return False
+
+    def _run(self, *args, **kwargs):
+        return _SessionBoundResult(self._rows, lambda: self._open)
+
+
 def _mock_driver():
     driver = MagicMock()
     session = MagicMock()
@@ -49,3 +86,76 @@ def test_get_nodes_returns_category_icon_key_field(monkeypatch):
 
     query = session.run.call_args.args[0]
     assert "c.icon_key as category_icon_key" in query
+
+
+def test_get_nodes_consumes_neo4j_result_before_session_closes(monkeypatch):
+    from repositories import topology_repo
+
+    row = {
+        "n": {"id": "ci-001", "name": "Router-01"},
+        "category": "Router",
+        "category_icon_key": "router",
+        "metrics": [],
+    }
+    driver = _SessionBoundDriver([row])
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    result = topology_repo.get_nodes(allowed_locations=None, is_admin=True)
+
+    assert result == [
+        {
+            "node": {"id": "ci-001", "name": "Router-01"},
+            "category": "Router",
+            "category_icon_key": "router",
+            "metrics": [],
+        }
+    ]
+
+
+def test_get_filtered_graph_data_includes_cis_without_coordinates(monkeypatch):
+    from repositories import topology_repo
+
+    driver, session = _mock_driver()
+    session.run.side_effect = [
+        [
+            {
+                "n": {"id": "ci-no-geo", "name": "Router without geo"},
+                "lat": None,
+                "lng": None,
+                "labels": ["CI"],
+                "metrics": [],
+            }
+        ],
+        [],
+    ]
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    nodes, links = topology_repo.get_filtered_graph_data(is_admin=True)
+
+    node_query = session.run.call_args_list[0].args[0]
+    assert "n.location IS NOT NULL" not in node_query
+    assert "n.location.latitude IS NOT NULL" not in node_query
+    assert nodes == [
+        {
+            "id": "ci-no-geo",
+            "name": "Router without geo",
+            "_labels": ["CI"],
+            "metrics": [],
+        }
+    ]
+    assert links == []
+
+
+def test_get_filtered_graph_data_builds_valid_where_without_coordinate_filter(monkeypatch):
+    from repositories import topology_repo
+
+    driver, session = _mock_driver()
+    session.run.side_effect = [[], []]
+    monkeypatch.setattr(topology_repo, "get_db", lambda: driver)
+
+    topology_repo.get_filtered_graph_data(location="HQ-Madrid", is_admin=True)
+
+    node_query = session.run.call_args_list[0].args[0]
+    assert "WHERE n.location_name IN $locations" in node_query
+    assert "MATCH (n:CI)\n            AND" not in node_query
+    assert session.run.call_args_list[0].kwargs["locations"] == ["HQ-Madrid"]


### PR DESCRIPTION
## Descripción del Cambio
Closes #274

- Corrige el 500 de `GET /api/nodes` materializando el resultado de Neo4j dentro de la sesión activa.
- Hace que `/api/graph/full` incluya CIs sin coordenadas geográficas; las coordenadas quedan como metadata opcional para posicionamiento.
- Agrega regresiones para el ciclo de vida de resultados Neo4j y para la visibilidad de CIs sin coordenadas.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `backend/repositories/topology_repo.py` | Consume `/nodes` rows inside the Neo4j session and includes non-geolocated CIs in graph topology. |
| `backend/tests/test_topology_repo_nodes.py` | Adds regression coverage for session-bound Neo4j results and graph topology CI inclusion. |

## ¿Cómo se probó?
- [x] `cd backend && .venv/bin/python -m pytest tests/test_topology_repo_nodes.py tests/test_node_service.py tests/test_routers_nodes.py -q`
- [x] `cd backend && .venv/bin/python -m pytest tests/test_routers_links.py::TestGraphFull -q`
- [x] `lens_diagnostics mode=all` — no issues in edited files.
- [x] `lsp_diagnostics` — no diagnostics in edited files.
- [x] `git diff --check -- backend/repositories/topology_repo.py backend/tests/test_topology_repo_nodes.py`

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran shellcheck on modified scripts, or no shell scripts were modified.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
