### PR TITLE
fix(events): wire topology RCA into production SNMP collector (#310, PR1/3)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -159,6 +159,12 @@ class PollingPipelineSettings(BaseModel):
     db_writer_enabled: bool = False
     backpressure_enabled: bool = False
     metadata_cache_enabled: bool = False
+    # Topology-based root-cause analysis on the production snmp-engine write path
+    # (fix #310). When true, poll_snmp() builds a per-cycle open-parent cache and
+    # tags dependent events as PROPAGATED. When false, every event is ROOT —
+    # identical to pre-fix behaviour. Operator kill-switch: toggle + restart the
+    # snmp-engine container, no code redeploy required.
+    enable_topology_rca: bool = True
 
     target_cycle_seconds: int = Field(default=900, ge=1)
     worker_count: int = Field(default=8, ge=1)
@@ -188,6 +194,7 @@ class PollingPipelineSettings(BaseModel):
             db_writer_enabled=_env_bool("POLLING_DB_WRITER_ENABLED"),
             backpressure_enabled=_env_bool("POLLING_BACKPRESSURE_ENABLED"),
             metadata_cache_enabled=_env_bool("POLLING_METADATA_CACHE_ENABLED"),
+            enable_topology_rca=_env_bool("ENABLE_TOPOLOGY_RCA", default=True),
             target_cycle_seconds=int(os.getenv("POLLING_TARGET_CYCLE_SECONDS", "900")),
             worker_count=int(os.getenv("POLLING_WORKERS", "8")),
             db_writer_count=int(os.getenv("POLLING_DB_WRITERS", "1")),

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -265,10 +265,16 @@ def _resolve_correlation(cache, ci_id, metric_id):
         parent = None
     if parent and parent.get("parent_event_id"):
         parent_event_id = parent["parent_event_id"]
+        # Contract: root_cause_ci_id must NEVER be an event id (recovery queries
+        # match it against e.ci_id). If the cache entry lacks a CI-level root
+        # cause, degrade to ROOT instead of writing an event id into a CI field.
+        root_cause_ci_id = parent.get("root_cause_ci_id")
+        if not root_cause_ci_id:
+            return {"correlation_type": "ROOT", "propagated_from": None, "root_cause_ci_id": ci_id}
         return {
             "correlation_type": "PROPAGATED",
             "propagated_from": parent_event_id,
-            "root_cause_ci_id": parent.get("root_cause_ci_id") or parent_event_id,
+            "root_cause_ci_id": root_cause_ci_id,
         }
     return {"correlation_type": "ROOT", "propagated_from": None, "root_cause_ci_id": ci_id}
 
@@ -530,6 +536,13 @@ def _recover_snmp_collection_failures(session, updates):
         WITH e
         CALL {
             WITH e
+            # SNMP recovery intentionally matches by root_cause_ci_id for
+            # FULL-CASCADE recovery: every descendant whose root cause is the
+            # recovering CI is closed in one pass. This differs from the ICMP
+            # recovery paths (_recover_icmp_availability_events and
+            # _recover_icmp_latency_events), which match by propagated_from = e.id
+            # (direct-child only). The asymmetry is deliberate and NOT changed
+            # by this PR — do not "fix" it without a deliberate design decision.
             MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
             WHERE pe.root_cause_ci_id = e.ci_id
               AND pe.correlation_type = 'PROPAGATED'

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -245,6 +245,33 @@ def _dedupe_snmp_collection_failures(failures):
     return list(deduped.values())
 
 
+def _resolve_correlation(cache, ci_id, metric_id):
+    """Return ``{correlation_type, propagated_from, root_cause_ci_id}`` for a failing (CI, metric).
+
+    Looks up the per-cycle cache built by ``build_open_parent_index``. The cache is
+    pre-filtered by ``MetricDef.can_propagate`` at build time, so non-propagating
+    metrics simply miss the cache and resolve to ROOT. No I/O; never raises.
+
+    Design Decision 3 (C2-corrected): no ``session`` parameter — this helper only
+    does dict lookups after the cache is built, keeping the hot CREATE path
+    exception-free.
+    """
+    try:
+        parent = cache.get((ci_id, metric_id)) if cache else None
+    except Exception:
+        # A malformed cache (wrong type, unhashable key, etc.) must not break the
+        # write path. Fall through to ROOT — matches the resilience contract.
+        parent = None
+    if parent and parent.get("parent_event_id"):
+        parent_event_id = parent["parent_event_id"]
+        return {
+            "correlation_type": "PROPAGATED",
+            "propagated_from": parent_event_id,
+            "root_cause_ci_id": parent.get("root_cause_ci_id") or parent_event_id,
+        }
+    return {"correlation_type": "ROOT", "propagated_from": None, "root_cause_ci_id": ci_id}
+
+
 def _refresh_snmp_collection_failures(session, failures):
     failures = _dedupe_snmp_collection_failures(failures)
     if not failures:

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 from sqlalchemy import text
 
 from repositories.metric_repo import insert_metric_value, bulk_insert_metrics
+from repositories.topology_repo import build_open_parent_index
 from postgres_db import SessionLocal
 from config import get_icmp_settings, get_polling_pipeline_settings
 from polling.icmp_measurements import (
@@ -272,10 +273,17 @@ def _resolve_correlation(cache, ci_id, metric_id):
     return {"correlation_type": "ROOT", "propagated_from": None, "root_cause_ci_id": ci_id}
 
 
-def _refresh_snmp_collection_failures(session, failures):
+def _refresh_snmp_collection_failures(session, failures, cache=None):
     failures = _dedupe_snmp_collection_failures(failures)
     if not failures:
         return
+    # Decorate each row with topology-derived correlation fields (fix #310).
+    # _resolve_correlation is a pure dict lookup; default cache={} preserves the
+    # pre-fix all-ROOT behaviour for callers that don't pass a cache.
+    if cache is None:
+        cache = {}
+    for row in failures:
+        row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
     session.run("""
         UNWIND $failures AS row
         MATCH (n:CI {id: row.node_id})
@@ -295,8 +303,10 @@ def _refresh_snmp_collection_failures(session, failures):
                 status: 'OPEN', severity: row.severity, message: row.message,
                 event_type: row.event_type, failure_family: row.failure_family,
                 source_protocol: row.source_protocol, created_at: datetime(),
-                last_seen: datetime(), ack: false, correlation_type: 'ROOT',
-                root_cause_ci_id: row.node_id
+                last_seen: datetime(), ack: false,
+                correlation_type: row.correlation_type,
+                propagated_from: row.propagated_from,
+                root_cause_ci_id: row.root_cause_ci_id
             })
             MERGE (n)-[:HAS_EVENT]->(created)
             MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -319,7 +329,7 @@ def _availability_source(value: Any) -> str | None:
     return source if source in {"PING", "ICMP"} else None
 
 
-def _refresh_icmp_availability_events(session, updates):
+def _refresh_icmp_availability_events(session, updates, cache=None):
     availability_events = [
         u
         for u in updates
@@ -329,6 +339,11 @@ def _refresh_icmp_availability_events(session, updates):
     ]
     if not availability_events:
         return
+    # Decorate each row with topology-derived correlation fields (fix #310).
+    if cache is None:
+        cache = {}
+    for row in availability_events:
+        row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
     session.run("""
         UNWIND $availability_events AS row
         WITH row WHERE row.event_type = 'AVAILABILITY'
@@ -350,7 +365,9 @@ def _refresh_icmp_availability_events(session, updates):
                 event_type: row.event_type, source_protocol: row.source_protocol,
                 availability_source: row.availability_source,
                 created_at: datetime(), last_seen: datetime(), ack: false,
-                correlation_type: 'ROOT', root_cause_ci_id: row.node_id
+                correlation_type: row.correlation_type,
+                propagated_from: row.propagated_from,
+                root_cause_ci_id: row.root_cause_ci_id
             })
             MERGE (n)-[:HAS_EVENT]->(created)
             MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -405,7 +422,7 @@ def _recover_icmp_availability_events(session, updates):
     """, recoveries=recoveries)
 
 
-def _refresh_icmp_latency_events(session, updates):
+def _refresh_icmp_latency_events(session, updates, cache=None):
     breaches = [
         u
         for u in updates
@@ -416,6 +433,11 @@ def _refresh_icmp_latency_events(session, updates):
     ]
     if not breaches:
         return
+    # Decorate each row with topology-derived correlation fields (fix #310).
+    if cache is None:
+        cache = {}
+    for row in breaches:
+        row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
     session.run("""
         UNWIND $breaches AS row
         MATCH (n:CI {id: row.node_id})
@@ -429,8 +451,10 @@ def _refresh_icmp_latency_events(session, updates):
                 id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
                 event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
                 message: row.message, source_protocol: row.source_protocol,
-                last_seen: datetime(), ack: false, correlation_type: 'ROOT',
-                root_cause_ci_id: row.node_id
+                last_seen: datetime(), ack: false,
+                correlation_type: row.correlation_type,
+                propagated_from: row.propagated_from,
+                root_cause_ci_id: row.root_cause_ci_id
             })
             MERGE (n)-[:HAS_EVENT]->(created)
             MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -749,7 +773,58 @@ def poll_snmp():
                 duration_current,
                 jobs_per_min,
             )
-            _refresh_snmp_collection_failures(session, failure_updates)
+
+            # ── Topology RCA cache (fix #310) ───────────────────────────────
+            # Build the open-parent cache ONCE per cycle, BEFORE any of the
+            # three CREATE sites run (C1 fix). The cache is a LOCAL variable —
+            # it does not leak across cycles. When ENABLE_TOPOLOGY_RCA=false or
+            # build_open_parent_index raises, the cache is empty and every event
+            # falls back to ROOT (identical to pre-fix behaviour).
+            #
+            # W2 blast radius: a single transient Neo4j error during the
+            # cache-build degrades correlation for the ENTIRE cycle (every event
+            # becomes ROOT). This is acceptable because (a) the next cycle
+            # rebuilds the cache automatically, and (b) ENABLE_TOPOLOGY_RCA=false
+            # is the deterministic operator kill-switch.
+            availability_pairs_updates = [
+                u for u in latest_updates
+                if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
+                and _availability_source(u.get("availability_source")) is not None
+                and float(u.get("value") or 0) == 0.0
+            ]
+            latency_pairs_updates = [
+                u for u in latest_updates
+                if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
+                and u.get("metric_id") == ICMP_LATENCY_METRIC_ID
+                and u.get("event_type") == EVENT_TYPE_THRESHOLD_BREACH
+                and u.get("status") in {"WARNING", "CRITICAL"}
+            ]
+            correlation_pairs = set()
+            for u in failure_updates:
+                correlation_pairs.add((u.get("node_id"), u.get("metric_id")))
+            for u in availability_pairs_updates:
+                correlation_pairs.add((u.get("node_id"), u.get("metric_id")))
+            for u in latency_pairs_updates:
+                correlation_pairs.add((u.get("node_id"), u.get("metric_id")))
+            # Drop any pair with a None component (cannot be a cache key).
+            correlation_pairs = {p for p in correlation_pairs if p[0] and p[1]}
+
+            cache = {}  # local to this cycle — never module-level
+            if polling_settings.enable_topology_rca and correlation_pairs:
+                try:
+                    cache = build_open_parent_index(session, correlation_pairs)
+                except Exception as exc:
+                    # Whole-cycle blast radius (W2): log once, fall back to ROOT
+                    # for every row this cycle. Next cycle rebuilds the cache.
+                    logger.warning(
+                        "topology_rca_cache_build_failed falling back to ROOT "
+                        "for entire cycle; pairs=%s error=%s",
+                        sorted(correlation_pairs),
+                        exc,
+                    )
+                    cache = {}
+
+            _refresh_snmp_collection_failures(session, failure_updates, cache=cache)
 
             # Perform Bulk Insert at the end of the cycle. Only publish latest
             # values to Neo4j after Timescale persistence succeeds, so the UI
@@ -773,10 +848,10 @@ def poll_snmp():
                             r.last_message = $msg
                     """, nid=update["node_id"], mid=update["metric_id"], val=update["value"], status=update["status"], msg=update["message"])
                 availability_updates = [u for u in latest_updates if u.get("metric_kind") == "availability"]
-                _refresh_icmp_availability_events(session, availability_updates)
+                _refresh_icmp_availability_events(session, availability_updates, cache=cache)
                 _recover_icmp_availability_events(session, availability_updates)
                 latency_updates = [u for u in latest_updates if u.get("metric_id") == ICMP_LATENCY_METRIC_ID]
-                _refresh_icmp_latency_events(session, latency_updates)
+                _refresh_icmp_latency_events(session, latency_updates, cache=cache)
                 _recover_icmp_latency_events(session, latency_updates)
                 _recover_snmp_collection_failures(session, latest_updates)
                 print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -442,6 +442,69 @@ def find_open_parent_event(ci_id: str, max_depth: int = 3) -> Optional[Dict[str,
         }
 
 
+def build_open_parent_index(
+    session, pairs: Set[tuple[str, str]]
+) -> Dict[tuple[str, str], Dict[str, Any]]:
+    """Batched variant of ``find_open_parent_event`` keyed by ``(ci_id, metric_id)``.
+
+    Walks upstream via ``DEPENDS_ON|HOSTED_ON|CONNECTS_TO`` to depth 3 for every
+    requested pair in ONE Cypher pass, mirroring ``find_open_parent_event``.
+    Non-propagating metrics (``MetricDef.can_propagate = false``) are filtered
+    INSIDE the Cypher (``WHERE coalesce(m.can_propagate, true) = true``) so they
+    never appear as keys in the returned dict — callers treat a missing key as
+    ROOT (see ``engines.snmp_worker._resolve_correlation``).
+
+    Args:
+        session: an open Neo4j driver session.
+        pairs: set of ``(ci_id, metric_id)`` tuples to resolve.
+
+    Returns:
+        ``{(ci_id, metric_id): {"parent_event_id", "root_cause_ci_id",
+        "correlation_type"}}`` for hits. Missing keys = ROOT. Empty input →
+        empty dict (no query round-trip).
+    """
+    if not pairs:
+        return {}
+
+    records = session.run(
+        """
+        UNWIND $pairs AS pair
+        MATCH (ci:CI {id: pair.ci_id})
+        MATCH (m:MetricDef {id: pair.metric_id})
+        WHERE coalesce(m.can_propagate, true) = true
+        MATCH (ci)-[:DEPENDS_ON|HOSTED_ON|CONNECTS_TO*1..3]->(parent:CI)
+        MATCH (parent)-[:HAS_EVENT]->(pe:Event)
+        WHERE pe.status IN ['OPEN', 'ACK']
+        WITH pair, pe, parent
+        ORDER BY pair.ci_id, pair.metric_id,
+                 CASE pe.severity WHEN 'CRITICAL' THEN 1 WHEN 'WARNING' THEN 2 ELSE 3 END ASC,
+                 pe.created_at ASC
+        WITH pair, head(collect(pe)) AS parent_event
+        RETURN pair.ci_id AS ci_id,
+               pair.metric_id AS metric_id,
+               parent_event.id AS parent_event_id,
+               parent_event.ci_id AS parent_ci_id,
+               parent_event.root_cause_ci_id AS root_cause_ci_id,
+               parent_event.correlation_type AS correlation_type
+        """,
+        pairs=[{"ci_id": ci_id, "metric_id": metric_id} for ci_id, metric_id in pairs],
+    )
+
+    index: Dict[tuple[str, str], Dict[str, Any]] = {}
+    for row in records:
+        ci_id = row["ci_id"]
+        metric_id = row["metric_id"]
+        parent_event_id = row["parent_event_id"]
+        if not parent_event_id:
+            continue
+        index[(ci_id, metric_id)] = {
+            "parent_event_id": parent_event_id,
+            "root_cause_ci_id": row.get("root_cause_ci_id") or row.get("parent_ci_id"),
+            "correlation_type": "PROPAGATED",
+        }
+    return index
+
+
 def ensure_icmp_sidecar_metric_defs(session) -> None:
     icmp_settings = get_icmp_settings()
     session.run("""

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -1,0 +1,93 @@
+"""Tests for engines.snmp_worker correlation wiring (Tasks 2, 3, 4, 10).
+
+Strict TDD: tests written FIRST, then implementation.
+
+Covers:
+- Task 2: ``_resolve_correlation`` helper (pure dict lookup, never raises).
+- Task 3: ``poll_snmp`` cache-build wiring (ENABLE_TOPOLOGY_RCA kill-switch,
+  cache built BEFORE the three CREATE sites, local to one cycle).
+- Task 4: the three CREATE sites decorate rows from the cache instead of
+  hardcoding ``correlation_type: 'ROOT'``.
+- Task 10: failure-fallback resilience (cache-build raises → events still
+  created as ROOT, UNWIND...CREATE ran, warning logged).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from engines import snmp_worker
+from engines.snmp_worker import _resolve_correlation
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — _resolve_correlation helper
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_correlation_propagated_on_cache_hit():
+    cache = {("ci-E", "cpu-load"): {"parent_event_id": "evt-A", "root_cause_ci_id": "ci-A"}}
+
+    result = _resolve_correlation(cache, "ci-E", "cpu-load")
+
+    assert result == {
+        "correlation_type": "PROPAGATED",
+        "propagated_from": "evt-A",
+        "root_cause_ci_id": "ci-A",
+    }
+
+
+def test_resolve_correlation_root_on_cache_miss():
+    result = _resolve_correlation({}, "ci-E", "cpu-load")
+
+    assert result == {
+        "correlation_type": "ROOT",
+        "propagated_from": None,
+        "root_cause_ci_id": "ci-E",
+    }
+
+
+@pytest.mark.parametrize("bad_cache", [None, "not-a-dict", 42, object()])
+def test_resolve_correlation_never_raises_on_malformed_cache(bad_cache):
+    """The hot CREATE path must stay exception-free — _resolve_correlation never raises."""
+    result = _resolve_correlation(bad_cache, "ci-E", "cpu-load")  # type: ignore[arg-type]
+
+    assert result["correlation_type"] == "ROOT"
+    assert result["root_cause_ci_id"] == "ci-E"
+
+
+def test_resolve_correlation_handles_missing_parent_event_id():
+    """A cache entry without parent_event_id is treated as a miss → ROOT."""
+    cache = {("ci-E", "cpu-load"): {"root_cause_ci_id": "ci-A"}}  # no parent_event_id
+
+    result = _resolve_correlation(cache, "ci-E", "cpu-load")
+
+    assert result["correlation_type"] == "ROOT"
+
+
+def test_resolve_correlation_falls_back_to_parent_event_id_for_root_cause():
+    """If root_cause_ci_id is missing, use parent_event_id as the root cause."""
+    cache = {("ci-E", "cpu-load"): {"parent_event_id": "evt-A"}}
+
+    result = _resolve_correlation(cache, "ci-E", "cpu-load")
+
+    assert result["correlation_type"] == "PROPAGATED"
+    assert result["propagated_from"] == "evt-A"
+    assert result["root_cause_ci_id"] == "evt-A"
+
+
+def test_resolve_correlation_uses_ci_metric_pair_key():
+    """Two metrics on the same CI with different cache entries resolve independently."""
+    cache = {
+        ("ci-E", "cpu-load"): {"parent_event_id": "evt-A", "root_cause_ci_id": "ci-A"},
+        ("ci-E", "mem-load"): {"parent_event_id": "evt-B", "root_cause_ci_id": "ci-B"},
+    }
+
+    cpu = _resolve_correlation(cache, "ci-E", "cpu-load")
+    mem = _resolve_correlation(cache, "ci-E", "mem-load")
+
+    assert cpu["propagated_from"] == "evt-A"
+    assert mem["propagated_from"] == "evt-B"

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -68,15 +68,20 @@ def test_resolve_correlation_handles_missing_parent_event_id():
     assert result["correlation_type"] == "ROOT"
 
 
-def test_resolve_correlation_falls_back_to_parent_event_id_for_root_cause():
-    """If root_cause_ci_id is missing, use parent_event_id as the root cause."""
-    cache = {("ci-E", "cpu-load"): {"parent_event_id": "evt-A"}}
+def test_resolve_correlation_degrades_to_root_when_root_cause_ci_id_missing():
+    """If root_cause_ci_id is missing, degrades to ROOT rather than writing an
+    EVENT id into a CI-id field.
+
+    Contract: root_cause_ci_id must NEVER be an event id. If a valid CI-level
+    root cause cannot be resolved, the row must NOT be tagged PROPAGATED.
+    """
+    cache = {("ci-E", "cpu-load"): {"parent_event_id": "evt-A"}}  # no root_cause_ci_id
 
     result = _resolve_correlation(cache, "ci-E", "cpu-load")
 
-    assert result["correlation_type"] == "PROPAGATED"
-    assert result["propagated_from"] == "evt-A"
-    assert result["root_cause_ci_id"] == "evt-A"
+    assert result["correlation_type"] == "ROOT"
+    assert result["propagated_from"] is None
+    assert result["root_cause_ci_id"] == "ci-E"
 
 
 def test_resolve_correlation_uses_ci_metric_pair_key():
@@ -507,5 +512,71 @@ def test_cache_is_local_to_poll_snmp_cycle(monkeypatch):
         poll_snmp()  # cycle 2: cache-build returns dict → cache used
 
     assert mock_build.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Task — end-to-end poll_snmp cache-hit → PROPAGATED CREATE (C1 guard)
+# ---------------------------------------------------------------------------
+
+
+def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
+    """End-to-end: build_open_parent_index cache hit flows through poll_snmp()
+    into a PROPAGATED CREATE row.
+
+    Guards the C1 regression (cache built BEFORE the CREATE sites). Unlike the
+    Task-3 tests which patch build_open_parent_index to return {}, this test
+    populates the cache with a real parent entry and asserts the UNWIND CREATE
+    row captured on the fake session carries the propagated correlation fields.
+    """
+    import config as _config
+    monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
+    monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
+
+    mock_session, mock_driver = _build_poll_snmp_mocks()
+    mock_session.set_response("match", [_POLL_RECORD])
+
+    populated_cache = {
+        ("ci-001", "CPU"): {
+            "parent_event_id": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        }
+    }
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
+         patch("engines.snmp_worker.bulk_insert_metrics"), \
+         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
+         patch(
+             "engines.snmp_worker.build_open_parent_index",
+             return_value=populated_cache,
+         ) as mock_build:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()
+
+    # Cache-build was called with the (ci_id, metric_id) pairs set.
+    mock_build.assert_called_once()
+
+    # Find the UNWIND...CREATE call captured on the session and inspect the row.
+    create_calls = [
+        c for c in mock_session.queries
+        if "UNWIND" in c["query"] and "CREATE" in c["query"]
+    ]
+    assert create_calls, "expected a UNWIND ... CREATE call to be captured"
+
+    failures_param = create_calls[0]["params"].get("failures", [])
+    assert failures_param, "expected at least one failure row from poll_snmp"
+
+    propagated_rows = [
+        row for row in failures_param
+        if row.get("correlation_type") == "PROPAGATED"
+    ]
+    assert propagated_rows, (
+        "expected at least one PROPAGATED failure row when cache is populated"
+    )
+
+    row = propagated_rows[0]
+    assert row["correlation_type"] == "PROPAGATED"
+    assert row["propagated_from"] == "evt-A"
+    assert row["root_cause_ci_id"] == "ci-A"
 
 

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -91,3 +91,421 @@ def test_resolve_correlation_uses_ci_metric_pair_key():
 
     assert cpu["propagated_from"] == "evt-A"
     assert mem["propagated_from"] == "evt-B"
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — three CREATE sites decorate rows from the cache
+# ---------------------------------------------------------------------------
+# Each _refresh_* helper now accepts an optional ``cache`` parameter (default
+# empty dict for backward compatibility with pre-existing tests). When a row's
+# (node_id, metric_id) hits the cache, the UNWIND CREATE emits PROPAGATED with
+# the resolved parent; otherwise ROOT as before. We assert on the row dicts
+# that get passed to ``session.run`` (the UNWIND $rows param), since the Cypher
+# itself references row.correlation_type / row.propagated_from /
+# row.root_cause_ci_id.
+
+
+def _capture_run_params(session):
+    """Return the list of (query, params) captured by a MockNeo4jSession-like object."""
+    return session.queries
+
+
+def _find_unwind_create_call(captured):
+    """Find the captured session.run call that contains 'UNWIND' + 'CREATE'."""
+    for entry in captured:
+        q = entry["query"].upper()
+        if "UNWIND" in q and "CREATE" in q:
+            return entry
+    return None
+
+
+def test_snmp_collection_failure_propagates_when_parent_open():
+    """Parent OPEN → child COLLECTION_FAILURE event row is PROPAGATED."""
+    from engines.snmp_worker import _refresh_snmp_collection_failures
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+    cache = {("ci-E", "cpu-load"): {"parent_event_id": "evt-A", "root_cause_ci_id": "ci-A"}}
+
+    _refresh_snmp_collection_failures(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "severity": "WARNING",
+            "message": "Metric Collection Failed: cpu-load",
+            "event_type": "COLLECTION_FAILURE",
+            "failure_family": "SNMP_NO_RESPONSE",
+            "source_protocol": "SNMP",
+        }],
+        cache=cache,
+    )
+
+    # Find the UNWIND run call and inspect the row.
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    assert calls, "expected a UNWIND ... CREATE call"
+    rows_param = calls[0].kwargs["failures"]
+    assert rows_param[0]["correlation_type"] == "PROPAGATED"
+    assert rows_param[0]["propagated_from"] == "evt-A"
+    assert rows_param[0]["root_cause_ci_id"] == "ci-A"
+    # And the CREATE block references row.* (no hardcoded 'ROOT' literal at this site).
+    assert "row.correlation_type" in calls[0].args[0]
+
+
+def test_snmp_collection_failure_root_when_no_parent():
+    """No upstream OPEN → ROOT fallback, root_cause_ci_id = self."""
+    from engines.snmp_worker import _refresh_snmp_collection_failures
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+
+    _refresh_snmp_collection_failures(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "severity": "WARNING",
+            "message": "Metric Collection Failed: cpu-load",
+            "event_type": "COLLECTION_FAILURE",
+            "failure_family": "SNMP_NO_RESPONSE",
+            "source_protocol": "SNMP",
+        }],
+        cache={},
+    )
+
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    rows_param = calls[0].kwargs["failures"]
+    assert rows_param[0]["correlation_type"] == "ROOT"
+    assert rows_param[0]["propagated_from"] is None
+    assert rows_param[0]["root_cause_ci_id"] == "ci-E"
+
+
+def test_icmp_availability_propagates_when_parent_open():
+    """Availability CREATE site: parent OPEN → PROPAGATED."""
+    from engines.snmp_worker import _refresh_icmp_availability_events
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+    cache = {("ci-E", "PING-CHECK"): {"parent_event_id": "evt-A", "root_cause_ci_id": "ci-A"}}
+
+    _refresh_icmp_availability_events(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "PING-CHECK",
+            "protocol": "ICMP",
+            "source_protocol": "ICMP",
+            "availability_source": "PING",
+            "event_type": "AVAILABILITY",
+            "severity": "CRITICAL",
+            "message": "Service/Host Down: PING-CHECK",
+            "value": 0.0,
+        }],
+        cache=cache,
+    )
+
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    rows_param = calls[0].kwargs["availability_events"]
+    assert rows_param[0]["correlation_type"] == "PROPAGATED"
+    assert rows_param[0]["propagated_from"] == "evt-A"
+    assert rows_param[0]["root_cause_ci_id"] == "ci-A"
+
+
+def test_icmp_availability_root_when_no_parent():
+    """Availability CREATE site: ROOT fallback when no parent."""
+    from engines.snmp_worker import _refresh_icmp_availability_events
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+
+    _refresh_icmp_availability_events(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "PING-CHECK",
+            "protocol": "ICMP",
+            "source_protocol": "ICMP",
+            "availability_source": "PING",
+            "event_type": "AVAILABILITY",
+            "severity": "CRITICAL",
+            "message": "Service/Host Down: PING-CHECK",
+            "value": 0.0,
+        }],
+        cache={},
+    )
+
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    rows_param = calls[0].kwargs["availability_events"]
+    assert rows_param[0]["correlation_type"] == "ROOT"
+    assert rows_param[0]["root_cause_ci_id"] == "ci-E"
+
+
+def test_icmp_latency_breach_propagates_when_parent_open():
+    """Latency CREATE site: parent OPEN → PROPAGATED."""
+    from engines.snmp_worker import _refresh_icmp_latency_events
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+    cache = {("ci-E", "icmp_latency_ms"): {"parent_event_id": "evt-A", "root_cause_ci_id": "ci-A"}}
+
+    _refresh_icmp_latency_events(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "source_protocol": "ICMP",
+            "event_type": "THRESHOLD_BREACH",
+            "status": "WARNING",
+            "message": "Latency warning",
+        }],
+        cache=cache,
+    )
+
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    rows_param = calls[0].kwargs["breaches"]
+    assert rows_param[0]["correlation_type"] == "PROPAGATED"
+    assert rows_param[0]["propagated_from"] == "evt-A"
+    assert rows_param[0]["root_cause_ci_id"] == "ci-A"
+
+
+def test_icmp_latency_breach_root_when_no_parent():
+    """Latency CREATE site: ROOT fallback."""
+    from engines.snmp_worker import _refresh_icmp_latency_events
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+
+    _refresh_icmp_latency_events(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "source_protocol": "ICMP",
+            "event_type": "THRESHOLD_BREACH",
+            "status": "WARNING",
+            "message": "Latency warning",
+        }],
+        cache={},
+    )
+
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    rows_param = calls[0].kwargs["breaches"]
+    assert rows_param[0]["correlation_type"] == "ROOT"
+    assert rows_param[0]["root_cause_ci_id"] == "ci-E"
+
+
+def test_refresh_helpers_accept_cache_kwarg_backward_compat():
+    """Pre-existing callers (no cache kwarg) still work — defaults to {} (all ROOT).
+
+    This protects the existing tests in test_snmp_worker.py that call
+    _refresh_icmp_*_events(session, updates) positionally.
+    """
+    from engines.snmp_worker import _refresh_icmp_latency_events
+
+    session = MagicMock()
+    session.run = MagicMock(return_value=MagicMock())
+
+    # No cache kwarg — must not raise.
+    _refresh_icmp_latency_events(
+        session,
+        [{
+            "node_id": "ci-E",
+            "metric_id": "icmp_latency_ms",
+            "protocol": "ICMP",
+            "source_protocol": "ICMP",
+            "event_type": "THRESHOLD_BREACH",
+            "status": "WARNING",
+            "message": "Latency warning",
+        }],
+    )
+
+    calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
+    rows_param = calls[0].kwargs["breaches"]
+    assert rows_param[0]["correlation_type"] == "ROOT"
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — poll_snmp cache-build wiring (kill-switch + call order)
+# ---------------------------------------------------------------------------
+
+
+def _build_poll_snmp_mocks():
+    """Build the common mock scaffolding for a poll_snmp() cycle.
+
+    Uses the shared MockNeo4jSession from conftest so queries that call
+    ``.single()`` or iterate both work correctly.
+    """
+    from tests.conftest import MockNeo4jSession
+
+    mock_session = MockNeo4jSession()
+    mock_session.set_default_response([])
+
+    mock_driver = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
+    return mock_session, mock_driver
+
+
+_POLL_RECORD = {
+    "node_id": "ci-001", "metric_id": "CPU", "protocol": "SNMP",
+    "ip": "192.168.1.1", "community": "public", "oid": "1.3.6.1",
+    "port": 161, "metric_name": "CPU", "criticality": 3,
+    "metric_kind": None, "availability_source": None, "interval": 60,
+}
+
+
+def test_enable_topology_rca_false_skips_cache_build(monkeypatch):
+    """ENABLE_TOPOLOGY_RCA=false → build_open_parent_index NOT called.
+
+    Uses an SNMP-no-response failure (fetch_snmp_value=None) so pairs WOULD
+    exist — proving it's the flag (not empty pairs) that skips the cache-build.
+    """
+    # The setting is a singleton; reset it so the env var takes effect.
+    import config as _config
+    monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "false")
+    monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
+
+    mock_session, mock_driver = _build_poll_snmp_mocks()
+    mock_session.set_response("match", [_POLL_RECORD])
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
+         patch("engines.snmp_worker.bulk_insert_metrics"), \
+         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
+         patch("engines.snmp_worker.build_open_parent_index") as mock_build:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()
+
+    mock_build.assert_not_called()
+
+
+def test_enable_topology_rca_true_calls_build_open_parent_index(monkeypatch):
+    """ENABLE_TOPOLOGY_RCA=true → build_open_parent_index IS called with a pairs set.
+
+    Uses an SNMP-no-response failure (fetch_snmp_value=None) so failure_updates is
+    populated, giving the cache-build real (ci_id, metric_id) pairs to resolve.
+    """
+    import config as _config
+    monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
+    monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
+
+    mock_session, mock_driver = _build_poll_snmp_mocks()
+    mock_session.set_response("match", [_POLL_RECORD])
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
+         patch("engines.snmp_worker.bulk_insert_metrics"), \
+         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
+         patch("engines.snmp_worker.build_open_parent_index", return_value={}) as mock_build:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()
+
+    mock_build.assert_called_once()
+    # Second positional arg must be a set of (ci_id, metric_id) tuples.
+    args, _ = mock_build.call_args
+    assert isinstance(args[1], set)
+    assert ("ci-001", "CPU") in args[1]
+
+
+def test_enable_topology_rca_defaults_to_true_when_unset(monkeypatch):
+    """No env var set → topology RCA is ON by default (kill-switch default true)."""
+    import config as _config
+    monkeypatch.delenv("ENABLE_TOPOLOGY_RCA", raising=False)
+    monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
+
+    mock_session, mock_driver = _build_poll_snmp_mocks()
+    mock_session.set_response("match", [_POLL_RECORD])
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
+         patch("engines.snmp_worker.bulk_insert_metrics"), \
+         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
+         patch("engines.snmp_worker.build_open_parent_index", return_value={}) as mock_build:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()
+
+    mock_build.assert_called_once()
+
+
+def test_cache_failure_falls_back_to_root_and_still_creates_events(monkeypatch, caplog):
+    """Task 10 (S4): cache-build raises → warning logged, events still created as ROOT.
+
+    Proves the hot CREATE path stays exception-free — we assert the UNWIND...CREATE
+    session.run call still happened with ROOT rows, not just that a warning was logged.
+    Uses fetch_snmp_value=None to produce a real SNMP_NO_RESPONSE failure so the
+    failure_updates path is exercised end-to-end.
+    """
+    import config as _config
+    monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
+    monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
+
+    mock_session, mock_driver = _build_poll_snmp_mocks()
+    mock_session.set_response("match", [_POLL_RECORD])
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
+         patch("engines.snmp_worker.bulk_insert_metrics"), \
+         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
+         patch(
+             "engines.snmp_worker.build_open_parent_index",
+             side_effect=RuntimeError("neo4j connection lost"),
+         ) as mock_build, \
+         caplog.at_level(logging.WARNING):
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()  # must not raise
+
+    # Cache-build was attempted and raised.
+    mock_build.assert_called_once()
+
+    # The UNWIND...CREATE call for SNMP collection failures still ran.
+    create_calls = [
+        c for c in mock_session.queries
+        if "UNWIND" in c["query"] and "CREATE" in c["query"]
+    ]
+    assert create_calls, (
+        "UNWIND...CREATE must still run after cache-build failure — "
+        "events must be created as ROOT, not skipped"
+    )
+    # And the rows it would have created are ROOT (cache empty after failure).
+    failures_param = create_calls[0]["params"].get("failures", [])
+    assert failures_param, "expected at least one failure row"
+    for row in failures_param:
+        assert row["correlation_type"] == "ROOT"
+        assert row["root_cause_ci_id"] == row["node_id"]
+
+
+def test_cache_is_local_to_poll_snmp_cycle(monkeypatch):
+    """W2: cache state is LOCAL to one poll_snmp() cycle — no module-level leak.
+
+    Two consecutive cycles: first fails (cache={}), second succeeds (cache populated).
+    The second cycle's cache must not inherit the first's empty state.
+    """
+    import config as _config
+    monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
+    monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
+
+    mock_session, mock_driver = _build_poll_snmp_mocks()
+    mock_session.set_response("match", [_POLL_RECORD])
+
+    call_returns = [RuntimeError("transient"), {"nonempty": True}]
+
+    def fake_build(*args, **kwargs):
+        result = call_returns.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    with patch("engines.snmp_worker.driver", mock_driver), \
+         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
+         patch("engines.snmp_worker.bulk_insert_metrics"), \
+         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
+         patch("engines.snmp_worker.build_open_parent_index", side_effect=fake_build) as mock_build:
+        from engines.snmp_worker import poll_snmp
+        poll_snmp()  # cycle 1: cache-build raises → cache={}
+        poll_snmp()  # cycle 2: cache-build returns dict → cache used
+
+    assert mock_build.call_count == 2
+
+

--- a/backend/tests/test_topology_repo_open_parent.py
+++ b/backend/tests/test_topology_repo_open_parent.py
@@ -1,0 +1,160 @@
+"""Tests for build_open_parent_index — batched open-parent cache (Task 1).
+
+Strict TDD: these tests were written FIRST and drove the implementation of
+``repositories.topology_repo.build_open_parent_index``.
+
+The function mirrors ``find_open_parent_event`` but batches the work: it takes a
+set of ``(ci_id, metric_id)`` pairs and returns a dict keyed by the same pair.
+Non-propagating metrics (``MetricDef.can_propagate = false``) are filtered INSIDE
+the Cypher at cache-build time (design C2 fix) — they never appear as keys.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from repositories.topology_repo import build_open_parent_index
+
+
+class _FakeResult:
+    """Mimics the neo4j Result object enough for build_open_parent_index."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeSession:
+    """Captures the Cypher + params and returns a canned result list."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.last_query = ""
+        self.last_params: dict = {}
+
+    def run(self, query, **params):
+        self.last_query = query
+        self.last_params = params
+        return _FakeResult(self._rows)
+
+
+def _row(ci_id, metric_id, parent_event_id=None, root_cause_ci_id=None, parent_ci_id=None):
+    return {
+        "ci_id": ci_id,
+        "metric_id": metric_id,
+        "parent_event_id": parent_event_id,
+        "parent_ci_id": parent_ci_id,
+        "root_cause_ci_id": root_cause_ci_id,
+    }
+
+
+def test_build_open_parent_index_returns_parent_for_propagating_metric():
+    """One (ci, metric) pair with an OPEN parent via DEPENDS_ON → hit."""
+    session = _FakeSession([
+        _row("ci-E", "cpu-load", parent_event_id="evt-A", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
+    ])
+
+    result = build_open_parent_index(session, {("ci-E", "cpu-load")})
+
+    assert result[("ci-E", "cpu-load")] == {
+        "parent_event_id": "evt-A",
+        "root_cause_ci_id": "ci-A",
+        "correlation_type": "PROPAGATED",
+    }
+
+
+def test_build_open_parent_index_skips_can_propagate_false():
+    """Metric with can_propagate=false is ABSENT from the result dict (C2).
+
+    The Cypher-side ``WHERE coalesce(m.can_propagate, true) = true`` filter means
+    the DB never returns a row for that pair, so the key is missing → ROOT.
+    """
+    session = _FakeSession([])  # query filtered the pair out, no rows returned
+
+    result = build_open_parent_index(session, {("ci-E", "cpu-noisy")})
+
+    assert ("ci-E", "cpu-noisy") not in result
+
+
+def test_build_open_parent_index_keys_by_ci_metric_pair():
+    """Same CI, two metrics with different parents → two independent keys."""
+    session = _FakeSession([
+        _row("ci-E", "cpu-load", parent_event_id="evt-A", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
+        _row("ci-E", "mem-load", parent_event_id="evt-B", root_cause_ci_id="ci-B", parent_ci_id="ci-B"),
+    ])
+
+    result = build_open_parent_index(session, {("ci-E", "cpu-load"), ("ci-E", "mem-load")})
+
+    assert result[("ci-E", "cpu-load")]["parent_event_id"] == "evt-A"
+    assert result[("ci-E", "mem-load")]["parent_event_id"] == "evt-B"
+
+
+def test_build_open_parent_index_respects_max_depth_3():
+    """Parent beyond depth 3 → absent. The Cypher uses *1..3."""
+    session = _FakeSession([])  # no parent within depth 3
+
+    result = build_open_parent_index(session, {("ci-E", "cpu-load")})
+
+    assert ("ci-E", "cpu-load") not in result
+
+
+def test_build_open_parent_index_traverses_connects_to():
+    """Open parent reachable only via CONNECTS_TO → hit.
+
+    The query must include CONNECTS_TO in the relationship traversal, mirroring
+    find_open_parent_event.
+    """
+    session = _FakeSession([
+        _row("ci-E", "cpu-load", parent_event_id="evt-A", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
+    ])
+
+    result = build_open_parent_index(session, {("ci-E", "cpu-load")})
+
+    # Verify the Cypher traverses CONNECTS_TO alongside DEPENDS_ON/HOSTED_ON
+    assert "CONNECTS_TO" in session.last_query
+    assert "DEPENDS_ON" in session.last_query
+    assert "HOSTED_ON" in session.last_query
+    assert result[("ci-E", "cpu-load")]["parent_event_id"] == "evt-A"
+
+
+def test_build_open_parent_index_filters_can_propagate_in_cypher():
+    """The Cypher must apply the WHERE coalesce(m.can_propagate, true) = true filter (C2)."""
+    session = _FakeSession([])
+
+    build_open_parent_index(session, {("ci-E", "cpu-load")})
+
+    assert "coalesce(m.can_propagate, true) = true" in session.last_query
+
+
+def test_build_open_parent_index_uses_depth_3_in_cypher():
+    """The Cypher must walk *1..3 (mirror find_open_parent_event default)."""
+    session = _FakeSession([])
+
+    build_open_parent_index(session, {("ci-E", "cpu-load")})
+
+    assert "*1..3" in session.last_query
+
+
+def test_build_open_parent_index_empty_input_returns_empty_dict():
+    """Empty pairs → empty dict, no query round-trip semantics issue."""
+    session = _FakeSession([])
+
+    result = build_open_parent_index(session, set())
+
+    assert result == {}
+
+
+def test_build_open_parent_index_prefers_critical_over_warning():
+    """ORDER BY severity mirrors find_open_parent_event — CRITICAL wins."""
+    session = _FakeSession([
+        # First row in DB order is WARNING, but query ORDER BY should surface CRITICAL.
+        # Here we simulate the DB already returning the CRITICAL one first (post-ORDER BY).
+        _row("ci-E", "cpu-load", parent_event_id="evt-crit", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
+    ])
+
+    result = build_open_parent_index(session, {("ci-E", "cpu-load")})
+
+    assert "CASE pe.severity" in session.last_query or "CASE parent.severity" in session.last_query
+    assert result[("ci-E", "cpu-load")]["parent_event_id"] == "evt-crit"


### PR DESCRIPTION
## What

Fixes the production side of #310. The event correlation / RCA logic (`find_open_parent_event` + PROPAGATED tagging + recovery propagation) was fully implemented and unit-tested, but the **production-active collector never executed the topology walk** — every event was hardcoded `correlation_type: ROOT`. When CI E depends on CI A and both fail, two independent ROOT incidents landed in Neo4j. The MonitoringConsole UI masked it via client-side grouping, but the raw event stream, AI agent, MQTT escalation, ITSM, audit logs, and `GET /api/events` all saw two unrelated incidents.

**This is PR1 of 3 (chained, stacked-to-main):**
- **PR1 (this)** — engine backbone: production write path now emits topology-derived PROPAGATED events.
- PR2 — authoritative-event filtering in consumers (escalation gate, AI chat).
- PR3 — frontend `CONNECTS_TO` grouping + end-to-end recovery-cascade test.

## Root cause (verified)

The sole production writer is `backend/engines/snmp_worker.py` serial `poll_snmp()` (both the legacy in-process collector and the leased-worker path are inert in production via `DISABLE_BACKEND_COLLECTOR=true` / `POLLING_SNMP_LEASED_WORKER=false`). That path hardcoded ROOT at three CREATE sites. The reference correlation logic in `backend/services/snmp_service.py:544-559` was dead code.

## Changes

- **`backend/repositories/topology_repo.py`** — new `build_open_parent_index(pairs)`: batched variant of `find_open_parent_event`, keyed by `(ci_id, metric_id)`, filters `WHERE coalesce(m.can_propagate, true) = true` inside Cypher (the metric def is Cypher-bound at the CREATE sites, so the gate must live in Cypher), walks `DEPENDS_ON|HOSTED_ON|CONNECTS_TO*1..3` upstream in one pass. Missing key = ROOT.
- **`backend/engines/snmp_worker.py`** — new `_resolve_correlation(cache, ci_id, metric_id)` (pure dict lookup, never raises, degrades to ROOT if `root_cause_ci_id` unresolved); cache built ONCE per cycle after `with driver.session()` opens and BEFORE the unconditional `_refresh_snmp_collection_failures` call; passed to all three `_refresh_*` helpers (signatures now accept `cache=None`); the three CREATE sites use the resolved `correlation_type`/`propagated_from`/`root_cause_ci_id` instead of hardcoded ROOT.
- **`backend/config.py`** — `ENABLE_TOPOLOGY_RCA` kill-switch (default `true`, opt-out) so operators can disable without redeploy if the on-call behavior change backfires.
- **Tests** — `test_topology_repo_open_parent.py` (9) + `test_snmp_worker_correlation.py` (22), covering per-metric independence, can_propagate Cypher gating, cache-build placement, whole-cycle blast-radius fallback, backward-compat, kill-switch true/false/unset, and an end-to-end test proving a real cache hit flows to a PROPAGATED CREATE row through `poll_snmp()`.

## Verified

- C1 corrected: cache built after session open, before the unconditional SNMP-failure refresh (not "between 747-748" as the original issue suggested — that would have skipped SNMP-collection-failure correlation).
- C2 corrected: `can_propagate` filtered in Cypher, not Python (no `metric_def` exists at the CREATE sites).
- Recovery-side propagation (`engines/snmp_worker.py` recovery queries) was already correct and dormant — it now fires on real PROPAGATED events automatically.
- Judgment Day (blind dual adversarial review) — **APPROVED** after 2 rounds: Round 1 found a confirmed test gap (e2e cache-hit→PROPAGATED) + a theoretical `root_cause_ci_id` fallback; both fixed; Round 2 CLEAN on both judges.

## Notes / follow-ups

- The dormant leased-worker path (`backend/polling/snmp_worker.py` + `event_writer.py`) is still ROOT-only; enabling it later would reintroduce the bug. Producer-side pre-tagging tracked as follow-up (out of scope here).
- SNMP recovery intentionally uses full-cascade matching (`root_cause_ci_id`) vs ICMP direct-child (`propagated_from`) — documented in-code, not changed.
- Pre-existing full-suite failures (~80-97 in unrelated RTU/auth/routers modules) are tracked separately in #267; this PR adds no regressions (affected-file suite 63/63 green).

## Linked

- Closes part of #310 (PR1 of 3).
- SDD artifacts (engram): `sdd/fix-310-events-correlation-root-hardcode/{explore,proposal,spec,design,tasks,apply-progress}`