### PR TITLE
feat(ai): add prompts override folder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,17 @@ LM_STUDIO_BASE_URL=http://host.docker.internal:1234/v1
 LM_STUDIO_MODEL=local-model
 LM_STUDIO_TIMEOUT_SECONDS=15
 
+# --- AI PROMPTS (USER-OVERRIDABLE) ---
+# Folder that holds the operator's copy of the AI prompt .md files.
+# On first boot it is seeded from the bundled defaults and then frozen: edit
+# freely, the app never overwrites your files. Leave empty to use the bundled
+# prompts read-only (legacy behavior).
+# Dev:    AI_PROMPTS_DIR=./.ai
+# Docker: container path is /data/ai; set AI_PROMPTS_DIR_HOST to the host folder
+#         mounted at that path (defaults to ./.docker/ai).
+AI_PROMPTS_DIR=
+AI_PROMPTS_DIR_HOST=.docker/ai
+
 # --- CLI CREDENTIALS ---
 # Default credentials for CLI polling (SSH/Telnet to network devices)
 CLI_DEFAULT_USER=

--- a/.gitignore
+++ b/.gitignore
@@ -83,10 +83,12 @@ docker/neo4j/data/
 docker/neo4j/logs/
 docker/postgres/data/
 .docker/backups/
+.docker/ai/
 
 # Directorios de datos genéricos
 data/
 db/
+.ai/
 
 # Archivos de bases de datos locales
 *.db

--- a/backend/ai/README.md
+++ b/backend/ai/README.md
@@ -17,6 +17,26 @@ an LM Studio tool-call loop. That is reserved for a future slice.
 The frontend cannot choose identity files, tool definitions, LM Studio URL, or
 model.
 
+## User overrides (operator-owned prompts)
+
+The files in this folder are the **bundled defaults**: the foundations NEX-GEN
+ships. Operators are expected to reshape them to their own network's needs, so
+at runtime the backend reads from a separate, operator-owned folder instead of
+this read-only tree.
+
+- Set `AI_PROMPTS_DIR` to point at the operator folder.
+  - Leave it empty to keep legacy behavior (read these bundled files in place).
+- On first boot, if the folder is empty, the backend **seeds** it with a full
+  copy of this tree. After that the folder is a **frozen snapshot**: the backend
+  never overwrites or adds files. Edit them freely.
+- For any file missing from the operator folder, the loader falls back to the
+  bundled default here (invisible safety net), so new features that need a new
+  `.md` keep working.
+
+In Docker the container path is `/data/ai`, bind-mounted to
+`${AI_PROMPTS_DIR_HOST:-.docker/ai}` on the host — edit the files on the host
+and restart the container. In local dev, set `AI_PROMPTS_DIR=./.ai` (gitignored).
+
 ## Files
 
 | Path | Purpose |

--- a/backend/config.py
+++ b/backend/config.py
@@ -303,3 +303,30 @@ class LMStudioSettings(BaseModel):
 def get_lm_studio_settings() -> LMStudioSettings:
     """Return fresh LM Studio settings so tests and env changes are respected."""
     return LMStudioSettings.from_env()
+
+
+# ---------------------------------------------------------------------------
+# AI Prompts Settings
+# ---------------------------------------------------------------------------
+
+
+class AIPromptsSettings(BaseModel):
+    """User-overridable AI prompts folder.
+
+    When ``prompts_dir`` is empty the loaders read the bundled defaults
+    in-place (legacy behavior). When set, it points at a runtime data folder
+    that is seeded once from the bundled tree and then treated as a frozen
+    snapshot owned by the operator.
+    """
+
+    prompts_dir: str = ""
+
+    @classmethod
+    def from_env(cls) -> "AIPromptsSettings":
+        """Load the AI prompts folder from the environment."""
+        return cls(prompts_dir=os.getenv("AI_PROMPTS_DIR", "").strip())
+
+
+def get_ai_prompts_settings() -> AIPromptsSettings:
+    """Return fresh AI prompts settings so tests and env changes are respected."""
+    return AIPromptsSettings.from_env()

--- a/backend/main.py
+++ b/backend/main.py
@@ -287,6 +287,14 @@ async def startup_event():
     except Exception as e:
         logger.error(f"Failed to seed roles: {e}")
 
+    # Seed AI Prompts (frozen user-override folder; non-fatal, bundled fallback applies)
+    try:
+        from services.ai_chat_service import ensure_ai_prompts_seeded
+
+        ensure_ai_prompts_seeded()
+    except Exception as e:
+        logger.error(f"Failed to seed AI prompts: {e}")
+
     # Start Background SNMP Collector
     disable_collector = os.getenv("DISABLE_BACKEND_COLLECTOR", "false").lower() in ("true", "1", "yes", "on")
     if not disable_collector:

--- a/backend/services/ai_chat_service.py
+++ b/backend/services/ai_chat_service.py
@@ -4,14 +4,15 @@ import ipaddress
 import json
 import logging
 import re
+import shutil
 import subprocess
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
-from config import LMStudioSettings, get_lm_studio_settings
+from config import LMStudioSettings, get_ai_prompts_settings, get_lm_studio_settings
 from models.ai_chat import AIChatMessage
 from services import event_service
 from models.user import AIPermission, User
@@ -25,15 +26,21 @@ FALLBACK_SYSTEM_PROMPT = (
     "context. Do not invent tool results."
 )
 AI_DIR = Path(__file__).resolve().parents[1] / "ai"
-AI_IDENTITY_DIR = AI_DIR / "identity"
-AI_MARKDOWN_DIR = AI_DIR
-REQUIRED_PROMPT_SOURCE_FILES = ("Soul.md", "scope.md", "context-policy.md")
+# User override root. ``None`` means "feature off" -> loaders read AI_DIR in
+# place (legacy behavior). Tests monkeypatch this directly; production resolves
+# it lazily from AI_PROMPTS_DIR via _user_dir().
+AI_USER_DIR: Optional[Path] = None
+REQUIRED_PROMPT_SOURCE_FILES = (
+    "identity/Soul.md",
+    "identity/scope.md",
+    "identity/context-policy.md",
+)
 OPTIONAL_PROMPT_SOURCE_FILES = (
-    "../tools/README.md",
-    "../tools/availability_check.md",
-    "../tools/event-list.md",
-    "../tools/network-basic.md",
-    "../tools/visualization.md",
+    "tools/README.md",
+    "tools/availability_check.md",
+    "tools/event-list.md",
+    "tools/network-basic.md",
+    "tools/visualization.md",
 )
 MAX_SYSTEM_PROMPT_CHARS = 10_000
 MAX_AI_MARKDOWN_CHARS = 20_000
@@ -56,27 +63,76 @@ class LMStudioTimeoutError(LMStudioError):
     """LM Studio did not answer within the configured timeout."""
 
 
+def _user_dir() -> Optional[Path]:
+    """Resolve the user override root, caching the env lookup in AI_USER_DIR."""
+    global AI_USER_DIR
+    if AI_USER_DIR is None:
+        configured = get_ai_prompts_settings().prompts_dir
+        if configured:
+            AI_USER_DIR = Path(configured)
+    return AI_USER_DIR
+
+
+def _resolve_prompt(rel: str) -> Path:
+    """Return the user override file when present, else the bundled default.
+
+    ``rel`` is relative to the prompts root (e.g. ``identity/Soul.md``).
+    The bundled tree is the invisible fallback so a missing user file never
+    breaks the runtime.
+    """
+    user_root = _user_dir()
+    if user_root is not None:
+        candidate = user_root / rel
+        if candidate.is_file():
+            return candidate
+    return AI_DIR / rel
+
+
+def _has_user_prompt_files(user_dir: Path) -> bool:
+    """Return true once the operator folder contains any prompt markdown file."""
+    return any(path.is_file() and path.suffix == ".md" for path in user_dir.rglob("*"))
+
+
+def ensure_ai_prompts_seeded() -> None:
+    """Seed the user prompts folder once from the bundled defaults (frozen).
+
+    No-op when AI_PROMPTS_DIR is unset. When the folder is empty or missing it
+    is populated with a full copy of the bundled ``ai/`` tree. Once any file is
+    present the folder is treated as a frozen snapshot: we never overwrite or
+    add files, honoring operator ownership.
+    """
+    prompts_dir = get_ai_prompts_settings().prompts_dir
+    if not prompts_dir:
+        return
+    user_dir = Path(prompts_dir)
+    if user_dir.exists() and _has_user_prompt_files(user_dir):
+        return
+    user_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(AI_DIR, user_dir, dirs_exist_ok=True)
+    logger.info("Seeded AI prompts folder at %s from bundled defaults", user_dir)
+
+
 def load_system_prompt() -> str:
     """Compose the bounded runtime system prompt from backend-owned sources."""
     sections: list[str] = []
     try:
-        for filename in REQUIRED_PROMPT_SOURCE_FILES:
-            source = AI_IDENTITY_DIR / filename
+        for rel in REQUIRED_PROMPT_SOURCE_FILES:
+            source = _resolve_prompt(rel)
             text = source.read_text(encoding="utf-8").strip()
             if not text:
                 return FALLBACK_SYSTEM_PROMPT
-            sections.append(f"## {filename}\n{text}")
+            sections.append(f"## {rel}\n{text}")
     except OSError:
         return FALLBACK_SYSTEM_PROMPT
 
-    for filename in OPTIONAL_PROMPT_SOURCE_FILES:
-        source = AI_IDENTITY_DIR / filename
+    for rel in OPTIONAL_PROMPT_SOURCE_FILES:
+        source = _resolve_prompt(rel)
         try:
             text = source.read_text(encoding="utf-8").strip()
         except OSError:
             continue
         if text:
-            sections.append(f"## {filename}\n{text}")
+            sections.append(f"## {rel}\n{text}")
 
     prompt = "\n\n".join(sections)
     if len(prompt) > MAX_SYSTEM_PROMPT_CHARS:
@@ -526,7 +582,7 @@ def load_ai_markdown_contract(section: str, filename: str) -> str:
     if section not in {"policies", "templates"} or "/" in filename or ".." in filename:
         return ""
     try:
-        path = AI_MARKDOWN_DIR / section / filename
+        path = _resolve_prompt(f"{section}/{filename}")
         return path.read_text(encoding="utf-8")[:MAX_AI_MARKDOWN_CHARS]
     except OSError:
         return ""

--- a/backend/tests/test_ai_chat_service.py
+++ b/backend/tests/test_ai_chat_service.py
@@ -173,7 +173,8 @@ def test_payload_system_prompt_uses_backend_identity_sources(tmp_path, monkeypat
     (identity_dir / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
     (identity_dir / "scope.md").write_text("# Scope\n\nRead-only diagnostics.", encoding="utf-8")
     (identity_dir / "context-policy.md").write_text("# Context\n\nUse compact context.", encoding="utf-8")
-    monkeypatch.setattr(ai_chat_service, "AI_IDENTITY_DIR", identity_dir)
+    # User override folder is the parent of identity/; resolver reads identity/<file>.
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", tmp_path)
 
     payload = ai_chat_service.build_lm_studio_payload(
         "What changed?",
@@ -202,7 +203,7 @@ def test_payload_system_prompt_loads_optional_tool_catalog(tmp_path, monkeypatch
     (tools_dir / "README.md").write_text("# AI tool system\n\nBackend-owned tool catalog.", encoding="utf-8")
     (tools_dir / "event-list.md").write_text("# Event list\n\nProvider-neutral event listing.", encoding="utf-8")
     (tools_dir / "network-basic.md").write_text("# Network basic tools\n\n`availability_check` and planned traceroute.", encoding="utf-8")
-    monkeypatch.setattr(ai_chat_service, "AI_IDENTITY_DIR", identity_dir)
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", tmp_path)
 
     payload = ai_chat_service.build_lm_studio_payload(
         "What tools are available?",
@@ -351,12 +352,161 @@ def test_ai_markdown_loader_is_bounded_and_safe(tmp_path, monkeypatch):
     base = tmp_path / "ai"
     (base / "templates").mkdir(parents=True)
     (base / "templates" / "event_list.md").write_text("x" * 25, encoding="utf-8")
-    monkeypatch.setattr(ai_chat_service, "AI_MARKDOWN_DIR", base)
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", base)
     monkeypatch.setattr(ai_chat_service, "MAX_AI_MARKDOWN_CHARS", 10)
 
     assert ai_chat_service.load_ai_markdown_contract("templates", "event_list.md") == "x" * 10
     assert ai_chat_service.load_ai_markdown_contract("templates", "missing.md") == ""
     assert ai_chat_service.load_ai_markdown_contract("../identity", "Soul.md") == ""
+
+
+def test_user_override_wins_over_bundled(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    user_dir = tmp_path / "user"
+    (user_dir / "templates").mkdir(parents=True)
+    (user_dir / "templates" / "event_list.md").write_text("USER-OVERRIDE-MARKER", encoding="utf-8")
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
+
+    assert (
+        ai_chat_service.load_ai_markdown_contract("templates", "event_list.md")
+        == "USER-OVERRIDE-MARKER"
+    )
+
+
+def test_bundled_fallback_when_user_file_missing(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    # User override folder exists but has no templates/event_list.md -> loader
+    # must fall back to the bundled default (real backend/ai tree).
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
+
+    bundled = (ai_chat_service.AI_DIR / "templates" / "event_list.md").read_text(encoding="utf-8")
+    assert ai_chat_service.load_ai_markdown_contract("templates", "event_list.md") == bundled
+
+
+def test_bundled_fallback_when_user_path_is_directory(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    user_dir = tmp_path / "user"
+    (user_dir / "templates" / "event_list.md").mkdir(parents=True)
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
+
+    bundled = (ai_chat_service.AI_DIR / "templates" / "event_list.md").read_text(encoding="utf-8")
+    assert ai_chat_service.load_ai_markdown_contract("templates", "event_list.md") == bundled
+
+
+def test_system_prompt_user_override_wins(tmp_path, monkeypatch):
+    from config import LMStudioSettings
+    from services import ai_chat_service
+
+    user_dir = tmp_path / "user"
+    (user_dir / "identity").mkdir(parents=True)
+    (user_dir / "identity" / "Soul.md").write_text("CUSTOM-SOUL-MARKER", encoding="utf-8")
+    (user_dir / "identity" / "scope.md").write_text("Read-only diagnostics.", encoding="utf-8")
+    (user_dir / "identity" / "context-policy.md").write_text("Use compact context.", encoding="utf-8")
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
+
+    payload = ai_chat_service.build_lm_studio_payload(
+        "What changed?",
+        None,
+        None,
+        LMStudioSettings(enabled=True, model="local-model"),
+    )
+
+    system_prompt = payload["messages"][0]["content"]
+    assert "CUSTOM-SOUL-MARKER" in system_prompt
+
+
+def test_system_prompt_bundled_fallback_when_user_dir_empty(tmp_path, monkeypatch):
+    from config import LMStudioSettings
+    from services import ai_chat_service
+
+    # Empty user override folder -> every file falls back to bundled defaults.
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
+
+    payload = ai_chat_service.build_lm_studio_payload(
+        "What changed?",
+        None,
+        None,
+        LMStudioSettings(enabled=True, model="local-model"),
+    )
+
+    system_prompt = payload["messages"][0]["content"]
+    assert system_prompt != ai_chat_service.FALLBACK_SYSTEM_PROMPT
+    assert "concise technical assistant for CMDB" in system_prompt
+
+
+def test_seed_copies_bundled_tree_into_empty_dir(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    target = tmp_path / "prompts"
+
+    class _Settings:
+        prompts_dir = str(target)
+
+    monkeypatch.setattr(ai_chat_service, "get_ai_prompts_settings", lambda: _Settings())
+    ai_chat_service.ensure_ai_prompts_seeded()
+
+    assert (target / "identity" / "Soul.md").exists()
+    assert (target / "identity" / "scope.md").exists()
+    assert (target / "templates" / "event_list.md").exists()
+    assert (target / "tools" / "README.md").exists()
+
+
+def test_seed_ignores_empty_dirs_and_dotfiles(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    target = tmp_path / "prompts"
+    (target / "identity").mkdir(parents=True)
+    (target / ".keep").write_text("", encoding="utf-8")
+
+    class _Settings:
+        prompts_dir = str(target)
+
+    monkeypatch.setattr(ai_chat_service, "get_ai_prompts_settings", lambda: _Settings())
+    ai_chat_service.ensure_ai_prompts_seeded()
+
+    assert (target / "identity" / "Soul.md").exists()
+    assert (target / "templates" / "event_list.md").exists()
+
+
+def test_seed_never_overwrites_existing_files(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    target = tmp_path / "prompts"
+    (target / "identity").mkdir(parents=True)
+    sentinel = "FROZEN-SENTINEL-DO-NOT-TOUCH"
+    (target / "identity" / "Soul.md").write_text(sentinel, encoding="utf-8")
+
+    class _Settings:
+        prompts_dir = str(target)
+
+    monkeypatch.setattr(ai_chat_service, "get_ai_prompts_settings", lambda: _Settings())
+    ai_chat_service.ensure_ai_prompts_seeded()
+
+    # Frozen snapshot: pre-existing user file is never clobbered.
+    assert (target / "identity" / "Soul.md").read_text(encoding="utf-8") == sentinel
+
+
+def test_seed_noop_when_prompts_dir_unset(tmp_path, monkeypatch):
+    from services import ai_chat_service
+
+    target = tmp_path / "prompts"
+    target.mkdir()
+
+    class _Settings:
+        prompts_dir = ""
+
+    monkeypatch.setattr(ai_chat_service, "get_ai_prompts_settings", lambda: _Settings())
+    ai_chat_service.ensure_ai_prompts_seeded()
+
+    # Feature off -> nothing written.
+    assert not any(target.iterdir())
 
 
 def test_render_event_list_response_uses_facts_and_safe_observed_diagnosis():
@@ -550,10 +700,17 @@ def test_payload_system_prompt_falls_back_when_identity_source_missing(tmp_path,
     from config import LMStudioSettings
     from services import ai_chat_service
 
-    identity_dir = tmp_path / "identity"
-    identity_dir.mkdir()
-    (identity_dir / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
-    monkeypatch.setattr(ai_chat_service, "AI_IDENTITY_DIR", identity_dir)
+    # Point BOTH the user override and the bundled root at dirs that lack the
+    # required scope.md / context-policy.md, so the resolver cannot find them
+    # anywhere and the system prompt degrades to FALLBACK_SYSTEM_PROMPT.
+    user_dir = tmp_path / "user"
+    bundled_dir = tmp_path / "bundled"
+    (user_dir / "identity").mkdir(parents=True)
+    (bundled_dir / "identity").mkdir(parents=True)
+    (user_dir / "identity" / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    (bundled_dir / "identity" / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
+    monkeypatch.setattr(ai_chat_service, "AI_DIR", bundled_dir)
 
     payload = ai_chat_service.build_lm_studio_payload(
         "What changed?",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,10 +85,12 @@ services:
       - LM_STUDIO_MODEL=${LM_STUDIO_MODEL:-local-model}
       - LM_STUDIO_TIMEOUT_SECONDS=${LM_STUDIO_TIMEOUT_SECONDS:-15}
       - LM_STUDIO_MAX_TOKENS=${LM_STUDIO_MAX_TOKENS:-800}
+      - AI_PROMPTS_DIR=/data/ai
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - ${BACKUP_DIR:-.docker/backups}:/backups
+      - ${AI_PROMPTS_DIR_HOST:-.docker/ai}:/data/ai
     healthcheck:
       test:
         [


### PR DESCRIPTION
Closes #285

## Descripción del Cambio
Agrega una carpeta de prompts AI propiedad del operador para poder personalizar identidad, políticas y templates sin editar los defaults versionados en `backend/ai`.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Resumen
- Añade `AI_PROMPTS_DIR` y seed inicial desde `backend/ai` cuando la carpeta configurada está vacía.
- Mantiene snapshot congelado: no sobrescribe archivos `.md` del operador después del seed.
- Usa fallback invisible a bundled defaults cuando falta un archivo user-owned o el override no es un archivo regular.
- Documenta uso local/Docker y monta `/data/ai` vía `AI_PROMPTS_DIR_HOST`.

## Cambios
| File | Change |
|------|--------|
| `.env.example` | Documenta `AI_PROMPTS_DIR` y `AI_PROMPTS_DIR_HOST`. |
| `.gitignore` | Ignora `.ai/` y `.docker/ai/`. |
| `backend/ai/README.md` | Explica el modelo de overrides user-owned/frozen. |
| `backend/config.py` | Agrega settings frescos para `AI_PROMPTS_DIR`. |
| `backend/main.py` | Ejecuta seed no fatal en startup. |
| `backend/services/ai_chat_service.py` | Implementa resolución override→bundled, seed congelado y fallback seguro. |
| `backend/tests/test_ai_chat_service.py` | Agrega cobertura de seed, override, frozen snapshot y fallback. |
| `docker-compose.yml` | Monta prompts en `/data/ai`. |

## ¿Cómo se probó?
- [x] `cd backend && PATH="$PWD/.venv/bin:$PATH" python -m pytest tests/test_ai_chat_service.py -q` — 60 passed.
- [x] `cd backend && PATH="$PWD/.venv/bin:$PATH" python -m py_compile services/ai_chat_service.py config.py main.py tests/test_ai_chat_service.py`.
- [x] `git diff --check`.
- [x] E2E smoke manual: seeded fresh `AI_PROMPTS_DIR`, edited `identity/Soul.md`, confirmed override precedence, confirmed frozen no-overwrite, confirmed missing template fallback to bundled.
- [x] Fresh read-only reviewer found no blockers.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Issue aprobado enlazado.
- [x] Exactly one `type:*` label will be applied: `type:feature`.
- [x] Conventional commit used: `feat(ai): add prompts override folder`.