### PR TITLE
ci(ci): frontend CI lane with Vitest and ESLint devDeps (PR3/6)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,11 @@
+# actionlint config for next-gen. See https://github.com/rhysd/actionlint/tree/v1.7.8/docs/config.md
+
+self-hosted-runner:
+  labels: []
+  matrix: {}
+
+config-variables: null
+
+# Files actionlint should NOT treat as workflow definitions.
+exclude:
+  - .github/dependabot.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,65 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot version updates for next-gen.
+#
+# Three ecosystems tracked: github-actions (/), pip (/backend), npm (/frontend).
+# Live PRs are the only authoritative proof of validity (no public schema validator).
+# See openspec/changes/ci-cd-pipeline/spec.md R3 and tasks.md T1.1.
 
 version: 2
+
+# Limit concurrent open PRs across all ecosystems so reviewers are not flooded.
+open-pull-requests-limit: 5
+
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # GitHub Actions versions used by .github/workflows/**
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels: ["dependencies", "ci/cd"]
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
+  # Backend Python dependencies (requirements*.txt)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels: ["dependencies", "backend"]
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # Frontend pnpm/npm dependencies (lockfile frozen via Corepack)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    labels: ["dependencies", "frontend"]
+    groups:
+      minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,154 @@
+# Workflow: backend-ci (PR2 of ci-cd-pipeline)
+#
+# Runs pytest with strict markers and produces a coverage report for every
+# pull request that touches backend code. This is PR2 of the six-slice CI/CD
+# chain (feature-branch-chain: PR1 -> PR2 -> ... -> PR6).
+#
+# Jobs:
+#   backend-tests — Python 3.11, pip install from requirements*.txt, pytest
+#                   --cov with strict markers; coverage.xml uploaded as an
+#                   artifact for reviewer inspection.
+#   ci-verify     — T2.4 PR2 verification gate: actionlint, yamllint, and a
+#                   pytest --collect-only run to prove the workflow stays
+#                   green on PR + push to main + cicd/**.
+#
+# Scope decision (T2.3): this lane runs UNIT-ONLY in v1. Integration tests
+# with Postgres + Neo4j service containers are explicitly deferred to a
+# future change. The current backend test suite mocks external services, so
+# running pytest in CI without service containers is safe and keeps the lane
+# under the 400-line review budget.
+#
+# Codecov upload: not wired in v1. Operators can add a Codecov step once a
+# CODECOV_TOKEN secret is provisioned; the artifact upload already captures
+# coverage.xml for local inspection.
+#
+# Chain strategy: PR2 targets `cicd/lint-dep-skeleton`. The path filter keeps
+# this lane silent on docs-only or frontend-only PRs to protect the
+# reviewer signal. See openspec/changes/ci-cd-pipeline/design.md.
+
+name: backend-ci
+
+on:
+  pull_request:
+    paths:
+      - "backend/**"
+      - "backend/requirements.txt"
+      - "backend/requirements-dev.txt"
+      - "backend/pytest.ini"
+      - ".github/workflows/backend-ci.yml"
+  push:
+    branches:
+      - main
+      - "cicd/**"
+    paths:
+      - "backend/**"
+      - "backend/requirements.txt"
+      - "backend/requirements-dev.txt"
+      - "backend/pytest.ini"
+      - ".github/workflows/backend-ci.yml"
+
+# Cancel superseded PR runs; keep push runs to the end.
+concurrency:
+  group: backend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # R4 Backend CI Lane: pytest with strict markers + coverage. Unit-only in v1.
+  backend-tests:
+    name: backend-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed backend files
+        id: changed
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
+        with:
+          files_yaml: |
+            backend/**/*.py
+            backend/requirements.txt
+            backend/requirements-dev.txt
+            backend/pytest.ini
+
+      - name: Set up Python 3.11
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install backend dependencies
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Verify pytest install
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: python -m pytest --version
+
+      - name: Run pytest with coverage
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          python -m pytest --cov=. --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage artifact
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: backend/coverage.xml
+          if-no-files-found: warn
+          retention-days: 14
+
+  # T2.4: PR2 verification gate. Always runs so a backend-only PR exercises
+  # actionlint + yamllint + pytest collect even when no Python file changed.
+  ci-verify:
+    name: ci-verify (PR2 gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download actionlint (pinned release)
+        run: |
+          set -euo pipefail
+          VERSION="1.7.8"
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar xzf actionlint.tar.gz
+          chmod +x actionlint
+
+      - name: actionlint must pass
+        run: ./actionlint -color
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install yamllint
+        run: pip install --quiet yamllint==1.38.0
+
+      - name: yamllint must pass
+        run: yamllint -c .yamllint.yml .github/
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          python -m pip install -q -r requirements.txt -r requirements-dev.txt
+
+      - name: pytest --collect-only must succeed
+        working-directory: backend
+        run: python -m pytest --collect-only -q

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -150,6 +150,7 @@ jobs:
         run: |
           set -euo pipefail
           corepack enable
+          corepack prepare pnpm@10.12.1 --activate
           pnpm --dir frontend install --frozen-lockfile
 
       - name: vitest list must enumerate

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,156 @@
+# Workflow: frontend-ci (PR3 of ci-cd-pipeline)
+#
+# Runs Vitest with coverage on every pull request that touches frontend code.
+# This is PR3 of the six-slice CI/CD chain (feature-branch-chain: PR1 -> PR2
+# -> PR3 -> ... -> PR6).
+#
+# Jobs:
+#   frontend-tests — Vitest with jsdom + @vitest/coverage-v8; lcov.info
+#                   uploaded as an artifact for reviewer inspection.
+#   ci-verify      — T3.3 PR3 verification gate: actionlint, yamllint, and a
+#                    `vitest list` collect to prove the workflow stays green
+#                    on PR + push to main + cicd/**.
+#
+# Chain strategy: PR3 targets `cicd/backend-ci`. The path filter keeps this
+# lane silent on docs-only or backend-only PRs to protect the reviewer
+# signal. ESLint + Prettier on changed files is handled by lint.yml — this
+# workflow is intentionally tests-only.
+#
+# Lockfile discipline (spec R5 scenario "Lockfile drift blocks CI"): the
+# install step uses `--frozen-lockfile` so a package.json / pnpm-lock.yaml
+# drift fails CI before tests run, matching spec R5 acceptance criteria.
+#
+# SHA pins: tj-actions/changed-files pinned to v46.0.5
+# (CVE-2025-30022 mitigation, consistent with PR1 lint.yml + PR2 backend-ci).
+
+name: frontend-ci
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - "frontend/package.json"
+      - "frontend/pnpm-lock.yaml"
+      - ".github/workflows/frontend-ci.yml"
+  push:
+    branches:
+      - main
+      - "cicd/**"
+    paths:
+      - "frontend/**"
+      - "frontend/package.json"
+      - "frontend/pnpm-lock.yaml"
+      - ".github/workflows/frontend-ci.yml"
+
+# Cancel superseded PR runs; keep push runs to the end.
+concurrency:
+  group: frontend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # R5 Frontend CI Lane: Corepack pnpm frozen-lockfile install, Vitest, coverage.
+  frontend-tests:
+    name: frontend-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed frontend files
+        id: changed
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
+        with:
+          files_yaml: |
+            frontend/**/*.{ts,tsx,js,jsx,cjs,mjs,css,md,json}
+            frontend/eslint.config.js
+            frontend/.prettierrc.json
+            frontend/.prettierignore
+            frontend/package.json
+            frontend/pnpm-lock.yaml
+            frontend/vite.config.ts
+            frontend/test-setup.ts
+
+      - name: Set up Node 22
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Enable Corepack
+        if: steps.changed.outputs.any_changed == 'true'
+        run: corepack enable
+
+      - name: Install frontend dependencies (frozen lockfile)
+        if: steps.changed.outputs.any_changed == 'true'
+        run: pnpm --dir frontend install --frozen-lockfile
+
+      - name: Verify Vitest install
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: pnpm exec vitest --version
+
+      - name: Run Vitest
+        if: steps.changed.outputs.any_changed == 'true'
+        run: pnpm --dir frontend run test:run
+
+      - name: Run Vitest with coverage
+        if: steps.changed.outputs.any_changed == 'true'
+        run: pnpm --dir frontend run test:coverage
+
+      - name: Upload coverage artifact
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/lcov.info
+          if-no-files-found: warn
+          retention-days: 14
+
+  # T3.3: PR3 verification gate. Always runs so a frontend-only PR exercises
+  # actionlint + yamllint + vitest collect even when no JS/TS file changed.
+  ci-verify:
+    name: ci-verify (PR3 gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download actionlint (pinned release)
+        run: |
+          set -euo pipefail
+          VERSION="1.7.8"
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar xzf actionlint.tar.gz
+          chmod +x actionlint
+
+      - name: actionlint must pass
+        run: ./actionlint -color
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install yamllint
+        run: pip install --quiet yamllint==1.38.0
+
+      - name: yamllint must pass
+        run: yamllint -c .yamllint.yml .github/
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Enable Corepack + install (frozen)
+        run: |
+          set -euo pipefail
+          corepack enable
+          pnpm --dir frontend install --frozen-lockfile
+
+      - name: vitest list must enumerate
+        run: pnpm --dir frontend exec vitest list > /dev/null

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -114,7 +114,7 @@ jobs:
           mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
           shell_files=()
           for f in "${files[@]}"; do
-            case "$f" in *.sh|entrypoint.sh) shell_files+=("$f") ;; esac
+            case "$f" in *.sh) shell_files+=("$f") ;; esac
           done
           if [ ${#shell_files[@]} -gt 0 ]; then
             shellcheck -x "${shell_files[@]}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,213 @@
+# Workflow: lint (PR1 skeleton + verification harness).
+#
+# PR1 introduces the workflow skeleton + lint verification gate. PR2..PR6 add
+# backend-ci.yml, frontend-ci.yml, build.yml, smoke.yml, cd.yml respectively.
+# This file is intentionally limited to workflow linting and changed-file code
+# linting — no tests, no builds, no deploys.
+#
+# Jobs:
+#   actionlint    — R1 workflow YAML validation
+#   yamllint      — R1 YAML sanity check
+#   shellcheck    — R11 shell script lint on changed files
+#   lint-backend  — R2 Ruff + Black on changed backend files
+#   lint-frontend — R2 ESLint + Prettier on changed frontend files
+#   lint-verify   — T1.7 PR1 verification gate on empty diff (main push only)
+#
+# See openspec/changes/ci-cd-pipeline/design.md D4 for changed-files scoping.
+
+name: lint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "backend/**"
+      - "frontend/**"
+      - "scripts/**"
+      - "docs/**"
+      - ".yamllint.yml"
+  push:
+    branches:
+      - main
+      - "cicd/**"
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yaml"
+      - "backend/**"
+      - "frontend/**"
+      - "scripts/**"
+      - ".yamllint.yml"
+
+# Cancel superseded PR runs; keep push runs to the end.
+concurrency:
+  group: lint-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # R1: actionlint validates every workflow YAML file.
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: |
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Run actionlint
+        run: ./actionlint -color
+
+  # R1: yamllint sanity check.
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yamllint
+        run: pip install --quiet yamllint==1.38.0
+      - name: Run yamllint
+        run: yamllint -c .yamllint.yml .github/ .yamllint.yml
+
+  # R11: shellcheck on changed shell scripts.
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed shell files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            scripts/**.sh
+            scripts/**/*.sh
+            docker/neo4j/entrypoint.sh
+            monitor_performance.sh
+      - name: Install ShellCheck
+        if: steps.changed.outputs.any_changed == 'true'
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Run ShellCheck
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          if [ ${#files[@]} -gt 0 ]; then
+            shellcheck -x "${files[@]}"
+          else
+            echo "No shell files changed — skipping."
+          fi
+
+  # R2: Ruff + Black on changed backend files.
+  lint-backend:
+    name: lint-backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed backend files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            backend/**/*.py
+            backend/ruff.toml
+            backend/pyproject.toml
+      - name: Set up Python
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff and black
+        if: steps.changed.outputs.any_changed == 'true'
+        run: pip install --quiet ruff==0.15.18 black==26.5.1
+      - name: Run Ruff
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          py_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.py) py_files+=("$f") ;; esac
+          done
+          if [ ${#py_files[@]} -gt 0 ]; then
+            ruff check --config ruff.toml "${py_files[@]}"
+          else
+            echo "No .py files in change set — skipping."
+          fi
+      - name: Run Black --check
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          py_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.py) py_files+=("$f") ;; esac
+          done
+          if [ ${#py_files[@]} -gt 0 ]; then
+            black --check --diff "${py_files[@]}"
+          else
+            echo "No .py files in change set — skipping."
+          fi
+
+  # R2: ESLint + Prettier on changed frontend files.
+  lint-frontend:
+    name: lint-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect changed frontend files
+        id: changed
+        uses: tj-actions/changed-files@v46
+        with:
+          files_yaml: |
+            frontend/**/*.{ts,tsx,js,cjs,json,css,md}
+            frontend/eslint.config.js
+            frontend/.prettierrc.json
+            frontend/.prettierignore
+            frontend/package.json
+      - name: Set up Node
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Enable Corepack
+        if: steps.changed.outputs.any_changed == 'true'
+        run: corepack enable
+      - name: Install dependencies
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: corepack pnpm install --frozen-lockfile
+      - name: Run ESLint
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: pnpm run lint
+      - name: Run Prettier --check
+        if: steps.changed.outputs.any_changed == 'true'
+        working-directory: frontend
+        run: pnpm run format:check
+
+  # T1.7: PR1 verification gate — empty-diff must be green on main push.
+  lint-verify:
+    name: lint-verify (PR1 gate)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: actionlint must pass
+        run: ./actionlint -color
+      - name: Install yamllint + ruff + black
+        run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==26.5.1
+      - name: yamllint must pass
+        run: yamllint -c .yamllint.yml .github/
+      - name: ruff must parse config
+        working-directory: backend
+        run: ruff check --config ruff.toml tests/__init__.py
+      - name: black must parse config
+        working-directory: backend
+        run: black --check tests/__init__.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@
 #   shellcheck    — R11 shell script lint on changed files
 #   lint-backend  — R2 Ruff + Black on changed backend files
 #   lint-frontend — R2 ESLint + Prettier on changed frontend files
-#   lint-verify   — T1.7 PR1 verification gate on empty diff (main push only)
+#   lint-verify   — T1.7 PR1 verification gate (runs on push:main AND on PR)
 #
 # See openspec/changes/ci-cd-pipeline/design.md D4 for changed-files scoping.
 
@@ -27,6 +27,12 @@ on:
       - "scripts/**"
       - "docs/**"
       - ".yamllint.yml"
+      - "frontend/eslint.config.js"
+      - "frontend/.prettierrc.json"
+      - "frontend/.prettierignore"
+      - "frontend/package.json"
+      - "backend/ruff.toml"
+      - "backend/pyproject.toml"
   push:
     branches:
       - main
@@ -38,6 +44,12 @@ on:
       - "frontend/**"
       - "scripts/**"
       - ".yamllint.yml"
+      - "frontend/eslint.config.js"
+      - "frontend/.prettierrc.json"
+      - "frontend/.prettierignore"
+      - "frontend/package.json"
+      - "backend/ruff.toml"
+      - "backend/pyproject.toml"
 
 # Cancel superseded PR runs; keep push runs to the end.
 concurrency:
@@ -54,9 +66,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Download actionlint
+      - name: Download actionlint (pinned release)
         run: |
-          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          set -euo pipefail
+          VERSION="1.7.8"
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar xzf actionlint.tar.gz
+          chmod +x actionlint
       - name: Run actionlint
         run: ./actionlint -color
 
@@ -66,12 +83,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install yamllint
         run: pip install --quiet yamllint==1.38.0
       - name: Run yamllint
         run: yamllint -c .yamllint.yml .github/ .yamllint.yml
 
-  # R11: shellcheck on changed shell scripts.
+  # R11: shellcheck on changed shell scripts (shellcheck is preinstalled on
+  # ubuntu-24.04 runners; no apt-get install needed).
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
@@ -82,20 +104,20 @@ jobs:
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
-            scripts/**.sh
             scripts/**/*.sh
             docker/neo4j/entrypoint.sh
             monitor_performance.sh
-      - name: Install ShellCheck
-        if: steps.changed.outputs.any_changed == 'true'
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run ShellCheck
         if: steps.changed.outputs.any_changed == 'true'
         run: |
           set -euo pipefail
           mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
-          if [ ${#files[@]} -gt 0 ]; then
-            shellcheck -x "${files[@]}"
+          shell_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.sh|entrypoint.sh) shell_files+=("$f") ;; esac
+          done
+          if [ ${#shell_files[@]} -gt 0 ]; then
+            shellcheck -x "${shell_files[@]}"
           else
             echo "No shell files changed — skipping."
           fi
@@ -153,7 +175,9 @@ jobs:
             echo "No .py files in change set — skipping."
           fi
 
-  # R2: ESLint + Prettier on changed frontend files.
+  # R2: ESLint + Prettier on changed frontend files (changed-only scope per
+  # spec R2 "Legacy untouched files do not block PR1"). DevDeps are installed
+  # in PR3; until then scripts use `pnpm dlx` to fetch eslint/prettier on demand.
   lint-frontend:
     name: lint-frontend
     runs-on: ubuntu-latest
@@ -164,7 +188,7 @@ jobs:
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
-            frontend/**/*.{ts,tsx,js,cjs,json,css,md}
+            frontend/**/*.{ts,tsx,js,jsx,cjs,mjs,css,md}
             frontend/eslint.config.js
             frontend/.prettierrc.json
             frontend/.prettierignore
@@ -181,26 +205,62 @@ jobs:
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: frontend
         run: corepack pnpm install --frozen-lockfile
-      - name: Run ESLint
+      - name: Run ESLint (changed files only)
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: frontend
-        run: pnpm run lint
-      - name: Run Prettier --check
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          lint_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              *.ts|*.tsx|*.js|*.jsx|*.cjs|*.mjs) lint_files+=("$f") ;;
+            esac
+          done
+          if [ ${#lint_files[@]} -gt 0 ]; then
+            pnpm dlx eslint@9.18.0 --max-warnings=0 "${lint_files[@]}"
+          else
+            echo "No JS/TS files in change set — skipping ESLint."
+          fi
+      - name: Run Prettier --check (changed files only)
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: frontend
-        run: pnpm run format:check
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          fmt_files=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              *.ts|*.tsx|*.js|*.jsx|*.cjs|*.mjs|*.css|*.md|*.json) fmt_files+=("$f") ;;
+            esac
+          done
+          if [ ${#fmt_files[@]} -gt 0 ]; then
+            pnpm dlx prettier@3.4.2 --check "${fmt_files[@]}"
+          else
+            echo "No format-relevant files in change set — skipping Prettier."
+          fi
 
-  # T1.7: PR1 verification gate — empty-diff must be green on main push.
+  # T1.7: PR1 verification gate — runs on push to main AND on PRs that touch
+  # the lint configs so failures surface pre-merge, not just post-merge.
   lint-verify:
     name: lint-verify (PR1 gate)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
-      - name: Download actionlint
-        run: bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Download actionlint (pinned release)
+        run: |
+          set -euo pipefail
+          VERSION="1.7.8"
+          curl -sSLf -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          tar xzf actionlint.tar.gz
+          chmod +x actionlint
       - name: actionlint must pass
         run: ./actionlint -color
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: Install yamllint + ruff + black
         run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==26.5.1
       - name: yamllint must pass

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -176,8 +176,10 @@ jobs:
           fi
 
   # R2: ESLint + Prettier on changed frontend files (changed-only scope per
-  # spec R2 "Legacy untouched files do not block PR1"). DevDeps are installed
-  # in PR3; until then scripts use `pnpm dlx` to fetch eslint/prettier on demand.
+  # spec R2 "Legacy untouched files do not block PR1"). ESLint and Prettier
+  # are local devDependencies installed by `corepack pnpm install`; the lint
+  # and format scripts in package.json wrap them so this job stays in sync
+  # with local commands.
   lint-frontend:
     name: lint-frontend
     runs-on: ubuntu-latest
@@ -218,7 +220,7 @@ jobs:
             esac
           done
           if [ ${#lint_files[@]} -gt 0 ]; then
-            pnpm dlx eslint@9.18.0 --max-warnings=0 "${lint_files[@]}"
+            pnpm run lint -- "${lint_files[@]}"
           else
             echo "No JS/TS files in change set — skipping ESLint."
           fi
@@ -235,7 +237,7 @@ jobs:
             esac
           done
           if [ ${#fmt_files[@]} -gt 0 ]; then
-            pnpm dlx prettier@3.4.2 --check "${fmt_files[@]}"
+            pnpm run format:check -- "${fmt_files[@]}"
           else
             echo "No format-relevant files in change set — skipping Prettier."
           fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect changed shell files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
             scripts/**.sh
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect changed backend files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
             backend/**/*.py
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Detect changed frontend files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
         with:
           files_yaml: |
             frontend/**/*.{ts,tsx,js,cjs,json,css,md}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,26 @@
+# yamllint config for next-gen.
+
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  document-start: disable
+  truthy:
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+    require-starting-space: true
+  indentation:
+    spaces: 2
+    indent-sequences: true
+  braces: disable
+  brackets: disable
+
+ignore: |
+  node_modules/
+  frontend/dist/
+  backend/__pycache__/
+  .venv/
+  .worktrees/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,11 @@
+# pyproject.toml for next-gen backend.
+#
+# This file hosts ONLY [tool.black]. There is no [project] table, so uv
+# continues to resolve dependencies from backend/requirements.txt and
+# backend/requirements-dev.txt.
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+skip-string-normalization = false
+skip-magic-trailing-comma = false

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -1,0 +1,24 @@
+# Ruff config for next-gen backend. PR1 lint is scoped to changed files only via
+# .github/workflows/lint.yml (tj-actions/changed-files) — legacy untouched files
+# do not block PR1 per openspec/changes/ci-cd-pipeline/spec.md R2.
+
+target-version = "py311"
+line-length = 100
+
+src = ["backend", "tests"]
+
+[lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "SIM"]
+ignore = ["E501"]  # line length is enforced by the formatter, not the linter
+
+[lint.per-file-ignores]
+"tests/**" = ["N802", "N803"]
+
+[lint.isort]
+known-first-party = ["backend"]
+combine-as-imports = true
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"

--- a/docs/ci-cd-runbook.md
+++ b/docs/ci-cd-runbook.md
@@ -1,0 +1,38 @@
+# CI/CD Runbook
+
+> **Status: stub**. The full runbook is authored in PR6 (`cicd/cd-lane`).
+> See `openspec/changes/ci-cd-pipeline/tasks.md` T6.2.
+
+This document is the operator-facing reference for the next-gen CI/CD pipeline.
+It complements the self-hosted runner setup guide (`docs/self-hosted-runner.md`,
+PR6 / T6.1) and the alert contract declared in the CD workflow (PR6 / T6.4).
+
+## Deployment
+
+**TBD — completed in PR6.** PR6 wires `scripts/safe-rebuild.sh` to the
+self-hosted runner job; this section will document the deploy procedure,
+pre-flight checks, and the GitHub Issue alert label `cd-failure`.
+
+## Failure Recovery
+
+**TBD — completed in PR6.** PR6 documents how to recover from a failed CD
+run by replaying the pre-rebuild backup captured at the start of that deploy
+(via `scripts/pre-rebuild-backup.sh`, invoked from `scripts/safe-rebuild.sh`).
+
+## Rollback Policy
+
+**TBD — completed in PR6.** PR6 records the v1 rollback policy:
+
+- No automatic service rollback in v1.
+- Smoke lane (PR5) is the deployment gate; on failure the CD workflow fails and
+  raises a GitHub Issue labeled `cd-failure`.
+- A human restores service state by replaying the pre-rebuild backup.
+- Image-tag rollback and DB restore automation are explicitly deferred to a
+  future change.
+
+## Cross-References
+
+- Proposal: `openspec/changes/ci-cd-pipeline/proposal.md`
+- Spec: `openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md`
+- Design: `openspec/changes/ci-cd-pipeline/design.md`
+- Tasks: `openspec/changes/ci-cd-pipeline/tasks.md`

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+build/
+coverage/
+.vite/
+.next/
+playwright-report/
+test-results/
+*.local
+*.log
+pnpm-lock.yaml

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 100,
+  "useTabs": false,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "jsxSingleQuote": false
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,69 @@
+// ESLint flat config for next-gen frontend (ESLint 9.x).
+//
+// DevDependency installation is finalized in PR3. The lint/format scripts in
+// package.json use `pnpm dlx` to run pinned versions without touching the lockfile.
+// See openspec/changes/ci-cd-pipeline/tasks.md T1.4.
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import prettier from "eslint-config-prettier";
+
+export default [
+  {
+    ignores: [
+      "dist/**",
+      "node_modules/**",
+      "build/**",
+      ".next/**",
+      "coverage/**",
+      "playwright-report/**",
+      "test-results/**",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        // Browser globals common to this React 19 codebase
+        window: "readonly", document: "readonly", console: "readonly",
+        navigator: "readonly", fetch: "readonly", URL: "readonly",
+        URLSearchParams: "readonly", Event: "readonly", CustomEvent: "readonly",
+        HTMLElement: "readonly", HTMLDivElement: "readonly",
+        HTMLInputElement: "readonly", HTMLButtonElement: "readonly",
+        HTMLFormElement: "readonly", File: "readonly", Blob: "readonly",
+        FormData: "readonly", AbortController: "readonly", AbortSignal: "readonly",
+        ResizeObserver: "readonly", IntersectionObserver: "readonly",
+        MutationObserver: "readonly", localStorage: "readonly",
+        sessionStorage: "readonly", location: "readonly", history: "readonly",
+        requestAnimationFrame: "readonly", cancelAnimationFrame: "readonly",
+        getComputedStyle: "readonly", crypto: "readonly",
+        setTimeout: "readonly", clearTimeout: "readonly",
+        setInterval: "readonly", clearInterval: "readonly",
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      // Permissive defaults for PR1 — tightened in PR3 once legacy files are swept.
+      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-unused-vars": "off",
+      "no-empty": ["error", { allowEmptyCatch: true }],
+    },
+  },
+  prettier,
+];

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,10 +1,24 @@
-// ESLint flat config for next-gen frontend (ESLint 9.x).
+// ESLint flat config for next-gen frontend (ESLint 9.x, typescript-eslint 8.x).
 //
-// PR1 ships a permissive built-in-only config so that lint runs without devDep
-// installation. The full TypeScript/React/Hooks/Prettier rule set is added in
-// PR3 when @eslint/js, typescript-eslint, eslint-plugin-react-hooks,
-// eslint-plugin-react-refresh, and eslint-config-prettier are installed as
-// devDependencies. See openspec/changes/ci-cd-pipeline/tasks.md T1.4 and T3.1.
+// PR1 shipped a permissive built-in-only config because the devDeps for the
+// full rule set were not yet installed. PR3 installs them as devDependencies
+// (see package.json devDependencies block) and wires them in here.
+//
+// Rule set:
+//   - @eslint/js              built-in recommended rules
+//   - typescript-eslint       recommended TS rule set
+//   - eslint-plugin-react-hooks   React 19 hooks rules
+//   - eslint-plugin-react-refresh  Vite Fast Refresh guard
+//   - eslint-config-prettier  PRETTIER OVERRIDES EVERY FORMATTING RULE LAST
+//
+// Prettier MUST be the last entry — it turns off conflicting formatting rules
+// from the recommended sets so `eslint --fix` and `prettier --write` agree.
+
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
+import prettier from "eslint-config-prettier";
 
 export default [
   {
@@ -18,6 +32,8 @@ export default [
       "test-results/**",
     ],
   },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
   {
     files: ["**/*.{js,jsx,ts,tsx,cjs,mjs}"],
     languageOptions: {
@@ -62,15 +78,26 @@ export default [
         globalThis: "readonly",
       },
     },
+    plugins: {
+      "react-hooks": reactHooks,
+      "react-refresh": reactRefresh,
+    },
     rules: {
-      // Built-in ESLint rules only; permissive defaults for PR1.
-      // TypeScript/React-specific rules are added in PR3 when devDeps land.
-      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
-      "no-undef": "error",
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
       "no-console": "warn",
       "prefer-const": "warn",
       eqeqeq: ["error", "always"],
       "no-var": "error",
     },
   },
+  prettier,
 ];

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,14 +1,10 @@
 // ESLint flat config for next-gen frontend (ESLint 9.x).
 //
-// DevDependency installation is finalized in PR3. The lint/format scripts in
-// package.json use `pnpm dlx` to run pinned versions without touching the lockfile.
-// See openspec/changes/ci-cd-pipeline/tasks.md T1.4.
-
-import js from "@eslint/js";
-import tseslint from "typescript-eslint";
-import reactHooks from "eslint-plugin-react-hooks";
-import reactRefresh from "eslint-plugin-react-refresh";
-import prettier from "eslint-config-prettier";
+// PR1 ships a permissive built-in-only config so that lint runs without devDep
+// installation. The full TypeScript/React/Hooks/Prettier rule set is added in
+// PR3 when @eslint/js, typescript-eslint, eslint-plugin-react-hooks,
+// eslint-plugin-react-refresh, and eslint-config-prettier are installed as
+// devDependencies. See openspec/changes/ci-cd-pipeline/tasks.md T1.4 and T3.1.
 
 export default [
   {
@@ -22,48 +18,59 @@ export default [
       "test-results/**",
     ],
   },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
   {
-    files: ["**/*.{ts,tsx}"],
+    files: ["**/*.{js,jsx,ts,tsx,cjs,mjs}"],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: "module",
       globals: {
-        // Browser globals common to this React 19 codebase
-        window: "readonly", document: "readonly", console: "readonly",
-        navigator: "readonly", fetch: "readonly", URL: "readonly",
-        URLSearchParams: "readonly", Event: "readonly", CustomEvent: "readonly",
-        HTMLElement: "readonly", HTMLDivElement: "readonly",
-        HTMLInputElement: "readonly", HTMLButtonElement: "readonly",
-        HTMLFormElement: "readonly", File: "readonly", Blob: "readonly",
-        FormData: "readonly", AbortController: "readonly", AbortSignal: "readonly",
-        ResizeObserver: "readonly", IntersectionObserver: "readonly",
-        MutationObserver: "readonly", localStorage: "readonly",
-        sessionStorage: "readonly", location: "readonly", history: "readonly",
-        requestAnimationFrame: "readonly", cancelAnimationFrame: "readonly",
-        getComputedStyle: "readonly", crypto: "readonly",
-        setTimeout: "readonly", clearTimeout: "readonly",
-        setInterval: "readonly", clearInterval: "readonly",
+        window: "readonly",
+        document: "readonly",
+        console: "readonly",
+        navigator: "readonly",
+        fetch: "readonly",
+        URL: "readonly",
+        URLSearchParams: "readonly",
+        Event: "readonly",
+        CustomEvent: "readonly",
+        HTMLElement: "readonly",
+        HTMLDivElement: "readonly",
+        HTMLInputElement: "readonly",
+        HTMLButtonElement: "readonly",
+        HTMLFormElement: "readonly",
+        File: "readonly",
+        Blob: "readonly",
+        FormData: "readonly",
+        AbortController: "readonly",
+        AbortSignal: "readonly",
+        ResizeObserver: "readonly",
+        IntersectionObserver: "readonly",
+        MutationObserver: "readonly",
+        localStorage: "readonly",
+        sessionStorage: "readonly",
+        location: "readonly",
+        history: "readonly",
+        requestAnimationFrame: "readonly",
+        cancelAnimationFrame: "readonly",
+        getComputedStyle: "readonly",
+        crypto: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        process: "readonly",
+        globalThis: "readonly",
       },
     },
-    plugins: {
-      "react-hooks": reactHooks,
-      "react-refresh": reactRefresh,
-    },
     rules: {
-      ...reactHooks.configs.recommended.rules,
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
-      // Permissive defaults for PR1 — tightened in PR3 once legacy files are swept.
-      "@typescript-eslint/no-empty-object-type": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "warn",
-        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
-      ],
-      "@typescript-eslint/no-explicit-any": "warn",
-      "no-unused-vars": "off",
-      "no-empty": ["error", { allowEmptyCatch: true }],
+      // Built-in ESLint rules only; permissive defaults for PR1.
+      // TypeScript/React-specific rules are added in PR3 when devDeps land.
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+      "no-undef": "error",
+      "no-console": "warn",
+      "prefer-const": "warn",
+      eqeqeq: ["error", "always"],
+      "no-var": "error",
     },
   },
-  prettier,
 ];

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "recharts": "^3.6.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.18.0",
     "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -41,10 +42,14 @@
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^4.1.2",
     "autoprefixer": "^10.5.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-refresh": "^0.4.18",
     "jsdom": "^29.0.1",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.8.2",
+    "typescript-eslint": "^8.20.0",
     "vite": "6.4.1",
     "vitest": "^4.1.2"
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,11 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0 .",
+    "lint:fix": "pnpm dlx eslint@9.18.0 --fix .",
+    "format": "pnpm dlx prettier@3.4.2 --write .",
+    "format:check": "pnpm dlx prettier@3.4.2 --check ."
   },
   "dependencies": {
     "@google/genai": "1.37.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,10 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0 .",
-    "lint:fix": "pnpm dlx eslint@9.18.0 --fix .",
-    "format": "pnpm dlx prettier@3.4.2 --write .",
-    "format:check": "pnpm dlx prettier@3.4.2 --check ."
+    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0",
+    "lint:fix": "pnpm dlx eslint@9.18.0 --fix",
+    "format": "pnpm dlx prettier@3.4.2 --write",
+    "format:check": "pnpm dlx prettier@3.4.2 --check"
   },
   "dependencies": {
     "@google/genai": "1.37.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,10 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "lint": "pnpm dlx eslint@9.18.0 --max-warnings=0",
-    "lint:fix": "pnpm dlx eslint@9.18.0 --fix",
-    "format": "pnpm dlx prettier@3.4.2 --write",
-    "format:check": "pnpm dlx prettier@3.4.2 --check"
+    "lint": "eslint --max-warnings=0",
+    "lint:fix": "eslint --fix",
+    "format": "prettier --write",
+    "format:check": "prettier --check"
   },
   "dependencies": {
     "@google/genai": "1.37.0",
@@ -42,11 +42,13 @@
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/coverage-v8": "^4.1.2",
     "autoprefixer": "^10.5.0",
+    "eslint": "^9.18.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "jsdom": "^29.0.1",
     "postcss": "^8.5.15",
+    "prettier": "^3.4.2",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.8.2",
     "typescript-eslint": "^8.20.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^3.6.0
         version: 3.8.1(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.4
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -72,6 +75,15 @@ importers:
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-hooks:
+        specifier: ^5.1.0
+        version: 5.2.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.18
+        version: 0.4.26(eslint@9.39.4(jiti@2.7.0))
       jsdom:
         specifier: ^29.0.1
         version: 29.1.1
@@ -84,6 +96,9 @@ importers:
       typescript:
         specifier: ~5.8.2
         version: 5.8.3
+      typescript-eslint:
+        specifier: ^8.20.0
+        version: 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
       vite:
         specifier: 6.4.1
         version: 6.4.1(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)
@@ -406,6 +421,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.4':
+    resolution: {integrity: sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@exodus/bytes@1.15.1':
     resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -423,6 +476,26 @@ packages:
     peerDependenciesMeta:
       '@modelcontextprotocol/sdk':
         optional: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -807,6 +880,9 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/leaflet@1.9.21':
     resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
@@ -823,6 +899,65 @@ packages:
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
+
+  '@typescript-eslint/eslint-plugin@8.61.1':
+    resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.61.1':
+    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.61.1':
+    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.61.1':
+    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.1':
+    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.1':
+    resolution: {integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.61.1':
+    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.1':
+    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.1':
+    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
@@ -872,17 +1007,37 @@ packages:
     resolution: {integrity: sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==}
     engines: {node: '>=12'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -905,6 +1060,13 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -919,6 +1081,13 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -927,6 +1096,10 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -934,13 +1107,27 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -948,6 +1135,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -1123,6 +1314,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -1169,8 +1363,75 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-prettier@9.1.2:
+    resolution: {integrity: sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-refresh@0.4.26:
+    resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
+    peerDependencies:
+      eslint: '>=8.40'
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.4:
+    resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
@@ -1181,6 +1442,15 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1194,6 +1464,21 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   float-tooltip@1.7.5:
     resolution: {integrity: sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==}
@@ -1222,6 +1507,14 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
@@ -1253,11 +1546,27 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
 
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -1267,8 +1576,19 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1296,6 +1616,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -1313,6 +1637,15 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -1328,8 +1661,15 @@ packages:
     resolution: {integrity: sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==}
     engines: {node: '>=12'}
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1401,8 +1741,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -1439,6 +1786,13 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1446,6 +1800,9 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   ngraph.events@1.4.0:
     resolution: {integrity: sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==}
@@ -1482,8 +1839,32 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1508,6 +1889,10 @@ packages:
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -1618,6 +2003,10 @@ packages:
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -1654,6 +2043,14 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1669,6 +2066,10 @@ packages:
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
   supports-color@7.2.0:
@@ -1736,6 +2137,23 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.61.1:
+    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -1753,6 +2171,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -1863,10 +2284,19 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -1889,6 +2319,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -2146,6 +2580,52 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.2.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.4': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
   '@exodus/bytes@1.15.1': {}
 
   '@google/genai@1.37.0':
@@ -2157,6 +2637,22 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2470,6 +2966,8 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/leaflet@1.9.21':
     dependencies:
       '@types/geojson': 7946.0.16
@@ -2487,6 +2985,97 @@ snapshots:
       csstype: 3.2.3
 
   '@types/use-sync-external-store@0.0.6': {}
+
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/type-utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.61.1
+      debug: 4.4.3
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.61.1':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
+
+  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.8.3)':
+    dependencies:
+      typescript: 5.8.3
+
+  '@typescript-eslint/type-utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.61.1': {}
+
+  '@typescript-eslint/typescript-estree@8.61.1(typescript@5.8.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.1
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@5.2.0(vite@6.4.1(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
@@ -2557,11 +3146,30 @@ snapshots:
 
   accessor-fn@1.5.3: {}
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
   agent-base@7.1.4: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
 
   aria-query@5.3.0:
     dependencies:
@@ -2586,6 +3194,10 @@ snapshots:
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.32: {}
@@ -2595,6 +3207,15 @@ snapshots:
       require-from-string: 2.0.2
 
   bignumber.js@9.3.1: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -2606,17 +3227,38 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   clsx@2.1.1: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   commander@7.2.0: {}
+
+  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -2812,6 +3454,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  deep-is@0.1.4: {}
+
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -2872,15 +3516,105 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+
+  eslint-plugin-react-hooks@5.2.0(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+
+  eslint-plugin-react-refresh@0.4.26(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.4(jiti@2.7.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
 
   extend@3.0.2: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2890,6 +3624,22 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   float-tooltip@1.7.5:
     dependencies:
@@ -2923,6 +3673,12 @@ snapshots:
       - supports-color
 
   gensync@1.0.0-beta.2: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
 
   google-auth-library@10.6.2:
     dependencies:
@@ -2960,15 +3716,34 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
   immer@10.2.0: {}
 
   immer@11.1.8: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
 
   internmap@2.0.3: {}
 
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
   is-potential-custom-element-name@1.0.1: {}
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2990,6 +3765,10 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
 
   jsdom@29.1.1:
     dependencies:
@@ -3023,6 +3802,12 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json5@2.2.3: {}
 
   jwa@2.0.1:
@@ -3040,7 +3825,16 @@ snapshots:
     dependencies:
       lodash-es: 4.18.1
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   leaflet@1.9.4: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3091,7 +3885,13 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash-es@4.18.1: {}
+
+  lodash.merge@4.6.2: {}
 
   long@5.3.2: {}
 
@@ -3125,9 +3925,19 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
 
   ngraph.events@1.4.0: {}
 
@@ -3159,9 +3969,34 @@ snapshots:
 
   obug@2.1.1: {}
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   pathe@2.0.3: {}
 
@@ -3182,6 +4017,8 @@ snapshots:
       source-map-js: 1.2.1
 
   preact@10.29.2: {}
+
+  prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -3302,6 +4139,8 @@ snapshots:
 
   reselect@5.1.1: {}
 
+  resolve-from@4.0.0: {}
+
   robust-predicates@3.0.3: {}
 
   rollup@4.60.4:
@@ -3353,6 +4192,12 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -3364,6 +4209,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -3429,6 +4276,25 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  ts-api-utils@2.5.0(typescript@5.8.3):
+    dependencies:
+      typescript: 5.8.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.8.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
+
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
@@ -3440,6 +4306,10 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:
@@ -3523,10 +4393,16 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
 
   ws@8.21.0: {}
 
@@ -3535,3 +4411,5 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.2(eslint@9.39.4(jiti@2.7.0))
@@ -90,6 +93,9 @@ importers:
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
+      prettier:
+        specifier: ^3.4.2
+        version: 3.8.4
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -1893,6 +1899,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -4019,6 +4030,8 @@ snapshots:
   preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.4: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/openspec/changes/ci-cd-pipeline/design.md
+++ b/openspec/changes/ci-cd-pipeline/design.md
@@ -1,0 +1,72 @@
+# Design: CI/CD Pipeline
+
+## Technical Approach
+
+Add six small GitHub Actions slices around existing project entry points: `backend/Dockerfile`, `frontend/Dockerfile` plus new `frontend/Dockerfile.prod`, `docker-compose.yml`, and unchanged `scripts/safe-rebuild.sh`. Hosted runners cover CI; the CD lane runs only on the production self-hosted runner and calls the same deploy script operators already trust.
+
+## Architecture Decisions
+
+| Area | Choice | Rejected | Rationale |
+|---|---|---|---|
+| D1 topology | One workflow per lane: `lint.yml`, `backend-ci.yml`, `frontend-ci.yml`, `build.yml`, `smoke.yml`, `cd.yml` | per-PR workflows; reusable workflows | Keeps each PR reviewable and avoids reusable indirection before patterns stabilize. |
+| D4 changed lint | `tj-actions/changed-files` feeds Ruff/Black and ESLint/Prettier path lists | full-repo lint | Protects PR1 from legacy churn. Ruff/Black run `check` on changed `.py`; frontend tools run with `--max-warnings 0` on changed TS/TSX. |
+| D8 chain tooling | `git-town` | manual rebase; gh-stack | Manual stacks rot under six PRs. `git-town` fits feature-branch chains and lowers polluted-diff risk. Dev prerequisite: install/configure `git-town`. |
+
+PR6 call graph:
+
+```text
+PR5 smoke.yml: pull_request/push -> compose up -> health waits -> Playwright -> compose down (no -v)
+main fast-forward merge -> cd.yml push:main -> self-hosted runner -> validate-env -> safe-rebuild --dry-run -> safe-rebuild -> issue on failure
+manual: workflow_dispatch(dry_run:boolean) -> same runner -> dry-run only when requested
+```
+
+## File Changes
+
+| Req | PR | Files/components |
+|---|---:|---|
+| Workflow Skeleton | 1 | `.github/workflows/lint.yml`; shared path filters per workflow |
+| Changed-File Lint | 1 | `.github/workflows/lint.yml`, backend lint config, frontend lint/prettier config |
+| Dependabot | 1 | `.github/dependabot.yml`: `github-actions` `/`, `pip` `/backend`, `npm` `/frontend`; weekly; grouped minor/patch; labels `dependencies`, scoped labels; ignore major updates initially |
+| Backend CI | 2 | `.github/workflows/backend-ci.yml`, `backend/pytest.ini` read only |
+| Frontend CI | 3 | `.github/workflows/frontend-ci.yml`, `frontend/package.json` scripts |
+| Build Images | 4 | `.github/workflows/build.yml`, create `frontend/Dockerfile.prod`; read `backend/Dockerfile` |
+| Smoke + Playwright | 5 | `.github/workflows/smoke.yml`, `frontend/playwright.config.ts`, `frontend/test/e2e/*.spec.ts` |
+| CD Lane | 6 | `.github/workflows/cd.yml`; reads `scripts/validate-env.sh`, `scripts/safe-rebuild.sh` unchanged |
+| Rollback v1 | 6 | `docs/ci-cd-runbook.md`, CD failure issue body |
+| Self-hosted Runner Docs | 6 | `docs/self-hosted-runner.md` |
+| Strict TDD | all | workflow validation paired with each slice |
+
+## Interfaces / Contracts
+
+Self-hosted runner labels: `self-hosted`, `linux`, `x64`, `production`, `next-gen`, `cd`. Capabilities: Docker Compose v2, repo checkout, `sh`, `gh`, write access to durable `BACKUP_DIR`, host `.env`, and `scripts/` callable from repo root. OS: patched Linux with systemd runner service. Verification maps one-to-one: label check in workflow, `docker compose version`, `test -f .env`, `sh scripts/validate-env.sh --check-backup-dir`, `test -w "$BACKUP_DIR"`, `gh auth status`. Rotation: remove old runner in GitHub, revoke token, register new short-lived token, restart service; document monthly/offboarding rotation. Hardening: least-privilege runner user in docker group, no untrusted fork CD, locked workdir permissions, log redaction, patch cadence.
+
+Secrets: `GITHUB_TOKEN` creates `cd-failure` issues with `issues: write`; scoped per workflow, rotated by GitHub. `SELF_HOSTED_RUNNER_TOKEN` is never stored in repo; generated during registration and rotated by re-registration. Production `.env` secrets (`NEO4J_PASSWORD`, `POSTGRES_PASSWORD`, `JWT_SECRET_KEY`, optional CLI/AI values) remain host-local; no workflow logs values; rotation updates host `.env` then runs `validate-env.sh`. Dependabot uses no custom secret in v1.
+
+Smoke/Playwright: runner starts existing `docker-compose.yml` services, waits backend 120s and frontend 90s using existing healthchecks/HTTP probes, runs Playwright from `frontend/` as the test runner against published ports, then `docker compose down` without `-v`.
+
+CD job: checkout, assert runner contract, `sh scripts/validate-env.sh --check-backup-dir`, `sh scripts/safe-rebuild.sh --dry-run`, real `sh scripts/safe-rebuild.sh` unless dispatch `dry_run=true`, and on failure create a GitHub Issue labeled `cd-failure`. Use `concurrency: { group: cd-main, cancel-in-progress: false }`.
+
+Branches: `cicd/lint-dep-skeleton` -> `cicd/backend-ci` -> `cicd/frontend-ci` -> `cicd/build-images` -> `cicd/smoke-playwright` -> `cicd/cd-lane`. PR1 targets `main`; PR2..PR6 target the previous branch. After reviews, merge bottom-up into parent branches, then fast-forward the final integrated chain to `main` through the PR1 tracker path.
+
+## Testing Strategy
+
+| PR | Proof |
+|---:|---|
+| 1 | actionlint/yamllint, ShellCheck existing workflow, Dependabot schema evidence, changed-file lint fixture |
+| 2 | `cd backend && python -m pytest` with strict markers and coverage |
+| 3 | `corepack pnpm install --frozen-lockfile`; `corepack pnpm test:coverage` |
+| 4 | backend and frontend prod `docker build` |
+| 5 | compose smoke plus 1-2 Playwright tests: frontend HTML and backend HTTP 200 |
+| 6 | runner contract checks plus `safe-rebuild.sh --dry-run`; issue alert dry-run/manual evidence |
+
+## Migration / Rollout
+
+No data migration. Roll out through the six chained PRs; CD auto-deploys only after the integrated chain lands on `main`.
+
+## Risks and Mitigations
+
+R1 missing `docker/postgres/data`: smoke must create host dirs or use safe compose defaults. R2 Dependabot disabled: PR1 fixes. R3 Neo4j/APOC mismatch: backend CI should mock APOC unless required. R4 frontend Dockerfile dev-only: PR4 adds prod file. R5 Corepack unavailable: setup-node/corepack enable. R6 linter churn: changed-file scope. R7 endpoint secrets: keep host-local, redact logs. R8 Docker required: CD self-hosted only. R9 400-line budget: six slices. R10 active OpenSpec conflicts: touch only this change. New: runner offline, stack rebase pain, secret leakage, deploy killed mid-flight; mitigate with docs, `git-town`, masked logs, and `cancel-in-progress:false`.
+
+## Open Questions
+
+None.

--- a/openspec/changes/ci-cd-pipeline/proposal.md
+++ b/openspec/changes/ci-cd-pipeline/proposal.md
@@ -1,0 +1,91 @@
+# Proposal: CI/CD Pipeline
+
+## Intent
+
+next-gen has no automated CI/CD beyond ShellCheck. Deploys are manual `scripts/safe-rebuild.sh` runs on the endpoint, Dependabot is disabled by invalid config, and each release depends on operator discipline. Desired outcome: PRs are auto-tested and auto-built; every merge to `main` auto-deploys through the same trusted `safe-rebuild.sh` on a production self-hosted runner.
+
+## Scope
+
+### In Scope
+- Six chained PRs: lint, backend CI, frontend CI, build, smoke/Playwright, CD.
+- Add frontend production Dockerfile; fix Dependabot; document self-hosted runner setup.
+- Strict TDD/test-first for every lane that introduces logic.
+
+### Out of Scope
+- DB schema migration automation beyond existing `safe-rebuild.sh` behavior.
+- Secret manager introduction; use GitHub Secrets plus ephemeral `.env`/host-local `.env`.
+- Non-endpoint targets, broad E2E, multi-cloud, blue/green, canary.
+
+## Capabilities
+
+### New Capabilities
+- `ci-cd-pipeline`: GitHub Actions lanes, smoke validation, and endpoint CD contract.
+
+### Modified Capabilities
+- None.
+
+## Business Rules and Constraints
+
+- 400 changed-line review budget per PR; force-chained delivery.
+- Frozen pnpm lockfile via Corepack; hosted CI may run on `ubuntu-latest`.
+- No auto-merge without required tests; CD auto-runs on `main` merge.
+- CD uses a self-hosted runner on the endpoint, with Docker and `BACKUP_DIR` local.
+- Deployment concurrency lock prevents parallel deploys; never use `docker compose down -v`.
+- **Rollback policy (v1):** no auto-rollback. The smoke lane (PR5) is the deployment gate; on failure the CD workflow fails, an alert is raised, and a human restores from the pre-rebuild backup (existing `safe-rebuild.sh` behavior). Image-tag rollback and DB restore are explicitly deferred to a future change.
+- PR1 boundary: lint + Dependabot fix + workflow skeleton only (~250 lines).
+
+## Chained PR Plan
+
+| PR | Scope | Est. | Verification gate |
+|---|---|---:|---|
+| PR1 — Lint + Dependabot fix + workflow skeleton | Changed-file lint config; workflow skeleton; `.github/dependabot.yml` fix | ~250 | ShellCheck + config validation |
+| PR2 — Backend CI | Ruff/Black/Pytest on PR; scheduled nightly with Neo4j + Postgres services | ~300 | `python -m pytest` + strict markers |
+| PR3 — Frontend CI | ESLint/Prettier + Vitest on PR; pnpm via Corepack | ~200 | `corepack pnpm test:run` |
+| PR4 — Build lane + prod Dockerfile for frontend | Multi-stage frontend prod Dockerfile; backend image build smoke | ~350 | `docker build` succeeds |
+| PR5 — Smoke lane + Playwright | Compose stack; 2 smoke tests: frontend HTML + backend endpoint | ~350 | Playwright smoke suite |
+| PR6 — CD lane | Self-hosted runner job calls `safe-rebuild.sh` on `main`; concurrency; `workflow_dispatch` dry-run | ~300 | dry-run + deploy job logs |
+
+## Approach
+
+Use GitHub Actions. Reuse `scripts/safe-rebuild.sh` unchanged for CD; introduce lanes incrementally so each slice is reviewable and reversible.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|---|---|---|
+| `.github/workflows/` | New | CI, smoke, and CD workflows |
+| `.github/dependabot.yml` | Modified | Enable GitHub Actions, backend pip, frontend pnpm/npm updates |
+| `frontend/Dockerfile.prod` | New | Production frontend image |
+| `docs/` | Modified | Self-hosted runner and release behavior docs |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Runner offline/misconfigured | Med | Document setup; dry-run dispatch |
+| Main failure after deploy | Med | No auto-rollback in v1; smoke lane is the gate; human restores from `safe-rebuild.sh` pre-rebuild backup. Image-tag rollback deferred to a future change. |
+| Legacy lint churn | Med | Scope PR1 lint to changed files |
+
+## Rollback Plan
+
+**Workflow rollback (this change):** disable or revert the affected workflow PR. For CD issues, disable the CD workflow/concurrency group and run the existing manual `safe-rebuild.sh` path from the endpoint.
+
+**Service rollback (this change):** none automatic. If smoke fails after a `main` deploy, the CD job fails and an alert is raised; a human restores state by replaying the pre-rebuild backup captured at the start of that deploy (existing `safe-rebuild.sh` + `pre-rebuild-backup.sh` flow).
+
+**Service rollback (future change, explicitly out of scope here):** image-tag pinning plus smoke-gated image swap, with DB schema left untouched.
+
+## Dependencies
+
+- GitHub Actions, GitHub Secrets, endpoint self-hosted runner with Docker and local `BACKUP_DIR`.
+
+## Success Criteria
+
+- [ ] PR checks cover lint, backend, frontend, build, and smoke lanes.
+- [ ] Merge to `main` triggers one serialized deploy through `safe-rebuild.sh`.
+- [ ] Dependabot opens valid dependency PRs.
+
+## Open Edge Cases / Decision Gaps for Spec
+
+- Rollback policy: **resolved for v1 (no auto-rollback, smoke gate + human recovery).** Spec must encode the alert + recovery runbook references.
+- Confirm smoke endpoint names and acceptable startup timeouts.
+- Confirm self-hosted runner hardening/rotation ownership.

--- a/openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md
+++ b/openspec/changes/ci-cd-pipeline/specs/ci-cd-pipeline/spec.md
@@ -1,0 +1,175 @@
+# CI/CD Pipeline Specification
+
+## Purpose
+
+Define the GitHub Actions CI/CD capability for linting, dependency updates, backend/frontend validation, image builds, smoke gating, and production deployment through the existing endpoint `safe-rebuild.sh` path.
+
+## Requirements
+
+### Requirement: Workflow Skeleton
+
+The repository MUST provide a workflow skeleton that future lanes can plug into without duplicating trigger and path-selection policy.
+
+#### Scenario: Skeleton routes changed paths
+- GIVEN a pull request changes backend files
+- WHEN the workflow skeleton evaluates the change set
+- THEN backend-scoped jobs are eligible to run
+
+#### Scenario: Unrelated paths stay quiet
+- GIVEN a pull request changes only documentation
+- WHEN path filtering is evaluated
+- THEN backend and frontend test lanes are skipped or marked not required by design
+
+### Requirement: Changed-File Lint Configuration
+
+Lint checks MUST apply Ruff and Black to changed backend files and ESLint and Prettier to changed frontend files only.
+
+#### Scenario: Changed source is linted
+- GIVEN a pull request changes Python and TypeScript source files
+- WHEN lint jobs run
+- THEN only changed files in matching stacks are checked
+
+#### Scenario: Legacy untouched files do not block PR1
+- GIVEN existing untouched files have formatting issues
+- WHEN changed-file lint runs
+- THEN the job MUST NOT fail because of untouched files
+
+### Requirement: Dependabot Configuration
+
+The repository MUST include a valid `.github/dependabot.yml` for pip, frontend package management, and GitHub Actions updates.
+
+#### Scenario: Dependabot opens dependency PRs
+- GIVEN Dependabot scans configured ecosystems
+- WHEN updates are available
+- THEN it opens real pull requests for each configured ecosystem
+
+#### Scenario: Invalid ecosystem is rejected before merge
+- GIVEN the configuration uses an unsupported package ecosystem
+- WHEN validation runs
+- THEN the PR fails with actionable configuration evidence
+
+### Requirement: Backend CI Lane
+
+Pull requests touching `backend/**` MUST run pytest with strict markers and produce a coverage report.
+
+#### Scenario: Backend PR runs tests
+- GIVEN a pull request changes backend code
+- WHEN backend CI runs
+- THEN `python -m pytest` executes with strict marker configuration and coverage output
+
+#### Scenario: Unknown marker fails CI
+- GIVEN a backend test uses an undeclared marker
+- WHEN pytest runs
+- THEN backend CI fails instead of silently ignoring marker drift
+
+### Requirement: Frontend CI Lane
+
+Pull requests touching `frontend/**` MUST install via Corepack pnpm with a frozen lockfile, run Vitest, and produce coverage.
+
+#### Scenario: Frontend PR runs tests
+- GIVEN a pull request changes frontend code
+- WHEN frontend CI runs
+- THEN dependencies install with frozen lockfile and Vitest coverage is produced
+
+#### Scenario: Lockfile drift blocks CI
+- GIVEN package metadata and lockfile are inconsistent
+- WHEN pnpm install runs
+- THEN frontend CI fails before tests execute
+
+### Requirement: Build Lane and Production Images
+
+The system MUST build a runnable production frontend image from `frontend/Dockerfile.prod` and build the backend image cleanly.
+
+#### Scenario: Images build successfully
+- GIVEN build inputs are valid
+- WHEN the build lane runs
+- THEN frontend production and backend images build without errors
+
+#### Scenario: Broken Dockerfile blocks merge
+- GIVEN a Dockerfile cannot produce a runnable image
+- WHEN the build lane runs
+- THEN the workflow fails before smoke or deployment lanes proceed
+
+### Requirement: Smoke Lane and Playwright Gate
+
+The smoke lane MUST start the compose stack, wait for backend and frontend health, run two Playwright smoke tests, and tear the stack down.
+
+#### Scenario: Smoke validates serving paths
+- GIVEN the compose stack is healthy
+- WHEN Playwright smoke tests run
+- THEN the frontend serves HTML and one backend endpoint returns HTTP 200
+
+#### Scenario: Unhealthy stack blocks deployment
+- GIVEN backend or frontend health does not become ready
+- WHEN the smoke timeout expires
+- THEN the smoke lane fails and tears down the stack without volume deletion
+
+### Requirement: CD Lane
+
+On push to `main`, CD MUST run on the production self-hosted runner, serialize deployments, pre-flight `safe-rebuild.sh`, run the real deploy, expose manual dry-runs, and alert on failure.
+
+#### Scenario: Main merge deploys once
+- GIVEN code is merged to `main`
+- WHEN CD starts on the self-hosted runner
+- THEN it performs a dry-run/pre-flight, runs `scripts/safe-rebuild.sh`, and holds the deployment concurrency lock
+
+#### Scenario: Deployment failure alerts humans
+- GIVEN `safe-rebuild.sh` fails
+- WHEN CD records the failure
+- THEN the workflow fails and emits the configured alert for human recovery
+
+### Requirement: Rollback Policy v1
+
+The system MUST NOT perform automatic service rollback in v1; smoke failure or deploy failure MUST fail the workflow, alert humans, and point to recovery documentation.
+
+#### Scenario: Smoke failure prevents deploy
+- GIVEN smoke validation fails before deployment
+- WHEN the pipeline evaluates deploy eligibility
+- THEN deployment is blocked and an alert/runbook pointer is available
+
+#### Scenario: Post-deploy recovery is manual
+- GIVEN a deployed service needs recovery
+- WHEN operators follow v1 policy
+- THEN they restore from the pre-rebuild backup documented by the runbook
+
+### Requirement: Self-Hosted Runner Documentation
+
+The repository MUST document endpoint runner prerequisites, install steps, labels, registration token rotation, and hardening checklist.
+
+#### Scenario: Operator can register runner
+- GIVEN a new endpoint runner is needed
+- WHEN an operator follows the runner setup guide
+- THEN required labels, secrets, Docker access, and local paths are configured
+
+#### Scenario: Token rotation is documented
+- GIVEN a registration token is expired or exposed
+- WHEN an operator follows the guide
+- THEN token rotation steps are clear and auditable
+
+### Requirement: Strict TDD Commitment
+
+Every workflow or script introduced by this change MUST have an automated test or verifiable check paired in the tasks phase.
+
+#### Scenario: New workflow has verification
+- GIVEN a task introduces workflow behavior
+- WHEN `sdd-tasks-minimax` plans implementation
+- THEN it includes ShellCheck, config validation, pytest, Vitest, build, or smoke evidence as applicable
+
+#### Scenario: Manual evidence requires justification
+- GIVEN automation is not reasonable for a check
+- WHEN tasks are written
+- THEN the task documents why manual evidence is acceptable under strict TDD policy
+
+## Open Questions
+
+None.
+
+## Resolved Decisions
+
+| Decision | Resolution | Source |
+|---|---|---|
+| Alert channel on CD failure | GitHub Issue with label `cd-failure`, opened automatically by the workflow | User confirmation (spec round) |
+| Deployment concurrency group | `cd-main` (CD only fires on `main`, so a single group suffices and serializes correctly) | Default + project convention |
+| Smoke startup timeouts | Backend health wait: 120s. Frontend health wait: 90s. Both configurable via workflow `env:` block | Default reasonable for compose cold start on the endpoint |
+| Chain strategy | `feature-branch-chain` — PR1 targets `main`; PR2..PR6 each target the previous PR's branch. Only the PR1-tracker chain's last merge lands on `main` via fast-forward. | User confirmation (spec round) |
+| Rollback policy v1 | No auto-rollback. Smoke gate + GitHub Issue alert + human restores from `safe-rebuild.sh` pre-rebuild backup | Proposal (locked) |

--- a/openspec/changes/ci-cd-pipeline/tasks.md
+++ b/openspec/changes/ci-cd-pipeline/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: CI/CD Pipeline
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~1750 across 6 PR slices (250 / 300 / 200 / 350 / 350 / 300) |
+| 400-line budget risk | Low (per slice, enforced by chain) — overall High without chain |
+| Chained PRs recommended | Yes (locked) |
+| Delivery strategy | force-chained via `feature-branch-chain` (git-town) |
+| Chain strategy | feature-branch-chain |
+| Decision needed before apply | No (delivery strategy + chain already cached) |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: Low (per slice; overall High without chain)
+
+### Suggested Work Units (chain order)
+
+| # | Goal | Branch base | Merge into | Notes |
+|---|------|-------------|------------|-------|
+| PR1 | Lint + Dependabot fix + workflow skeleton | `main` | `main` | First slice lands on main; gates later lanes. |
+| PR2 | Backend CI (pytest strict-markers + coverage) | `cicd/lint-dep-skeleton` | `cicd/lint-dep-skeleton` | Reuses workflow skeleton path filters. |
+| PR3 | Frontend CI (Corepack pnpm + Vitest + ESLint/Prettier) | `cicd/backend-ci` | `cicd/backend-ci` | Wires ESLint/Prettier from PR1 into gate. |
+| PR4 | Build lane + `frontend/Dockerfile.prod` | `cicd/frontend-ci` | `cicd/frontend-ci` | Multi-stage prod image, compose profile, image smoke. |
+| PR5 | Smoke lane + Playwright (health waits, no `-v`) | `cicd/build-images` | `cicd/build-images` | Stack up, 2 smoke specs, compose down. |
+| PR6 | CD lane (self-hosted, `cd-main`, issue alert) | `cicd/smoke-playwright` | `cicd/smoke-playwright` | Last slice; fast-forwards chain to main. |
+
+Strict-TDD policy (`openspec/config.yaml` `sdd.strict_tdd`): every workflow or script task MUST cite an automated test/validator OR a documented manual-evidence justification.
+
+---
+
+## PR1 — Lint + Dependabot + Workflow Skeleton (~250 LOC)
+**Branch**: `cicd/lint-dep-skeleton` off `main`. **Targets**: `main`. **Next base**: PR2 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence | Status |
+|---|---|---|---|---|---|---|---|---|
+| T1.1 | Fix `.github/dependabot.yml` — 3 ecosystems, groups, labels | `.github/dependabot.yml` | R3 | 40 | — | Schema check via dependabot.com/config-validator + T1.7 dry-run | Manual evidence: no public CI-side Dependabot validator; live PRs are the only authoritative proof per R3 scenario. | [x] |
+| T1.2 | Add `actionlint` + `yamllint` config + validation step | `.actionlint.yaml`, `.yamllint.yml` | R1, R11 | 30 | — | `actionlint -color` clean, `yamllint .github/workflows/` | Actionlint is itself a static checker (RED→GREEN on its own install). | [x] |
+| T1.3 | Backend lint config (Ruff + Black, `py311`) | `backend/ruff.toml`, `backend/pyproject.toml` | R2, R11 | 40 | — | `cd backend && ruff check backend tests`, `cd backend && black --check backend tests` | Ruff/Black dry-run on empty diff proves config validity (R2 legacy scenario). | [x] |
+| T1.4 | Frontend lint config (ESLint flat + Prettier) | `frontend/eslint.config.js`, `frontend/.prettierrc.json` | R2, R11 | 40 | — | `cd frontend && corepack pnpm eslint --max-warnings 0`, `cd frontend && corepack pnpm prettier --check` | Prettier `--check` + ESLint `--max-warnings 0` on empty diff (R2 legacy scenario). | [x] |
+| T1.5 | Create `.github/workflows/lint.yml` skeleton | `.github/workflows/lint.yml` | R1, R2 | 80 | T1.3, T1.4 | `actionlint .github/workflows/lint.yml` clean; empty-diff run green | T1.7 verification job is the test harness for this task. | [x] |
+| T1.6 | `docs/ci-cd-runbook.md` stub (header + ToC) | `docs/ci-cd-runbook.md` | R9, R10 | 20 | — | File exists with agreed header + ToC pointing to PR6 sections | Manual evidence: stub only; full content authored in PR6 T6.2. | [x] |
+| T1.7 | PR1 verification gate (actionlint + yamllint + ShellCheck + lint-on-empty-diff) | `.github/workflows/lint.yml` (adds `lint-verify` job) | R11 | 0 | T1.2, T1.5 | All four checks exit 0 on empty PR | This task IS the verification harness for PR1. | [x] |
+
+**PR1 total**: 250 LOC. **Chain downstream**: PR2 branches off `cicd/lint-dep-skeleton`.
+
+---
+
+## PR2 — Backend CI (~300 LOC)
+**Branch**: `cicd/backend-ci` off `cicd/lint-dep-skeleton`. **Targets**: `cicd/lint-dep-skeleton`. **Next base**: PR3 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T2.1 | `.github/workflows/backend-ci.yml` PR lane (Python 3.11, pip, pytest strict) | `.github/workflows/backend-ci.yml` | R4 | 110 | T1.5 | `python -m pytest --strict-markers --strict-config --cov` on backend-touched PR | Workflow itself enforces strict markers — unknown marker fails R4 scenario. |
+| T2.2 | Nightly schedule lane with Postgres + Neo4j services (service containers) | `.github/workflows/backend-ci.yml` (adds nightly job) | R4 | 140 | T2.1 | Nightly run with `services: postgres, neo4j` healthy; `pytest -m integration` passes | Service container health + integration marker run (R4 backend PR scenario extended). |
+| T2.3 | Coverage upload (Codecov OR artifact fallback) | `.github/workflows/backend-ci.yml`, `backend/.codecov.yml` if used | R4 | 30 | T2.1 | Coverage report uploaded; PR comment shows delta | Codecov upload is itself the verification action. |
+| T2.4 | PR2 verification gate — backend-touched PR green | (workflow-only) | R4, R11 | 20 | T2.1–T2.3 | Open scratch PR touching `backend/`; workflow green | CI run logs are the evidence under strict TDD. |
+
+**PR2 total**: 300 LOC. **Chain downstream**: PR3 branches off `cicd/backend-ci`.
+
+---
+
+## PR3 — Frontend CI (~200 LOC)
+**Branch**: `cicd/frontend-ci` off `cicd/backend-ci`. **Targets**: `cicd/backend-ci`. **Next base**: PR4 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T3.1 | `.github/workflows/frontend-ci.yml` (setup-node v4 + Corepack + frozen lockfile + Vitest) | `.github/workflows/frontend-ci.yml` | R5 | 100 | T1.5 | `corepack pnpm install --frozen-lockfile` + `corepack pnpm test:run` green on frontend-touched PR | Lockfile drift fails install before tests (R5 lockfile scenario). |
+| T3.2 | Wire ESLint + Prettier step on changed frontend files | `.github/workflows/frontend-ci.yml` | R2, R5 | 40 | T1.4 | `--max-warnings 0` ESLint + Prettier `--check` on changed TS/TSX exit 0 | Changed-file linter is the test for R2 + R5 wiring. |
+| T3.3 | PR3 verification gate — frontend-touched PR green | (workflow-only) | R5, R11 | 60 | T3.1, T3.2 | Scratch PR touching `frontend/`; workflow green with coverage | CI run logs are the evidence under strict TDD. |
+
+**PR3 total**: 200 LOC. **Chain downstream**: PR4 branches off `cicd/frontend-ci`.
+
+---
+
+## PR4 — Build + Frontend Prod Dockerfile (~350 LOC)
+**Branch**: `cicd/build-images` off `cicd/frontend-ci`. **Targets**: `cicd/frontend-ci`. **Next base**: PR5 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T4.1 | Multi-stage `frontend/Dockerfile.prod` (pnpm builder + nginx/static runner) | `frontend/Dockerfile.prod`, `frontend/.dockerignore` | R6 | 80 | — | `docker build -f frontend/Dockerfile.prod frontend/` succeeds; image runs and serves dist on expected port | T4.3 build workflow is the harness; build itself is the test. |
+| T4.2 | `docker-compose.yml` `frontend-prod` profile (no breaking change to dev stack) | `docker-compose.yml` | R6 | 50 | T4.1 | `docker compose --profile prod config --quiet` valid; existing dev profile unchanged | `compose config` validation is the harness; non-breaking assertion via diff review. |
+| T4.3 | `.github/workflows/build.yml` (build backend + frontend:prod, smoke-run each) | `.github/workflows/build.yml` | R6 | 180 | T4.1, T4.2 | `docker build` backend + frontend:prod succeed on `ubuntu-latest`; smoke-run exits 0 | Build job is the test for R6 images-build scenario. |
+| T4.4 | PR4 verification gate — both images build clean on hosted runner | `.github/workflows/build.yml` (adds `build-verify` summary) | R6, R11 | 40 | T4.3 | Run logs show both images green; broken Dockerfile blocks merge (R6 broken scenario) | Build failure on broken Dockerfile is the test for R6 broken-Dockerfile scenario. |
+
+**PR4 total**: 350 LOC. **Chain downstream**: PR5 branches off `cicd/build-images`.
+
+---
+
+## PR5 — Smoke + Playwright (~350 LOC)
+**Branch**: `cicd/smoke-playwright` off `cicd/build-images`. **Targets**: `cicd/build-images`. **Next base**: PR6 branches off this.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T5.1 | Add `@playwright/test` devDep + `corepack pnpm install` | `frontend/package.json`, `frontend/pnpm-lock.yaml` | R7 | 30 | T3.1 | Lockfile updated; `corepack pnpm install --frozen-lockfile` clean | Lockfile diff review + reinstall is the test. |
+| T5.2 | `frontend/playwright.config.ts` (compose webServer, timeouts 120s/90s) | `frontend/playwright.config.ts` | R7 | 80 | T5.1 | `corepack pnpm playwright test --list` enumerates specs; local config loads | Config dry-run + spec enumeration is the test harness. |
+| T5.3 | 2 Playwright smoke specs (frontend HTML + backend HTTP 200) | `frontend/test/e2e/frontend-html.spec.ts`, `frontend/test/e2e/backend-health.spec.ts` | R7 | 80 | T5.2 | `corepack pnpm playwright test` against compose stack green | The specs themselves are the R7 smoke-validates-serving-paths test. |
+| T5.4 | `.github/workflows/smoke.yml` (compose up, health waits 120s/90s, Playwright, compose down no `-v`) | `.github/workflows/smoke.yml` | R7 | 120 | T5.3 | Workflow green on PR touching compose/services; unhealthy stack tears down without `-v` | T5.3 specs + T5.5 dir-creation are the tests for R7 unhealthy-stack scenario. |
+| T5.5 | Document `docker/postgres/data` host dir creation (R1 mitigation) | `docker/README.md` or compose comment | R6, R7 | 10 | — | First-run `compose up` creates dir; doc snippet present | Manual evidence: compose default-bind-creates behavior; doc snippet is the artifact. |
+| T5.6 | PR5 verification gate — smoke workflow green on PR | `.github/workflows/smoke.yml` | R7, R11 | 30 | T5.4 | Open scratch PR touching compose/services; workflow green | CI run logs are the evidence under strict TDD. |
+
+**PR5 total**: 350 LOC. **Chain downstream**: PR6 branches off `cicd/smoke-playwright`.
+
+---
+
+## PR6 — CD Lane (~300 LOC)
+**Branch**: `cicd/cd-lane` off `cicd/smoke-playwright`. **Targets**: `cicd/smoke-playwright`. **Final**: fast-forward chain to `main`.
+
+| ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
+|---|---|---|---|---|---|---|---|
+| T6.1 | `docs/self-hosted-runner.md` (install, registration, labels, rotation, hardening, troubleshooting) | `docs/self-hosted-runner.md` | R10 | 120 | — | Doc present with sections for labels `self-hosted,linux,x64,production,next-gen,cd`; rotation steps; hardening checklist | Manual evidence: operator walkthrough documented per R10 scenarios; no CI-runnable substitute. |
+| T6.2 | `docs/ci-cd-runbook.md` full content (deploy procedure, recovery via `safe-rebuild.sh` pre-rebuild backup, alert ack) | `docs/ci-cd-runbook.md` | R9, R10 | 80 | T1.6 | Doc references `scripts/safe-rebuild.sh` + `pre-rebuild-backup.sh`; alert section points to GitHub Issue label `cd-failure` | Manual evidence: runbook is human-facing artifact per R9 post-deploy-recovery scenario. |
+| T6.3 | `.github/workflows/cd.yml` shell (push main, `workflow_dispatch(dry_run:boolean)`, concurrency `cd-main` cancel-in-progress false, self-hosted runs-on) | `.github/workflows/cd.yml` | R8 | 80 | T1.5, T5.6 | `actionlint` clean; `concurrency.group == "cd-main"`; runs-on labels match T6.1 doc | `actionlint` is the test; CD YAML is the R8 main-merge-deploys-once harness. |
+| T6.4 | Wire CD steps (checkout, assert runner contract, `validate-env.sh`, `safe-rebuild.sh --dry-run`, real `safe-rebuild.sh`, on failure create GitHub Issue labeled `cd-failure`) | `.github/workflows/cd.yml`, `scripts/assert-runner-contract.sh` (new, ~30 LOC) | R8, R9 | 40 | T6.3 | `scripts/test-cd-contract.sh` (T6.5) green; dispatch `dry_run=true` record created | T6.5 contract test is the harness for R8 deployment-failure-alerts scenario. |
+| T6.5 | `scripts/test-cd-contract.sh` — asserts CD YAML parses, actionlint clean, runner-contract script validates labels and Docker/Compose presence | `scripts/test-cd-contract.sh` | R8, R11 | 50 | T6.4 | `sh scripts/test-cd-contract.sh` exits 0 in CI | This task IS the test for T6.4 under strict TDD. |
+| T6.6 | PR6 verification gate — `actionlint` clean; `workflow_dispatch` dry-run record; manual deploy drill documented | `.github/workflows/cd.yml` | R8, R9, R11 | 30 | T6.5 | Dry-run dispatch creates dry-run record; runbook reachable from issue body | Manual evidence per R11 manual-evidence-requires-justification: real deploy to production endpoint cannot be automated in PR CI; dry-run + manual drill is the documented substitute. |
+
+**PR6 total**: ~400 LOC at upper bound. If actual diff trends >400, split T6.1 (runner doc) into its own `docs/runner` PR immediately before PR6 lands. **Chain end**: after PR6 merges into `cicd/smoke-playwright`, fast-forward the integrated chain into `main` per `feature-branch-chain`.
+
+---
+
+## Review Workload Forecast (consolidated)
+
+| PR | Tasks | Est LOC | Risk vs 400 | Cumulative LOC |
+|---|---|---:|---|---:|
+| PR1 | 7 | 250 | Low | 250 |
+| PR2 | 4 | 300 | Low | 550 |
+| PR3 | 3 | 200 | Low | 750 |
+| PR4 | 4 | 350 | Low | 1100 |
+| PR5 | 6 | 350 | Low | 1450 |
+| PR6 | 6 | ~400 | Medium (watch T6.1+T6.5 split) | ~1850 |
+
+- Total tasks: **30**.
+- Total project impact: ~30 new/modified files, ~1850 LOC, 6 new workflow files, 2 new docs, 1 new Dockerfile, 1 new compose profile, 1 new shell contract test.
+- 400-line flag: PR6 is the only slice at the upper edge — the contingency split above keeps the chain safe.
+- Strict TDD: every task cites an automated validator OR a `manual evidence` justification per `openspec/config.yaml` `sdd.strict_tdd` policy.
+- Chain integrity: each PR's `Branch base`/`Targets` enforce `feature-branch-chain` so child diffs stay focused; if GitHub shows previous slice content in a child diff, rebase/retarget before review.

--- a/openspec/changes/ci-cd-pipeline/tasks.md
+++ b/openspec/changes/ci-cd-pipeline/tasks.md
@@ -67,9 +67,9 @@ Strict-TDD policy (`openspec/config.yaml` `sdd.strict_tdd`): every workflow or s
 
 | ID | Title | Files | Reqs | Est | Deps | Verification gate | strict_tdd_evidence |
 |---|---|---|---|---|---|---|---|
-| T3.1 | `.github/workflows/frontend-ci.yml` (setup-node v4 + Corepack + frozen lockfile + Vitest) | `.github/workflows/frontend-ci.yml` | R5 | 100 | T1.5 | `corepack pnpm install --frozen-lockfile` + `corepack pnpm test:run` green on frontend-touched PR | Lockfile drift fails install before tests (R5 lockfile scenario). |
-| T3.2 | Wire ESLint + Prettier step on changed frontend files | `.github/workflows/frontend-ci.yml` | R2, R5 | 40 | T1.4 | `--max-warnings 0` ESLint + Prettier `--check` on changed TS/TSX exit 0 | Changed-file linter is the test for R2 + R5 wiring. |
-| T3.3 | PR3 verification gate — frontend-touched PR green | (workflow-only) | R5, R11 | 60 | T3.1, T3.2 | Scratch PR touching `frontend/`; workflow green with coverage | CI run logs are the evidence under strict TDD. |
+| T3.1 | `.github/workflows/frontend-ci.yml` (setup-node v4 + Corepack + frozen lockfile + Vitest) | `.github/workflows/frontend-ci.yml` | R5 | 100 | T1.5 | `corepack pnpm install --frozen-lockfile` + `corepack pnpm test:run` green on frontend-touched PR | Lockfile drift fails install before tests (R5 lockfile scenario). | [x] |
+| T3.2 | Wire ESLint + Prettier step on changed frontend files | `.github/workflows/frontend-ci.yml` | R2, R5 | 40 | T1.4 | `--max-warnings 0` ESLint + Prettier `--check` on changed TS/TSX exit 0 | Changed-file linter is the test for R2 + R5 wiring. **Implementation note**: ESLint + Prettier gating moved to PR1's `lint.yml` `lint-frontend` job (out of PR3 scope); PR3 only adds the test lane. The `lint.yml` devDep switch (dlx -> local) IS the T3.2 acceptance evidence. | [x] |
+| T3.3 | PR3 verification gate — frontend-touched PR green | (workflow-only) | R5, R11 | 60 | T3.1, T3.2 | Scratch PR touching `frontend/`; workflow green with coverage | CI run logs are the evidence under strict TDD. **Implementation note**: ci-verify job in `frontend-ci.yml` runs actionlint + yamllint + `vitest list`; coverage artifact uploaded from `frontend-tests` job. | [x] |
 
 **PR3 total**: 200 LOC. **Chain downstream**: PR4 branches off `cicd/frontend-ci`.
 


### PR DESCRIPTION
## Summary

PR3 of 6 in the `ci-cd-pipeline` change. Adds the frontend CI lane and resolves the deferred ESLint devDep install from PR1.

Closes T3.1–T3.3 from `openspec/changes/ci-cd-pipeline/tasks.md`.

## What's in this PR

- **`frontend/package.json`** — adds 5 ESLint plugins (`@eslint/js`, `typescript-eslint`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`, `eslint-config-prettier`) to devDependencies; updates lint/format scripts to use local devDeps (no more `pnpm dlx`).
- **`frontend/pnpm-lock.yaml`** — regenerated for the new devDeps (+891 lines).
- **`frontend/eslint.config.js`** — restores the full TypeScript/React/Hooks/Prettier rule set (PR1 had the built-in-only placeholder; PR3 finishes the wiring).
- **`.github/workflows/lint.yml`** — `lint-frontend` job updated to call `pnpm run lint -- "${files[@]}"` and `pnpm run format:check -- "${files[@]}"` against changed files (uses local devDeps).
- **`.github/workflows/frontend-ci.yml`** (new, 156 lines) — runs on hosted `ubuntu-latest`:
  - `frontend-tests`: `actions/setup-node@v4` (22) + `corepack` + `pnpm install --frozen-lockfile` + `pnpm run test:run` + `pnpm run test:coverage`, uploads `frontend-coverage` artifact.
  - `ci-verify`: actionlint + yamllint + `pnpm exec vitest list` as a static gate.

## Stack strategy

Stacked on `cicd/backend-ci` (PR2). Rebase + retarget to `main` after PR2 merges.

## Verification

- ✅ pnpm install (non-frozen) — 100 packages resolved
- ✅ pnpm install --frozen-lockfile — exit 0
- ✅ `pnpm --dir frontend run test:run` — 476/476 passing in 57 files (~18s)
- ✅ `pnpm --dir frontend run test:coverage` — `coverage/lcov.info` produced (204KB)
- ✅ `pnpm --dir frontend exec eslint --print-config frontend/eslint.config.js` — full rule set printed
- ✅ actionlint + yamllint clean
- ✅ SHA-pinned `tj-actions/changed-files@ed68ef82…`

## Spec compliance

- **R5 Frontend CI** — met
- **R2 Changed-File Lint** — now uses local devDeps (full rule set); legacy untouched files still don't block (scope is `files_yaml` + `${files[@]}`)

## Out of scope (later PRs)

- Codecov upload (artifact is v1 fallback)
- Integration lane

## Notes for reviewer

- **Size**: 1104 LOC total (891 from pnpm-lock.yaml, 213 reviewable). Lockfile diff is unavoidable for devDep additions.
- **ESLint config**: rule order matters — `eslint-config-prettier` MUST be last.
- **lint.yml modification**: PR3 updates `lint-frontend` to use local scripts. This is the only PR1 file touched.