### PR TITLE
fix(ci): scope shellcheck.yml to changed files only (#313)

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,13 +18,29 @@ on:
 
 jobs:
   shellcheck:
+    name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install ShellCheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
-
+      - uses: actions/checkout@v4
+      - name: Detect changed shell files
+        id: changed
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)
+        with:
+          files_yaml: |
+            scripts/**/*.sh
+            docker/neo4j/entrypoint.sh
+            monitor_performance.sh
       - name: Run ShellCheck
-        run: shellcheck -x scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh
+        if: steps.changed.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+          mapfile -t files <<<"${{ steps.changed.outputs.all_changed_files }}"
+          shell_files=()
+          for f in "${files[@]}"; do
+            case "$f" in *.sh) shell_files+=("$f") ;; esac
+          done
+          if [ ${#shell_files[@]} -gt 0 ]; then
+            shellcheck -x "${shell_files[@]}"
+          else
+            echo "No shell files changed — skipping."
+          fi


### PR DESCRIPTION
## Summary

Fixes GitHub issue #313 by scoping `.github/workflows/shellcheck.yml` to lint only the shell scripts the PR actually changed, matching the proven pattern in `.github/workflows/lint.yml` L97-123.

One-file workflow body rewrite, no new files, no version bumps, no `# shellcheck disable=`, no edits to `lint.yml`.

## Why

`shellcheck.yml` ran `shellcheck -x scripts/*.sh monitor_performance.sh docker/neo4j/entrypoint.sh` against **every** shell script in the repo with no filter and no severity floor. Any PR touching `scripts/` picked up pre-existing findings from files it did not modify and was blocked.

`lint.yml` L11 documents the repo's convention: "shell script lint on changed files." `lint.yml` L97-123 implements that convention via `tj-actions/changed-files`. `shellcheck.yml` ignored it.

Validation case — PR #308 (`fix(scripts): renew stale frontend node_modules anonymous volumes`, issue #306): state MERGEABLE but `shellcheck.yml/shellcheck` check FAILURE. The failing run produced 27 diagnostics: 6 pre-existing (SC2317 ×4 + SC2034 in `scripts/test-check-frontend-deps.sh`; SC2088 in `scripts/validate-env.sh`) plus 22 PR-308-owned findings in the PR's new test files.

This change is the parallel of PR #312 (issue #309) — same pattern, different organ. PR #312 fixed the actionlint+shellcheck cascade on `.github/workflows/cd.yml`; this PR fixes the equivalent on `scripts/*.sh`.

## What changes

`.github/workflows/shellcheck.yml` jobs block (lines 19-30) — full rewrite:

- Drop the redundant `Install ShellCheck` step (Ubuntu 24.04 runners ship shellcheck preinstalled per the existing comment in `lint.yml`).
- Add `tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5 — SHA pin (CVE-2025-30022)` — **same SHA as `lint.yml`**.
- `files_yaml`: `scripts/**/*.sh`, `docker/neo4j/entrypoint.sh`, `monitor_performance.sh` — same set as `lint.yml`.
- `Run ShellCheck` step guarded by `if: steps.changed.outputs.any_changed == 'true'` and filters to `*.sh` files only.
- Else branch prints `No shell files changed — skipping.`

Trigger block (lines 1-18) is **unchanged** — `pull_request` and `push` paths preserved verbatim.

Diff: 1 file, +23/-7.

## Verification expectation

After this lands on `main`:

- The `shellcheck.yml/shellcheck` check on this PR turns green.
- A test PR that touches no shell scripts passes with a "skipping" message.
- PR #308's pre-existing findings (SC2317 ×4, SC2034, SC2088) no longer block — they appear in `shellcheck.yml` output only when their owning files are touched.
- PR #308 still has its own 22 findings to clean up before it can merge; that is PR #308's responsibility, not this change's.

## Out of scope

- Editing `.github/workflows/lint.yml` (proven working).
- Cleaning pre-existing findings in `scripts/test-check-frontend-deps.sh` / `scripts/validate-env.sh` (a follow-up cleanup PR is owed but is separate from this fix).
- Adding `.shellcheckrc`, pre-commit hooks, or shellcheck severity policy changes.
- Bumping `tj-actions/changed-files` beyond `ed68ef82`/`v46.0.5` (must stay in lockstep with `lint.yml`).
- Changing the `if: false` real-deploy step or other workflow files.

Refs: #313, #308