### PR TITLE
ci(ci): lint lane + Dependabot fix + workflow skeleton (PR1/6)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,11 @@
+# actionlint config for next-gen. See https://github.com/rhysd/actionlint/tree/v1.7.8/docs/config.md
+
+self-hosted-runner:
+  labels: []
+  matrix: {}
+
+config-variables: null
+
+# Files actionlint should NOT treat as workflow definitions.
+exclude:
+  - .github/dependabot.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,65 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates for next-gen.
+#
+# Three ecosystems tracked: github-actions (/), pip (/backend), npm (/frontend).
+# Live PRs are the only authoritative proof of validity (no public schema validator).
+# See openspec/changes/ci-cd-pipeline/spec.md R3 and tasks.md T1.1.
 
 version: 2
+
+# Limit concurrent open PRs across all ecosystems so reviewers are not flooded.
+open-pull-requests-limit: 5
+
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # GitHub Actions versions used by .github/workflows/**
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels: ["dependencies", "ci/cd"]
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
+  # Backend Python dependencies (requirements*.txt)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels: ["dependencies", "backend"]
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Frontend pnpm/npm dependencies (lockfile frozen via Corepack)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels: ["dependencies", "frontend"]
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -114,7 +114,7 @@ jobs:
           mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
           shell_files=()
           for f in "${files[@]}"; do
-            case "$f" in *.sh|entrypoint.sh) shell_files+=("$f") ;; esac
+            case "$f" in *.sh) shell_files+=("$f") ;; esac
           done
           if [ ${#shell_files[@]} -gt 0 ]; then
             shellcheck -x "${shell_files[@]}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,213 @@
+# Workflow: lint (PR1 skeleton + verification harness).
+#
+# PR1 introduces the workflow skeleton + lint verification gate. PR2..PR6 add
+# backend-ci.yml, frontend-ci.yml, build.yml, smoke.yml, cd.yml respectively.
+# This file is intentionally limited to workflow linting and changed-file code
+# linting — no tests, no builds, no deploys.
+#
+# Jobs:
+#   actionlint    — R1 workflow YAML validation
+#   yamllint      — R1 YAML sanity check
+#   shellcheck    — R11 shell script lint on changed files
+#   lint-backend  — R2 Ruff + Black on changed backend files
+#   lint-frontend — R2 ESLint + Prettier on changed frontend files
+#   lint-verify   — T1.7 PR1 verification gate on empty diff (main push only)
+#
+# See openspec/changes/ci-cd-pipeline/design.md D4 for changed-files scoping.
+
+name: lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "backend/**"
+      - "frontend/**"
+      - "scripts/**"
+      - "docs/**"
+      - ".yamllint.yml"
+  push:
+    branches:
+      - main
+      - "cicd/**"
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "backend/**"
+      - "frontend/**"
+      - "scripts/**"
+      - ".yamllint.yml"
+
+# Cancel superseded PR runs; keep push runs to the end.
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # R1: actionlint validates every workflow YAML file.
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: |
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Run actionlint
+        run: ./actionlint -color
+
+  # R1: yamllint sanity check.
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yamllint
+        run: pip install --quiet yamllint==1.38.0
+      - name: Run yamllint
+        run: yamllint -c .yamllint.yml .github/ .yamllint.yml
+
+  # R11: shellcheck on changed shell scripts.
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed shell files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            scripts/**.sh
+            scripts/**/*.sh
+            docker/neo4j/entrypoint.sh
+            monitor_performance.sh
+      - name: Install ShellCheck
+        if: steps.changed.outputs.any_changed == 'true'
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          if [ ${#files[@]} -gt 0 ]; then
+            shellcheck -x "${files[@]}"
+          else
+            echo "No shell files changed — skipping."
+          fi
+
+  # R2: Ruff + Black on changed backend files.
+  lint-backend:
+    name: lint-backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed backend files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            backend/**/*.py
+            backend/ruff.toml
+            backend/pyproject.toml
+      - name: Set up Python
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff and black
+        if: steps.changed.outputs.any_changed == 'true'
+        run: pip install --quiet ruff==0.15.18 black==26.5.1
+      - name: Run Ruff
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          py_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.py) py_files+=("$f") ;; esac
+          done
+          if [ ${#py_files[@]} -gt 0 ]; then
+            ruff check --config ruff.toml "${py_files[@]}"
+          else
+            echo "No .py files in change set — skipping."
+          fi
+      - name: Run Black --check
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          py_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.py) py_files+=("$f") ;; esac
+          done
+          if [ ${#py_files[@]} -gt 0 ]; then
+            black --check --diff "${py_files[@]}"
+          else
+            echo "No .py files in change set — skipping."
+          fi
+
+  # R2: ESLint + Prettier on changed frontend files.
+  lint-frontend:
+    name: lint-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed frontend files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            frontend/**/*.{ts,tsx,js,cjs,json,css,md}
+            frontend/eslint.config.js
+            frontend/.prettierrc.json
+            frontend/.prettierignore
+            frontend/package.json
+      - name: Set up Node
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Enable Corepack
+        if: steps.changed.outputs.any_changed == 'true'
+        run: corepack enable
+      - name: Install dependencies
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: corepack pnpm install --frozen-lockfile
+      - name: Run ESLint
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: pnpm run lint
+      - name: Run Prettier --check
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: pnpm run format:check
+
+  # T1.7: PR1 verification gate — empty-diff must be green on main push.
+  lint-verify:
+    name: lint-verify (PR1 gate)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: actionlint must pass
+        run: ./actionlint -color
+      - name: Install yamllint + ruff + black
+        run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==26.5.1
+      - name: yamllint must pass
+        run: yamllint -c .yamllint.yml .github/
+      - name: ruff must parse config
+        working-directory: backend
+        run: ruff check --config ruff.toml tests/__init__.py
+      - name: black must parse config
+        working-directory: backend
+        run: black --check tests/__init__.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@
 #   shellcheck    — R11 shell script lint on changed files
 #   lint-backend  — R2 Ruff + Black on changed backend files
 #   lint-frontend — R2 ESLint + Prettier on changed frontend files
-#   lint-verify   — T1.7 PR1 verification gate on empty diff (main push only)
+#   lint-verify   — T1.7 PR1 verification gate (runs on push:main AND on PR)
 #
 # See openspec/changes/ci-cd-pipeline/design.md D4 for changed-files scoping.
 
@@ -27,6 +27,12 @@ on:
       - "scripts/**"
       - "docs/**"
       - ".yamllint.yml"
+      - "frontend/eslint.config.js"
+      - "frontend/.prettierrc.json"
+      - "frontend/.prettierignore"
+      - "frontend/package.json"
+      - "backend/ruff.toml"
+      - "backend/pyproject.toml"
   push:
     branches:
       - main
@@ -38,6 +44,12 @@ on:
       - "frontend/**"
       - "scripts/**"
       - ".yamllint.yml"
+      - "frontend/eslint.config.js"
+      - "frontend/.prettierrc.json"
+      - "frontend/.prettierignore"
+      - "frontend/package.json"
+      - "backend/ruff.toml"
+      - "backend/pyproject.toml"
 
 # Cancel superseded PR runs; keep push runs to the end.
 concurrency:
@@ -54,9 +66,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Download actionlint
+      - name: Download actionlint (pinned release)
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          set -euo pipefail
+          VERSION="1.7.8"
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar xzf actionlint.tar.gz
+          chmod +x actionlint
       - name: Run actionlint
         run: ./actionlint -color
 
@@ -66,12 +83,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install yamllint
         run: pip install --quiet yamllint==1.38.0
       - name: Run yamllint
         run: yamllint -c .yamllint.yml .github/ .yamllint.yml
 
-  # R11: shellcheck on changed shell scripts.
+  # R11: shellcheck on changed shell scripts (shellcheck is preinstalled on
+  # ubuntu-24.04 runners; no apt-get install needed).
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
@@ -82,20 +104,20 @@ jobs:
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
-            scripts/**.sh
             scripts/**/*.sh
             docker/neo4j/entrypoint.sh
             monitor_performance.sh
-      - name: Install ShellCheck
-        if: steps.changed.outputs.any_changed == 'true'
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run ShellCheck
         if: steps.changed.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
           mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
-          if [ ${#files[@]} -gt 0 ]; then
-            shellcheck -x "${files[@]}"
+          shell_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.sh|entrypoint.sh) shell_files+=("$f") ;; esac
+          done
+          if [ ${#shell_files[@]} -gt 0 ]; then
+            shellcheck -x "${shell_files[@]}"
           else
             echo "No shell files changed — skipping."
           fi
@@ -153,7 +175,9 @@ jobs:
             echo "No .py files in change set — skipping."
           fi
 
-  # R2: ESLint + Prettier on changed frontend files.
+  # R2: ESLint + Prettier on changed frontend files (changed-only scope per
+  # spec R2 "Legacy untouched files do not block PR1"). DevDeps are installed
+  # in PR3; until then scripts use `pnpm dlx` to fetch eslint/prettier on demand.
   lint-frontend:
     name: lint-frontend
     runs-on: ubuntu-latest
@@ -164,7 +188,7 @@ jobs:
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
-            frontend/**/*.{ts,tsx,js,cjs,json,css,md}
+            frontend/**/*.{ts,tsx,js,jsx,cjs,mjs,css,md}
             frontend/eslint.config.js
             frontend/.prettierrc.json
             frontend/.prettierignore
@@ -181,26 +205,62 @@ jobs:
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: frontend
         run: corepack pnpm install --frozen-lockfile
-      - name: Run ESLint
+      - name: Run ESLint (changed files only)
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: frontend
-        run: pnpm run lint
-      - name: Run Prettier --check
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          lint_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              *.ts|*.tsx|*.js|*.jsx|*.cjs|*.mjs) lint_files+=("$f") ;;
+            esac
+          done
+          if [ ${#lint_files[@]} -gt 0 ]; then
+            pnpm dlx eslint@9.18.0 --max-warnings=0 "${lint_files[@]}"
+          else
+            echo "No JS/TS files in change set — skipping ESLint."
+          fi
+      - name: Run Prettier --check (changed files only)
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: frontend
-        run: pnpm run format:check
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          fmt_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              *.ts|*.tsx|*.js|*.jsx|*.cjs|*.mjs|*.css|*.md|*.json) fmt_files+=("$f") ;;
+            esac
+          done
+          if [ ${#fmt_files[@]} -gt 0 ]; then
+            pnpm dlx prettier@3.4.2 --check "${fmt_files[@]}"
+          else
+            echo "No format-relevant files in change set — skipping Prettier."
+          fi
 
-  # T1.7: PR1 verification gate — empty-diff must be green on main push.
+  # T1.7: PR1 verification gate — runs on push to main AND on PRs that touch
+  # the lint configs so failures surface pre-merge, not just post-merge.
   lint-verify:
     name: lint-verify (PR1 gate)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
-      - name: Download actionlint
-        run: bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Download actionlint (pinned release)
+        run: |
+          set -euo pipefail
+          VERSION="1.7.8"
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar xzf actionlint.tar.gz
+          chmod +x actionlint
       - name: actionlint must pass
         run: ./actionlint -color
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install yamllint + ruff + black
         run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==26.5.1
       - name: yamllint must pass

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect changed shell files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
             scripts/**.sh
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect changed backend files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
             backend/**/*.py
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect changed frontend files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
             frontend/**/*.{ts,tsx,js,cjs,json,css,md}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,26 @@
+# yamllint config for next-gen.
+
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start: disable
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+    require-starting-space: true
+  indentation:
+    spaces: 2
+    indent-sequences: true
+  braces: disable
+  brackets: disable
+
+ignore: |
+  node_modules/
+  frontend/dist/
+  backend/__pycache__/
+  .venv/
+  .worktrees/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,11 @@
+# pyproject.toml for next-gen backend.
+#
+# This file hosts ONLY [tool.black]. There is no [project] table, so uv
+# continues to resolve dependencies from backend/requirements.txt and
+# backend/requirements-dev.txt.
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+skip-string-normalization = false
+skip-magic-trailing-comma = false

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,24 @@
+# Ruff config for next-gen backend. PR1 lint is scoped to changed files only via
+# .github/workflows/lint.yml (tj-actions/changed-files) — legacy untouched files
+# do not block PR1 per openspec/changes/ci-cd-pipeline/spec.md R2.
+
+target-version = "py311"
+line-length = 100
+
+src = ["backend", "tests"]
+
+[lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "SIM"]
+ignore = ["E501"]  # line length is enforced by the formatter, not the linter
+
+[lint.per-file-ignores]
+"tests/**" = ["N802", "N803"]
+
+[lint.isort]
+known-first-party = ["backend"]
+combine-as-imports = true
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"

--- a/docs/ci-cd-runbook.md
+++ b/docs/ci-cd-runbook.md
@@ -1,0 +1,38 @@
+# CI/CD Runbook
+
+> **Status: stub**. The full runbook is authored in PR6 (`cicd/cd-lane`).
+> See `openspec/changes/ci-cd-pipeline/tasks.md` T6.2.
+
+This document is the operator-facing reference for the next-gen CI/CD pipeline.
+It complements the self-hosted runner setup guide (`docs/self-hosted-runner.md`,
+PR6 / T6.1) and the alert contract declared in the CD workflow (PR6 / T6.4).
+
+## Deployment
+
+**TBD — completed in PR6.** PR6 wires `scripts/safe-rebuild.sh` to the
+self-hosted runner job; this section will document the deploy procedure,
+pre-flight checks, and the GitHub Issue alert label `cd-failure`.
+
+## Failure Recovery
+
+**TBD — completed in PR6.** PR6 documents how to recover from a failed CD
+run by replaying the pre-rebuild backup captured at the start of that deploy
+(via `scripts/pre-rebuild-backup.sh`, invoked from `scripts/safe-rebuild.sh`).
+
+## Rollback Policy
+
+**TBD — completed in PR6.** PR6 records the v1 rollback policy:
+
+- No automatic service rollback in v1.
+- Smoke lane (PR5) is the deployment gate; on failure the CD workflow fails and
+  raises a GitHub Issue labeled `cd-failure`.
+- A human restores service state by replaying the pre-rebuild backup.
+- Image-tag rollback and DB restore automation are explicitly deferred to a
+  future change.
+
+## Cross-References
+
+- Proposal: `openspec/changes/ci-cd-pipeline/proposal.md`
+- Spec: `openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md`
+- Design: `openspec/changes/ci-cd-pipeline/design.md`
+- Tasks: `openspec/changes/ci-cd-pipeline/tasks.md`

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+build/
+coverage/
+.vite/
+.next/
+playwright-report/
+test-results/
+*.local
+*.log
+pnpm-lock.yaml

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "jsxSingleQuote": false
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,69 @@
+// ESLint flat config for next-gen frontend (ESLint 9.x).
+//
+// DevDependency installation is finalized in PR3. The lint/format scripts in
+// package.json use `pnpm dlx` to run pinned versions without touching the lockfile.
+// See openspec/changes/ci-cd-pipeline/tasks.md T1.4.
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import prettier from "eslint-config-prettier";
+
+export default [
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "build/**",
+      ".next/**",
+      "coverage/**",
+      "playwright-report/**",
+      "test-results/**",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        // Browser globals common to this React 19 codebase
+        window: "readonly", document: "readonly", console: "readonly",
+        navigator: "readonly", fetch: "readonly", URL: "readonly",
+        URLSearchParams: "readonly", Event: "readonly", CustomEvent: "readonly",
+        HTMLElement: "readonly", HTMLDivElement: "readonly",
+        HTMLInputElement: "readonly", HTMLButtonElement: "readonly",
+        HTMLFormElement: "readonly", File: "readonly", Blob: "readonly",
+        FormData: "readonly", AbortController: "readonly", AbortSignal: "readonly",
+        ResizeObserver: "readonly", IntersectionObserver: "readonly",
+        MutationObserver: "readonly", localStorage: "readonly",
+        sessionStorage: "readonly", location: "readonly", history: "readonly",
+        requestAnimationFrame: "readonly", cancelAnimationFrame: "readonly",
+        getComputedStyle: "readonly", crypto: "readonly",
+        setTimeout: "readonly", clearTimeout: "readonly",
+        setInterval: "readonly", clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      // Permissive defaults for PR1 — tightened in PR3 once legacy files are swept.
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-unused-vars": "off",
+      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+  },
+  prettier,
+];

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,14 +1,10 @@
 // ESLint flat config for next-gen frontend (ESLint 9.x).
 //
-// DevDependency installation is finalized in PR3. The lint/format scripts in
-// package.json use `pnpm dlx` to run pinned versions without touching the lockfile.
-// See openspec/changes/ci-cd-pipeline/tasks.md T1.4.
-
-import js from "@eslint/js";
-import tseslint from "typescript-eslint";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import prettier from "eslint-config-prettier";
+// PR1 ships a permissive built-in-only config so that lint runs without devDep
+// installation. The full TypeScript/React/Hooks/Prettier rule set is added in
+// PR3 when @eslint/js, typescript-eslint, eslint-plugin-react-hooks,
+// eslint-plugin-react-refresh, and eslint-config-prettier are installed as
+// devDependencies. See openspec/changes/ci-cd-pipeline/tasks.md T1.4 and T3.1.
 
 export default [
   {
@@ -22,48 +18,59 @@ export default [
       "test-results/**",
     ],
   },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ["**/*.{js,jsx,ts,tsx,cjs,mjs}"],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: "module",
       globals: {
-        // Browser globals common to this React 19 codebase
-        window: "readonly", document: "readonly", console: "readonly",
-        navigator: "readonly", fetch: "readonly", URL: "readonly",
-        URLSearchParams: "readonly", Event: "readonly", CustomEvent: "readonly",
-        HTMLElement: "readonly", HTMLDivElement: "readonly",
-        HTMLInputElement: "readonly", HTMLButtonElement: "readonly",
-        HTMLFormElement: "readonly", File: "readonly", Blob: "readonly",
-        FormData: "readonly", AbortController: "readonly", AbortSignal: "readonly",
-        ResizeObserver: "readonly", IntersectionObserver: "readonly",
-        MutationObserver: "readonly", localStorage: "readonly",
-        sessionStorage: "readonly", location: "readonly", history: "readonly",
-        requestAnimationFrame: "readonly", cancelAnimationFrame: "readonly",
-        getComputedStyle: "readonly", crypto: "readonly",
-        setTimeout: "readonly", clearTimeout: "readonly",
-        setInterval: "readonly", clearInterval: "readonly",
+        window: "readonly",
+        document: "readonly",
+        console: "readonly",
+        navigator: "readonly",
+        fetch: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
+        Event: "readonly",
+        CustomEvent: "readonly",
+        HTMLElement: "readonly",
+        HTMLDivElement: "readonly",
+        HTMLInputElement: "readonly",
+        HTMLButtonElement: "readonly",
+        HTMLFormElement: "readonly",
+        File: "readonly",
+        Blob: "readonly",
+        FormData: "readonly",
+        AbortController: "readonly",
+        AbortSignal: "readonly",
+        ResizeObserver: "readonly",
+        IntersectionObserver: "readonly",
+        MutationObserver: "readonly",
+        localStorage: "readonly",
+        sessionStorage: "readonly",
+        location: "readonly",
+        history: "readonly",
+        requestAnimationFrame: "readonly",
+        cancelAnimationFrame: "readonly",
+        getComputedStyle: "readonly",
+        crypto: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        process: "readonly",
+        globalThis: "readonly",
       },
     },
-    plugins: {
-      "react-hooks": reactHooks,
-      "react-refresh": reactRefresh,
-    },
     rules: {
-      ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      // Permissive defaults for PR1 — tightened in PR3 once legacy files are swept.
-      "@typescript-eslint/no-empty-object-type": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
-      ],
-      "@typescript-eslint/no-explicit-any": "warn",
-      "no-unused-vars": "off",
-      "no-empty": ["error", { allowEmptyCatch: true }],
+      // Built-in ESLint rules only; permissive defaults for PR1.
+      // TypeScript/React-specific rules are added in PR3 when devDeps land.
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "no-undef": "error",
+      "no-console": "warn",
+      "prefer-const": "warn",
+      eqeqeq: ["error", "always"],
+      "no-var": "error",
     },
   },
-  prettier,
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,11 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0 .",
+    "lint:fix": "pnpm dlx eslint@9.18.0 --fix .",
+    "format": "pnpm dlx prettier@3.4.2 --write .",
+    "format:check": "pnpm dlx prettier@3.4.2 --check ."
   },
   "dependencies": {
     "@google/genai": "1.37.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,10 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0 .",
-    "lint:fix": "pnpm dlx eslint@9.18.0 --fix .",
-    "format": "pnpm dlx prettier@3.4.2 --write .",
-    "format:check": "pnpm dlx prettier@3.4.2 --check ."
+    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0",
+    "lint:fix": "pnpm dlx eslint@9.18.0 --fix",
+    "format": "pnpm dlx prettier@3.4.2 --write",
+    "format:check": "pnpm dlx prettier@3.4.2 --check"
   },
   "dependencies": {
     "@google/genai": "1.37.0",

--- a/openspec/changes/ci-cd-pipeline/design.md
+++ b/openspec/changes/ci-cd-pipeline/design.md
@@ -1,0 +1,72 @@
+# Design: CI/CD Pipeline
+
+## Technical Approach
+
+Add six small GitHub Actions slices around existing project entry points: `backend/Dockerfile`, `frontend/Dockerfile` plus new `frontend/Dockerfile.prod`, `docker-compose.yml`, and unchanged `scripts/safe-rebuild.sh`. Hosted runners cover CI; the CD lane runs only on the production self-hosted runner and calls the same deploy script operators already trust.
+
+## Architecture Decisions
+
+| Area | Choice | Rejected | Rationale |
+|---|---|---|---|
+| D1 topology | One workflow per lane: `lint.yml`, `backend-ci.yml`, `frontend-ci.yml`, `build.yml`, `smoke.yml`, `cd.yml` | per-PR workflows; reusable workflows | Keeps each PR reviewable and avoids reusable indirection before patterns stabilize. |
+| D4 changed lint | `tj-actions/changed-files` feeds Ruff/Black and ESLint/Prettier path lists | full-repo lint | Protects PR1 from legacy churn. Ruff/Black run `check` on changed `.py`; frontend tools run with `--max-warnings 0` on changed TS/TSX. |
+| D8 chain tooling | `git-town` | manual rebase; gh-stack | Manual stacks rot under six PRs. `git-town` fits feature-branch chains and lowers polluted-diff risk. Dev prerequisite: install/configure `git-town`. |
+
+PR6 call graph:
+
+```text
+PR5 smoke.yml: pull_request/push -> compose up -> health waits -> Playwright -> compose down (no -v)
+main fast-forward merge -> cd.yml push:main -> self-hosted runner -> validate-env -> safe-rebuild --dry-run -> safe-rebuild -> issue on failure
+manual: workflow_dispatch(dry_run:boolean) -> same runner -> dry-run only when requested
+```
+
+## File Changes
+
+| Req | PR | Files/components |
+|---|---:|---|
+| Workflow Skeleton | 1 | `.github/workflows/lint.yml`; shared path filters per workflow |
+| Changed-File Lint | 1 | `.github/workflows/lint.yml`, backend lint config, frontend lint/prettier config |
+| Dependabot | 1 | `.github/dependabot.yml`: `github-actions` `/`, `pip` `/backend`, `npm` `/frontend`; weekly; grouped minor/patch; labels `dependencies`, scoped labels; ignore major updates initially |
+| Backend CI | 2 | `.github/workflows/backend-ci.yml`, `backend/pytest.ini` read only |
+| Frontend CI | 3 | `.github/workflows/frontend-ci.yml`, `frontend/package.json` scripts |
+| Build Images | 4 | `.github/workflows/build.yml`, create `frontend/Dockerfile.prod`; read `backend/Dockerfile` |
+| Smoke + Playwright | 5 | `.github/workflows/smoke.yml`, `frontend/playwright.config.ts`, `frontend/test/e2e/*.spec.ts` |
+| CD Lane | 6 | `.github/workflows/cd.yml`; reads `scripts/validate-env.sh`, `scripts/safe-rebuild.sh` unchanged |
+| Rollback v1 | 6 | `docs/ci-cd-runbook.md`, CD failure issue body |
+| Self-hosted Runner Docs | 6 | `docs/self-hosted-runner.md` |
+| Strict TDD | all | workflow validation paired with each slice |
+
+## Interfaces / Contracts
+
+Self-hosted runner labels: `self-hosted`, `linux`, `x64`, `production`, `next-gen`, `cd`. Capabilities: Docker Compose v2, repo checkout, `sh`, `gh`, write access to durable `BACKUP_DIR`, host `.env`, and `scripts/` callable from repo root. OS: patched Linux with systemd runner service. Verification maps one-to-one: label check in workflow, `docker compose version`, `test -f .env`, `sh scripts/validate-env.sh --check-backup-dir`, `test -w "$BACKUP_DIR"`, `gh auth status`. Rotation: remove old runner in GitHub, revoke token, register new short-lived token, restart service; document monthly/offboarding rotation. Hardening: least-privilege runner user in docker group, no untrusted fork CD, locked workdir permissions, log redaction, patch cadence.
+
+Secrets: `GITHUB_TOKEN` creates `cd-failure` issues with `issues: write`; scoped per workflow, rotated by GitHub. `SELF_HOSTED_RUNNER_TOKEN` is never stored in repo; generated during registration and rotated by re-registration. Production `.env` secrets (`NEO4J_PASSWORD`, `POSTGRES_PASSWORD`, `JWT_SECRET_KEY`, optional CLI/AI values) remain host-local; no workflow logs values; rotation updates host `.env` then runs `validate-env.sh`. Dependabot uses no custom secret in v1.
+
+Smoke/Playwright: runner starts existing `docker-compose.yml` services, waits backend 120s and frontend 90s using existing healthchecks/HTTP probes, runs Playwright from `frontend/` as the test runner against published ports, then `docker compose down` without `-v`.
+
+CD job: checkout, assert runner contract, `sh scripts/validate-env.sh --check-backup-dir`, `sh scripts/safe-rebuild.sh --dry-run`, real `sh scripts/safe-rebuild.sh` unless dispatch `dry_run=true`, and on failure create a GitHub Issue labeled `cd-failure`. Use `concurrency: { group: cd-main, cancel-in-progress: false }`.
+
+Branches: `cicd/lint-dep-skeleton` -> `cicd/backend-ci` -> `cicd/frontend-ci` -> `cicd/build-images` -> `cicd/smoke-playwright` -> `cicd/cd-lane`. PR1 targets `main`; PR2..PR6 target the previous branch. After reviews, merge bottom-up into parent branches, then fast-forward the final integrated chain to `main` through the PR1 tracker path.
+
+## Testing Strategy
+
+| PR | Proof |
+|---:|---|
+| 1 | actionlint/yamllint, ShellCheck existing workflow, Dependabot schema evidence, changed-file lint fixture |
+| 2 | `cd backend && python -m pytest` with strict markers and coverage |
+| 3 | `corepack pnpm install --frozen-lockfile`; `corepack pnpm test:coverage` |
+| 4 | backend and frontend prod `docker build` |
+| 5 | compose smoke plus 1-2 Playwright tests: frontend HTML and backend HTTP 200 |
+| 6 | runner contract checks plus `safe-rebuild.sh --dry-run`; issue alert dry-run/manual evidence |
+
+## Migration / Rollout
+
+No data migration. Roll out through the six chained PRs; CD auto-deploys only after the integrated chain lands on `main`.
+
+## Risks and Mitigations
+
+R1 missing `docker/postgres/data`: smoke must create host dirs or use safe compose defaults. R2 Dependabot disabled: PR1 fixes. R3 Neo4j/APOC mismatch: backend CI should mock APOC unless required. R4 frontend Dockerfile dev-only: PR4 adds prod file. R5 Corepack unavailable: setup-node/corepack enable. R6 linter churn: changed-file scope. R7 endpoint secrets: keep host-local, redact logs. R8 Docker required: CD self-hosted only. R9 400-line budget: six slices. R10 active OpenSpec conflicts: touch only this change. New: runner offline, stack rebase pain, secret leakage, deploy killed mid-flight; mitigate with docs, `git-town`, masked logs, and `cancel-in-progress:false`.
+
+## Open Questions
+
+None.

--- a/openspec/changes/ci-cd-pipeline/proposal.md
+++ b/openspec/changes/ci-cd-pipeline/proposal.md
@@ -1,0 +1,91 @@
+# Proposal: CI/CD Pipeline
+
+## Intent
+
+next-gen has no automated CI/CD beyond ShellCheck. Deploys are manual `scripts/safe-rebuild.sh` runs on the endpoint, Dependabot is disabled by invalid config, and each release depends on operator discipline. Desired outcome: PRs are auto-tested and auto-built; every merge to `main` auto-deploys through the same trusted `safe-rebuild.sh` on a production self-hosted runner.
+
+## Scope
+
+### In Scope
+- Six chained PRs: lint, backend CI, frontend CI, build, smoke/Playwright, CD.
+- Add frontend production Dockerfile; fix Dependabot; document self-hosted runner setup.
+- Strict TDD/test-first for every lane that introduces logic.
+
+### Out of Scope
+- DB schema migration automation beyond existing `safe-rebuild.sh` behavior.
+- Secret manager introduction; use GitHub Secrets plus ephemeral `.env`/host-local `.env`.
+- Non-endpoint targets, broad E2E, multi-cloud, blue/green, canary.
+
+## Capabilities
+
+### New Capabilities
+- `ci-cd-pipeline`: GitHub Actions lanes, smoke validation, and endpoint CD contract.
+
+### Modified Capabilities
+- None.
+
+## Business Rules and Constraints
+
+- 400 changed-line review budget per PR; force-chained delivery.
+- Frozen pnpm lockfile via Corepack; hosted CI may run on `ubuntu-latest`.
+- No auto-merge without required tests; CD auto-runs on `main` merge.
+- CD uses a self-hosted runner on the endpoint, with Docker and `BACKUP_DIR` local.
+- Deployment concurrency lock prevents parallel deploys; never use `docker compose down -v`.
+- **Rollback policy (v1):** no auto-rollback. The smoke lane (PR5) is the deployment gate; on failure the CD workflow fails, an alert is raised, and a human restores from the pre-rebuild backup (existing `safe-rebuild.sh` behavior). Image-tag rollback and DB restore are explicitly deferred to a future change.
+- PR1 boundary: lint + Dependabot fix + workflow skeleton only (~250 lines).
+
+## Chained PR Plan
+
+| PR | Scope | Est. | Verification gate |
+|---|---|---:|---|
+| PR1 — Lint + Dependabot fix + workflow skeleton | Changed-file lint config; workflow skeleton; `.github/dependabot.yml` fix | ~250 | ShellCheck + config validation |
+| PR2 — Backend CI | Ruff/Black/Pytest on PR; scheduled nightly with Neo4j + Postgres services | ~300 | `python -m pytest` + strict markers |
+| PR3 — Frontend CI | ESLint/Prettier + Vitest on PR; pnpm via Corepack | ~200 | `corepack pnpm test:run` |
+| PR4 — Build lane + prod Dockerfile for frontend | Multi-stage frontend prod Dockerfile; backend image build smoke | ~350 | `docker build` succeeds |
+| PR5 — Smoke lane + Playwright | Compose stack; 2 smoke tests: frontend HTML + backend endpoint | ~350 | Playwright smoke suite |
+| PR6 — CD lane | Self-hosted runner job calls `safe-rebuild.sh` on `main`; concurrency; `workflow_dispatch` dry-run | ~300 | dry-run + deploy job logs |
+
+## Approach
+
+Use GitHub Actions. Reuse `scripts/safe-rebuild.sh` unchanged for CD; introduce lanes incrementally so each slice is reviewable and reversible.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|---|---|---|
+| `.github/workflows/` | New | CI, smoke, and CD workflows |
+| `.github/dependabot.yml` | Modified | Enable GitHub Actions, backend pip, frontend pnpm/npm updates |
+| `frontend/Dockerfile.prod` | New | Production frontend image |
+| `docs/` | Modified | Self-hosted runner and release behavior docs |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Runner offline/misconfigured | Med | Document setup; dry-run dispatch |
+| Main failure after deploy | Med | No auto-rollback in v1; smoke lane is the gate; human restores from `safe-rebuild.sh` pre-rebuild backup. Image-tag rollback deferred to a future change. |
+| Legacy lint churn | Med | Scope PR1 lint to changed files |
+
+## Rollback Plan
+
+**Workflow rollback (this change):** disable or revert the affected workflow PR. For CD issues, disable the CD workflow/concurrency group and run the existing manual `safe-rebuild.sh` path from the endpoint.
+
+**Service rollback (this change):** none automatic. If smoke fails after a `main` deploy, the CD job fails and an alert is raised; a human restores state by replaying the pre-rebuild backup captured at the start of that deploy (existing `safe-rebuild.sh` + `pre-rebuild-backup.sh` flow).
+
+**Service rollback (future change, explicitly out of scope here):** image-tag pinning plus smoke-gated image swap, with DB schema left untouched.
+
+## Dependencies
+
+- GitHub Actions, GitHub Secrets, endpoint self-hosted runner with Docker and local `BACKUP_DIR`.
+
+## Success Criteria
+
+- [ ] PR checks cover lint, backend, frontend, build, and smoke lanes.
+- [ ] Merge to `main` triggers one serialized deploy through `safe-rebuild.sh`.
+- [ ] Dependabot opens valid dependency PRs.
+
+## Open Edge Cases / Decision Gaps for Spec
+
+- Rollback policy: **resolved for v1 (no auto-rollback, smoke gate + human recovery).** Spec must encode the alert + recovery runbook references.
+- Confirm smoke endpoint names and acceptable startup timeouts.
+- Confirm self-hosted runner hardening/rotation ownership.

--- a/openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md
+++ b/openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md
@@ -1,0 +1,175 @@
+# CI/CD Pipeline Specification
+
+## Purpose
+
+Define the GitHub Actions CI/CD capability for linting, dependency updates, backend/frontend validation, image builds, smoke gating, and production deployment through the existing endpoint `safe-rebuild.sh` path.
+
+## Requirements
+
+### Requirement: Workflow Skeleton
+
+The repository MUST provide a workflow skeleton that future lanes can plug into without duplicating trigger and path-selection policy.
+
+#### Scenario: Skeleton routes changed paths
+- GIVEN a pull request changes backend files
+- WHEN the workflow skeleton evaluates the change set
+- THEN backend-scoped jobs are eligible to run
+
+#### Scenario: Unrelated paths stay quiet
+- GIVEN a pull request changes only documentation
+- WHEN path filtering is evaluated
+- THEN backend and frontend test lanes are skipped or marked not required by design
+
+### Requirement: Changed-File Lint Configuration
+
+Lint checks MUST apply Ruff and Black to changed backend files and ESLint and Prettier to changed frontend files only.
+
+#### Scenario: Changed source is linted
+- GIVEN a pull request changes Python and TypeScript source files
+- WHEN lint jobs run
+- THEN only changed files in matching stacks are checked
+
+#### Scenario: Legacy untouched files do not block PR1
+- GIVEN existing untouched files have formatting issues
+- WHEN changed-file lint runs
+- THEN the job MUST NOT fail because of untouched files
+
+### Requirement: Dependabot Configuration
+
+The repository MUST include a valid `.github/dependabot.yml` for pip, frontend package management, and GitHub Actions updates.
+
+#### Scenario: Dependabot opens dependency PRs
+- GIVEN Dependabot scans configured ecosystems
+- WHEN updates are available
+- THEN it opens real pull requests for each configured ecosystem
+
+#### Scenario: Invalid ecosystem is rejected before merge
+- GIVEN the configuration uses an unsupported package ecosystem
+- WHEN validation runs
+- THEN the PR fails with actionable configuration evidence
+
+### Requirement: Backend CI Lane
+
+Pull requests touching `backend/**` MUST run pytest with strict markers and produce a coverage report.
+
+#### Scenario: Backend PR runs tests
+- GIVEN a pull request changes backend code
+- WHEN backend CI runs
+- THEN `python -m pytest` executes with strict marker configuration and coverage output
+
+#### Scenario: Unknown marker fails CI
+- GIVEN a backend test uses an undeclared marker
+- WHEN pytest runs
+- THEN backend CI fails instead of silently ignoring marker drift
+
+### Requirement: Frontend CI Lane
+
+Pull requests touching `frontend/**` MUST install via Corepack pnpm with a frozen lockfile, run Vitest, and produce coverage.
+
+#### Scenario: Frontend PR runs tests
+- GIVEN a pull request changes frontend code
+- WHEN frontend CI runs
+- THEN dependencies install with frozen lockfile and Vitest coverage is produced
+
+#### Scenario: Lockfile drift blocks CI
+- GIVEN package metadata and lockfile are inconsistent
+- WHEN pnpm install runs
+- THEN frontend CI fails before tests execute
+
+### Requirement: Build Lane and Production Images
+
+The system MUST build a runnable production frontend image from `frontend/Dockerfile.prod` and build the backend image cleanly.
+
+#### Scenario: Images build successfully
+- GIVEN build inputs are valid
+- WHEN the build lane runs
+- THEN frontend production and backend images build without errors
+
+#### Scenario: Broken Dockerfile blocks merge
+- GIVEN a Dockerfile cannot produce a runnable image
+- WHEN the build lane runs
+- THEN the workflow fails before smoke or deployment lanes proceed
+
+### Requirement: Smoke Lane and Playwright Gate
+
+The smoke lane MUST start the compose stack, wait for backend and frontend health, run two Playwright smoke tests, and tear the stack down.
+
+#### Scenario: Smoke validates serving paths
+- GIVEN the compose stack is healthy
+- WHEN Playwright smoke tests run
+- THEN the frontend serves HTML and one backend endpoint returns HTTP 200
+
+#### Scenario: Unhealthy stack blocks deployment
+- GIVEN backend or frontend health does not become ready
+- WHEN the smoke timeout expires
+- THEN the smoke lane fails and tears down the stack without volume deletion
+
+### Requirement: CD Lane
+
+On push to `main`, CD MUST run on the production self-hosted runner, serialize deployments, pre-flight `safe-rebuild.sh`, run the real deploy, expose manual dry-runs, and alert on failure.
+
+#### Scenario: Main merge deploys once
+- GIVEN code is merged to `main`
+- WHEN CD starts on the self-hosted runner
+- THEN it performs a dry-run/pre-flight, runs `scripts/safe-rebuild.sh`, and holds the deployment concurrency lock
+
+#### Scenario: Deployment failure alerts humans
+- GIVEN `safe-rebuild.sh` fails
+- WHEN CD records the failure
+- THEN the workflow fails and emits the configured alert for human recovery
+
+### Requirement: Rollback Policy v1
+
+The system MUST NOT perform automatic service rollback in v1; smoke failure or deploy failure MUST fail the workflow, alert humans, and point to recovery documentation.
+
+#### Scenario: Smoke failure prevents deploy
+- GIVEN smoke validation fails before deployment
+- WHEN the pipeline evaluates deploy eligibility
+- THEN deployment is blocked and an alert/runbook pointer is available
+
+#### Scenario: Post-deploy recovery is manual
+- GIVEN a deployed service needs recovery
+- WHEN operators follow v1 policy
+- THEN they restore from the pre-rebuild backup documented by the runbook
+
+### Requirement: Self-Hosted Runner Documentation
+
+The repository MUST document endpoint runner prerequisites, install steps, labels, registration token rotation, and hardening checklist.
+
+#### Scenario: Operator can register runner
+- GIVEN a new endpoint runner is needed
+- WHEN an operator follows the runner setup guide
+- THEN required labels, secrets, Docker access, and local paths are configured
+
+#### Scenario: Token rotation is documented
+- GIVEN a registration token is expired or exposed
+- WHEN an operator follows the guide
+- THEN token rotation steps are clear and auditable
+
+### Requirement: Strict TDD Commitment
+
+Every workflow or script introduced by this change MUST have an automated test or verifiable check paired in the tasks phase.
+
+#### Scenario: New workflow has verification
+- GIVEN a task introduces workflow behavior
+- WHEN `sdd-tasks-minimax` plans implementation
+- THEN it includes ShellCheck, config validation, pytest, Vitest, build, or smoke evidence as applicable
+
+#### Scenario: Manual evidence requires justification
+- GIVEN automation is not reasonable for a check
+- WHEN tasks are written
+- THEN the task documents why manual evidence is acceptable under strict TDD policy
+
+## Open Questions
+
+None.
+
+## Resolved Decisions
+
+| Decision | Resolution | Source |
+|---|---|---|
+| Alert channel on CD failure | GitHub Issue with label `cd-failure`, opened automatically by the workflow | User confirmation (spec round) |
+| Deployment concurrency group | `cd-main` (CD only fires on `main`, so a single group suffices and serializes correctly) | Default + project convention |
+| Smoke startup timeouts | Backend health wait: 120s. Frontend health wait: 90s. Both configurable via workflow `env:` block | Default reasonable for compose cold start on the endpoint |
+| Chain strategy | `feature-branch-chain` — PR1 targets `main`; PR2..PR6 each target the previous PR's branch. Only the PR1-tracker chain's last merge lands on `main` via fast-forward. | User confirmation (spec round) |
+| Rollback policy v1 | No auto-rollback. Smoke gate + GitHub Issue alert + human restores from `safe-rebuild.sh` pre-rebuild backup | Proposal (locked) |

--- a/openspec/changes/ci-cd-pipeline/tasks.md
+++ b/openspec/changes/ci-cd-pipeline/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: CI/CD Pipeline
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~1750 across 6 PR slices (250 / 300 / 200 / 350 / 350 / 300) |
+| 400-line budget risk | Low (per slice, enforced by chain) — overall High without chain |
+| Chained PRs recommended | Yes (locked) |
+| Delivery strategy | force-chained via `feature-branch-chain` (git-town) |
+| Chain strategy | feature-branch-chain |
+| Decision needed before apply | No (delivery strategy + chain already cached) |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: Low (per slice; overall High without chain)
+
+### Suggested Work Units (chain order)
+
+| # | Goal | Branch base | Merge into | Notes |
+|---|------|-------------|------------|-------|
+| PR1 | Lint + Dependabot fix + workflow skeleton | `main` | `main` | First slice lands on main; gates later lanes. |
+| PR2 | Backend CI (pytest strict-markers + coverage) | `cicd/lint-dep-skeleton` | `cicd/lint-dep-skeleton` | Reuses workflow skeleton path filters. |
+| PR3 | Frontend CI (Corepack pnpm + Vitest + ESLint/Prettier) | `cicd/backend-ci` | `cicd/backend-ci` | Wires ESLint/Prettier from PR1 into gate. |
+| PR4 | Build lane + `frontend/Dockerfile.prod` | `cicd/frontend-ci` | `cicd/frontend-ci` | Multi-stage prod image, compose profile, image smoke. |
+| PR5 | Smoke lane + Playwright (health waits, no `-v`) | `cicd/build-images` | `cicd/build-images` | Stack up, 2 smoke specs, compose down. |
+| PR6 | CD lane (self-hosted, `cd-main`, issue alert) | `cicd/smoke-playwright` | `cicd/smoke-playwright` | Last slice; fast-forwards chain to main. |
+
+Strict-TDD policy (`openspec/config.yaml` `sdd.strict_tdd`): every workflow or script task MUST cite an automated test/validator OR a documented manual-evidence justification.
+
+---
+
+## PR1 — Lint + Dependabot + Workflow Skeleton (~250 LOC)
+**Branch**: `cicd/lint-dep-skeleton` off `main`. **Targets**: `main`. **Next base**: PR2 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence | Status |
+|---|---|---|---|---|---|---|---|---|
+| T1.1 | Fix `.github/dependabot.yml` — 3 ecosystems, groups, labels | `.github/dependabot.yml` | R3 | 40 | — | Schema check via dependabot.com/config-validator + T1.7 dry-run | Manual evidence: no public CI-side Dependabot validator; live PRs are the only authoritative proof per R3 scenario. | [x] |
+| T1.2 | Add `actionlint` + `yamllint` config + validation step | `.actionlint.yaml`, `.yamllint.yml` | R1, R11 | 30 | — | `actionlint -color` clean, `yamllint .github/workflows/` | Actionlint is itself a static checker (RED→GREEN on its own install). | [x] |
+| T1.3 | Backend lint config (Ruff + Black, `py311`) | `backend/ruff.toml`, `backend/pyproject.toml` | R2, R11 | 40 | — | `cd backend && ruff check backend tests`, `cd backend && black --check backend tests` | Ruff/Black dry-run on empty diff proves config validity (R2 legacy scenario). | [x] |
+| T1.4 | Frontend lint config (ESLint flat + Prettier) | `frontend/eslint.config.js`, `frontend/.prettierrc.json` | R2, R11 | 40 | — | `cd frontend && corepack pnpm eslint --max-warnings 0`, `cd frontend && corepack pnpm prettier --check` | Prettier `--check` + ESLint `--max-warnings 0` on empty diff (R2 legacy scenario). | [x] |
+| T1.5 | Create `.github/workflows/lint.yml` skeleton | `.github/workflows/lint.yml` | R1, R2 | 80 | T1.3, T1.4 | `actionlint .github/workflows/lint.yml` clean; empty-diff run green | T1.7 verification job is the test harness for this task. | [x] |
+| T1.6 | `docs/ci-cd-runbook.md` stub (header + ToC) | `docs/ci-cd-runbook.md` | R9, R10 | 20 | — | File exists with agreed header + ToC pointing to PR6 sections | Manual evidence: stub only; full content authored in PR6 T6.2. | [x] |
+| T1.7 | PR1 verification gate (actionlint + yamllint + ShellCheck + lint-on-empty-diff) | `.github/workflows/lint.yml` (adds `lint-verify` job) | R11 | 0 | T1.2, T1.5 | All four checks exit 0 on empty PR | This task IS the verification harness for PR1. | [x] |
+
+**PR1 total**: 250 LOC. **Chain downstream**: PR2 branches off `cicd/lint-dep-skeleton`.
+
+---
+
+## PR2 — Backend CI (~300 LOC)
+**Branch**: `cicd/backend-ci` off `cicd/lint-dep-skeleton`. **Targets**: `cicd/lint-dep-skeleton`. **Next base**: PR3 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T2.1 | `.github/workflows/backend-ci.yml` PR lane (Python 3.11, pip, pytest strict) | `.github/workflows/backend-ci.yml` | R4 | 110 | T1.5 | `python -m pytest --strict-markers --strict-config --cov` on backend-touched PR | Workflow itself enforces strict markers — unknown marker fails R4 scenario. |
+| T2.2 | Nightly schedule lane with Postgres + Neo4j services (service containers) | `.github/workflows/backend-ci.yml` (adds nightly job) | R4 | 140 | T2.1 | Nightly run with `services: postgres, neo4j` healthy; `pytest -m integration` passes | Service container health + integration marker run (R4 backend PR scenario extended). |
+| T2.3 | Coverage upload (Codecov OR artifact fallback) | `.github/workflows/backend-ci.yml`, `backend/.codecov.yml` if used | R4 | 30 | T2.1 | Coverage report uploaded; PR comment shows delta | Codecov upload is itself the verification action. |
+| T2.4 | PR2 verification gate — backend-touched PR green | (workflow-only) | R4, R11 | 20 | T2.1–T2.3 | Open scratch PR touching `backend/`; workflow green | CI run logs are the evidence under strict TDD. |
+
+**PR2 total**: 300 LOC. **Chain downstream**: PR3 branches off `cicd/backend-ci`.
+
+---
+
+## PR3 — Frontend CI (~200 LOC)
+**Branch**: `cicd/frontend-ci` off `cicd/backend-ci`. **Targets**: `cicd/backend-ci`. **Next base**: PR4 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T3.1 | `.github/workflows/frontend-ci.yml` (setup-node v4 + Corepack + frozen lockfile + Vitest) | `.github/workflows/frontend-ci.yml` | R5 | 100 | T1.5 | `corepack pnpm install --frozen-lockfile` + `corepack pnpm test:run` green on frontend-touched PR | Lockfile drift fails install before tests (R5 lockfile scenario). |
+| T3.2 | Wire ESLint + Prettier step on changed frontend files | `.github/workflows/frontend-ci.yml` | R2, R5 | 40 | T1.4 | `--max-warnings 0` ESLint + Prettier `--check` on changed TS/TSX exit 0 | Changed-file linter is the test for R2 + R5 wiring. |
+| T3.3 | PR3 verification gate — frontend-touched PR green | (workflow-only) | R5, R11 | 60 | T3.1, T3.2 | Scratch PR touching `frontend/`; workflow green with coverage | CI run logs are the evidence under strict TDD. |
+
+**PR3 total**: 200 LOC. **Chain downstream**: PR4 branches off `cicd/frontend-ci`.
+
+---
+
+## PR4 — Build + Frontend Prod Dockerfile (~350 LOC)
+**Branch**: `cicd/build-images` off `cicd/frontend-ci`. **Targets**: `cicd/frontend-ci`. **Next base**: PR5 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T4.1 | Multi-stage `frontend/Dockerfile.prod` (pnpm builder + nginx/static runner) | `frontend/Dockerfile.prod`, `frontend/.dockerignore` | R6 | 80 | — | `docker build -f frontend/Dockerfile.prod frontend/` succeeds; image runs and serves dist on expected port | T4.3 build workflow is the harness; build itself is the test. |
+| T4.2 | `docker-compose.yml` `frontend-prod` profile (no breaking change to dev stack) | `docker-compose.yml` | R6 | 50 | T4.1 | `docker compose --profile prod config --quiet` valid; existing dev profile unchanged | `compose config` validation is the harness; non-breaking assertion via diff review. |
+| T4.3 | `.github/workflows/build.yml` (build backend + frontend:prod, smoke-run each) | `.github/workflows/build.yml` | R6 | 180 | T4.1, T4.2 | `docker build` backend + frontend:prod succeed on `ubuntu-latest`; smoke-run exits 0 | Build job is the test for R6 images-build scenario. |
+| T4.4 | PR4 verification gate — both images build clean on hosted runner | `.github/workflows/build.yml` (adds `build-verify` summary) | R6, R11 | 40 | T4.3 | Run logs show both images green; broken Dockerfile blocks merge (R6 broken scenario) | Build failure on broken Dockerfile is the test for R6 broken-Dockerfile scenario. |
+
+**PR4 total**: 350 LOC. **Chain downstream**: PR5 branches off `cicd/build-images`.
+
+---
+
+## PR5 — Smoke + Playwright (~350 LOC)
+**Branch**: `cicd/smoke-playwright` off `cicd/build-images`. **Targets**: `cicd/build-images`. **Next base**: PR6 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T5.1 | Add `@playwright/test` devDep + `corepack pnpm install` | `frontend/package.json`, `frontend/pnpm-lock.yaml` | R7 | 30 | T3.1 | Lockfile updated; `corepack pnpm install --frozen-lockfile` clean | Lockfile diff review + reinstall is the test. |
+| T5.2 | `frontend/playwright.config.ts` (compose webServer, timeouts 120s/90s) | `frontend/playwright.config.ts` | R7 | 80 | T5.1 | `corepack pnpm playwright test --list` enumerates specs; local config loads | Config dry-run + spec enumeration is the test harness. |
+| T5.3 | 2 Playwright smoke specs (frontend HTML + backend HTTP 200) | `frontend/test/e2e/frontend-html.spec.ts`, `frontend/test/e2e/backend-health.spec.ts` | R7 | 80 | T5.2 | `corepack pnpm playwright test` against compose stack green | The specs themselves are the R7 smoke-validates-serving-paths test. |
+| T5.4 | `.github/workflows/smoke.yml` (compose up, health waits 120s/90s, Playwright, compose down no `-v`) | `.github/workflows/smoke.yml` | R7 | 120 | T5.3 | Workflow green on PR touching compose/services; unhealthy stack tears down without `-v` | T5.3 specs + T5.5 dir-creation are the tests for R7 unhealthy-stack scenario. |
+| T5.5 | Document `docker/postgres/data` host dir creation (R1 mitigation) | `docker/README.md` or compose comment | R6, R7 | 10 | — | First-run `compose up` creates dir; doc snippet present | Manual evidence: compose default-bind-creates behavior; doc snippet is the artifact. |
+| T5.6 | PR5 verification gate — smoke workflow green on PR | `.github/workflows/smoke.yml` | R7, R11 | 30 | T5.4 | Open scratch PR touching compose/services; workflow green | CI run logs are the evidence under strict TDD. |
+
+**PR5 total**: 350 LOC. **Chain downstream**: PR6 branches off `cicd/smoke-playwright`.
+
+---
+
+## PR6 — CD Lane (~300 LOC)
+**Branch**: `cicd/cd-lane` off `cicd/smoke-playwright`. **Targets**: `cicd/smoke-playwright`. **Final**: fast-forward chain to `main`.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T6.1 | `docs/self-hosted-runner.md` (install, registration, labels, rotation, hardening, troubleshooting) | `docs/self-hosted-runner.md` | R10 | 120 | — | Doc present with sections for labels `self-hosted,linux,x64,production,next-gen,cd`; rotation steps; hardening checklist | Manual evidence: operator walkthrough documented per R10 scenarios; no CI-runnable substitute. |
+| T6.2 | `docs/ci-cd-runbook.md` full content (deploy procedure, recovery via `safe-rebuild.sh` pre-rebuild backup, alert ack) | `docs/ci-cd-runbook.md` | R9, R10 | 80 | T1.6 | Doc references `scripts/safe-rebuild.sh` + `pre-rebuild-backup.sh`; alert section points to GitHub Issue label `cd-failure` | Manual evidence: runbook is human-facing artifact per R9 post-deploy-recovery scenario. |
+| T6.3 | `.github/workflows/cd.yml` shell (push main, `workflow_dispatch(dry_run:boolean)`, concurrency `cd-main` cancel-in-progress false, self-hosted runs-on) | `.github/workflows/cd.yml` | R8 | 80 | T1.5, T5.6 | `actionlint` clean; `concurrency.group == "cd-main"`; runs-on labels match T6.1 doc | `actionlint` is the test; CD YAML is the R8 main-merge-deploys-once harness. |
+| T6.4 | Wire CD steps (checkout, assert runner contract, `validate-env.sh`, `safe-rebuild.sh --dry-run`, real `safe-rebuild.sh`, on failure create GitHub Issue labeled `cd-failure`) | `.github/workflows/cd.yml`, `scripts/assert-runner-contract.sh` (new, ~30 LOC) | R8, R9 | 40 | T6.3 | `scripts/test-cd-contract.sh` (T6.5) green; dispatch `dry_run=true` record created | T6.5 contract test is the harness for R8 deployment-failure-alerts scenario. |
+| T6.5 | `scripts/test-cd-contract.sh` — asserts CD YAML parses, actionlint clean, runner-contract script validates labels and Docker/Compose presence | `scripts/test-cd-contract.sh` | R8, R11 | 50 | T6.4 | `sh scripts/test-cd-contract.sh` exits 0 in CI | This task IS the test for T6.4 under strict TDD. |
+| T6.6 | PR6 verification gate — `actionlint` clean; `workflow_dispatch` dry-run record; manual deploy drill documented | `.github/workflows/cd.yml` | R8, R9, R11 | 30 | T6.5 | Dry-run dispatch creates dry-run record; runbook reachable from issue body | Manual evidence per R11 manual-evidence-requires-justification: real deploy to production endpoint cannot be automated in PR CI; dry-run + manual drill is the documented substitute. |
+
+**PR6 total**: ~400 LOC at upper bound. If actual diff trends >400, split T6.1 (runner doc) into its own `docs/runner` PR immediately before PR6 lands. **Chain end**: after PR6 merges into `cicd/smoke-playwright`, fast-forward the integrated chain into `main` per `feature-branch-chain`.
+
+---
+
+## Review Workload Forecast (consolidated)
+
+| PR | Tasks | Est LOC | Risk vs 400 | Cumulative LOC |
+|---|---|---:|---|---:|
+| PR1 | 7 | 250 | Low | 250 |
+| PR2 | 4 | 300 | Low | 550 |
+| PR3 | 3 | 200 | Low | 750 |
+| PR4 | 4 | 350 | Low | 1100 |
+| PR5 | 6 | 350 | Low | 1450 |
+| PR6 | 6 | ~400 | Medium (watch T6.1+T6.5 split) | ~1850 |
+
+- Total tasks: **30**.
+- Total project impact: ~30 new/modified files, ~1850 LOC, 6 new workflow files, 2 new docs, 1 new Dockerfile, 1 new compose profile, 1 new shell contract test.
+- 400-line flag: PR6 is the only slice at the upper edge — the contingency split above keeps the chain safe.
+- Strict TDD: every task cites an automated validator OR a `manual evidence` justification per `openspec/config.yaml` `sdd.strict_tdd` policy.
+- Chain integrity: each PR's `Branch base`/`Targets` enforce `feature-branch-chain` so child diffs stay focused; if GitHub shows previous slice content in a child diff, rebase/retarget before review.


### PR DESCRIPTION
## Summary

PR1 of 6 in the `ci-cd-pipeline` change. Introduces the CI workflow skeleton and the changed-file lint gate, fixes the broken Dependabot config, and stubs the CD runbook.

Closes the first slice of the chained PR plan in `openspec/changes/ci-cd-pipeline/tasks.md` (PR1: T1.1–T1.7).

## What's in this PR

- **`.github/workflows/lint.yml`** — workflow skeleton with 6 jobs (actionlint, yamllint, shellcheck, lint-backend, lint-frontend, lint-verify). Changed-file scope via `tj-actions/changed-files` (SHA-pinned). `lint-verify` runs on push:main AND on PRs touching the lint configs.
- **`.github/dependabot.yml`** — fixed: 3 ecosystems (`github-actions` `/`, `pip` `/backend`, `npm` `/frontend`), weekly Monday 09:00 UTC, minor/patch groups, semver-major ignored, `open-pull-requests-limit: 5`, scoped labels.
- **`.github/actionlint.yaml`** + **`.yamllint.yml`** — local validators used by the workflow.
- **`backend/ruff.toml`** + **`backend/pyproject.toml`** — ruff + black config (`py311`, line-length 100, rules E/F/W/I/N/UP/B/SIM).
- **`frontend/eslint.config.js`** + **`.prettierrc.json`** + **`.prettierignore`** + **`package.json` lint/format scripts** — permissive built-in ESLint config (PR1 placeholder; full TypeScript/React/Hooks rule set lands in PR3 when devDeps are installed).
- **`docs/ci-cd-runbook.md`** — stub with TBD sections completed in PR6.

## Verification

- ✅ `yamllint -c .yamllint.yml .github/` — clean
- ✅ actionlint YAML syntax valid
- ✅ `ruff check --config ruff.toml tests/__init__.py` — pass
- ✅ `black --check tests/__init__.py` — pass
- ✅ `eslint eslint.config.js` — clean (built-in rules only)
- ✅ `prettier --check` on config files — clean
- ✅ All third-party actions SHA-pinned (`tj-actions/changed-files@ed68ef82…` = v46.0.5, post-CVE-2025-30022)
- ✅ First-party actions use major-version pins (`actions/checkout@v4`, `actions/setup-python@v5`, `actions/setup-node@v4`)

## Spec compliance

- **R1 Workflow Skeleton** — met
- **R2 Changed-File Lint** — met (lint scope is `${files[@]}`, legacy untouched files do not block)
- **R3 Dependabot** — met (live Dependabot PRs as the authoritative proof per strict-TDD manual evidence policy)
- **R11 Strict TDD** — partial (live Dependabot PRs are manual evidence per `openspec/config.yaml` strict_tdd policy; automated validators cover the rest)

## Out of scope (later PRs)

- Backend CI lane → PR2
- Frontend CI lane (install eslint/prettier devDeps) → PR3
- Build lane + `frontend/Dockerfile.prod` → PR4
- Smoke lane + Playwright → PR5
- CD lane on self-hosted runner + `safe-rebuild.sh` integration → PR6

## Notes for reviewer

- **Size**: 546 LOC code/config (over the 400-line budget by ~36%) + 477 LOC of OpenSpec planning artifacts (not counted toward the budget per repo convention). Config files are inherently larger than the per-task LOC estimate suggested; PR2..PR6 estimates will be re-baselined.
- **`lint-frontend`**: uses `pnpm dlx eslint@9.18.0` and `pnpm dlx prettier@3.4.2` on changed files. DevDeps install deferred to PR3 per the task plan.
- **`lint-verify`**: triggers on push to `main` AND on PRs touching the lint configs so config validation failures surface pre-merge.

## Linked artifacts

- Proposal: `openspec/changes/ci-cd-pipeline/proposal.md`
- Spec: `openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md`
- Design: `openspec/changes/ci-cd-pipeline/design.md`
- Tasks: `openspec/changes/ci-cd-pipeline/tasks.md`