### PR TITLE
fix(auth): honor should_count_rate_limit for ROTATED_STALE_RECOVERABLE (#292)

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -401,7 +401,8 @@ async def refresh_tokens(
             verification.token_id,
             policy.stale_rotation_max_recoveries,
         ):
-            increment_attempts(rate_limit_key, identity_type="refresh_token")
+            if verification.should_count_rate_limit:
+                increment_attempts(rate_limit_key, identity_type="refresh_token")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="session expired",

--- a/backend/tests/test_auth_router_refresh.py
+++ b/backend/tests/test_auth_router_refresh.py
@@ -701,6 +701,139 @@ class TestAuthRefresh:
 
         app.dependency_overrides.pop(get_pg_db, None)
 
+    def test_terminal_abuse_statuses_still_increment_rate_limit_revoked(self, rate_limit_db):
+        """Regression guard: REVOKED (a terminal abuse status) must keep
+        counting toward the refresh-token rate limit even after the T3 fix
+        narrowed the should_count_rate_limit guard to the
+        ROTATED_STALE_RECOVERABLE branch. This test pins the contract that
+        the model default flag (should_count_rate_limit=True) keeps every
+        terminal status counting."""
+        raw_token = "revoked_refresh_token"
+        rate_limit_key = refresh_token_rate_limit_key(raw_token)
+
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch(
+            "routers.auth.verify_refresh_token",
+            return_value=RefreshVerificationResult(
+                status=RefreshVerificationStatus.REVOKED,
+                # should_count_rate_limit omitted on purpose: relies on the
+                # model default of True. The T3 fix only narrowed the guard
+                # for ROTATED_STALE_RECOVERABLE, so REVOKED still counts.
+            ),
+        ):
+            response = client.post(
+                "/api/auth/refresh",
+                cookies={"refresh_token": raw_token},
+            )
+
+        assert response.status_code == 401
+
+        session = rate_limit_db()
+        try:
+            rows = (
+                session.query(RateLimitAttempt)
+                .filter_by(identity_key=rate_limit_key)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].identity_type == "refresh_token"
+        finally:
+            session.close()
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_terminal_abuse_statuses_still_increment_rate_limit_expired(self, rate_limit_db):
+        """Regression guard: EXPIRED (a terminal abuse status) must keep
+        counting toward the refresh-token rate limit. Mirrors the REVOKED
+        guard above."""
+        raw_token = "expired_refresh_token"
+        rate_limit_key = refresh_token_rate_limit_key(raw_token)
+
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch(
+            "routers.auth.verify_refresh_token",
+            return_value=RefreshVerificationResult(
+                status=RefreshVerificationStatus.EXPIRED,
+                # should_count_rate_limit omitted on purpose: relies on the
+                # model default of True.
+            ),
+        ):
+            response = client.post(
+                "/api/auth/refresh",
+                cookies={"refresh_token": raw_token},
+            )
+
+        assert response.status_code == 401
+
+        session = rate_limit_db()
+        try:
+            rows = (
+                session.query(RateLimitAttempt)
+                .filter_by(identity_key=rate_limit_key)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].identity_type == "refresh_token"
+        finally:
+            session.close()
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_missing_refresh_token_increments_rate_limit(self, rate_limit_db):
+        """Regression guard: a request with no refresh token cookie at all
+        must still record exactly one RateLimitAttempt row. The MISSING
+        branch at routers/auth.py:298 is upstream of the T3 fix and must
+        keep counting."""
+        raw_token = "missing_refresh_token"
+        rate_limit_key = refresh_token_rate_limit_key(raw_token)
+
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch(
+            "routers.auth.verify_refresh_token",
+            return_value=RefreshVerificationResult(status=RefreshVerificationStatus.MISSING),
+        ):
+            response = client.post(
+                "/api/auth/refresh",
+                cookies={"refresh_token": raw_token},
+            )
+
+        assert response.status_code == 401
+
+        session = rate_limit_db()
+        try:
+            rows = (
+                session.query(RateLimitAttempt)
+                .filter_by(identity_key=rate_limit_key)
+                .all()
+            )
+            assert len(rows) == 1
+            assert rows[0].identity_type == "refresh_token"
+        finally:
+            session.close()
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
     def test_refresh_success_records_session_activity(self):
         """Successful refresh must call record_session_activity once with the
         rotated refresh's session_id and the resolved user_id."""

--- a/backend/tests/test_auth_router_refresh.py
+++ b/backend/tests/test_auth_router_refresh.py
@@ -508,6 +508,199 @@ class TestAuthRefresh:
 
         app.dependency_overrides.pop(get_pg_db, None)
 
+    def test_recoverable_stale_exhaustion_does_not_increment_rate_limit(self, rate_limit_db):
+        """Bug-proof: ROTATED_STALE_RECOVERABLE with should_count_rate_limit=False
+        MUST NOT call increment_attempts even when recovery atomic is exhausted.
+        This is RED against current main: the buggy increment_attempts call at
+        routers/auth.py:404 fires unconditionally when try_increment_refresh_recovery_count
+        returns False, regardless of the should_count_rate_limit flag."""
+        stale_refresh_token = "stale_refresh_exhausted"
+        rate_limit_key = refresh_token_rate_limit_key(stale_refresh_token)
+
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            role="OPERATOR",
+            user_id=42,
+        )
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.add = MagicMock()
+        mock_db.commit = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch(
+            "routers.auth.verify_refresh_token",
+            return_value=RefreshVerificationResult(
+                status=RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE,
+                user_id=42,
+                session_id="sid-recoverable-exhausted",
+                token_id=99,
+                should_count_rate_limit=False,
+            ),
+        ):
+            with patch(
+                "routers.auth.try_increment_refresh_recovery_count",
+                return_value=False,
+            ) as recovery_count:
+                with patch("routers.auth.increment_attempts") as increment_attempts:
+                    response = client.post(
+                        "/api/auth/refresh",
+                        cookies={"refresh_token": stale_refresh_token},
+                    )
+
+        assert response.status_code == 401
+        # The bug proof: increment_attempts must NOT have been called.
+        # Today this assertion FAILS — the buggy :404 line calls it unconditionally.
+        increment_attempts.assert_not_called()
+        recovery_count.assert_called_once_with(mock_db, 99, 3)
+
+        # Cross-check: no RateLimitAttempt row for this token.
+        session = rate_limit_db()
+        try:
+            row = session.query(RateLimitAttempt).filter_by(identity_key=rate_limit_key).first()
+            assert row is None
+        finally:
+            session.close()
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_recoverable_stale_within_cap_does_not_increment_rate_limit(self, rate_limit_db):
+        """Bug-proof (within-cap branch): even when try_increment_refresh_recovery_count
+        returns True and the path succeeds, increment_attempts must NOT be called
+        because should_count_rate_limit=False.
+
+        Note: this test currently passes against main for the wrong reason — the
+        atomic=True short-circuit skips the buggy :404 line. The explicit
+        increment_attempts.assert_not_called() guard below is what makes this test
+        a real proof of the fix once the inline guard lands in T3: today the patch
+        is never invoked; after the fix the patch IS invoked (the path enters the
+        success branch via atomic=True) but is correctly skipped because of the
+        flag guard."""
+        stale_refresh_token = "stale_refresh_within_cap"
+        rate_limit_key = refresh_token_rate_limit_key(stale_refresh_token)
+
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            role="OPERATOR",
+            user_id=42,
+        )
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.add = MagicMock()
+        mock_db.commit = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch(
+            "routers.auth.verify_refresh_token",
+            return_value=RefreshVerificationResult(
+                status=RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE,
+                user_id=42,
+                session_id="sid-recoverable-within-cap",
+                token_id=99,
+                should_count_rate_limit=False,
+            ),
+        ):
+            with patch(
+                "routers.auth.try_increment_refresh_recovery_count",
+                return_value=True,
+            ) as recovery_count:
+                with patch(
+                    "routers.auth.create_refresh_token",
+                    return_value=("recovered-refresh-token", MagicMock(id=125)),
+                ):
+                    with patch("routers.auth.create_access_token", return_value="new_access_token"):
+                        with patch("routers.auth.increment_attempts") as increment_attempts:
+                            response = client.post(
+                                "/api/auth/refresh",
+                                cookies={"refresh_token": stale_refresh_token},
+                            )
+
+        assert response.status_code == 200
+        # The bug-proof guard. Today this passes for the wrong reason (atomic
+        # short-circuits before the buggy line). After the T3 inline guard lands
+        # this is the real proof.
+        increment_attempts.assert_not_called()
+        recovery_count.assert_called_once_with(mock_db, 99, 3)
+
+        # Cross-check: no RateLimitAttempt row for this token.
+        session = rate_limit_db()
+        try:
+            row = session.query(RateLimitAttempt).filter_by(identity_key=rate_limit_key).first()
+            assert row is None
+        finally:
+            session.close()
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
+    def test_recoverable_stale_token_id_none_does_not_increment_rate_limit(self, rate_limit_db):
+        """Bug-proof (token_id=None branch): when verification.token_id is None
+        the router skips recovery reservation and falls into the buggy :404
+        increment_attempts call. With should_count_rate_limit=False it must
+        NOT increment. This is RED against current main."""
+        stale_refresh_token = "stale_refresh_no_token_id"
+        rate_limit_key = refresh_token_rate_limit_key(stale_refresh_token)
+
+        mock_user = _make_mock_pg_user(
+            username="testuser",
+            role="OPERATOR",
+            user_id=42,
+        )
+        mock_db = MagicMock(spec=Session)
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_user
+        mock_db.add = MagicMock()
+        mock_db.commit = MagicMock()
+
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_pg_db] = override_get_db
+
+        with patch(
+            "routers.auth.verify_refresh_token",
+            return_value=RefreshVerificationResult(
+                status=RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE,
+                user_id=42,
+                session_id="sid-recoverable-no-token-id",
+                token_id=None,
+                should_count_rate_limit=False,
+            ),
+        ):
+            with patch(
+                "routers.auth.try_increment_refresh_recovery_count",
+            ) as recovery_count:
+                with patch("routers.auth.increment_attempts") as increment_attempts:
+                    response = client.post(
+                        "/api/auth/refresh",
+                        cookies={"refresh_token": stale_refresh_token},
+                    )
+
+        assert response.status_code == 401
+        # The bug proof: increment_attempts must NOT have been called when the
+        # service said do not count. Today this assertion FAILS — the token_id
+        # is None so the inner `or` short-circuits to True, the buggy :404
+        # line fires, and increment_attempts IS called.
+        increment_attempts.assert_not_called()
+        # token_id is None so the recovery atomic is never called.
+        recovery_count.assert_not_called()
+
+        # Cross-check: no RateLimitAttempt row for this token.
+        session = rate_limit_db()
+        try:
+            row = session.query(RateLimitAttempt).filter_by(identity_key=rate_limit_key).first()
+            assert row is None
+        finally:
+            session.close()
+
+        app.dependency_overrides.pop(get_pg_db, None)
+
     def test_refresh_success_records_session_activity(self):
         """Successful refresh must call record_session_activity once with the
         rotated refresh's session_id and the resolved user_id."""

--- a/backend/tests/test_auth_service_refresh.py
+++ b/backend/tests/test_auth_service_refresh.py
@@ -313,6 +313,68 @@ class TestVerifyRefreshToken:
         result = verify_refresh_token(token, mock_db)
         assert result.status == RefreshVerificationStatus.ROTATED_STALE_REJECTED
 
+    def test_all_rotated_stale_recoverable_paths_set_should_count_rate_limit_false(self):
+        """Req 4: verify_refresh_token must always set
+        should_count_rate_limit=False on a ROTATED_STALE_RECOVERABLE result.
+
+        The service has exactly one ROTATED_STALE_RECOVERABLE branch today
+        (within stale grace AND below recovery cap). This test pins that
+        branch and acts as a guardrail: a future service refactor that adds
+        a new recoverable path or relaxes the flag will fail this test."""
+        token = "recoverable-flag-contract"
+        token_hash = hash_token(token)
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = self._mock_rt(
+            token_hash=token_hash,
+            user_id=42,
+            expires_at=datetime.utcnow() + timedelta(days=7),
+            session_id="sess-flag-contract",
+            revoked_at=datetime.utcnow() - timedelta(seconds=1),
+            revoked_reason="rotated",
+            rotated_at=datetime.utcnow() - timedelta(seconds=10),
+            stale_recovery_count=0,
+            policy_profile="standard",
+            last_activity_at=datetime.utcnow(),
+        )
+
+        result = verify_refresh_token(token, mock_db)
+
+        assert result.status == RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE
+        assert result.should_count_rate_limit is False
+
+    def test_rotated_token_beyond_grace_is_stale_rejected_not_recoverable(self):
+        """Req 4 boundary: a rotated token past stale grace must be
+        ROTATED_STALE_REJECTED, NOT ROTATED_STALE_RECOVERABLE.
+
+        The existing test_rotated_token_beyond_grace_is_rejected asserts
+        status == ROTATED_STALE_REJECTED (which implicitly excludes the
+        recoverable status). This test pins the boundary explicitly so a
+        future regression where the boundary slips — for example, a grace
+        window expansion that re-classifies past-grace tokens as
+        recoverable — fails loudly."""
+        token = "late-stale-flag-contract"
+        token_hash = hash_token(token)
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = self._mock_rt(
+            token_hash=token_hash,
+            user_id=88,
+            expires_at=datetime.utcnow() + timedelta(days=7),
+            session_id="sess-88-flag-contract",
+            revoked_at=datetime.utcnow() - timedelta(seconds=1),
+            revoked_reason="rotated",
+            rotated_at=datetime.utcnow() - timedelta(seconds=get_stale_recovery_grace_seconds() + 1),
+            stale_recovery_count=0,
+            policy_profile="standard",
+            last_activity_at=datetime.utcnow(),
+        )
+
+        result = verify_refresh_token(token, mock_db)
+
+        assert result.status == RefreshVerificationStatus.ROTATED_STALE_REJECTED
+        # Explicit boundary guard: the past-grace path MUST NOT collapse
+        # into ROTATED_STALE_RECOVERABLE.
+        assert result.status != RefreshVerificationStatus.ROTATED_STALE_RECOVERABLE
+
 
 class TestTryIncrementRefreshRecoveryCount:
     """Tests for atomic stale recovery reservation."""
@@ -336,6 +398,35 @@ class TestTryIncrementRefreshRecoveryCount:
         assert result is False
         mock_db.query.return_value.filter.return_value.update.assert_called_once()
         mock_db.commit.assert_called_once()
+
+    def test_try_increment_refresh_recovery_count_contract_unchanged(self):
+        """Req 5: the recovery atomic contract is pinned.
+
+        Verifies that try_increment_refresh_recovery_count:
+        - Returns True when the atomic update affects exactly one row
+          (recovery slot reserved within the cap).
+        - Returns False when the atomic update affects zero rows
+          (cap already consumed).
+        - Calls commit() once for both branches (existing contract).
+
+        The fix MUST NOT alter the atomic implementation or the
+        stale_rotation_max_recoveries default; only the router counter
+        honoring changes."""
+        # True branch: one row affected.
+        mock_db_true = MagicMock()
+        mock_db_true.query.return_value.filter.return_value.update.return_value = 1
+
+        assert try_increment_refresh_recovery_count(mock_db_true, token_id=321, max_recoveries=3) is True
+        mock_db_true.query.return_value.filter.return_value.update.assert_called_once()
+        mock_db_true.commit.assert_called_once()
+
+        # False branch: zero rows affected.
+        mock_db_false = MagicMock()
+        mock_db_false.query.return_value.filter.return_value.update.return_value = 0
+
+        assert try_increment_refresh_recovery_count(mock_db_false, token_id=321, max_recoveries=3) is False
+        mock_db_false.query.return_value.filter.return_value.update.assert_called_once()
+        mock_db_false.commit.assert_called_once()
 
 
 class TestRevokeRefreshToken:


### PR DESCRIPTION
## Summary

Closes #292.

The router's `ROTATED_STALE_RECOVERABLE` branch was unconditionally calling `increment_attempts(rate_limit_key, identity_type="refresh_token")` when the recovery atomic returned `False` (cap exhausted), even though `verify_refresh_token` already returns `should_count_rate_limit=False` for that status. Legitimate stale-rotation races could therefore drive the rate-limit counter past the lockout threshold and lock out a user who never did anything wrong.

This PR honors the flag by wrapping the counter write in an `if verification.should_count_rate_limit:` guard at `backend/routers/auth.py:404`. The bug-proof tests assert that the guard works for the exhausted, within-cap, and `token_id=None` branches; regression tests confirm REVOKED, EXPIRED, and MISSING still count; service tests confirm `verify_refresh_token` consistently sets `should_count_rate_limit=False` for `ROTATED_STALE_RECOVERABLE` and that the recovery atomic contract is unchanged.

## Test plan

- [x] `uv run pytest backend/tests/test_auth_router_refresh.py backend/tests/test_auth_service_refresh.py -v` — 9 new tests, all green; existing tests in those files unchanged and still green.
- [x] `uv run pytest` — full backend suite green on auth/refresh test files (1134 → 1143 expected; actual baseline on this worktree is 1058 passing before this PR, 1067 after — see note below).
- [x] No frontend changes.
- [x] Existing `test_stale_refresh_recoverable_does_not_increment_rate_limit` still passes (left untouched on purpose; it currently passes for the wrong reason but the new within-cap test asserts the guard directly).

> Note: This worktree's full suite has 97 pre-existing failures across 13 unrelated test files (test_auth_extended, test_backup_service, test_cli_worker, test_dictionary_service, test_event_correlation, test_routers_dictionaries, test_routers_events, test_routers_links, test_routers_metrics_events, test_routers_nodes, test_rtu_integration, test_rtu_sensor_repo, test_rtus_router). These failures exist on `main@e9557e0` and are not introduced by this PR — they are unrelated to the auth/refresh surgical fix and are out of scope for #292.

## Commits

1. `test(auth): add RED tests for ROTATED_STALE_RECOVERABLE rate-limit honoring` — `1c27f55`
2. `fix(auth): honor should_count_rate_limit in ROTATED_STALE_RECOVERABLE branch` — `c1d4655`
3. `test(auth): add regression coverage for terminal abuse statuses` — `2a69b9e`
4. `test(auth): cover service stale-recovery flag and atomic contract` — `462e321`

## New tests (9 total)

`backend/tests/test_auth_router_refresh.py` (6):
- `test_recoverable_stale_exhaustion_does_not_increment_rate_limit` (Req 1 — RED→GREEN)
- `test_recoverable_stale_within_cap_does_not_increment_rate_limit` (Req 1 — explicit assert_not_called guard)
- `test_recoverable_stale_token_id_none_does_not_increment_rate_limit` (Req 1 — RED→GREEN)
- `test_terminal_abuse_statuses_still_increment_rate_limit_revoked` (Req 2 regression)
- `test_terminal_abuse_statuses_still_increment_rate_limit_expired` (Req 2 regression)
- `test_missing_refresh_token_increments_rate_limit` (Req 2 regression)

`backend/tests/test_auth_service_refresh.py` (3):
- `test_all_rotated_stale_recoverable_paths_set_should_count_rate_limit_false` (Req 4)
- `test_rotated_token_beyond_grace_is_stale_rejected_not_recoverable` (Req 4 boundary; complementary to existing `test_rotated_token_beyond_grace_is_rejected`)
- `test_try_increment_refresh_recovery_count_contract_unchanged` (Req 5)

## Acceptance criteria mapping

| # | Criterion (proposal.md:62-70) | Test |
|---|---|---|
| 1 | Exhausted branch with `should_count_rate_limit=False` does NOT increment | `test_recoverable_stale_exhaustion_does_not_increment_rate_limit` |
| 2 | Within-cap branch with `should_count_rate_limit=False` does NOT increment | `test_recoverable_stale_within_cap_does_not_increment_rate_limit` |
| 3 | `token_id=None` branch with `should_count_rate_limit=False` does NOT increment | `test_recoverable_stale_token_id_none_does_not_increment_rate_limit` |
| 4 | REVOKED still increments | `test_terminal_abuse_statuses_still_increment_rate_limit_revoked` |
| 5 | EXPIRED still increments | `test_terminal_abuse_statuses_still_increment_rate_limit_expired` |
| 6 | MISSING still increments | `test_missing_refresh_token_increments_rate_limit` |

Plus contract-level guarantees (Req 4 boundary + Req 5 atomic unchanged) via the service tests.

## Out of scope

No telemetry, no `stale_rotation_max_recoveries` change, no recovery atomic change, no frontend work. A follow-up change may extend the `should_count_rate_limit` guard to every router counter write site (the broader "flag is source of truth" invariant), but that is explicitly deferred per the spec's deferred-work note.

## Deferred follow-up

The spec at `openspec/changes/fix-292-stale-recovery-rate-limit/specs/auth-rate-limit-flag-honoring/spec.md` notes that the broader "Router does NOT call increment_attempts when should_count_rate_limit is False for any status" invariant is deferred. A future change may add the guard at every counter write site.