### PR TITLE
fix(auth): batched refresh token activity backfill (#287 PR0)

### DIFF
--- a/backend/scripts/backfill_refresh_token_activity.py
+++ b/backend/scripts/backfill_refresh_token_activity.py
@@ -1,0 +1,149 @@
+"""Batched deployment-time backfill for ``refresh_tokens.last_activity_at IS NULL``.
+
+Part of PR0 (DB-only) for fix #287 / `fix-287-session-keep-alive`. The legacy
+schema declared the column NOT NULL but historical deployments may have rows
+inserted before the column existed or before the runtime started populating it.
+This script fills those rows with ``now()`` in bounded batches with a short
+sleep between batches so that operators can run it during a low-traffic window
+without taking a long lock on the ``refresh_tokens`` table.
+
+The script is intentionally DB-only: it MUST NOT change login, refresh, logout,
+audit, or frontend runtime behavior. It also MUST be idempotent — running it
+twice is safe and the second run is a no-op.
+
+Usage:
+    python backend/scripts/backfill_refresh_token_activity.py
+    python backend/scripts/backfill_refresh_token_activity.py --batch-size 500 --sleep-seconds 0.05
+
+Live evidence (run before/after on production PostgreSQL):
+    SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL;
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+# Allow running this script directly from the repository root or from inside
+# backend/scripts without requiring PYTHONPATH manipulation by callers.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select, update  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from models.refresh_token import RefreshToken  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _build_backfill_statement(batch_size: int):
+    """Build a bounded ``UPDATE refresh_tokens`` for one batch of NULL rows.
+
+    The LIMIT subquery keeps each batch under ``batch_size`` rows so the lock
+    window stays short even when many legacy rows exist.
+    """
+    null_ids_subquery = (
+        select(RefreshToken.id)
+        .where(RefreshToken.last_activity_at.is_(None))
+        .limit(batch_size)
+    )
+    return (
+        update(RefreshToken)
+        .where(RefreshToken.id.in_(null_ids_subquery))
+        .values(last_activity_at=datetime.utcnow())
+    )
+
+
+def backfill_refresh_token_activity(
+    db: Session,
+    *,
+    batch_size: int = 1000,
+    sleep_seconds: float = 0.1,
+) -> int:
+    """Update legacy ``refresh_tokens`` rows where ``last_activity_at IS NULL``.
+
+    Iterates bounded UPDATE batches (default 1000 rows) with ``sleep_seconds``
+    of pause between batches. Returns the total number of rows updated. The
+    function is idempotent: once no NULL rows remain the loop exits cleanly
+    and returns ``0`` on subsequent calls.
+    """
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if sleep_seconds < 0:
+        raise ValueError("sleep_seconds must be non-negative")
+
+    stmt = _build_backfill_statement(batch_size)
+    total = 0
+
+    while True:
+        result = db.execute(stmt)
+        rowcount = result.rowcount or 0
+        if rowcount == 0:
+            break
+        total += rowcount
+        # Commit each batch so the lock is released between iterations and so
+        # that a partial run still leaves a consistent partial state.
+        db.commit()
+        if sleep_seconds:
+            time.sleep(sleep_seconds)
+
+    logger.info("Refresh-token activity backfill updated %d rows", total)
+    return total
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Batched deployment-time backfill for "
+            "refresh_tokens.last_activity_at IS NULL rows. "
+            "Live evidence query: "
+            "SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL;"
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1000,
+        help="Maximum number of rows updated per batch (default: 1000).",
+    )
+    parser.add_argument(
+        "--sleep-seconds",
+        type=float,
+        default=0.1,
+        help="Sleep seconds between batches (default: 0.1).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    # Lazy import so unit tests that import the module do not pull in the
+    # postgres_db engine (which connects on import).
+    from postgres_db import SessionLocal
+
+    db = SessionLocal()
+    try:
+        updated = backfill_refresh_token_activity(
+            db,
+            batch_size=args.batch_size,
+            sleep_seconds=args.sleep_seconds,
+        )
+    finally:
+        db.close()
+
+    print(f"backfill_refresh_token_activity updated {updated} rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/backfill_refresh_token_activity.py
+++ b/backend/scripts/backfill_refresh_token_activity.py
@@ -24,41 +24,40 @@ import argparse
 import logging
 import sys
 import time
-from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 # Allow running this script directly from the repository root or from inside
 # backend/scripts without requiring PYTHONPATH manipulation by callers.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from sqlalchemy import select, update  # noqa: E402
-from sqlalchemy.orm import Session  # noqa: E402
+from sqlalchemy import text  # noqa: E402
 
-from models.refresh_token import RefreshToken  # noqa: E402
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
 
-def _build_backfill_statement(batch_size: int):
-    """Build a bounded ``UPDATE refresh_tokens`` for one batch of NULL rows.
-
-    The LIMIT subquery keeps each batch under ``batch_size`` rows so the lock
-    window stays short even when many legacy rows exist.
+# Raw SQL keeps this script free of ORM model imports so `python ... --help`
+# works on hosts that do not have psycopg2 / the backend models importable.
+# The bounded subquery keeps each UPDATE under ``batch_size`` rows so the lock
+# window stays short even when many legacy rows exist.
+BACKFILL_SQL = text(
     """
-    null_ids_subquery = (
-        select(RefreshToken.id)
-        .where(RefreshToken.last_activity_at.is_(None))
-        .limit(batch_size)
+    UPDATE refresh_tokens
+    SET last_activity_at = NOW()
+    WHERE id IN (
+        SELECT id FROM refresh_tokens
+        WHERE last_activity_at IS NULL
+        LIMIT :batch_size
     )
-    return (
-        update(RefreshToken)
-        .where(RefreshToken.id.in_(null_ids_subquery))
-        .values(last_activity_at=datetime.utcnow())
-    )
+    """
+)
 
 
 def backfill_refresh_token_activity(
-    db: Session,
+    db: "Session",
     *,
     batch_size: int = 1000,
     sleep_seconds: float = 0.1,
@@ -69,17 +68,19 @@ def backfill_refresh_token_activity(
     of pause between batches. Returns the total number of rows updated. The
     function is idempotent: once no NULL rows remain the loop exits cleanly
     and returns ``0`` on subsequent calls.
+
+    Uses raw SQL with ``NOW()`` so the timestamp comes from the database clock
+    and avoids any app-server / Postgres clock-skew risk.
     """
     if batch_size <= 0:
         raise ValueError("batch_size must be positive")
     if sleep_seconds < 0:
         raise ValueError("sleep_seconds must be non-negative")
 
-    stmt = _build_backfill_statement(batch_size)
     total = 0
 
     while True:
-        result = db.execute(stmt)
+        result = db.execute(BACKFILL_SQL, {"batch_size": batch_size})
         rowcount = result.rowcount or 0
         if rowcount == 0:
             break

--- a/backend/scripts/backfill_refresh_token_activity.py
+++ b/backend/scripts/backfill_refresh_token_activity.py
@@ -95,13 +95,21 @@ def backfill_refresh_token_activity(
 
 
 def _build_arg_parser() -> argparse.ArgumentParser:
+    description = (
+        "Batched deployment-time backfill for "
+        "refresh_tokens.last_activity_at IS NULL rows."
+    )
+    epilog = (
+        "Live evidence (run before/after the backfill):\n"
+        "  SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL;\n"
+        "  SELECT id, user_id, last_activity_at FROM refresh_tokens "
+        "WHERE last_activity_at IS NULL;\n"
+        "Both queries must return zero rows once the backfill completes."
+    )
     parser = argparse.ArgumentParser(
-        description=(
-            "Batched deployment-time backfill for "
-            "refresh_tokens.last_activity_at IS NULL rows. "
-            "Live evidence query: "
-            "SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL;"
-        ),
+        description=description,
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--batch-size",

--- a/backend/tests/test_refresh_token_activity_backfill.py
+++ b/backend/tests/test_refresh_token_activity_backfill.py
@@ -1,0 +1,75 @@
+"""Tests for the refresh-token activity backfill script (PR0 of #287).
+
+The script (`backend/scripts/backfill_refresh_token_activity.py`) is the
+deployment-time repair step for legacy `refresh_tokens.last_activity_at IS NULL`
+rows. PR0 keeps this slice DB-only and avoids any auth behavior changes.
+
+These tests are intentionally strict-TDD RED scaffolds: they import the
+production helper that lands in Task 0.2, so they fail with ``ImportError``
+until that helper is implemented.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _make_execute_mock(rowcounts):
+    """Build a mock SQLAlchemy ``Session`` whose ``execute`` returns rowcounts.
+
+    The helper records every (statement, params) call so tests can assert the
+    bounded-batch UPDATE shape used by the backfill loop. ``rowcounts`` is the
+    sequence of rowcounts returned in order; once exhausted the mock returns
+    ``0`` so the loop can exit.
+    """
+    calls = []
+    remaining = list(rowcounts)
+
+    def fake_execute(stmt, *args, **kwargs):
+        calls.append({"stmt": stmt, "params": args, "kwargs": kwargs})
+        rowcount = remaining.pop(0) if remaining else 0
+        result = MagicMock()
+        result.rowcount = rowcount
+        return result
+
+    db = MagicMock()
+    db.execute.side_effect = fake_execute
+    db.commit = MagicMock()
+    return db, calls
+
+
+class TestBackfillRefreshTokenActivity:
+    """RED scaffolds for the batched backfill helper."""
+
+    def test_sets_last_activity_at_non_null_for_legacy_row(self, monkeypatch):
+        # Import the helper from its final location so the test references
+        # production code that does not exist yet (RED).
+        from scripts import backfill_refresh_token_activity as script
+
+        # Avoid real sleeps during the unit test run.
+        monkeypatch.setattr(script.time, "sleep", lambda *_a, **_k: None)
+
+        db, calls = _make_execute_mock([1, 0])
+
+        updated = script.backfill_refresh_token_activity(
+            db, batch_size=1000, sleep_seconds=0
+        )
+
+        assert updated == 1
+        # First batch updated one row; loop probed again with rowcount=0 and
+        # exited cleanly.
+        assert len(calls) == 2
+
+    def test_empty_batch_returns_zero_without_raising(self, monkeypatch):
+        from scripts import backfill_refresh_token_activity as script
+
+        monkeypatch.setattr(script.time, "sleep", lambda *_a, **_k: None)
+
+        db, calls = _make_execute_mock([0])
+
+        updated = script.backfill_refresh_token_activity(
+            db, batch_size=1000, sleep_seconds=0
+        )
+
+        assert updated == 0
+        assert len(calls) == 1

--- a/backend/tests/test_refresh_token_activity_backfill.py
+++ b/backend/tests/test_refresh_token_activity_backfill.py
@@ -78,6 +78,36 @@ class TestBackfillRefreshTokenActivity:
         assert updated == 0
         assert len(calls) == 1
 
+    def test_update_uses_database_now_not_python_clock(self, monkeypatch):
+        # Regression: the UPDATE must use the database NOW() so backfill time
+        # comes from a single authoritative clock. Using `datetime.utcnow()`
+        # from the application host introduces clock-skew risk between the
+        # app server and the Postgres host.
+        from scripts import backfill_refresh_token_activity as script
+
+        monkeypatch.setattr(script.time, "sleep", lambda *_a, **_k: None)
+
+        db, calls = _make_execute_mock([0])
+
+        script.backfill_refresh_token_activity(
+            db, batch_size=1000, sleep_seconds=0
+        )
+
+        assert calls, "expected the backfill to call db.execute at least once"
+        rendered_sql = str(calls[0]["stmt"]).upper()
+        assert "NOW()" in rendered_sql, (
+            "Backfill UPDATE must use DB NOW() (no clock skew). "
+            f"Got SQL: {rendered_sql!r}"
+        )
+        assert "LIMIT" in rendered_sql, (
+            "Backfill UPDATE must be bounded by batch_size LIMIT. "
+            f"Got SQL: {rendered_sql!r}"
+        )
+        assert "LAST_ACTIVITY_AT" in rendered_sql, (
+            "Backfill UPDATE must target last_activity_at. "
+            f"Got SQL: {rendered_sql!r}"
+        )
+
 
 class TestBackfillScriptHelp:
     """The CLI help must advertise the live-evidence SQL operators run before/after."""
@@ -125,3 +155,57 @@ class TestBackfillScriptHelp:
             "Backfill CLI --help must include a row-identification SQL so "
             "operators can capture at least one exercised row id for the PR body."
         )
+
+    def test_help_works_without_postgres_db_import(self):
+        # Regression: `python backend/scripts/backfill_refresh_token_activity.py --help`
+        # must succeed even if `postgres_db` / `psycopg2` is not importable
+        # on the host. The verify agent for PR0 caught this: the eager
+        # `from models.refresh_token import RefreshToken` inside the script
+        # pulled `models/__init__.py` which in turn loaded `postgres_db`,
+        # which then tried to create a SQLAlchemy engine with the postgresql
+        # dialect and crashed with `ModuleNotFoundError: psycopg2`.
+        #
+        # We exercise the failure in a clean subprocess so Python's import
+        # cache cannot mask the bug the way in-process monkeypatch can.
+        import os
+        import subprocess
+        import sys
+
+        repo_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..")
+        )
+        script_path = os.path.join(
+            repo_root, "backend", "scripts", "backfill_refresh_token_activity.py"
+        )
+
+        result = subprocess.run(
+            [sys.executable, script_path, "--help"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, (
+            f"Script --help failed with code {result.returncode}. "
+            f"stderr: {result.stderr!r}"
+        )
+        assert self.EVIDENCE_SQL in result.stdout, (
+            "--help output must include the live-evidence SQL for operators."
+        )
+
+    def test_invalid_batch_size_rejected(self):
+        from scripts import backfill_refresh_token_activity as script
+
+        with pytest.raises(ValueError, match="batch_size must be positive"):
+            script.backfill_refresh_token_activity(
+                MagicMock(), batch_size=0, sleep_seconds=0
+            )
+
+    def test_invalid_sleep_seconds_rejected(self):
+        from scripts import backfill_refresh_token_activity as script
+
+        with pytest.raises(ValueError, match="sleep_seconds must be non-negative"):
+            script.backfill_refresh_token_activity(
+                MagicMock(), batch_size=1000, sleep_seconds=-0.1
+            )

--- a/backend/tests/test_refresh_token_activity_backfill.py
+++ b/backend/tests/test_refresh_token_activity_backfill.py
@@ -11,7 +11,11 @@ until that helper is implemented.
 
 from __future__ import annotations
 
+import contextlib
+import io
 from unittest.mock import MagicMock
+
+import pytest
 
 
 def _make_execute_mock(rowcounts):
@@ -73,3 +77,51 @@ class TestBackfillRefreshTokenActivity:
 
         assert updated == 0
         assert len(calls) == 1
+
+
+class TestBackfillScriptHelp:
+    """The CLI help must advertise the live-evidence SQL operators run before/after."""
+
+    EVIDENCE_SQL = (
+        "SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL"
+    )
+    EVIDENCE_ROW_SQL = (
+        "SELECT id, user_id, last_activity_at FROM refresh_tokens "
+        "WHERE last_activity_at IS NULL"
+    )
+
+    def _capture_help(self, script):
+        # argparse writes help to stdout and calls ``parser.exit(0)`` which
+        # raises SystemExit; capture both so the test sees the help text.
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with pytest.raises(SystemExit) as exc_info:
+                script.main(["--help"])
+        assert exc_info.value.code == 0
+        return buf.getvalue()
+
+    def test_help_documents_live_evidence_query(self, monkeypatch):
+        from scripts import backfill_refresh_token_activity as script
+
+        # The script must not actually try to open a database when --help is
+        # requested; if it does we want the test to fail loudly.
+        monkeypatch.setattr(script.time, "sleep", lambda *_a, **_k: None)
+
+        help_text = self._capture_help(script)
+
+        assert self.EVIDENCE_SQL in help_text, (
+            "Backfill CLI --help must include the live-evidence SQL so "
+            "operators can copy/paste it for before/after validation."
+        )
+
+    def test_help_documents_row_identification_query(self, monkeypatch):
+        from scripts import backfill_refresh_token_activity as script
+
+        monkeypatch.setattr(script.time, "sleep", lambda *_a, **_k: None)
+
+        help_text = self._capture_help(script)
+
+        assert self.EVIDENCE_ROW_SQL in help_text, (
+            "Backfill CLI --help must include a row-identification SQL so "
+            "operators can capture at least one exercised row id for the PR body."
+        )

--- a/openspec/changes/fix-287-session-keep-alive/apply-progress.md
+++ b/openspec/changes/fix-287-session-keep-alive/apply-progress.md
@@ -1,0 +1,112 @@
+# Apply Progress: fix-287-session-keep-alive — PR0 (`fix/287-db-backfill`)
+
+**Branch**: `fix/287-db-backfill`
+**PR**: https://github.com/alexandervazquez98/next-gen/pull/289
+**Base branch**: `fix/287-session-keep-alive` (tracker, `feature-branch-chain`)
+**Strict TDD mode**: enabled
+**Linked issue**: Part of `alexandervazquez98/next-gen#287` (Bug 1 + Bug 2 stay open for PR1/PR2)
+
+---
+
+## Slice Status
+
+**PR0 (`fix/287-db-backfill`) — COMPLETE**
+
+### Completed Tasks
+
+- [x] **Task 0.1** — `test(auth): define refresh token activity backfill contract`
+  - Commit: `b85aa36`
+  - Files: `backend/tests/test_refresh_token_activity_backfill.py` (new, 75 LOC)
+  - RED: 2 tests failed with `ImportError` for missing `backfill_refresh_token_activity` (confirmed via `uv run pytest`).
+
+- [x] **Task 0.2** — `fix(auth): add batched refresh token activity backfill`
+  - Commit: `f6f6801`
+  - Files: `backend/scripts/backfill_refresh_token_activity.py` (new, 149 LOC)
+  - GREEN: 2 baseline tests pass.
+  - Implementation: bounded `UPDATE refresh_tokens SET last_activity_at = now() WHERE id IN (SELECT id FROM refresh_tokens WHERE last_activity_at IS NULL LIMIT batch_size)`; loop with `time.sleep(sleep_seconds)` between batches; `main()` opens `SessionLocal`, runs helper, prints count.
+
+- [x] **Task 0.3** — `test(auth): document live backfill evidence command`
+  - Commit: `72ba56b`
+  - Files: `backend/scripts/backfill_refresh_token_activity.py` (tweaked to use `RawDescriptionHelpFormatter`), `backend/tests/test_refresh_token_activity_backfill.py` (+54 LOC for 2 help tests).
+  - GREEN: 2 help tests pass.
+  - Added explicit `--help` epilog with the live-evidence SQL operators run before/after.
+
+### Housekeeping commit
+
+- [x] `chore(sdd): mark PR0 tasks complete in tasks.md` — commit `9ddaa05`. Adds the OpenSpec `tasks.md` artifact to the branch so reviewers see the marked checkboxes.
+
+---
+
+## TDD Cycle Evidence (Strict TDD)
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 0.1 | `backend/tests/test_refresh_token_activity_backfill.py` | Unit | N/A (new) | ✅ `ImportError` (helper missing) | n/a (test-only commit) | ✅ 2 cases (NULL row + empty batch) | ➖ None needed |
+| 0.2 | `backend/tests/test_refresh_token_activity_backfill.py` | Unit | n/a (helper doesn't exist) | ✅ 0.1's RED | ✅ 2/2 passed | ➖ Same 2 baseline cases | ✅ Switched to `LIMIT` subquery for true bounded batching |
+| 0.3 | `backend/tests/test_refresh_token_activity_backfill.py` | Unit | ✅ 2/2 (from 0.2) | ✅ Help SQL assertion failed (wrapped description) | ✅ 2/2 passed | ✅ 2 help cases (count + row-id SQL) | ✅ Used `RawDescriptionHelpFormatter` so SQL is not wrapped |
+
+### Test Summary
+- **Total tests written in PR0**: 4
+- **Total tests passing**: 4 (PR0 file) / 80 (auth-adjacent files) / 1040 (full backend)
+- **Layers used**: Unit (4)
+- **Approval tests**: None (no existing-code refactor in PR0)
+- **Pure functions created**: 1 (`backfill_refresh_token_activity`)
+
+---
+
+## Files Changed
+
+| File | Action | What was done |
+|------|--------|---------------|
+| `backend/scripts/backfill_refresh_token_activity.py` | Created | Batched UPDATE helper + argparse CLI with live-evidence epilog. |
+| `backend/tests/test_refresh_token_activity_backfill.py` | Created | Strict-TDD RED/GREEN coverage (4 tests). |
+| `openspec/changes/fix-287-session-keep-alive/tasks.md` | Created in branch | Marks PR0 tasks complete; first commit of OpenSpec artifacts in this branch so the PR shows the updated checkboxes. |
+
+**PR diff**: 2 source files, 284 insertions vs `fix/287-session-keep-alive`. Under the 400-line review budget.
+
+---
+
+## Test Status
+
+| Scope | Command | Result |
+|-------|---------|--------|
+| Focused (PR0) | `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` | 4 passed |
+| Auth-adjacent | `uv run pytest tests/test_auth_service_refresh.py tests/test_auth_router_refresh.py tests/test_auth_service.py tests/test_audit_service.py tests/test_refresh_token_activity_backfill.py -q` | 80 passed |
+| Full backend | `uv run pytest backend/tests -q` | **1040 passed, 97 pre-existing failures, 1 skipped** (baseline pre-PR0 was 1036 passed + 97 pre-existing failures; +4 new tests, no new failures) |
+| Pre-existing failures | RTU/backup/dictionary/cli_worker/event_correlation tests | **Unchanged** — same 13 files, 97 cases as before PR0; no regressions introduced by PR0. |
+
+---
+
+## Deviations from the Plan
+
+- **Live PostgreSQL evidence**: Not collected. The local dev environment used to author this PR does NOT have a running PostgreSQL instance (`pg_isready` returns "no response"). The repo's `.env.example` configures `POSTGRES_HOST=postgres` for the Docker Compose stack, which was not started in this slice. The PR body documents this risk and asks the first reviewer to run the script against a populated `refresh_tokens` table before merge. No fake data was seeded; this is a deliberate honesty gap, not a fabricated-evidence claim.
+- **`RawDescriptionHelpFormatter` added in 0.3 instead of 0.2**: Task 0.2 already included a brief description mentioning the SQL, but argparse was wrapping it across two lines and breaking the test substring search. The minor help refactor (`description` → `description + epilog + RawDescriptionHelpFormatter`) and the 2 help tests landed together in commit `72ba56b` because splitting them would have left a RED test in the 0.2 GREEN commit. This is a non-substantive split.
+- **Housekeeping commit `9ddaa05`**: The OpenSpec `tasks.md` was untracked in the worktree when PR0 started, so I committed it as a `chore(sdd)` commit to surface the `[x]` marks to reviewers. This is consistent with the project's "ship the SDD artifacts in the PR" convention.
+- **Commit title format**: All three PR0 commit titles match the exact strings from `tasks.md` (`test(auth): …`, `fix(auth): …`, `test(auth): …`). No `Co-Authored-By` trailer, no AI attribution.
+
+---
+
+## Risks
+
+- **Local Postgres not running**: As above. First reviewer must run the script against the staging or production `refresh_tokens` table and paste before/after counts + one exercised row id into the PR body before merge.
+- **Pre-existing 97 backend test failures (RTU/backup/dictionary/cli_worker)**: Unrelated to auth/session. Not addressed by PR0 by design (no scope creep). Listed in PR body under verification so reviewers know they are pre-existing.
+- **No `ci-cd-pipeline` lint gate yet**: This PR will not be auto-validated by the new lint lane from PR1 of the ci-cd-pipeline change because that workflow is still in draft. PR0 does not add lint config or break any existing one.
+
+---
+
+## Open Items for PR1 (`fix/287-backend-activity-bump`)
+
+- Open branch `fix/287-backend-activity-bump` from `fix/287-db-backfill` (after this PR merges) — but with `feature-branch-chain` the PR1 base is `fix/287-db-backfill`, so PR1 should branch from `fix/287-db-backfill` immediately after PR0 opens (even before merge) to keep the diff minimal and avoid the tracker accumulating backend changes.
+- Tasks 1.1 through 1.8 from `tasks.md` are all still pending. None of them depend on PR0 for compilation (PR1 still reads `COALESCE(last_activity_at, created_at)` defensively).
+- The per-worker throttle cache size (10,000 entries with TTL eviction) from the design open question is still to be decided.
+- Audit event allow-list keys (`session_id`, `user_id`, `policy_profile`, `throttle_seconds`, `activity_anchor`) are confirmed in `tasks.md` and `design.md`.
+
+---
+
+## Verification Recommendation
+
+`next_recommended`: `sdd-verify-minimax` for this slice — the orchestrator should:
+1. Confirm `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` is still 4/4 passing.
+2. Confirm full backend suite still shows **1040 passed / 97 pre-existing failures** (no new regressions).
+3. Confirm PR #289 is the only one in the chain that is `OPEN`.
+4. Confirm the live-evidence gap is acceptable for the reviewer (or block and ask for live row exercise before merge).

--- a/openspec/changes/fix-287-session-keep-alive/apply-progress.md
+++ b/openspec/changes/fix-287-session-keep-alive/apply-progress.md
@@ -31,6 +31,24 @@
   - GREEN: 2 help tests pass.
   - Added explicit `--help` epilog with the live-evidence SQL operators run before/after.
 
+### Follow-up commits (post-PR0-verify, after `verify-report-pr0.md` flagged regressions)
+
+- [x] **Regression d9e2997** — `test(auth): add CLI subprocess regression and DB NOW coverage`
+  - Adds 3 tests in `backend/tests/test_refresh_token_activity_backfill.py`:
+    - `test_help_works_without_postgres_db_import` (subprocess; RED against the original `f6f6801` script because of the eager `models.refresh_token` import chain).
+    - `test_update_uses_database_now_not_python_clock` (RED against the original `datetime.utcnow()` UPDATE).
+    - `test_invalid_batch_size_rejected` and `test_invalid_sleep_seconds_rejected` (validation tests, GREEN already).
+  - RED state (script reverted via `git stash`): 2 of the 4 new tests fail with the exact errors the verify agent caught (`ModuleNotFoundError: psycopg2`; assertion error on rendered SQL).
+
+- [x] **Regression 54c3ec0** — `fix(auth): make backfill script import-light and use DB NOW()`
+  - Rewrites the backfill SQL as a single `text("UPDATE refresh_tokens SET last_activity_at = NOW() WHERE id IN (SELECT id FROM refresh_tokens WHERE last_activity_at IS NULL LIMIT :batch_size)")`.
+  - Drops `from sqlalchemy import select, update` and `from models.refresh_token import RefreshToken` at module level; the script no longer pulls `postgres_db` at import time.
+  - `Session` only imported under `TYPE_CHECKING` for type hints.
+  - GREEN: 8/8 tests pass; `python backend/scripts/backfill_refresh_token_activity.py --help` succeeds on hosts without `psycopg2`.
+
+- [x] **Evidence 67ee589** — `chore(sdd): record PR0 live PostgreSQL backfill evidence`
+  - Adds `openspec/changes/fix-287-session-keep-alive/live-evidence-pr0.md` with BEFORE / RUN / AFTER output from a live `timescale/timescaledb:2.15.0-pg16` Docker container. Legacy row id=1 was updated to `NOW()`; control row id=2 was untouched; second run = 0 rows (idempotent).
+
 ### Housekeeping commit
 
 - [x] `chore(sdd): mark PR0 tasks complete in tasks.md` — commit `9ddaa05`. Adds the OpenSpec `tasks.md` artifact to the branch so reviewers see the marked checkboxes.
@@ -46,9 +64,9 @@
 | 0.3 | `backend/tests/test_refresh_token_activity_backfill.py` | Unit | ✅ 2/2 (from 0.2) | ✅ Help SQL assertion failed (wrapped description) | ✅ 2/2 passed | ✅ 2 help cases (count + row-id SQL) | ✅ Used `RawDescriptionHelpFormatter` so SQL is not wrapped |
 
 ### Test Summary
-- **Total tests written in PR0**: 4
-- **Total tests passing**: 4 (PR0 file) / 80 (auth-adjacent files) / 1040 (full backend)
-- **Layers used**: Unit (4)
+- **Total tests written in PR0**: 8 (4 initial + 4 regression tests)
+- **Total tests passing**: 8 (PR0 file) / 84 (auth-adjacent files) / 1044 (full backend)
+- **Layers used**: Unit (7) + subprocess CLI regression (1)
 - **Approval tests**: None (no existing-code refactor in PR0)
 - **Pure functions created**: 1 (`backfill_refresh_token_activity`)
 
@@ -70,25 +88,28 @@
 
 | Scope | Command | Result |
 |-------|---------|--------|
-| Focused (PR0) | `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` | 4 passed |
-| Auth-adjacent | `uv run pytest tests/test_auth_service_refresh.py tests/test_auth_router_refresh.py tests/test_auth_service.py tests/test_audit_service.py tests/test_refresh_token_activity_backfill.py -q` | 80 passed |
-| Full backend | `uv run pytest backend/tests -q` | **1040 passed, 97 pre-existing failures, 1 skipped** (baseline pre-PR0 was 1036 passed + 97 pre-existing failures; +4 new tests, no new failures) |
+| Focused (PR0) | `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` | 8 passed |
+| Auth-adjacent | `uv run pytest tests/test_auth_service_refresh.py tests/test_auth_router_refresh.py tests/test_auth_service.py tests/test_audit_service.py tests/test_refresh_token_activity_backfill.py -q` | 84 passed |
+| Full backend | `uv run pytest backend/tests -q` | **1044 passed, 97 pre-existing failures, 1 skipped** (baseline pre-PR0 was 1036 passed + 97 pre-existing failures; +8 new tests, no new failures) |
+| CLI `--help` (no DB driver installed) | `uv run python backend/scripts/backfill_refresh_token_activity.py --help` | exit 0, evidence SQL present |
+| Live PostgreSQL evidence | `RUNNING_LOCALLY=true POSTGRES_HOST=localhost uv run python backend/scripts/backfill_refresh_token_activity.py` against `timescale/timescaledb:2.15.0-pg16` container with 1 legacy NULL + 1 control row | updated 1 row; control untouched; second run = 0 rows (idempotent). Full output in `live-evidence-pr0.md`. |
 | Pre-existing failures | RTU/backup/dictionary/cli_worker/event_correlation tests | **Unchanged** — same 13 files, 97 cases as before PR0; no regressions introduced by PR0. |
 
 ---
 
 ## Deviations from the Plan
 
-- **Live PostgreSQL evidence**: Not collected. The local dev environment used to author this PR does NOT have a running PostgreSQL instance (`pg_isready` returns "no response"). The repo's `.env.example` configures `POSTGRES_HOST=postgres` for the Docker Compose stack, which was not started in this slice. The PR body documents this risk and asks the first reviewer to run the script against a populated `refresh_tokens` table before merge. No fake data was seeded; this is a deliberate honesty gap, not a fabricated-evidence claim.
+- **Live PostgreSQL evidence**: Initially not collected by the apply agent because the local dev environment had no Postgres. The orchestrator raised `nexgen_postgres` (`timescale/timescaledb:2.15.0-pg16`), seeded one legacy NULL row + one control row, ran the script, and committed the BEFORE / RUN / AFTER output as `openspec/changes/fix-287-session-keep-alive/live-evidence-pr0.md` (commit `67ee589`). This satisfies the PR0 acceptance criterion that required live PostgreSQL evidence with at least one exercised row.
+- **Three follow-up commits after the verify agent flagged regressions** (`d9e2997`, `54c3ec0`, `67ee589`): these are RED-then-GREEN pairs addressing the verify agent's three findings (live evidence, CLI `--help` import chain, `datetime.utcnow` vs DB `NOW()`). They were not in the original `tasks.md` PR0 plan but are necessary follow-ups.
 - **`RawDescriptionHelpFormatter` added in 0.3 instead of 0.2**: Task 0.2 already included a brief description mentioning the SQL, but argparse was wrapping it across two lines and breaking the test substring search. The minor help refactor (`description` → `description + epilog + RawDescriptionHelpFormatter`) and the 2 help tests landed together in commit `72ba56b` because splitting them would have left a RED test in the 0.2 GREEN commit. This is a non-substantive split.
-- **Housekeeping commit `9ddaa05`**: The OpenSpec `tasks.md` was untracked in the worktree when PR0 started, so I committed it as a `chore(sdd)` commit to surface the `[x]` marks to reviewers. This is consistent with the project's "ship the SDD artifacts in the PR" convention.
-- **Commit title format**: All three PR0 commit titles match the exact strings from `tasks.md` (`test(auth): …`, `fix(auth): …`, `test(auth): …`). No `Co-Authored-By` trailer, no AI attribution.
+- **Housekeeping commits `9ddaa05`, `819df6d`**: The OpenSpec `tasks.md` and `apply-progress.md` were untracked in the worktree when PR0 started, so they were committed as `chore(sdd)` commits to surface the `[x]` marks and the progress report to reviewers. This is consistent with the project's "ship the SDD artifacts in the PR" convention.
+- **Commit title format**: All work-unit commit titles match the exact strings from `tasks.md` plus the regression-fix follow-ups (`test(auth): …`, `fix(auth): …`, `chore(sdd): …`). No `Co-Authored-By` trailer, no AI attribution.
 
 ---
 
 ## Risks
 
-- **Local Postgres not running**: As above. First reviewer must run the script against the staging or production `refresh_tokens` table and paste before/after counts + one exercised row id into the PR body before merge.
+- **PR body wording**: The PR body says `Closes #287`. With this wording GitHub will auto-close the parent issue when PR0 merges, but PR1 and PR2 are still pending. The orchestrator will fix this to `Part of #287 (PR0 of 3 in the feature-branch chain)` before merge.
 - **Pre-existing 97 backend test failures (RTU/backup/dictionary/cli_worker)**: Unrelated to auth/session. Not addressed by PR0 by design (no scope creep). Listed in PR body under verification so reviewers know they are pre-existing.
 - **No `ci-cd-pipeline` lint gate yet**: This PR will not be auto-validated by the new lint lane from PR1 of the ci-cd-pipeline change because that workflow is still in draft. PR0 does not add lint config or break any existing one.
 
@@ -106,7 +127,7 @@
 ## Verification Recommendation
 
 `next_recommended`: `sdd-verify-minimax` for this slice — the orchestrator should:
-1. Confirm `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` is still 4/4 passing.
-2. Confirm full backend suite still shows **1040 passed / 97 pre-existing failures** (no new regressions).
+1. Confirm `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` is still 8/8 passing.
+2. Confirm full backend suite still shows **1044 passed / 97 pre-existing failures** (no new regressions).
 3. Confirm PR #289 is the only one in the chain that is `OPEN`.
-4. Confirm the live-evidence gap is acceptable for the reviewer (or block and ask for live row exercise before merge).
+4. Confirm live-evidence captured in `live-evidence-pr0.md` is met (legacy row updated, control row untouched, idempotent on second run).

--- a/openspec/changes/fix-287-session-keep-alive/live-evidence-pr0.md
+++ b/openspec/changes/fix-287-session-keep-alive/live-evidence-pr0.md
@@ -1,0 +1,69 @@
+# Live PostgreSQL Evidence — PR0 (`fix/287-db-backfill`)
+
+Captured: 2026-06-20 (local dev environment, single Docker `timescale/timescaledb:2.15.0-pg16` container `nexgen_postgres`, host machine running script via `RUNNING_LOCALLY=true POSTGRES_HOST=localhost`).
+
+## BEFORE — seeded rows
+
+```sql
+SELECT id, user_id, session_id, last_activity_at FROM refresh_tokens ORDER BY id;
+
+ id | user_id | session_id |      last_activity_at
+----+---------+------------+----------------------------
+  1 |       1 | legacy-1   |                           -- NULL: target of backfill
+  2 |       1 | live-2     | 2026-06-20 21:00:02.961832  -- control: already populated
+```
+
+## Run
+
+```bash
+RUNNING_LOCALLY=true POSTGRES_HOST=localhost \
+  uv run python backend/scripts/backfill_refresh_token_activity.py
+```
+
+```
+2026-06-20 14:05:15,727 [INFO] Refresh-token activity backfill updated 1 rows
+backfill_refresh_token_activity updated 1 rows
+```
+
+## AFTER — exercised row
+
+```sql
+SELECT id, user_id, session_id, last_activity_at FROM refresh_tokens ORDER BY id;
+
+ id | user_id | session_id |      last_activity_at
+----+---------+------------+----------------------------
+  1 |       1 | legacy-1   | 2026-06-20 21:05:15.622024  -- backfilled with DB NOW()
+  2 |       1 | live-2     | 2026-06-20 21:00:02.961832  -- control row untouched
+```
+
+## Remaining NULLs
+
+```sql
+SELECT count(*) AS still_null FROM refresh_tokens WHERE last_activity_at IS NULL;
+
+ still_null
+------------
+          0
+```
+
+## Idempotency
+
+A second run of the same script with the same DB state updates `0` rows, confirming the bounded-batch loop exits cleanly once no NULL rows remain:
+
+```bash
+RUNNING_LOCALLY=true POSTGRES_HOST=localhost \
+  uv run python backend/scripts/backfill_refresh_token_activity.py
+```
+
+```
+2026-06-20 14:05:22,709 [INFO] Refresh-token activity backfill updated 0 rows
+backfill_refresh_token_activity updated 0 rows
+```
+
+## Acceptance criterion
+
+- [x] PR0 backfills live PostgreSQL `refresh_tokens.last_activity_at IS NULL` rows in batches, with evidence against at least one real row (id=1 above).
+- [x] Control row (id=2) is NOT modified by the backfill.
+- [x] Idempotency: running twice updates 0 rows on the second run.
+- [x] Backfilled timestamp comes from DB `NOW()`, not the application host clock.
+- [x] Script `python backend/scripts/backfill_refresh_token_activity.py --help` works without `psycopg2` installed (verified by `test_help_works_without_postgres_db_import` subprocess test).

--- a/openspec/changes/fix-287-session-keep-alive/tasks.md
+++ b/openspec/changes/fix-287-session-keep-alive/tasks.md
@@ -1,0 +1,259 @@
+# Tasks: Fix #287 Session Keep-Alive Regression
+
+- **Change ID**: `fix-287-session-keep-alive`
+- **Issue**: `alexandervazquez98/next-gen#287` (status: approved)
+- **Tracker branch**: `fix/287-session-keep-alive` (from `main@71a3c66`, clean)
+- **Chain strategy**: `feature-branch-chain` (locked from session)
+- **Delivery strategy**: `force-chained`
+- **Strict TDD**: RED before GREEN per work unit
+- **Preflight**: ORM `last_activity_at` stays non-null; transitional NULLs use `COALESCE(last_activity_at, created_at)`; Bug 3 deferred to follow-up issue.
+
+## Slice / PR Topology
+
+```text
+main
+ └── fix/287-session-keep-alive                    ← tracker (no-merge until all children land)
+       ├── fix/287-db-backfill                     ← PR0 → base: tracker
+       │     └── fix/287-backend-activity-bump     ← PR1 → base: PR0
+       │           └── fix/287-frontend-idle-logout ← PR2 → base: PR1
+```
+
+## Review Workload Forecast
+
+| Slice | Insertions | Deletions | Files touched | Risk | Exceeds 800-line budget |
+|---|---:|---:|---|---|---|
+| PR0 — DB backfill | ~140 | ~20 | 2 | Low | No |
+| PR1 — Backend activity bump | ~560 | ~80 | 7 | Medium | No |
+| PR2 — Frontend idle logout | ~280 | ~40 | 5 | Medium | No |
+
+`chained_prs_recommended`: Yes (3 PRs already locked by `force-chained`; each PR is reviewable in ≤60 min).
+`400-line budget risk`: Medium (PR1 spans services + routers + 3 test files; PR2 adds `sonner` dep + AuthContext + tests).
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: Medium
+
+---
+
+## Slice 0 — `fix/287-db-backfill` (PR0)
+
+### Task 0.1 — `test(auth): define refresh token activity backfill contract`
+- **Branch**: `fix/287-db-backfill`
+- **Files**: `backend/tests/test_refresh_token_activity_backfill.py` (create)
+- **RED**: assert `backfill_refresh_token_activity(db)` sets `last_activity_at` non-null on a seeded row whose `last_activity_at IS NULL`; assert empty batch returns `0` and does not raise.
+- **GREEN**: N/A — test-only commit. Implementation follows in 0.2.
+- **Verify**: `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` (expected: RED).
+- **Done when**: both tests fail with `ImportError` (function missing) and would pass once 0.2 lands.
+- **Work-unit commit**: `test(auth): define refresh token activity backfill contract`
+- **Est. lines**: ~60 (test file, RED scaffold)
+- **Status**: [x] Completed (commit `b85aa36`)
+
+### Task 0.2 — `fix(auth): add batched refresh token activity backfill`
+- **Branch**: `fix/287-db-backfill`
+- **Files**: `backend/scripts/backfill_refresh_token_activity.py` (create); `backend/tests/test_refresh_token_activity_backfill.py`
+- **RED**: 0.1's failing tests.
+- **GREEN**: implement `backfill_refresh_token_activity(db, *, batch_size=1000, sleep_seconds=0.1) -> int` using bounded `UPDATE refresh_tokens SET last_activity_at = now() WHERE last_activity_at IS NULL` with batch loop and `time.sleep(sleep_seconds)` between batches; add `main()` that opens a session, runs the helper, and prints the updated count.
+- **Verify**: `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` (expected: GREEN).
+- **Done when**: RED from 0.1 passes; helper returns row count; script runs end-to-end against a seeded DB without raising.
+- **Work-unit commit**: `fix(auth): add batched refresh token activity backfill`
+- **Est. lines**: ~80 (script) + ~10 (test tweaks)
+- **Status**: [x] Completed (commit `f6f6801`)
+
+### Task 0.3 — `test(auth): document live backfill evidence command`
+- **Branch**: `fix/287-db-backfill`
+- **Files**: `backend/scripts/backfill_refresh_token_activity.py`, `backend/tests/test_refresh_token_activity_backfill.py`
+- **RED**: assert script `--help` output documents the live-evidence invocation (`SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL` before/after).
+- **GREEN**: extend `argparse` `--help` text and add a test that exercises `main()` argv with `--help` and asserts the evidence command appears in the help string.
+- **Verify**: `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v`; `uv run pytest backend/tests -q` (full backend suite, expected: GREEN, no regressions in 1134 tests).
+- **Done when**: script help text references the live evidence SQL; full backend suite passes; at least one local PostgreSQL row was exercised (evidence captured in PR body).
+- **Work-unit commit**: `test(auth): document live backfill evidence command`
+- **Est. lines**: ~15 (script help) + ~25 (help test)
+- **Status**: [x] Completed (commit `72ba56b`)
+
+---
+
+## Slice 1 — `fix/287-backend-activity-bump` (PR1)
+
+### Task 1.1 — `test(auth): define activity recorder throttle contract`
+- **Branch**: `fix/287-backend-activity-bump` (base: `fix/287-db-backfill`)
+- **Files**: `backend/tests/test_auth_service_refresh.py` (extend)
+- **RED**: assert `record_session_activity(session_id, user_id, db, policy)` returns `False` for missing `sid`; assert 5 calls within `SESSION_ACTIVITY_WRITE_THROTTLE_SECONDS=60` on the same `session_id` produce exactly one `db.execute` against `refresh_tokens`; assert operational profile returns `False` and writes nothing; assert a raised `SQLAlchemyError` from `db.execute` is caught and returns `False` while `logger.exception` is called.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `uv run pytest backend/tests/test_auth_service_refresh.py -v` (expected: RED with `ImportError`).
+- **Done when**: four RED tests fail with import errors and would pass once 1.2 lands.
+- **Work-unit commit**: `test(auth): define activity recorder throttle contract`
+- **Est. lines**: ~100 (test additions)
+
+### Task 1.2 — `fix(auth): add deterministic session activity recorder`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/services/auth_service.py` (modify), `backend/services/session_policy.py` (modify), `backend/tests/test_auth_service_refresh.py`
+- **RED**: 1.1's failing tests.
+- **GREEN**: add `get_session_activity_write_throttle_seconds() -> int` (default 60) in `session_policy.py` reading `SESSION_ACTIVITY_WRITE_THROTTLE_SECONDS`; add `record_session_activity(session_id, user_id, db, policy, request=None) -> bool` in `auth_service.py` that (a) returns `False` for `None` session_id or operational profile, (b) runs a hybrid throttle: conditional `UPDATE refresh_tokens SET last_activity_at = now() WHERE session_id=:sid AND user_id=:uid AND (last_activity_at IS NULL OR last_activity_at <= now() - :throttle) RETURNING session_id`, (c) caches `(session_id -> next_allowed_at)` in a per-process dict bounded to 10000 entries with TTL eviction on write path, (d) wraps the update in try/except, logs `logger.exception(...)` and returns `False` on failure, (e) on success emits `session.activity_recorded` audit event and returns `True`.
+- **Verify**: `uv run pytest backend/tests/test_auth_service_refresh.py -v` (expected: GREEN).
+- **Done when**: all four 1.1 tests pass; the SQL is exactly one conditional `UPDATE` (no read-then-write).
+- **Work-unit commit**: `fix(auth): add deterministic session activity recorder`
+- **Est. lines**: ~110 (recorder + cache + helper) + ~10 (test cleanup)
+
+### Task 1.3 — `test(auth): require idle expiry coalesce semantics`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/tests/test_auth_service_refresh.py`
+- **RED**: assert `verify_refresh_token` returns `IDLE_EXPIRED` for a token whose `last_activity_at IS NULL` and `created_at = now - 16 minutes` under a 15-minute standard timeout; assert a token with `last_activity_at = now - 5 minutes` is still valid.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `uv run pytest backend/tests/test_auth_service_refresh.py -v` (expected: RED: NULL case wrongly returns `VALID`).
+- **Done when**: the NULL-anchor test fails today (proving the gap) and would pass once 1.4 lands.
+- **Work-unit commit**: `test(auth): require idle expiry coalesce semantics`
+- **Est. lines**: ~40 (test additions)
+
+### Task 1.4 — `fix(auth): enforce coalesced idle activity anchor`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/services/auth_service.py`
+- **RED**: 1.3's failing tests.
+- **GREEN**: change `_is_token_idle_expired(rt, now, policy)` so the activity anchor is `rt.last_activity_at or rt.created_at` instead of returning `False` when `last_activity_at is None`.
+- **Verify**: `uv run pytest backend/tests/test_auth_service_refresh.py -v` (expected: GREEN).
+- **Done when**: both 1.3 tests pass; existing refresh tests still pass.
+- **Work-unit commit**: `fix(auth): enforce coalesced idle activity anchor`
+- **Est. lines**: ~5 (one-line behavior change)
+
+### Task 1.5 — `test(auth): require audit allow-list for session lifecycle`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/tests/test_audit_service.py` (extend), `backend/tests/test_auth_service_refresh.py` (extend)
+- **RED**: assert `AUDIT_CONTEXT_ALLOWED_KEYS` includes `session_id`, `user_id`, `policy_profile`, `throttle_seconds`, `activity_anchor`; assert `record_auth_event(..., context={...})` retains those keys in the persisted audit row; assert sensitive keys (`token`, `cookies`, `authorization`, `raw_body`, `refresh_token`) are still stripped.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `uv run pytest backend/tests/test_audit_service.py backend/tests/test_auth_service_refresh.py -v` (expected: RED on the new key assertions).
+- **Done when**: new allow-list assertions fail; the existing audit tests still pass.
+- **Work-unit commit**: `test(auth): require audit allow-list for session lifecycle`
+- **Est. lines**: ~60 (test additions)
+
+### Task 1.6 — `fix(auth): expand AUDIT_CONTEXT_ALLOWED_KEYS for session lifecycle`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/services/audit_service.py`
+- **RED**: 1.5's failing tests.
+- **GREEN**: add `session_id`, `user_id`, `policy_profile`, `throttle_seconds`, `activity_anchor` to `AUDIT_CONTEXT_ALLOWED_KEYS` in `backend/services/audit_service.py:18-24`.
+- **Verify**: `uv run pytest backend/tests/test_audit_service.py backend/tests/test_auth_service_refresh.py -v` (expected: GREEN).
+- **Done when**: 1.5's allow-list assertions pass; the sensitive-key stripping tests still pass.
+- **Work-unit commit**: `fix(auth): expand AUDIT_CONTEXT_ALLOWED_KEYS for session lifecycle`
+- **Est. lines**: ~5 (allow-list addition)
+
+### Task 1.7 — `test(auth): cover refresh and users-me activity wiring`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/tests/test_auth_router_refresh.py` (extend), `backend/tests/test_routers_auth_users_roles.py` (extend `TestGetCurrentUser` at line 610)
+- **RED**: in `test_auth_router_refresh.py`: assert `POST /auth/refresh` success path calls `record_session_activity` once with the rotated refresh's `session_id`; assert idle-expired refresh returns 401, clears `access_token` and `refresh_token` cookies, and persists a `session.idle_expired` audit event. In `test_routers_auth_users_roles.py::TestGetCurrentUser`: assert `GET /api/auth/users/me` with a valid JWT carrying `sid` calls `record_session_activity` with that `sid` and the resolved `user_id`.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `uv run pytest backend/tests/test_auth_router_refresh.py backend/tests/test_routers_auth_users_roles.py -v` (expected: RED).
+- **Done when**: wiring assertions fail; existing 1134-test suite is still green except for the new REDs.
+- **Work-unit commit**: `test(auth): cover refresh and users-me activity wiring`
+- **Est. lines**: ~150 (test additions across both files)
+
+### Task 1.8 — `fix(auth): wire activity recording and lifecycle audit events`
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: `backend/routers/auth.py`, `backend/services/auth_service.py`
+- **RED**: 1.7's failing tests.
+- **GREEN**: in `verify_refresh_token`, after a successful rotation, call `record_session_activity(rt.session_id, rt.user_id, db, policy)`; on `IDLE_EXPIRED` (now using COALESCE from 1.4), call `audit_service.record_auth_event(event_type="session.idle_expired", outcome="DENIED", context={session_id, user_id, policy_profile, activity_anchor})` and ensure the router clears `access_token` and `refresh_token` cookies before returning 401. In `get_current_user` (at `backend/services/auth_service.py:336`), after resolving `user` and `policy`, if the access token's JWT carries a `sid` claim, call `record_session_activity(sid, user.id, db, policy)`. No-op if `sid` is missing.
+- **Verify**: `uv run pytest backend/tests/test_auth_service_refresh.py backend/tests/test_auth_router_refresh.py backend/tests/test_routers_auth_users_roles.py backend/tests/test_audit_service.py -v` (expected: GREEN); then `uv run pytest backend/tests -q` (full backend suite, 1134 tests, no regressions).
+- **Done when**: all 1.7 tests pass; the full backend suite passes; no Prometheus metrics added; no raw token material in audit `context`.
+- **Work-unit commit**: `fix(auth): wire activity recording and lifecycle audit events`
+- **Est. lines**: ~40 (router) + ~10 (service call site)
+
+### Task 1.9 — PR1 slice gate
+- **Branch**: `fix/287-backend-activity-bump`
+- **Files**: none (verification only)
+- **RED/GREEN**: N/A — gate, not a commit.
+- **Verify**: `uv run pytest backend/tests -q` (must show 1134+ tests, all passing); manual review: 1 audit row with `event_type=session.activity_recorded` and 1 with `event_type=session.idle_expired` in dev DB.
+- **Done when**: full backend suite green; audit evidence captured in PR body; PR1 PR opened against `fix/287-db-backfill`.
+
+---
+
+## Slice 2 — `fix/287-frontend-idle-logout` (PR2)
+
+### Task 2.1 — `test(auth): define local-only idle expiry behavior`
+- **Branch**: `fix/287-frontend-idle-logout` (base: `fix/287-backend-activity-bump`)
+- **Files**: `frontend/context/AuthContext.test.tsx` (extend)
+- **RED**: use `vi.useFakeTimers()` + `vi.advanceTimersByTime(...)`; assert that after the configured `idle_timeout_minutes` elapses with no activity, `mocks.api.post` is NOT called with `/auth/logout` from the inactivity path; assert that calling `result.current.logout()` manually DOES call `mocks.api.post('/auth/logout', {})` and clears user state.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `pnpm --dir frontend run test:run` (no `--reporter=basic`); expect: RED on the inactivity-no-logout assertion.
+- **Done when**: inactivity test fails today (`api.post('/auth/logout', ...)` is called once at lines 122-134 of `AuthContext.tsx`); manual logout test still passes.
+- **Work-unit commit**: `test(auth): define local-only idle expiry behavior`
+- **Est. lines**: ~50 (test additions)
+
+### Task 2.2 — `fix(auth): make idle expiry local-only`
+- **Branch**: `fix/287-frontend-idle-logout`
+- **Files**: `frontend/context/AuthContext.tsx`
+- **RED**: 2.1's failing test.
+- **GREEN**: in the `expireForInactivity` callback (current `AuthContext.tsx:122-134`), remove the `await api.post('/auth/logout', ...)` call; only call `endLocalSession('idle_timeout', 'session-expired', user.session_id)`.
+- **Verify**: `pnpm --dir frontend run test:run` (expected: GREEN for the inactivity assertion; existing manual-logout test still passes).
+- **Done when**: 2.1's inactivity test passes; existing 476 frontend tests still pass.
+- **Work-unit commit**: `fix(auth): make idle expiry local-only`
+- **Est. lines**: ~8 (delete + minor reshuffle)
+
+### Task 2.3 — `test(auth): require idle toast and deferred redirect`
+- **Branch**: `fix/287-frontend-idle-logout`
+- **Files**: `frontend/context/AuthContext.test.tsx`
+- **RED**: with `vi.useFakeTimers()`, assert that after the idle timeout fires, `toast` (from `sonner`) is called with the exact Spanish string `Tu sesión expiró por inactividad. Volvé a iniciar sesión.` and `{ duration: 15000 }`; assert `redirectToLoginOnce` (or its `window.location` side effect) fires at `30000ms` after the inactivity event if no further activity is detected.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `pnpm --dir frontend run test:run` (expected: RED).
+- **Done when**: toast and redirect assertions fail until 2.4 lands.
+- **Work-unit commit**: `test(auth): require idle toast and deferred redirect`
+- **Est. lines**: ~45 (test additions with fake timers)
+
+### Task 2.4 — `feat(auth): show idle expiry toast before redirect`
+- **Branch**: `fix/287-frontend-idle-logout`
+- **Files**: `frontend/context/AuthContext.tsx`, `frontend/package.json` (add `sonner` to `dependencies`), `frontend/pnpm-lock.yaml` (lock `sonner`)
+- **RED**: 2.3's failing tests.
+- **GREEN**: add `sonner` to `frontend/package.json`; in `AuthContext.tsx`, after the inactivity timer fires, import `toast` from `sonner` and call `toast('Tu sesión expiró por inactividad. Volvé a iniciar sesión.', { duration: 15000 })`; schedule a 30000 ms `setTimeout` that calls `redirectToLoginOnce()`. The toast/redirect is local-only; `endLocalSession` still broadcasts `session-expired` as today.
+- **Verify**: `pnpm --dir frontend run test:run` (expected: GREEN for 2.3's toast/redirect assertions); `pnpm --dir frontend install --frozen-lockfile` is NOT used here (lockfile changed on purpose; CI must run with the updated lock).
+- **Done when**: 2.3's tests pass; 476 frontend tests still pass; `frontend/package.json` includes `sonner`; `pnpm-lock.yaml` is updated.
+- **Work-unit commit**: `feat(auth): show idle expiry toast before redirect`
+- **Est. lines**: ~25 (AuthContext) + ~2 (package.json) + lockfile churn
+
+### Task 2.5 — `test(auth): reset idle timer on touch activity`
+- **Branch**: `fix/287-frontend-idle-logout`
+- **Files**: `frontend/context/AuthContext.test.tsx`
+- **RED**: assert that dispatching `window.dispatchEvent(new Event('touchstart'))` or `'touchmove'` calls `resetTimer`, so advancing fake timers past `idle_timeout_minutes` without other activity still does not fire `expireForInactivity`.
+- **GREEN**: N/A — test-only commit.
+- **Verify**: `pnpm --dir frontend run test:run` (expected: RED).
+- **Done when**: touch-reset assertions fail until 2.6 lands.
+- **Work-unit commit**: `test(auth): reset idle timer on touch activity`
+- **Est. lines**: ~30 (test additions)
+
+### Task 2.6 — `fix(auth): add touch activity listeners`
+- **Branch**: `fix/287-frontend-idle-logout`
+- **Files**: `frontend/context/AuthContext.tsx`
+- **RED**: 2.5's failing tests.
+- **GREEN**: extend `ACTIVITY_EVENTS` (current `AuthContext.tsx:33`) to include `'touchstart'` and `'touchmove'`.
+- **Verify**: `pnpm --dir frontend run test:run` (expected: GREEN; 2.5's tests pass; 476 frontend tests still pass).
+- **Done when**: touch events reset the timer; full frontend suite green.
+- **Work-unit commit**: `fix(auth): add touch activity listeners`
+- **Est. lines**: ~1 (`ACTIVITY_EVENTS` constant)
+
+### Task 2.7 — PR2 slice gate
+- **Branch**: `fix/287-frontend-idle-logout`
+- **Files**: none (verification only)
+- **RED/GREEN**: N/A — gate, not a commit.
+- **Verify**: `pnpm --dir frontend run test:run` (must show 476+ tests, all passing); manual two-tab smoke documented in PR body: background tab idle does NOT force active tab server logout; explicit Logout still logs out sibling tabs.
+- **Done when**: full frontend suite green; manual two-tab smoke evidence attached; PR2 PR opened against `fix/287-backend-activity-bump`.
+
+---
+
+## Dependencies Between Slices
+
+| Slice | Compile dependency | Test gate before PR open | PR target base |
+|---|---|---|---|
+| PR0 (`fix/287-db-backfill`) | None | `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` + full backend suite | `fix/287-session-keep-alive` (tracker) |
+| PR1 (`fix/287-backend-activity-bump`) | PR0 merged (compile works without PR0; PR0 needed for production hygiene) | focused backend files + full backend suite (1134 tests) | `fix/287-db-backfill` |
+| PR2 (`fix/287-frontend-idle-logout`) | PR1 merged (backend activity is authoritative) | full frontend suite (476 tests) + manual two-tab smoke | `fix/287-backend-activity-bump` |
+
+Tracker branch `fix/287-session-keep-alive` stays open as a no-merge draft PR until all three child PRs land. Rebase child branches onto the immediate parent's latest tip before each PR opens; if the diff shows previous-slice content, retarget/rebase before review.
+
+## Out of Scope (TODO post-#287)
+
+- Create follow-up issue "Fix stale-recovery rate-limit follow-up from Bug 3" referencing `openspec/changes/fix-multi-window-session-timeout/verify-report-pr2.md:56-57`.
+- No `SESSION_OPERATIONAL_ENABLED` default change.
+- No broad ORM/DB nullable mismatch refactor.
+- No `openspec/changes/fix-multi-window-session-timeout/` edits.
+
+## Manual Evidence Required
+
+- PR0: PostgreSQL before/after `SELECT count(*) FROM refresh_tokens WHERE last_activity_at IS NULL;` plus at least one exercised row id.
+- PR1: One `session.activity_recorded` and one `session.idle_expired` audit row captured in dev DB.
+- PR2: Two-tab manual smoke (idle background tab preserves active tab; explicit Logout revokes sibling tabs).


### PR DESCRIPTION
Part of #287 — PR0 of 3 in the `fix-287-session-keep-alive` feature-branch chain
Up next: PR #290 (`fix/287-backend-activity-bump`) — branches from this PR once merged.

## What

Adds a batched deployment-time backfill for legacy `refresh_tokens.last_activity_at IS NULL` rows in `backend/scripts/backfill_refresh_token_activity.py`. The script:

- Updates rows in bounded batches (default 1000) with a short sleep between batches.
- Uses DB `NOW()` so the backfilled timestamp comes from the database clock, not the application host.
- Is idempotent — a second run on a clean DB updates 0 rows.
- Runs the SQL via raw `text()` so the script does not import any ORM model; `python ... --help` works on hosts without `psycopg2` installed.

## Why

Issue #287 Bug 1: the chain that closed #188 (PRs #245–#257) declared `record_session_activity` in `get_current_user` but never wired it. The startup DDL backfills any `last_activity_at IS NULL` rows at deploy time, but production tables may still have rows from before that DDL landed, or rows whose INSERT path did not populate the column. This script is the operator-facing repair step for those rows.

## Work-unit commits

```
b85aa36 test(auth): define refresh token activity backfill contract
f6f6801 fix(auth): add batched refresh token activity backfill
72ba56b test(auth): document live backfill evidence command
d9e2997 test(auth): add CLI subprocess regression and DB NOW coverage    ← RED regression
54c3ec0 fix(auth): make backfill script import-light and use DB NOW()   ← GREEN regression
9ddaa05 chore(sdd): mark PR0 tasks complete in tasks.md
819df6d chore(sdd): record PR0 apply-progress
67ee589 chore(sdd): record PR0 live PostgreSQL backfill evidence
a765b57 chore(sdd): refresh PR0 apply-progress after follow-up fixes
```

## Live PostgreSQL evidence ✅

Captured against a local `timescale/timescaledb:2.15.0-pg16` container (`nexgen_postgres`). Two rows were seeded: one legacy NULL row (id=1) and one already-populated control (id=2). The backfill updated exactly the legacy row and left the control untouched. A second run updated 0 rows. Full BEFORE / RUN / AFTER output is in `openspec/changes/fix-287-session-keep-alive/live-evidence-pr0.md`.

```
BEFORE
 id | session_id | last_activity_at
----+------------+----------------------------
  1 | legacy-1   |                              <- target
  2 | live-2     | 2026-06-20 21:00:02.961832     <- control

RUN
2026-06-20 14:05:15,727 [INFO] Refresh-token activity backfill updated 1 rows

AFTER
 id | session_id | last_activity_at
----+------------+----------------------------
  1 | legacy-1   | 2026-06-20 21:05:15.622024     <- backfilled with DB NOW()
  2 | live-2     | 2026-06-20 21:00:02.961832     <- untouched

Second run: 0 rows updated (idempotent).
```

## Tests

- `uv run pytest backend/tests/test_refresh_token_activity_backfill.py -v` → 8 passed
- `uv run pytest backend -q` → 1044 passed (+8 new), 97 pre-existing failures unchanged (RTU/backup/dictionary/cli_worker; out of scope, unrelated)
- `uv run python backend/scripts/backfill_refresh_token_activity.py --help` → exit 0, evidence SQL present

## Reviewer Acceptance Checklist

- [ ] Backfill SQL uses DB `NOW()`, not Python `datetime.utcnow()`.
- [ ] Script `python ... --help` succeeds without `psycopg2` installed (verified via `test_help_works_without_postgres_db_import`).
- [ ] Live PostgreSQL evidence in `live-evidence-pr0.md` shows exactly the expected behaviour.
- [ ] No edits to `backend/services/auth_service.py`, `backend/routers/auth.py`, `backend/services/audit_service.py`, or any `frontend/` file (PR1/PR2 scope).
- [ ] No `Co-Authored-By` trailers.
- [ ] Base branch is `fix/287-session-keep-alive` (the tracker), NOT `main`.
- [ ] Label `type:bug` is set.

## Out of Scope

- PR1 (backend activity bump): `record_session_activity`, audit events, `get_current_user` hook.
- PR2 (frontend idle logout): local-only idle expiry, `sonner` toast, touch listeners.
- Bug 3 (stale-recovery + `should_count_rate_limit=False` ignored): tracked separately in #292.

## Related

- Issue: `alexandervazquez98/next-gen#287`
- Prior chain: `openspec/changes/fix-multi-window-session-timeout/` (PR6 explicitly documented this gap as PENDING and not executed).
- Live evidence: `openspec/changes/fix-287-session-keep-alive/live-evidence-pr0.md`
- Verify report: `openspec/changes/fix-287-session-keep-alive/verify-report-pr0.md`
- Apply progress: `openspec/changes/fix-287-session-keep-alive/apply-progress.md`
