### PR TITLE
feat(events): wire pg_advisory_xact_lock into 3 writers + poll_collector_id (#322, PR2/3)

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -1,6 +1,5 @@
 import os
 import platform
-import socket
 import time
 import schedule
 import random
@@ -36,7 +35,7 @@ from polling.icmp_measurements import (
     PingMeasurement,
     parse_ping_latency_ms,
 )
-from services.event_lock import acquire_event_triplet_lock
+from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
@@ -48,13 +47,9 @@ from services.polling_event_lifecycle import (
     normalized_protocol,
 )
 
-# poll_collector_id: cached at module load to avoid per-row socket calls.
-# Falls back to HOSTNAME env var (set automatically in Kubernetes/Docker pods)
-# and finally to socket.gethostname() for bare-metal deployments.
-POLL_COLLECTOR_ID = (
-    (os.getenv("HOSTNAME") or "").strip()
-    or socket.gethostname().strip()
-) or "unknown-poll-collector"
+# poll_collector_id is sourced from services.event_lock.get_poll_collector_id
+# (cached at module load from HOSTNAME env var with socket.gethostname()
+# fallback) — see services/event_lock.py for the canonical implementation.
 
 # SNMP Support
 try:

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import socket
 import time
 import schedule
 import random
@@ -35,6 +36,7 @@ from polling.icmp_measurements import (
     PingMeasurement,
     parse_ping_latency_ms,
 )
+from services.event_lock import acquire_event_triplet_lock
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
@@ -45,6 +47,14 @@ from services.polling_event_lifecycle import (
     is_snmp_no_response_failure,
     normalized_protocol,
 )
+
+# poll_collector_id: cached at module load to avoid per-row socket calls.
+# Falls back to HOSTNAME env var (set automatically in Kubernetes/Docker pods)
+# and finally to socket.gethostname() for bare-metal deployments.
+POLL_COLLECTOR_ID = (
+    (os.getenv("HOSTNAME") or "").strip()
+    or socket.gethostname().strip()
+) or "unknown-poll-collector"
 
 # SNMP Support
 try:
@@ -279,7 +289,7 @@ def _resolve_correlation(cache, ci_id, metric_id):
     return {"correlation_type": "ROOT", "propagated_from": None, "root_cause_ci_id": ci_id}
 
 
-def _refresh_snmp_collection_failures(session, failures, cache=None):
+def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=None):
     failures = _dedupe_snmp_collection_failures(failures)
     if not failures:
         return
@@ -290,6 +300,18 @@ def _refresh_snmp_collection_failures(session, failures, cache=None):
         cache = {}
     for row in failures:
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
+    # Serialize concurrent writers for the same (ci_id, metric_id, event_type)
+    # triplet before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) block
+    # (issue #322). Locks are sorted lexicographically so two batches do not
+    # trigger Postgres deadlock detection when they overlap on different keys.
+    if lock_db is not None:
+        distinct_triplets = sorted({
+            (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
+            for row in failures
+            if row.get("node_id") and row.get("metric_id") and row.get("event_type")
+        })
+        for ci_id, metric_id, event_type in distinct_triplets:
+            acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
     session.run("""
         UNWIND $failures AS row
         MATCH (n:CI {id: row.node_id})
@@ -312,7 +334,8 @@ def _refresh_snmp_collection_failures(session, failures, cache=None):
                 last_seen: datetime(), ack: false,
                 correlation_type: row.correlation_type,
                 propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id
+                root_cause_ci_id: row.root_cause_ci_id,
+                poll_collector_id: $poll_collector_id
             })
             MERGE (n)-[:HAS_EVENT]->(created)
             MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -323,11 +346,12 @@ def _refresh_snmp_collection_failures(session, failures, cache=None):
                 existing.recovered_at = NULL, existing.ack = false,
                 existing.event_type = row.event_type,
                 existing.failure_family = row.failure_family,
-                existing.source_protocol = row.source_protocol
+                existing.source_protocol = row.source_protocol,
+                poll_collector_id = $poll_collector_id
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
-    """, failures=failures)
+    """, failures=failures, poll_collector_id=POLL_COLLECTOR_ID)
 
 
 def _availability_source(value: Any) -> str | None:
@@ -335,7 +359,7 @@ def _availability_source(value: Any) -> str | None:
     return source if source in {"PING", "ICMP"} else None
 
 
-def _refresh_icmp_availability_events(session, updates, cache=None):
+def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None):
     availability_events = [
         u
         for u in updates
@@ -350,6 +374,18 @@ def _refresh_icmp_availability_events(session, updates, cache=None):
         cache = {}
     for row in availability_events:
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
+    # Serialize concurrent writers per (ci_id, metric_id, event_type) triplet
+    # before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) block (issue #322).
+    # Sorted lexicographic acquisition prevents Postgres deadlock detection
+    # from aborting one of two overlapping batches.
+    if lock_db is not None:
+        distinct_triplets = sorted({
+            (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
+            for row in availability_events
+            if row.get("node_id") and row.get("metric_id") and row.get("event_type")
+        })
+        for ci_id, metric_id, event_type in distinct_triplets:
+            acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
     session.run("""
         UNWIND $availability_events AS row
         WITH row WHERE row.event_type = 'AVAILABILITY'
@@ -373,7 +409,8 @@ def _refresh_icmp_availability_events(session, updates, cache=None):
                 created_at: datetime(), last_seen: datetime(), ack: false,
                 correlation_type: row.correlation_type,
                 propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id
+                root_cause_ci_id: row.root_cause_ci_id,
+                poll_collector_id: $poll_collector_id
             })
             MERGE (n)-[:HAS_EVENT]->(created)
             MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -384,11 +421,12 @@ def _refresh_icmp_availability_events(session, updates, cache=None):
                 existing.recovered_at = NULL, existing.ack = false,
                 existing.event_type = row.event_type,
                 existing.source_protocol = row.source_protocol,
-                existing.availability_source = row.availability_source
+                existing.availability_source = row.availability_source,
+                poll_collector_id = $poll_collector_id
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
-    """, availability_events=availability_events)
+    """, availability_events=availability_events, poll_collector_id=POLL_COLLECTOR_ID)
 
 
 def _recover_icmp_availability_events(session, updates):
@@ -428,7 +466,7 @@ def _recover_icmp_availability_events(session, updates):
     """, recoveries=recoveries)
 
 
-def _refresh_icmp_latency_events(session, updates, cache=None):
+def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
     breaches = [
         u
         for u in updates
@@ -444,6 +482,18 @@ def _refresh_icmp_latency_events(session, updates, cache=None):
         cache = {}
     for row in breaches:
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
+    # Serialize concurrent writers per (ci_id, metric_id, event_type) triplet
+    # before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) block (issue #322).
+    # Sorted lexicographic acquisition prevents Postgres deadlock detection
+    # from aborting one of two overlapping batches.
+    if lock_db is not None:
+        distinct_triplets = sorted({
+            (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
+            for row in breaches
+            if row.get("node_id") and row.get("metric_id") and row.get("event_type")
+        })
+        for ci_id, metric_id, event_type in distinct_triplets:
+            acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
     session.run("""
         UNWIND $breaches AS row
         MATCH (n:CI {id: row.node_id})
@@ -460,7 +510,8 @@ def _refresh_icmp_latency_events(session, updates, cache=None):
                 last_seen: datetime(), ack: false,
                 correlation_type: row.correlation_type,
                 propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id
+                root_cause_ci_id: row.root_cause_ci_id,
+                poll_collector_id: $poll_collector_id
             })
             MERGE (n)-[:HAS_EVENT]->(created)
             MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -473,11 +524,12 @@ def _refresh_icmp_latency_events(session, updates, cache=None):
                 existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
                 existing.recovered_at = NULL,
                 existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
-                existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id)
+                existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id),
+                poll_collector_id = $poll_collector_id
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
-    """, breaches=breaches)
+    """, breaches=breaches, poll_collector_id=POLL_COLLECTOR_ID)
 
 
 def _recover_icmp_latency_events(session, updates):
@@ -837,7 +889,7 @@ def poll_snmp():
                     )
                     cache = {}
 
-            _refresh_snmp_collection_failures(session, failure_updates, cache=cache)
+            _refresh_snmp_collection_failures(session, failure_updates, cache=cache, lock_db=db)
 
             # Perform Bulk Insert at the end of the cycle. Only publish latest
             # values to Neo4j after Timescale persistence succeeds, so the UI
@@ -861,10 +913,10 @@ def poll_snmp():
                             r.last_message = $msg
                     """, nid=update["node_id"], mid=update["metric_id"], val=update["value"], status=update["status"], msg=update["message"])
                 availability_updates = [u for u in latest_updates if u.get("metric_kind") == "availability"]
-                _refresh_icmp_availability_events(session, availability_updates, cache=cache)
+                _refresh_icmp_availability_events(session, availability_updates, cache=cache, lock_db=db)
                 _recover_icmp_availability_events(session, availability_updates)
                 latency_updates = [u for u in latest_updates if u.get("metric_id") == ICMP_LATENCY_METRIC_ID]
-                _refresh_icmp_latency_events(session, latency_updates, cache=cache)
+                _refresh_icmp_latency_events(session, latency_updates, cache=cache, lock_db=db)
                 _recover_icmp_latency_events(session, latency_updates)
                 _recover_snmp_collection_failures(session, latest_updates)
                 print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import os
+import socket
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Iterable, Mapping
 from uuid import UUID
 
+from services.event_lock import acquire_event_triplet_lock
 from services.polling_event_lifecycle import (
     COLLECTION_FAILURE_PREFIX,
     EVENT_TYPE_AVAILABILITY,
@@ -18,6 +21,15 @@ from services.polling_event_lifecycle import (
     is_snmp_no_response_failure,
     normalized_protocol,
 )
+
+# poll_collector_id: cached at module load (HOSTNAME env var with
+# socket.gethostname() fallback). All Event CREATE / SET clauses pass
+# this constant so the host that observed the failure is recorded for
+# forensic correlation (issue #322 / spec §Poll collector identity persistence).
+POLL_COLLECTOR_ID = (
+    (os.getenv("HOSTNAME") or "").strip()
+    or socket.gethostname().strip()
+) or "unknown-poll-collector"
 
 
 def _value(item: Any) -> Any:
@@ -125,6 +137,23 @@ def _non_collection_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str,
     ]
 
 
+def _acquire_sorted_locks(lock_db, rows: Iterable[Mapping[str, Any]]) -> None:
+    """Acquire ``pg_advisory_xact_lock`` for each distinct triplet in ``rows``.
+
+    Per design §4 — Deterministic lock ordering (mandatory). Triplets are
+    sorted lexicographically by ``(ci_id, metric_id, event_type)`` BEFORE
+    acquisition so two overlapping batches contend in the same order and
+    never trigger Postgres deadlock detection.
+    """
+    distinct_triplets = sorted({
+        (row.get("ci_id"), row.get("metric_id"), row.get("event_type"))
+        for row in rows
+        if row.get("ci_id") and row.get("metric_id") and row.get("event_type")
+    })
+    for ci_id, metric_id, event_type in distinct_triplets:
+        acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+
+
 def _latest_metric_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     row_list = list(rows)
     non_collection_latest_ids = {id(row) for row in _dedupe_non_collection_latest_state(row_list)}
@@ -224,12 +253,35 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
             "service_category": metadata.get("service_category"),
             "service_tier": metadata.get("service_tier"),
             "sla_minutes": metadata.get("sla_minutes"),
+            "poll_collector_id": POLL_COLLECTOR_ID,
         })
     return rows
 
 
-def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
-    """Apply latest metric/result/event updates with batched UNWIND queries."""
+def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]], lock_db=None) -> int:
+    """Apply latest metric/result/event updates with batched UNWIND queries.
+
+    Parameters
+    ----------
+    driver:
+        Neo4j driver used to open the session for the UNWIND queries.
+    envelopes:
+        Normalized result envelopes to translate into Event / Metric rows.
+    lock_db:
+        Optional open SQLAlchemy ``Session``. When provided, advisory locks
+        (``pg_advisory_xact_lock``) are acquired for every distinct
+        ``(ci_id, metric_id, event_type)`` triplet in lexicographic order
+        BEFORE each UNWIND query that touches the Event collection. This
+        serializes concurrent writers across poll collectors (issue #322).
+        Lock acquisition is sorted lexicographically so two overlapping
+        batches contend in the same order and never trigger Postgres
+        deadlock detection.
+
+        When ``lock_db is None`` (default, e.g. in unit tests that only
+        exercise the Cypher shape), no lock is acquired. Production
+        callers (``writer_pool.run_writer_once``) always pass the leased
+        ``timescale_db`` as ``lock_db``.
+    """
     rows = build_event_rows(envelopes)
     if not rows:
         return 0
@@ -251,6 +303,10 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
             """,
             rows=latest_metric_rows,
         )
+
+        # COLLECTION_FAILURE batch — sorted lock acquisition per design §4.
+        if lock_db is not None and collection_failure_rows:
+            _acquire_sorted_locks(lock_db, collection_failure_rows)
         session.run(
             """
             UNWIND $rows AS row
@@ -280,7 +336,8 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                     business_service_tier: row.business_service_tier, owner_t1: row.owner_t1, owner_t2: row.owner_t2,
                     owner_t3: row.owner_t3, impacted_users: row.impacted_users, site: row.site,
                     service_catalog_id: row.service_catalog_id, service_category: row.service_category,
-                    service_tier: row.service_tier, sla_minutes: row.sla_minutes
+                    service_tier: row.service_tier, sla_minutes: row.sla_minutes,
+                    poll_collector_id: row.poll_collector_id
                 })
                 MERGE (n)-[:HAS_EVENT]->(created)
                 MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -290,13 +347,18 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                     existing.last_seen = datetime(), existing.ack = false, existing.recovered_at = NULL,
                     existing.event_type = row.event_type, existing.failure_family = row.failure_family,
                     existing.source_protocol = row.source_protocol,
-                    existing.availability_source = row.availability_source
+                    existing.availability_source = row.availability_source,
+                    existing.poll_collector_id = row.poll_collector_id
                 MERGE (n)-[:HAS_EVENT]->(existing)
                 MERGE (existing)-[:TRIGGERED_BY]->(m)
             )
             """,
             rows=collection_failure_rows,
         )
+
+        # Non-collection batch (threshold / availability) — sorted lock acquisition.
+        if lock_db is not None and non_collection_event_rows:
+            _acquire_sorted_locks(lock_db, non_collection_event_rows)
         session.run(
             """
             UNWIND $rows AS row
@@ -326,7 +388,8 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                     business_service_name: row.business_service_name, business_service_tier: row.business_service_tier,
                     owner_t1: row.owner_t1, owner_t2: row.owner_t2, owner_t3: row.owner_t3,
                     impacted_users: row.impacted_users, site: row.site, service_catalog_id: row.service_catalog_id,
-                    service_category: row.service_category, service_tier: row.service_tier, sla_minutes: row.sla_minutes
+                    service_category: row.service_category, service_tier: row.service_tier, sla_minutes: row.sla_minutes,
+                    poll_collector_id: row.poll_collector_id
                 })
                 MERGE (n)-[:HAS_EVENT]->(created)
                 MERGE (created)-[:TRIGGERED_BY]->(m)
@@ -355,7 +418,8 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]]) -> int:
                     existing.service_catalog_id = coalesce(existing.service_catalog_id, row.service_catalog_id),
                     existing.service_category = coalesce(existing.service_category, row.service_category),
                     existing.service_tier = coalesce(existing.service_tier, row.service_tier),
-                    existing.sla_minutes = coalesce(existing.sla_minutes, row.sla_minutes)
+                    existing.sla_minutes = coalesce(existing.sla_minutes, row.sla_minutes),
+                    existing.poll_collector_id = row.poll_collector_id
                 MERGE (n)-[:HAS_EVENT]->(existing)
                 MERGE (existing)-[:TRIGGERED_BY]->(m)
             )

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import os
-import socket
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Iterable, Mapping
 from uuid import UUID
 
-from services.event_lock import acquire_event_triplet_lock
+from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
 from services.polling_event_lifecycle import (
     COLLECTION_FAILURE_PREFIX,
     EVENT_TYPE_AVAILABILITY,
@@ -22,14 +20,9 @@ from services.polling_event_lifecycle import (
     normalized_protocol,
 )
 
-# poll_collector_id: cached at module load (HOSTNAME env var with
-# socket.gethostname() fallback). All Event CREATE / SET clauses pass
-# this constant so the host that observed the failure is recorded for
-# forensic correlation (issue #322 / spec §Poll collector identity persistence).
-POLL_COLLECTOR_ID = (
-    (os.getenv("HOSTNAME") or "").strip()
-    or socket.gethostname().strip()
-) or "unknown-poll-collector"
+# poll_collector_id is sourced from services.event_lock.get_poll_collector_id
+# (cached at module load from HOSTNAME env var with socket.gethostname()
+# fallback) — see services/event_lock.py for the canonical implementation.
 
 
 def _value(item: Any) -> Any:

--- a/backend/polling/writer_pool.py
+++ b/backend/polling/writer_pool.py
@@ -288,7 +288,18 @@ def run_writer_once(
         if latency_envelope is not None:
             event_payloads.append({**item, "envelope": latency_envelope})
     try:
-        event_writer.batch_update_events(neo4j_driver, [item["envelope"] for item in event_payloads])
+        # #322 / design §3 — pass the leased timescale_db as lock_db so
+        # the advisory lock acquired before each Event UNWIND is held by
+        # the same Postgres transaction that backs the metric insert.
+        # Lock lifecycle: lock_db stays open for the duration of the
+        # batch_update_events call; commit/close below releases the
+        # locks. timescale_db is passed (not queue_db) because the lock
+        # targets Timescale event correlation tables.
+        event_writer.batch_update_events(
+            neo4j_driver,
+            [item["envelope"] for item in event_payloads],
+            lock_db=timescale_db,
+        )
     except Exception as exc:
         retry_at = (now or _utc_now()) + timedelta(seconds=30)
         retried_result_ids = set()

--- a/backend/services/event_lock.py
+++ b/backend/services/event_lock.py
@@ -23,6 +23,9 @@ no session management, no Neo4j concerns, just one well-named primitive.
 
 from __future__ import annotations
 
+import os
+import socket
+
 from sqlalchemy import text
 
 
@@ -51,3 +54,47 @@ def acquire_event_triplet_lock(pg_db, ci_id: str, metric_id: str, event_type: st
         text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
         {"key": key},
     )
+
+
+# ---------------------------------------------------------------------------
+# poll_collector_id — forensic attribution for #322 / spec §Poll collector
+# identity persistence. Every Event CREATE / SET clause persists the
+# hostname of the container that observed the failure so operators can
+# correlate Events with the collector instance responsible. Cached at
+# module load so per-row writes don't trigger repeated socket / env reads.
+# ---------------------------------------------------------------------------
+
+_CACHED_HOSTNAME: str | None = None
+
+
+def get_poll_collector_id() -> str:
+    """Return the hostname of the current container/pod for ``poll_collector_id``.
+
+    Sources the value from the ``HOSTNAME`` env var (set automatically in
+    Kubernetes / Docker / systemd-nspawn containers) with a fallback to
+    ``socket.gethostname()`` for bare-metal deployments. The value is
+    cached at module load — subsequent calls return the cached string.
+
+    Raises
+    ------
+    RuntimeError
+        If both the ``HOSTNAME`` env var and ``socket.gethostname()``
+        return empty strings. We refuse to silently persist an empty
+        ``poll_collector_id`` because that would defeat forensic
+        correlation entirely.
+    """
+    global _CACHED_HOSTNAME
+    if _CACHED_HOSTNAME is None:
+        raw = (os.getenv("HOSTNAME") or "").strip() or socket.gethostname().strip()
+        if not raw:
+            raise RuntimeError(
+                "Cannot determine poll_collector_id: HOSTNAME env var and "
+                "socket.gethostname() are both empty"
+            )
+        _CACHED_HOSTNAME = raw
+    return _CACHED_HOSTNAME
+
+
+# Resolve once at import time so all three writers see the same constant
+# without re-running the env / socket lookup on every Event CREATE.
+POLL_COLLECTOR_ID = get_poll_collector_id()

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -4,8 +4,6 @@ import asyncio
 import ast
 import json
 import logging
-import os
-import socket
 import subprocess
 import time
 from datetime import datetime
@@ -14,7 +12,7 @@ from typing import Any, Dict
 from database import get_db
 from postgres_db import SessionLocal
 from repositories.metric_repo import insert_metric_value
-from services.event_lock import acquire_event_triplet_lock
+from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
 from services.metric_service import metric_matches_ci
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
@@ -26,14 +24,9 @@ from services.polling_event_lifecycle import (
     normalized_protocol,
 )
 
-# poll_collector_id: cached at module load (HOSTNAME env var with
-# socket.gethostname() fallback). All Event CREATE / SET clauses pass
-# this constant so the host that observed the failure is recorded for
-# forensic correlation (issue #322 / spec §Poll collector identity persistence).
-POLL_COLLECTOR_ID = (
-    (os.getenv("HOSTNAME") or "").strip()
-    or socket.gethostname().strip()
-) or "unknown-poll-collector"
+# poll_collector_id is sourced from services.event_lock.get_poll_collector_id
+# (cached at module load from HOSTNAME env var with socket.gethostname()
+# fallback) — see services/event_lock.py for the canonical implementation.
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -4,6 +4,8 @@ import asyncio
 import ast
 import json
 import logging
+import os
+import socket
 import subprocess
 import time
 from datetime import datetime
@@ -12,6 +14,7 @@ from typing import Any, Dict
 from database import get_db
 from postgres_db import SessionLocal
 from repositories.metric_repo import insert_metric_value
+from services.event_lock import acquire_event_triplet_lock
 from services.metric_service import metric_matches_ci
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
@@ -22,6 +25,15 @@ from services.polling_event_lifecycle import (
     is_snmp_no_response_failure,
     normalized_protocol,
 )
+
+# poll_collector_id: cached at module load (HOSTNAME env var with
+# socket.gethostname() fallback). All Event CREATE / SET clauses pass
+# this constant so the host that observed the failure is recorded for
+# forensic correlation (issue #322 / spec §Poll collector identity persistence).
+POLL_COLLECTOR_ID = (
+    (os.getenv("HOSTNAME") or "").strip()
+    or socket.gethostname().strip()
+) or "unknown-poll-collector"
 
 logger = logging.getLogger(__name__)
 
@@ -416,226 +428,253 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
         except ValueError:
             pass
 
-    if numeric_value is not None:
-        pg_db = SessionLocal()
-        try:
-            insert_metric_value(pg_db, ci.get("id"), metric_def["id"], numeric_value)
-        except Exception:
-            pg_db.rollback()
-            logger.exception(
-                "[Collector] Failed to persist metric %s for CI %s",
-                metric_def.get("id"),
-                ci.get("id"),
-            )
-        finally:
-            pg_db.close()
+    # #322 / design §3 — Restructure session lifetime. ONE
+    # `with SessionLocal() as pg_db:` block wraps BOTH the Timescale metric
+    # insert AND the Neo4j Event write so the pg_advisory_xact_lock acquired
+    # BEFORE the line-493 Neo4j read is held until the Neo4j transaction
+    # commits. Without this restructure the lock would be released at line
+    # 431 (old close) BEFORE the Neo4j session at line 433, defeating the
+    # cross-writer serialization guarantee.
+    needs_pg_session = numeric_value is not None or is_breach
 
-    with driver.session() as session:
-        session.run(
-            """
-            MATCH (n:CI {id: $nid})
-            MATCH (m:MetricDef {id: $mid})
-            MERGE (n)-[r:HAS_METRIC]->(m)
-            SET r.last_value = $val, r.last_updated = datetime(), r.status = $status, r.last_message = $msg
-
-            CREATE (res:MetricResult {
-                timestamp: datetime(),
-                value: $val,
-                status: $status
-            })
-            CREATE (n)-[:HAS_RESULT]->(res)
-            CREATE (res)-[:FOR_METRIC]->(m)
-        """,
-            nid=ci.get("id"),
-            mid=metric_def["id"],
-            val=str(val),
-            status=status,
-            msg=message,
-        )
-
-        if numeric_value is not None:
+    def _neo4j_write(pg_db=None):
+        with driver.session() as session:
             session.run(
                 """
-                MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
-                WHERE e.status IN ['OPEN', 'ACK']
-                  AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
-                  AND (
-                    e.event_type = 'COLLECTION_FAILURE'
-                    OR (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
-                  )
-                  AND ($source_protocol IS NULL OR e.source_protocol IS NULL OR toUpper(e.source_protocol) = $source_protocol)
-                  AND (
-                    $source_protocol <> 'SNMP'
-                    OR e.failure_family = 'SNMP_NO_RESPONSE'
-                    OR e.failure_family IS NULL
-                  )
-                SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
-                WITH e
-                CALL {
-                    WITH e
-                    MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
-                    WHERE pe.root_cause_ci_id = e.ci_id
-                      AND pe.correlation_type = 'PROPAGATED'
-                      AND pe.status IN ['OPEN', 'ACK']
-                      AND coalesce(m.can_propagate, true) = true
-                    SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
-                    RETURN count(pe) AS propagated_recovered
-                }
-                RETURN e
+                MATCH (n:CI {id: $nid})
+                MATCH (m:MetricDef {id: $mid})
+                MERGE (n)-[r:HAS_METRIC]->(m)
+                SET r.last_value = $val, r.last_updated = datetime(), r.status = $status, r.last_message = $msg
+
+                CREATE (res:MetricResult {
+                    timestamp: datetime(),
+                    value: $val,
+                    status: $status
+                })
+                CREATE (n)-[:HAS_RESULT]->(res)
+                CREATE (res)-[:FOR_METRIC]->(m)
             """,
                 nid=ci.get("id"),
                 mid=metric_def["id"],
-                source_protocol=source_protocol,
-                msg=f"Metric collection recovered. Value: {val}",
+                val=str(val),
+                status=status,
+                msg=message,
             )
 
-        if is_breach:
-            existing = session.run(
-                """
-                MATCH (existing:Event)
-                WHERE existing.ci_id = $nid AND existing.metric_id = $mid AND existing.status IN ['OPEN', 'ACK', 'RECOVERED']
-                  AND (
-                    existing.event_type = $event_type
-                    OR ($event_type = 'COLLECTION_FAILURE' AND existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
-                  )
-                  AND (
-                    ($failure_family IS NOT NULL AND (existing.failure_family = $failure_family OR existing.failure_family IS NULL))
-                    OR ($failure_family IS NULL AND existing.failure_family IS NULL)
-                  )
-                  AND ($source_protocol IS NULL OR existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = $source_protocol)
-                RETURN elementId(existing) AS existing_element_id, existing.status AS existing_status
-                LIMIT 1
-            """,
-                nid=ci.get("id"),
-                mid=metric_def["id"],
-                event_type=event_type,
-                failure_family=failure_family,
-                source_protocol=source_protocol,
-            ).single()
-
-            if existing:
-                existing_element_id = existing.get("existing_element_id")
+            if numeric_value is not None:
                 session.run(
                     """
-                    MATCH (existing:Event)
-                    WHERE elementId(existing) = $existing_element_id
-                    SET existing.status = 'OPEN',
-                        existing.last_seen = datetime(),
-                        existing.message = $msg,
-                        existing.severity = $sev,
-                        existing.recovered_at = NULL,
-                        existing.event_type = $event_type,
-                        existing.failure_family = $failure_family,
-                        existing.source_protocol = $source_protocol,
-                        existing.availability_source = $availability_source
-                """,
-                    existing_element_id=existing_element_id,
-                    msg=message,
-                    sev=severity,
-                    event_type=event_type,
-                    failure_family=failure_family,
-                    source_protocol=source_protocol,
-                    availability_source=availability_source,
-                )
-            else:
-                snapshot = resolve_event_snapshot(session, ci.get("id"))
-
-                # --- Correlation check: only if metric CAN propagate ---
-                correlation_type = "ROOT"
-                propagated_from = None
-                root_cause_ci_id = ci.get("id")
-
-                if metric_def.get("can_propagate", True):
-                    try:
-                        from repositories.topology_repo import find_open_parent_event
-                        parent_info = find_open_parent_event(ci.get("id"), max_depth=3)
-                        if parent_info:
-                            correlation_type = "PROPAGATED"
-                            propagated_from = parent_info["parent_event_id"]
-                            root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
-                    except Exception as exc:
-                        logger.warning("Topology correlation check failed for CI %s metric %s: %s",
-                                       ci.get("id"), metric_def.get("id"), exc)
-                # --- End correlation check ---
-
-                session.run(
-                    """
-                    MATCH (n:CI {id: $nid})
-                    MATCH (m:MetricDef {id: $mid})
-                    CREATE (e:Event {
-                        id: randomUUID(),
-                        ci_id: $nid,
-                        metric_id: $mid,
-                        status: 'OPEN',
-                        severity: $sev,
-                        message: $msg,
-                        event_type: $event_type,
-                        failure_family: $failure_family,
-                        source_protocol: $source_protocol,
-                        availability_source: $availability_source,
-                        created_at: datetime(),
-                        last_seen: datetime(),
-                        ack: false,
-                        business_service_id: $business_service_id,
-                        business_service_name: $business_service_name,
-                        business_service_tier: $business_service_tier,
-                        owner_t1: $owner_t1,
-                        owner_t2: $owner_t2,
-                        owner_t3: $owner_t3,
-                        impacted_users: $impacted_users,
-                        site: $site,
-                        service_catalog_id: $service_catalog_id,
-                        service_category: $service_category,
-                        service_tier: $service_tier,
-                        sla_minutes: $sla_minutes,
-                        propagated_from: $propagated_from,
-                        correlation_type: $correlation_type,
-                        root_cause_ci_id: $root_cause_ci_id
-                    })
-                    MERGE (n)-[:HAS_EVENT]->(e)
-                    MERGE (e)-[:TRIGGERED_BY]->(m)
+                    MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
+                    WHERE e.status IN ['OPEN', 'ACK']
+                      AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
+                      AND (
+                        e.event_type = 'COLLECTION_FAILURE'
+                        OR (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
+                      )
+                      AND ($source_protocol IS NULL OR e.source_protocol IS NULL OR toUpper(e.source_protocol) = $source_protocol)
+                      AND (
+                        $source_protocol <> 'SNMP'
+                        OR e.failure_family = 'SNMP_NO_RESPONSE'
+                        OR e.failure_family IS NULL
+                      )
+                    SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
+                    WITH e
+                    CALL {
+                        WITH e
+                        MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+                        WHERE pe.root_cause_ci_id = e.ci_id
+                          AND pe.correlation_type = 'PROPAGATED'
+                          AND pe.status IN ['OPEN', 'ACK']
+                          AND coalesce(m.can_propagate, true) = true
+                        SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
+                        RETURN count(pe) AS propagated_recovered
+                    }
+                    RETURN e
                 """,
                     nid=ci.get("id"),
                     mid=metric_def["id"],
-                    sev=severity,
-                    msg=message,
+                    source_protocol=source_protocol,
+                    msg=f"Metric collection recovered. Value: {val}",
+                )
+
+            if is_breach:
+                # Acquire advisory lock BEFORE the Neo4j read at the
+                # existing-Event lookup. Lock MUST be held in the same
+                # Postgres transaction as the Neo4j write (transaction-
+                # scoped advisory lock semantics).
+                if pg_db is not None:
+                    acquire_event_triplet_lock(
+                        pg_db,
+                        ci.get("id"),
+                        metric_def["id"],
+                        event_type,
+                    )
+                existing = session.run(
+                    """
+                    MATCH (existing:Event)
+                    WHERE existing.ci_id = $nid AND existing.metric_id = $mid AND existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+                      AND (
+                        existing.event_type = $event_type
+                        OR ($event_type = 'COLLECTION_FAILURE' AND existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+                      )
+                      AND (
+                        ($failure_family IS NOT NULL AND (existing.failure_family = $failure_family OR existing.failure_family IS NULL))
+                        OR ($failure_family IS NULL AND existing.failure_family IS NULL)
+                      )
+                      AND ($source_protocol IS NULL OR existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = $source_protocol)
+                    RETURN elementId(existing) AS existing_element_id, existing.status AS existing_status
+                    LIMIT 1
+                """,
+                    nid=ci.get("id"),
+                    mid=metric_def["id"],
                     event_type=event_type,
                     failure_family=failure_family,
                     source_protocol=source_protocol,
-                    availability_source=availability_source,
-                    propagated_from=propagated_from,
-                    correlation_type=correlation_type,
-                    root_cause_ci_id=root_cause_ci_id,
-                    **snapshot,
-                )
-        else:
-            # Recovery path for threshold/availability events; SNMP collection failures
-            # are recovered independently above so threshold lifecycles stay separate.
-            session.run(
-                """
-                MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
-                WHERE e.status IN ['OPEN', 'ACK']
-                  AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
-                  AND (e.event_type IS NULL OR e.event_type <> 'COLLECTION_FAILURE')
-                  AND NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
-                SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
-                WITH e
-                CALL {
+                ).single()
+
+                if existing:
+                    existing_element_id = existing.get("existing_element_id")
+                    session.run(
+                        """
+                        MATCH (existing:Event)
+                        WHERE elementId(existing) = $existing_element_id
+                        SET existing.status = 'OPEN',
+                            existing.last_seen = datetime(),
+                            existing.message = $msg,
+                            existing.severity = $sev,
+                            existing.recovered_at = NULL,
+                            existing.event_type = $event_type,
+                            existing.failure_family = $failure_family,
+                            existing.source_protocol = $source_protocol,
+                            existing.availability_source = $availability_source,
+                            existing.poll_collector_id = $poll_collector_id
+                    """,
+                        existing_element_id=existing_element_id,
+                        msg=message,
+                        sev=severity,
+                        event_type=event_type,
+                        failure_family=failure_family,
+                        source_protocol=source_protocol,
+                        availability_source=availability_source,
+                        poll_collector_id=POLL_COLLECTOR_ID,
+                    )
+                else:
+                    snapshot = resolve_event_snapshot(session, ci.get("id"))
+
+                    # --- Correlation check: only if metric CAN propagate ---
+                    correlation_type = "ROOT"
+                    propagated_from = None
+                    root_cause_ci_id = ci.get("id")
+
+                    if metric_def.get("can_propagate", True):
+                        try:
+                            from repositories.topology_repo import find_open_parent_event
+                            parent_info = find_open_parent_event(ci.get("id"), max_depth=3)
+                            if parent_info:
+                                correlation_type = "PROPAGATED"
+                                propagated_from = parent_info["parent_event_id"]
+                                root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
+                        except Exception as exc:
+                            logger.warning("Topology correlation check failed for CI %s metric %s: %s",
+                                           ci.get("id"), metric_def.get("id"), exc)
+                    # --- End correlation check ---
+
+                    session.run(
+                        """
+                        MATCH (n:CI {id: $nid})
+                        MATCH (m:MetricDef {id: $mid})
+                        CREATE (e:Event {
+                            id: randomUUID(),
+                            ci_id: $nid,
+                            metric_id: $mid,
+                            status: 'OPEN',
+                            severity: $sev,
+                            message: $msg,
+                            event_type: $event_type,
+                            failure_family: $failure_family,
+                            source_protocol: $source_protocol,
+                            availability_source: $availability_source,
+                            poll_collector_id: $poll_collector_id,
+                            created_at: datetime(),
+                            last_seen: datetime(),
+                            ack: false,
+                            business_service_id: $business_service_id,
+                            business_service_name: $business_service_name,
+                            business_service_tier: $business_service_tier,
+                            owner_t1: $owner_t1,
+                            owner_t2: $owner_t2,
+                            owner_t3: $owner_t3,
+                            impacted_users: $impacted_users,
+                            site: $site,
+                            service_catalog_id: $service_catalog_id,
+                            service_category: $service_category,
+                            service_tier: $service_tier,
+                            sla_minutes: $sla_minutes,
+                            propagated_from: $propagated_from,
+                            correlation_type: $correlation_type,
+                            root_cause_ci_id: $root_cause_ci_id
+                        })
+                        MERGE (n)-[:HAS_EVENT]->(e)
+                        MERGE (e)-[:TRIGGERED_BY]->(m)
+                    """,
+                        nid=ci.get("id"),
+                        mid=metric_def["id"],
+                        sev=severity,
+                        msg=message,
+                        event_type=event_type,
+                        failure_family=failure_family,
+                        source_protocol=source_protocol,
+                        availability_source=availability_source,
+                        poll_collector_id=POLL_COLLECTOR_ID,
+                        propagated_from=propagated_from,
+                        correlation_type=correlation_type,
+                        root_cause_ci_id=root_cause_ci_id,
+                        **snapshot,
+                    )
+            else:
+                # Recovery path for threshold/availability events; SNMP collection failures
+                # are recovered independently above so threshold lifecycles stay separate.
+                session.run(
+                    """
+                    MATCH (n:CI {id: $nid})-[:HAS_EVENT]->(e:Event {metric_id: $mid})
+                    WHERE e.status IN ['OPEN', 'ACK']
+                      AND coalesce(e.correlation_type, 'ROOT') = 'ROOT'
+                      AND (e.event_type IS NULL OR e.event_type <> 'COLLECTION_FAILURE')
+                      AND NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')
+                    SET e.status = 'RECOVERED', e.recovered_at = datetime(), e.message = $msg
                     WITH e
-                    MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
-                    WHERE pe.root_cause_ci_id = e.ci_id
-                      AND pe.correlation_type = 'PROPAGATED'
-                      AND pe.status IN ['OPEN', 'ACK']
-                      AND coalesce(m.can_propagate, true) = true
-                    SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
-                    RETURN count(pe) AS propagated_recovered
-                }
-                RETURN e
-            """,
-                nid=ci.get("id"),
-                mid=metric_def["id"],
-                msg=message,
-            )
+                    CALL {
+                        WITH e
+                        MATCH (pe:Event)-[:TRIGGERED_BY]->(m:MetricDef)
+                        WHERE pe.root_cause_ci_id = e.ci_id
+                          AND pe.correlation_type = 'PROPAGATED'
+                          AND pe.status IN ['OPEN', 'ACK']
+                          AND coalesce(m.can_propagate, true) = true
+                        SET pe.status = 'RECOVERED', pe.recovered_at = datetime()
+                        RETURN count(pe) AS propagated_recovered
+                    }
+                    RETURN e
+                """,
+                    nid=ci.get("id"),
+                    mid=metric_def["id"],
+                    msg=message,
+                )
+
+    if needs_pg_session:
+        with SessionLocal() as pg_db:
+            try:
+                if numeric_value is not None:
+                    insert_metric_value(pg_db, ci.get("id"), metric_def["id"], numeric_value)
+            except Exception:
+                pg_db.rollback()
+                logger.exception(
+                    "[Collector] Failed to persist metric %s for CI %s",
+                    metric_def.get("id"),
+                    ci.get("id"),
+                )
+            _neo4j_write(pg_db)
+    else:
+        _neo4j_write()
 
 
 def run_diagnostic(ci, metric):

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -178,20 +178,63 @@ def test_event_writer_direct_latency_recovery_excludes_propagated_events():
 
 
 def test_event_writer_threshold_breach_refresh_updates_open_or_ack_events_without_merge_duplicate():
+    from unittest.mock import MagicMock, patch
+
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [{
-        **_event_row(500.0),
-        "protocol": "ICMP",
-        "metric_id": "icmp_latency_ms",
-        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-    }])
+    lock_db = MagicMock()
+    # Track call ORDER between lock helper and session.run, tagged with the
+    # query so we can verify the lock precedes the SPECIFIC breach query
+    # (not just any neo4j call — earlier writes like ``latest_metric_rows``
+    # legitimately run before the lock for the breach batch).
+    call_order: list[tuple[str, str | None]] = []
+
+    with patch("polling.event_writer.acquire_event_triplet_lock") as mock_lock:
+        mock_lock.side_effect = lambda *_a, **_kw: call_order.append(("lock", None))
+        original_run = driver.mock_session.run
+
+        def tracking_run(query, **params):
+            call_order.append(("neo4j", query))
+            return original_run(query, **params)
+
+        driver.mock_session.run = tracking_run
+
+        batch_update_events(driver, [{
+            **_event_row(500.0),
+            "protocol": "ICMP",
+            "metric_id": "icmp_latency_ms",
+            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        }], lock_db=lock_db)
 
     breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
     assert "existing.status IN ['OPEN', 'ACK']" in breach_query["query"]
     assert "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')" in breach_query["query"]
     assert "coalesce(row.correlation_type, 'ROOT') <> 'PROPAGATED'" in breach_query["query"]
+    # #322 / design §6/§11 — POSITIVE flipped assertion: lock helper IS called
+    # with the open PG session and the breach triplet. Replaces the old
+    # negative MERGE-absent check.
+    assert mock_lock.call_count == 1, (
+        f"acquire_event_triplet_lock MUST be called once; got {mock_lock.call_count}"
+    )
+    lock_args = mock_lock.call_args_list[0].args
+    assert lock_args[0] is lock_db, "lock helper must receive the open PG session"
+    assert lock_args[1] == "ci-1"
+    assert lock_args[2] == "icmp_latency_ms"
+    assert lock_args[3] == "THRESHOLD_BREACH"
+    # Lock MUST be acquired BEFORE the breach query's session.run.
+    lock_idx = next(
+        i for i, (kind, _) in enumerate(call_order) if kind == "lock"
+    )
+    breach_idx = next(
+        i for i, (kind, q) in enumerate(call_order)
+        if kind == "neo4j" and "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in (q or "")
+    )
+    assert lock_idx < breach_idx, (
+        f"lock (idx {lock_idx}) must precede breach query (idx {breach_idx}); "
+        f"order={call_order!r}"
+    )
+    # Defensive regression: no MERGE pattern in the breach query.
     assert "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN'})" not in breach_query["query"]
     assert "created_at: datetime(), last_seen: datetime()" in breach_query["query"]
     assert "SET existing.severity = row.severity" in breach_query["query"]
@@ -495,18 +538,126 @@ def test_event_writer_marks_valid_rows_for_collection_failure_recovery_even_on_b
 
 
 def test_event_writer_uses_discriminator_aware_event_queries():
+    from unittest.mock import MagicMock, patch
+
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [_event_row(None, status="NO_DATA"), _event_row(42.0)])
+    lock_db = MagicMock()
+
+    # Two envelopes that produce TWO distinct Event types in the same batch:
+    #   1. NO_DATA → COLLECTION_FAILURE (failure_family = SNMP_NO_RESPONSE)
+    #   2. value=500 + critical=100 → THRESHOLD_BREACH
+    with patch("polling.event_writer.acquire_event_triplet_lock") as mock_lock:
+        batch_update_events(
+            driver,
+            [
+                _event_row(None, status="NO_DATA"),  # COLLECTION_FAILURE
+                {**_event_row(500.0), "protocol": "SNMP", "metric_id": "cpu",
+                 "metadata": {"name": "cpu", "criticality": 3, "critical": 100, "warning": 80, "operator": ">="}},
+            ],
+            lock_db=lock_db,
+        )
 
     queries = "\n".join(q["query"] for q in driver.mock_session.queries)
     assert "event_type" in queries
     assert "failure_family" in queries
     assert "Metric Collection Failed:" in queries
+    # #322 / design §6/§11 — POSITIVE flipped assertion: lock helper IS called
+    # for each distinct triplet in the batch (one COLLECTION_FAILURE +
+    # one THRESHOLD_BREACH). Replaces the old negative MERGE-absent check
+    # on the union of queries.
+    assert mock_lock.call_count >= 2, (
+        f"acquire_event_triplet_lock MUST be called once per distinct triplet; "
+        f"got {mock_lock.call_count} calls"
+    )
+    triplets = [
+        (call.args[1], call.args[2], call.args[3])
+        for call in mock_lock.call_args_list
+        if len(call.args) >= 4
+    ]
+    # The collection-failure envelope and the threshold-breach envelope
+    # produce different triplets — both MUST be locked.
+    assert ("ci-1", "cpu", "COLLECTION_FAILURE") in triplets, (
+        f"collection-failure triplet MUST be locked; got {triplets!r}"
+    )
+    assert ("ci-1", "cpu", "THRESHOLD_BREACH") in triplets, (
+        f"threshold-breach triplet MUST be locked; got {triplets!r}"
+    )
+    # Defensive regression: no MERGE pattern in any of the queries.
     assert "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN'})" not in queries
     assert "COLLECTION_FAILURE" in queries
     assert "SNMP_NO_RESPONSE" in queries
+
+
+def test_event_writer_acquires_locks_in_lexicographic_order_across_batch():
+    """#322 / design §4 — deterministic lock ordering (mandatory).
+
+    When a batch contains MULTIPLE distinct triplets, lock acquisition MUST
+    be in lexicographic order by ``(ci_id, metric_id, event_type)`` BEFORE
+    the Neo4j UNWIND query. Without this rule, two concurrent batches with
+    overlapping triplets contended in opposite order would trigger
+    Postgres deadlock detection.
+
+    Reverse-ordered input proves the sort happens internally: the writer
+    sees envelopes in order Z, Y, X but MUST acquire locks in X, Y, Z order.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    lock_db = MagicMock()
+    lock_call_order: list[tuple[str, str, str]] = []
+
+    def _capture(lock_db_arg, ci_id, metric_id, event_type):
+        lock_call_order.append((ci_id, metric_id, event_type))
+
+    # Input ORDER is Z, Y, X — writer MUST sort to X, Y, Z internally.
+    envelopes_in_reverse = [
+        {**_event_row(500.0), "ci_id": "ci-Z", "metric_id": "metric-Z",
+         "protocol": "ICMP",
+         "metadata": {"name": "metric-Z", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3}},
+        {**_event_row(500.0), "ci_id": "ci-Y", "metric_id": "metric-Y",
+         "protocol": "ICMP",
+         "metadata": {"name": "metric-Y", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3}},
+        {**_event_row(500.0), "ci_id": "ci-X", "metric_id": "metric-X",
+         "protocol": "ICMP",
+         "metadata": {"name": "metric-X", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3}},
+    ]
+
+    with patch("polling.event_writer.acquire_event_triplet_lock", side_effect=_capture):
+        batch_update_events(driver, envelopes_in_reverse, lock_db=lock_db)
+
+    # Acquisitions MUST be in lexicographic order regardless of input order.
+    assert lock_call_order == [
+        ("ci-X", "metric-X", "THRESHOLD_BREACH"),
+        ("ci-Y", "metric-Y", "THRESHOLD_BREACH"),
+        ("ci-Z", "metric-Z", "THRESHOLD_BREACH"),
+    ], (
+        f"locks MUST be acquired in lexicographic order; got {lock_call_order!r}"
+    )
+
+
+def test_event_writer_persists_poll_collector_id_on_event_create():
+    """#322 / spec §Poll collector identity persistence — every Event row
+    built by ``build_event_rows`` MUST include ``poll_collector_id`` so the
+    writer can persist it on CREATE / SET.
+    """
+    from polling.event_writer import build_event_rows
+
+    rows = build_event_rows([
+        _event_row(500.0, metadata={"name": "cpu", "criticality": 3, "critical": 90}),
+    ])
+
+    assert rows, "expected at least one row"
+    for row in rows:
+        assert "poll_collector_id" in row, (
+            f"row MUST carry poll_collector_id; got keys={list(row.keys())!r}"
+        )
+        assert row["poll_collector_id"], (
+            f"poll_collector_id MUST be non-empty; got {row['poll_collector_id']!r}"
+        )
 
 
 def test_event_writer_collection_failure_matching_does_not_treat_null_family_as_wildcard():

--- a/backend/tests/test_polling_writer_pool.py
+++ b/backend/tests/test_polling_writer_pool.py
@@ -74,7 +74,7 @@ def test_writer_expands_icmp_sidecar_samples_and_keeps_events_primary_only(monke
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
     monkeypatch.setattr(writer_pool, "previous_metric_value", lambda db, node_id, metric_id, before: 12.5)
     monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
-    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows, **kwargs: event_rows.extend(rows))
     monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: None)
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
@@ -109,7 +109,7 @@ def test_writer_expands_failed_icmp_availability_to_packet_loss_sidecar(monkeypa
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
     monkeypatch.setattr(writer_pool, "previous_metric_value", lambda *a, **k: (_ for _ in ()).throw(AssertionError("latency lookup not expected")))
     monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
-    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows, **kwargs: event_rows.extend(rows))
     monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: None)
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
@@ -144,7 +144,7 @@ def test_writer_persists_only_sidecars_for_internal_icmp_availability(monkeypatc
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
     monkeypatch.setattr(writer_pool, "previous_metric_value", lambda db, node_id, metric_id, before: 12.5)
     monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
-    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows, **kwargs: event_rows.extend(rows))
     monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: completed.append(rid))
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
@@ -181,7 +181,7 @@ def test_writer_emits_warning_latency_event_from_icmp_sidecar(monkeypatch):
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
     monkeypatch.setattr(writer_pool, "previous_metric_value", lambda db, node_id, metric_id, before: None)
     monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
-    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows, **kwargs: event_rows.extend(rows))
     monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: None)
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")
@@ -202,7 +202,7 @@ def test_writer_batches_timescale_inserts_receipts_and_neo4j_updates(monkeypatch
     monkeypatch.setattr(writer_pool.pg_queue, "claim_results", lambda *a, **k: [row])
     monkeypatch.setattr(writer_pool, "receipt_exists", lambda db, key: False)
     monkeypatch.setattr(writer_pool, "persist_samples_and_receipts", lambda db, rows, samples: persisted.append((list(rows), list(samples))))
-    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows: event_rows.extend(rows))
+    monkeypatch.setattr(writer_pool.event_writer, "batch_update_events", lambda driver, rows, **kwargs: event_rows.extend(rows))
     monkeypatch.setattr(writer_pool.pg_queue, "complete_result", lambda db, rid: completed.append(rid))
 
     stats = writer_pool.run_writer_once(object(), object(), object(), settings=FakeSettings(), worker_id="writer-a")

--- a/backend/tests/test_snmp_service_collection_failures.py
+++ b/backend/tests/test_snmp_service_collection_failures.py
@@ -8,20 +8,37 @@ def _load_snmp_service_module():
     return importlib.import_module("services.snmp_service")
 
 
+def _make_context_mock():
+    """Build a MagicMock that supports the ``with`` statement and returns
+    itself from ``__enter__``.
+
+    Used by tests that patch ``services.snmp_service.SessionLocal`` after the
+    #322 restructure moved metric persistence into a single
+    ``with SessionLocal() as pg_db:`` block.
+    """
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    return fake
+
+
 def test_snmp_collection_failure_on_critical_metric_is_warning_with_discriminators(mock_neo4j_driver):
     snmp_service = _load_snmp_service_module()
     session = mock_neo4j_driver.mock_session
     session.set_response("MATCH (existing:Event)", [])
     session.set_response("MATCH (ci:CI", [])
 
-    snmp_service.store_metric_result(
-        {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-        {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
-        None,
-        "TIMEOUT",
-        "No SNMP response received before timeout",
-        mock_neo4j_driver,
-    )
+    fake_pg = _make_context_mock()
+
+    with patch("services.snmp_service.SessionLocal", return_value=fake_pg):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
+            None,
+            "TIMEOUT",
+            "No SNMP response received before timeout",
+            mock_neo4j_driver,
+        )
 
     create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
     assert create_event["params"]["sev"] == "WARNING"
@@ -36,14 +53,17 @@ def test_snmp_generic_error_is_not_labeled_no_response(mock_neo4j_driver):
     session.set_response("MATCH (existing:Event)", [])
     session.set_response("MATCH (ci:CI", [])
 
-    snmp_service.store_metric_result(
-        {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-        {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
-        None,
-        "ERROR",
-        "could not convert string to float",
-        mock_neo4j_driver,
-    )
+    fake_pg = _make_context_mock()
+
+    with patch("services.snmp_service.SessionLocal", return_value=fake_pg):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
+            None,
+            "ERROR",
+            "could not convert string to float",
+            mock_neo4j_driver,
+        )
 
     create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
     assert create_event["params"]["sev"] == "CRITICAL"
@@ -135,14 +155,17 @@ def test_repeated_collection_failure_updates_exact_matched_event(mock_neo4j_driv
     session = mock_neo4j_driver.mock_session
     session.set_response("MATCH (existing:Event)", [{"existing_status": "OPEN", "existing_element_id": "element-collection"}])
 
-    snmp_service.store_metric_result(
-        {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-        {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
-        None,
-        "TIMEOUT",
-        "No SNMP response received before timeout",
-        mock_neo4j_driver,
-    )
+    fake_pg = _make_context_mock()
+
+    with patch("services.snmp_service.SessionLocal", return_value=fake_pg):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "ifInOctets", "name": "ifInOctets", "protocol": "SNMP", "criticality": 3},
+            None,
+            "TIMEOUT",
+            "No SNMP response received before timeout",
+            mock_neo4j_driver,
+        )
 
     lookup_event = next(q for q in session.queries if "MATCH (existing:Event)" in q["query"])
     assert "$failure_family IS NULL OR existing.failure_family = $failure_family" not in lookup_event["query"]
@@ -232,3 +255,170 @@ def test_poll_metric_timeout_error_indication_returns_timeout():
     assert value is None
     assert status == "TIMEOUT"
     assert error == "No SNMP response received before timeout"
+
+
+# ---------------------------------------------------------------------------
+# #322 / PR2 — pg_advisory_xact_lock wiring + session-lifetime restructure
+# (tasks 5.1 / 5.2). Two positive flipped assertions, replacing the old
+# implicit assumption that pg_db closed before the Neo4j session started.
+# ---------------------------------------------------------------------------
+
+
+def test_store_metric_result_keeps_pg_session_open_during_neo4j_write(mock_neo4j_driver):
+    """#322 / design §3 — the PG session MUST stay open across the Neo4j write.
+
+    Current state: ``pg_db.close()`` is called at line 431 BEFORE the Neo4j
+    ``driver.session()`` block at line 433. This would release the
+    ``pg_advisory_xact_lock`` lock BEFORE the Neo4j read-then-create block,
+    defeating the cross-writer serialization guarantee.
+
+    Required state: one ``with SessionLocal() as pg_db:`` block wraps BOTH
+    the Timescale metric insert AND the Neo4j write. The PG context exits
+    AFTER the Neo4j write completes.
+    """
+    import services.snmp_service as snmp_service
+
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+
+    fake_pg = _make_context_mock()
+    call_order: list[str] = []
+
+    def pg_enter(_self=None, *_args, **_kwargs):
+        call_order.append("pg_enter")
+        return fake_pg
+
+    def pg_exit(_self=None, *_args):
+        call_order.append("pg_exit")
+        return False
+
+    fake_pg.__enter__ = pg_enter
+    fake_pg.__exit__ = pg_exit
+
+    original_run = session.run
+
+    def tracking_run(query, **params):
+        call_order.append("neo4j_run")
+        return original_run(query, **params)
+
+    session.run = tracking_run
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            "97",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    # The PG context MUST be entered BEFORE the Neo4j write.
+    assert "pg_enter" in call_order, "pg context was never entered"
+    assert "neo4j_run" in call_order, "neo4j session.run never executed"
+    assert call_order.index("pg_enter") < call_order.index("neo4j_run"), (
+        f"pg context enter must precede neo4j run; order={call_order}"
+    )
+
+    # The PG context MUST NOT exit BEFORE the Neo4j write completes —
+    # otherwise the advisory lock would be released mid-transaction.
+    assert "pg_exit" in call_order, "pg context was never exited"
+    assert call_order.index("pg_exit") > call_order.index("neo4j_run"), (
+        f"pg context exited BEFORE neo4j run (lock released too early); "
+        f"order={call_order}"
+    )
+
+
+def test_store_metric_result_acquires_pg_advisory_lock_before_neo4j_read(mock_neo4j_driver):
+    """#322 / design §3-§4 — POSITIVE flipped assertion.
+
+    ``store_metric_result`` MUST call ``acquire_event_triplet_lock`` with
+    the open PG session and the (ci_id, metric_id, event_type) triplet
+    BEFORE the Neo4j read at line 493. Otherwise concurrent writers can
+    create duplicate OPEN Events for the same triplet.
+    """
+    import services.snmp_service as snmp_service
+
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+
+    fake_pg = _make_context_mock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+        patch("services.snmp_service.acquire_event_triplet_lock") as mock_lock,
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            "97",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    assert mock_lock.call_count >= 1, "acquire_event_triplet_lock was never called"
+
+    # Locate the call that matches the breach triplet (ci-1, cpu, THRESHOLD_BREACH).
+    matching = [
+        call for call in mock_lock.call_args_list
+        if len(call.args) >= 4
+        and call.args[1] == "ci-1"
+        and call.args[2] == "cpu"
+        and call.args[3] == "THRESHOLD_BREACH"
+    ]
+    assert matching, (
+        f"no acquire_event_triplet_lock call with triplet (ci-1, cpu, THRESHOLD_BREACH); "
+        f"got calls={mock_lock.call_args_list!r}"
+    )
+    # The first matching call MUST use the open PG session as the lock target.
+    assert matching[0].args[0] is fake_pg, (
+        f"lock helper must receive the writer's open PG session; got {matching[0].args[0]!r}"
+    )
+
+
+def test_store_metric_result_persists_poll_collector_id_on_event_create(mock_neo4j_driver):
+    """#322 / spec §Poll collector identity persistence — every Event CREATE
+    MUST include ``poll_collector_id`` so the host that observed the failure
+    is recorded for forensic correlation.
+    """
+    import services.snmp_service as snmp_service
+
+    session = mock_neo4j_driver.mock_session
+    session.set_response("MATCH (existing:Event)", [])
+    session.set_response("MATCH (ci:CI", [])
+
+    fake_pg = _make_context_mock()
+
+    with (
+        patch("services.snmp_service.SessionLocal", return_value=fake_pg),
+        patch("services.snmp_service.insert_metric_value"),
+    ):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            "97",
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
+
+    create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
+    assert "poll_collector_id" in create_event["query"], (
+        f"poll_collector_id MUST be set in CREATE clause; query={create_event['query']!r}"
+    )
+    assert create_event["params"].get("poll_collector_id"), (
+        f"poll_collector_id MUST be passed as a non-empty parameter; "
+        f"params={create_event['params']!r}"
+    )
+    from services.snmp_service import POLL_COLLECTOR_ID
+    assert create_event["params"]["poll_collector_id"] == POLL_COLLECTOR_ID, (
+        f"poll_collector_id MUST match the cached POLL_COLLECTOR_ID; "
+        f"got={create_event['params']['poll_collector_id']!r}, expected={POLL_COLLECTOR_ID!r}"
+    )

--- a/backend/tests/test_snmp_service_snapshots.py
+++ b/backend/tests/test_snmp_service_snapshots.py
@@ -8,6 +8,14 @@ def _load_snmp_service_module():
     return importlib.import_module("services.snmp_service")
 
 
+def _make_context_mock():
+    """MagicMock that supports the ``with`` statement and returns itself from ``__enter__``."""
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    return fake
+
+
 def test_get_collector_status_exposes_last_cycle_metrics_processed(mock_neo4j_session):
     snmp_service = _load_snmp_service_module()
     mock_neo4j_session.set_response(
@@ -123,21 +131,24 @@ def test_store_metric_result_writes_snapshot_fields_on_new_event(mock_neo4j_driv
         ],
     )
 
-    snmp_service.store_metric_result(
-        {"id": "ci-002", "ip": "10.0.0.2", "name": "Payments-API"},
-        {
-            "id": "latency",
-            "name": "latency",
-            "protocol": "HTTP",
-            "criticality": 3,
-            "critical": 500,
-            "operator": ">=",
-        },
-        900,
-        "OK",
-        None,
-        mock_neo4j_driver,
-    )
+    fake_pg = _make_context_mock()
+
+    with patch("services.snmp_service.SessionLocal", return_value=fake_pg):
+        snmp_service.store_metric_result(
+            {"id": "ci-002", "ip": "10.0.0.2", "name": "Payments-API"},
+            {
+                "id": "latency",
+                "name": "latency",
+                "protocol": "HTTP",
+                "criticality": 3,
+                "critical": 500,
+                "operator": ">=",
+            },
+            900,
+            "OK",
+            None,
+            mock_neo4j_driver,
+        )
 
     create_event_query = session.queries[-1]
     assert "CREATE (e:Event" in create_event_query["query"]
@@ -151,7 +162,7 @@ def test_store_metric_result_writes_snapshot_fields_on_new_event(mock_neo4j_driv
 def test_store_metric_result_persists_numeric_values_to_timescale(mock_neo4j_driver):
     snmp_service = _load_snmp_service_module()
 
-    fake_pg = MagicMock()
+    fake_pg = _make_context_mock()
 
     with (
         patch("services.snmp_service.SessionLocal", return_value=fake_pg),
@@ -174,5 +185,8 @@ def test_store_metric_result_persists_numeric_values_to_timescale(mock_neo4j_dri
             mock_neo4j_driver,
         )
 
+    # After the #322 restructure, insert_metric_value receives the same
+    # MagicMock that was returned by SessionLocal (because __enter__ returns
+    # self). The session is now closed via __exit__, not close().
     mock_insert.assert_called_once_with(fake_pg, "ci-003", "cmb450i-cpu-util", 17.0)
-    fake_pg.close.assert_called_once()
+    fake_pg.__exit__.assert_called_once()

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -868,6 +868,73 @@ def test_refresh_icmp_latency_events_updates_open_or_ack_events_without_merge_du
     assert "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END" in query
 
 
+def test_refresh_icmp_latency_events_acquires_pg_advisory_lock_before_neo4j_write():
+    """#322 / design §6/§11 — POSITIVE flipped assertion.
+
+    The writer MUST acquire ``pg_advisory_xact_lock`` for the
+    ``(ci_id, metric_id, event_type)`` triplet BEFORE running the
+    Neo4j OPTIONAL MATCH + FOREACH(CREATE) block. Lock acquisition
+    serializes concurrent poll collectors so only one OPEN Event
+    is created per triplet.
+
+    Replaces the old negative "MERGE absent" check (line 866 before
+    the flip) with a positive "lock helper invoked" check. The MERGE
+    invariant stays as a defensive assertion in the sibling test.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from engines.snmp_worker import _refresh_icmp_latency_events
+
+    session = MockNeo4jSession()
+    lock_db = MagicMock()
+    call_order: list[str] = []
+
+    with patch("engines.snmp_worker.acquire_event_triplet_lock") as mock_lock:
+        mock_lock.side_effect = lambda *_a, **_kw: call_order.append("lock")
+
+        original_run = session.run
+
+        def tracking_run(query, **params):
+            call_order.append("neo4j")
+            return original_run(query, **params)
+
+        session.run = tracking_run
+
+        _refresh_icmp_latency_events(
+            session,
+            [{
+                "node_id": "ci-001",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "event_type": "THRESHOLD_BREACH",
+                "status": "WARNING",
+                "message": "Latency warning",
+            }],
+            lock_db=lock_db,
+        )
+
+    # Lock helper MUST be called with the writer's open PG session and the triplet.
+    assert mock_lock.call_count == 1, (
+        f"expected acquire_event_triplet_lock called once, got {mock_lock.call_count}"
+    )
+    lock_args = mock_lock.call_args_list[0].args
+    assert lock_args[0] is lock_db, "lock helper must receive the writer's open PG session"
+    assert lock_args[1] == "ci-001"
+    assert lock_args[2] == "icmp_latency_ms"
+    assert lock_args[3] == "THRESHOLD_BREACH"
+
+    # Lock MUST be acquired BEFORE the Neo4j write — design §5 race-safety analysis.
+    assert call_order, "no calls recorded"
+    assert call_order[0] == "lock", (
+        f"expected lock acquisition first, got order={call_order}"
+    )
+    assert "neo4j" in call_order
+    assert call_order.index("lock") < call_order.index("neo4j"), (
+        f"lock must precede neo4j write; got order={call_order}"
+    )
+
+
 def test_recover_icmp_availability_events_excludes_propagated_direct_match_and_recovers_descendants():
     from engines.snmp_worker import _recover_icmp_availability_events
 

--- a/backend/tests/test_writer_advisory_lock.py
+++ b/backend/tests/test_writer_advisory_lock.py
@@ -91,6 +91,73 @@ def test_acquire_event_triplet_lock_helper():
     )
 
 
+def test_get_poll_collector_id_returns_non_empty_string():
+    """#322 / spec §Poll collector identity persistence — helper returns a
+    non-empty hostname string sourced from ``HOSTNAME`` env var with
+    ``socket.gethostname()`` fallback. Cached at module load so per-row
+    Event writes don't trigger repeated system calls.
+    """
+    import os
+    import socket
+
+    from backend.services.event_lock import get_poll_collector_id
+
+    value = get_poll_collector_id()
+    assert isinstance(value, str)
+    assert value.strip(), f"poll_collector_id must be non-empty; got {value!r}"
+
+    # The value MUST match the HOSTNAME env var OR socket.gethostname()
+    # — whichever is non-empty (HOSTNAME takes precedence per design §4).
+    expected = (os.getenv("HOSTNAME") or socket.gethostname()).strip()
+    assert value == expected, (
+        f"poll_collector_id must match HOSTNAME-or-gethostname; "
+        f"got {value!r}, expected {expected!r}"
+    )
+
+
+def test_get_poll_collector_id_is_cached_at_module_load(monkeypatch):
+    """Hostname MUST be read once at module load (design §4 / task 7).
+    Subsequent calls return the SAME object even if socket.gethostname()
+    is patched to return something different — proves the cache.
+    """
+    import socket
+
+    from backend.services import event_lock as event_lock_module
+
+    # Reset the cache to force re-evaluation against the patched hostname.
+    monkeypatch.setattr(event_lock_module, "_CACHED_HOSTNAME", None)
+    monkeypatch.setattr(socket, "gethostname", lambda: "sentinel-host")
+    monkeypatch.delenv("HOSTNAME", raising=False)
+
+    first = event_lock_module.get_poll_collector_id()
+    assert first == "sentinel-host", f"first call should use the patched hostname; got {first!r}"
+
+    # Mutate the source — second call MUST still return the cached value.
+    monkeypatch.setattr(socket, "gethostname", lambda: "different-host")
+    second = event_lock_module.get_poll_collector_id()
+    assert second == "sentinel-host", (
+        f"second call MUST return cached value (got {second!r}); "
+        f"hostname was not cached at module load"
+    )
+
+
+def test_get_poll_collector_id_raises_when_hostname_unavailable(monkeypatch):
+    """If both HOSTNAME env var AND socket.gethostname() are empty,
+    ``get_poll_collector_id`` MUST raise ``RuntimeError`` rather than
+    silently writing an empty string to the database.
+    """
+    import socket
+
+    from backend.services import event_lock as event_lock_module
+
+    monkeypatch.setattr(event_lock_module, "_CACHED_HOSTNAME", None)
+    monkeypatch.setenv("HOSTNAME", "")
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+
+    with pytest.raises(RuntimeError, match="Cannot determine poll_collector_id"):
+        event_lock_module.get_poll_collector_id()
+
+
 # ---------------------------------------------------------------------------
 # Task 2 — primary real-Postgres concurrency proof (design §6 "Primary test").
 # PR1 ships this in PASSING state because the test exercises the lock

--- a/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
+++ b/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
@@ -198,4 +198,4 @@ Test additions: +498 lines (positive flipped assertions, new lock + collector he
 - Task 9 full suite verification: run `cd backend && uv run pytest backend/tests/...` and confirm 0 new failures. Pre-existing 139 failures on `main` are unrelated (RTU routers, MQTT subscriber) per issue #267.
 
 ### PR link
-<filled in after `gh pr create`>
+https://github.com/alexandervazquez98/next-gen/pull/330

--- a/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
+++ b/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
@@ -1,10 +1,13 @@
 # Apply Progress — fix-event-duplication-cross-writer
 
 > SDD `apply` phase output for the chained-3 delivery strategy
-> (`stacked-to-main` chain). PR1 only; PR2 and PR3 are separate apply
-> sessions.
+> (`stacked-to-main` chain). PR1 merged as #328; PR2 follows; PR3
+> (deadlock + integration) is the final piece.
 
 ## PR1 — Test infra + lock helper
+
+### Status
+complete (merged via PR #328)
 
 ### Status
 complete
@@ -84,3 +87,115 @@ clean `main` checkout; PR1 introduces no new regressions.
 
 ### PR link
 https://github.com/alexandervazquez98/next-gen/pull/328
+
+---
+
+## PR2 — Wire all 3 writers to lock helper + poll_collector_id
+
+### Status
+complete (PR opened, awaiting review)
+
+### Branch
+`fix-event-dedup-pr2-writers` (targets `main` directly — stacked-to-main)
+
+### Chain context
+
+- **Dependency**: depends on PR1's `acquire_event_triplet_lock` helper (PR #328 merged into main).
+- **Next**: PR3 (deadlock prevention tests + full-cycle integration + full suite verification) — separate session.
+- **Out of scope (this PR)**: Task 3 (deadlock tests), Task 8 (full poll-cycle integration), Task 9 (full suite verification).
+
+### Commits (in order)
+
+| SHA (short) | Message |
+|-------------|---------|
+| `12a8e50` | `feat(snmp-worker): wire 3 refresh helpers to acquire_event_triplet_lock + persist poll_collector_id` |
+| `05a878e` | `feat(snmp-service): restructure session lifetime + acquire pg_advisory_lock + persist poll_collector_id` |
+| `e796afe` | `feat(event-writer): add lock_db parameter + sorted triplet acquisition + poll_collector_id` |
+| `a40ea7a` | `feat(events): centralize poll_collector_id helper in services.event_lock` |
+
+### Tasks completed
+- **Task 4** — `backend/engines/snmp_worker.py` — 3 refresh helpers (`_refresh_snmp_collection_failures`, `_refresh_icmp_availability_events`, `_refresh_icmp_latency_events`) now accept `lock_db` and acquire sorted `pg_advisory_xact_lock` per distinct triplet before `session.run`. `poll_snmp()` passes its `db = SessionLocal()` as `lock_db` to all 3 helpers.
+- **Task 5** — `backend/services/snmp_service.py` — `pg_db = SessionLocal() ... pg_db.close()` restructured to ONE `with SessionLocal() as pg_db:` wrapping BOTH the Timescale metric insert AND the Neo4j write. `acquire_event_triplet_lock` called before the existing-Event read at the original line 493. Conditional PG session opening preserved (no PG session when no metric insert and no breach).
+- **Task 6** — `backend/polling/event_writer.py` — `batch_update_events` signature `→ (driver, envelopes, lock_db=None)`. New `_acquire_sorted_locks()` helper acquires distinct triplets in lexicographic order BEFORE each UNWIND query (collection failures AND non-collection rows). `writer_pool.run_writer_once` passes `lock_db=timescale_db` (leased session still open).
+- **Task 7** — `poll_collector_id` centralized into `backend/services/event_lock.py::get_poll_collector_id()` (cached at module load, raises `RuntimeError` if both `HOSTNAME` and `socket.gethostname()` are empty). All 3 writer modules import the helper; `os` / `socket` imports removed where no longer needed.
+
+### Tasks remaining (out of PR2 scope)
+- Task 3 — Batched writer deadlock-prevention tests (PR3, will reuse `_swap_in_real_psycopg2` from PR1).
+- Task 8 — Full poll-cycle integration test (PR3).
+- Task 9 — Full backend suite verification (PR3).
+
+### Test results
+
+| Scope | Passed | Failed | Notes |
+|-------|--------|--------|-------|
+| `tests/test_writer_advisory_lock.py` (PR1 + new helper tests) | 5 | 0 | 2 PR1 tests + 3 new tests for `get_poll_collector_id` (non-empty, cache, RuntimeError) |
+| `tests/test_snmp_worker.py` (PR1 + new lock test) | 33 | 0 | +1 new test: `test_refresh_icmp_latency_events_acquires_pg_advisory_lock_before_neo4j_write` |
+| `tests/test_snmp_service_collection_failures.py` | 13 | 0 | +3 new tests: pg session lifetime, lock acquisition, poll_collector_id persistence |
+| `tests/test_snmp_service_snapshots.py` | 6 | 0 | existing tests patched with `_make_context_mock` for `SessionLocal` |
+| `tests/test_polling_event_writer.py` | 28 | 0 | +2 flipped asserts (lines 195 & 507), +2 new tests (sorted acquisition + poll_collector_id) |
+| `tests/test_polling_writer_pool.py` | 11 | 0 | lambda stubs updated to accept `**kwargs` for `lock_db` |
+| Writer-related in-scope total | 122 | 0 | No regressions |
+| Full `backend/tests/` (excl. rtu_integration, subscriber_e2e) | **1181** | **139** | +9 new tests passing vs `main` (1172 passed); 139 failures pre-existed on `main` (RTU routers, MQTT subscriber, etc., unrelated per issue #267). PR2 introduces **zero new failures**. |
+
+### Files changed
+
+| File | Action | Notes |
+|------|--------|-------|
+| `backend/engines/snmp_worker.py` | modified | +62/-15 (whitespace-ignored): 3 helpers gain `lock_db` param; lock acquisition + sorted sort + Cypher `poll_collector_id`; module imports `POLL_COLLECTOR_ID` from `services.event_lock` |
+| `backend/services/snmp_service.py` | modified | +46/-14 (whitespace-ignored): session-lifetime restructure (raw diff larger due to `with` block indentation); imports `POLL_COLLECTOR_ID`; new `_neo4j_write` helper to avoid code duplication between the PG-session and no-PG-session paths |
+| `backend/polling/event_writer.py` | modified | +63/-6: `batch_update_events` signature change; new `_acquire_sorted_locks` helper; `build_event_rows` includes `poll_collector_id`; UNWIND Cypher passes `poll_collector_id: row.poll_collector_id` |
+| `backend/polling/writer_pool.py` | modified | +12/-1: `batch_update_events` call now passes `lock_db=timescale_db` |
+| `backend/services/event_lock.py` | modified | +47: new `get_poll_collector_id()` helper + `_CACHED_HOSTNAME` cache + `POLL_COLLECTOR_ID` constant |
+| `backend/tests/test_writer_advisory_lock.py` | modified | +67: 3 new tests for `get_poll_collector_id` (non-empty, cache, RuntimeError) |
+| `backend/tests/test_snmp_worker.py` | modified | +67: 1 new test (lock acquisition + before-Neo4j ordering) |
+| `backend/tests/test_snmp_service_collection_failures.py` | modified | +190: 3 new tests + `_make_context_mock` helper + 3 existing tests patched with the helper |
+| `backend/tests/test_snmp_service_snapshots.py` | modified | +16: `_make_context_mock` helper + 2 existing tests updated for context-manager `SessionLocal` |
+| `backend/tests/test_polling_event_writer.py` | modified | +153: 2 flipped assertions (lines 195 & 507), 2 new tests (sorted lexicographic + poll_collector_id in built row) |
+| `backend/tests/test_polling_writer_pool.py` | modified | +5: 5 `lambda driver, rows:` → `lambda driver, rows, **kwargs:` to accept `lock_db` kwarg |
+
+### Reviewer-relevant diff (whitespace-ignored)
+
+```
+backend/engines/snmp_worker.py            +62
+backend/polling/event_writer.py           +63
+backend/polling/writer_pool.py            +12
+backend/services/event_lock.py            +47
+backend/services/snmp_service.py          +46
+─────────────────────────────────────────────
+TOTAL production additions                +230   (well within 400-line budget)
+```
+
+Test additions: +498 lines (positive flipped assertions, new lock + collector helper tests). Snmp_service raw diff inflates to ~428 lines due to indentation changes from the `with` block restructure; semantic diff is +46 lines.
+
+### Strict TDD evidence
+
+| Task | Sub-step | RED | GREEN | Refactor |
+|------|----------|-----|-------|----------|
+| 4 | 4.1 snmp-worker lock test | `AttributeError: ... does not have the attribute 'acquire_event_triplet_lock'` | after 4.2 impl + poll_collector_id Cypher: PASS | docstring on lock acquisition block |
+| 5 | 5.1 snmp-service pg lifetime test | `pg context was never entered` (call_order empty) | after 5.3 refactor: PASS | introduced `_make_context_mock` test helper |
+| 5 | 5.2 snmp-service lock test | `AttributeError: ... does not have the attribute 'acquire_event_triplet_lock'` | after 5.4: PASS | — |
+| 5 | 5.3 snmp-service collector test | `poll_collector_id MUST be set in CREATE clause` | after 5.3: PASS | — |
+| 6 | 6.1 event-writer breach flipped assert | `AttributeError: ... does not have the attribute 'acquire_event_triplet_lock'` | after 6.2: PASS | tightened call_order to track query text alongside kind |
+| 6 | 6.1 event-writer discriminator flipped assert | `mock_lock.call_count >= 2` (was 1 with single-event-type envelope) | after fixing test envelope shape (NO_DATA + threshold breach): PASS | — |
+| 6 | 6.1 event-writer sorted-acquisition test | `assert mock_lock.call_order == [X, Y, Z]` failed (no sort yet) | after 6.2: PASS | proved by reverse-ordered input |
+| 6 | 6.2 event-writer poll_collector_id row test | `poll_collector_id MUST be in row` | after 6.2: PASS | — |
+| 7 | 7.1 helper returns non-empty | `ImportError: cannot import name 'get_poll_collector_id'` | after helper impl: PASS | — |
+| 7 | 7.2 helper is cached | `AttributeError: ... has no attribute '_CACHED_HOSTNAME'` | after impl: PASS | — |
+| 7 | 7.3 helper raises on empty hostname | same AttributeError | after impl: PASS | — |
+
+### Discoveries worth noting
+
+- **MagicMock `with` gotcha**: `with FakeMock() as x:` does NOT bind `x` to `FakeMock`. By default `FakeMock.__enter__.return_value` is a NEW MagicMock. Must explicitly set `fake.__enter__.return_value = fake` for identity assertions (`is fake`) to hold. Introduced `_make_context_mock()` helper in two test files.
+- **Snmp_service restructure cost**: Wrapping `pg_db = SessionLocal()...pg_db.close()` in `with SessionLocal() as pg_db:` doubles the function's indentation for the entire Neo4j block, inflating the raw diff to ~428 lines. Whitespace-ignored diff is +46/-14; semantic change is small.
+- **Lambda mock fragility**: Tests using `monkeypatch.setattr(..., lambda driver, rows: ...)` need `**kwargs` once the function gains new kwargs. The lock_db parameter broke 5 mocks until updated.
+- **POLL_COLLECTOR_ID centralization**: Removed `os` / `socket` imports from all 3 writers, replaced inline hostname resolution with single helper import. Future PR (observability #326) can leverage this for metrics.
+- **Deterministic lock ordering**: The test that proves sorted acquisition uses REVERSE-ordered envelopes (Z,Y,X) and asserts locks come out in lex order (X,Y,Z). This pattern catches off-by-one sort errors that a same-order test would miss.
+
+### Notes for PR3
+
+- Task 3 deadlock-prevention tests reuse `_swap_in_real_psycopg2` from PR1. The `test_sorted_lock_acquisition_prevents_deadlock` should now pass (writers DO sort). `test_unsorted_lock_acquisition_deadlocks` will fail unless we add a deliberate unsorted path — PR3 may need to construct a synthetic test that bypasses `event_writer._acquire_sorted_locks` to prove the deadlock exists in the unsorted case.
+- Task 8 full poll-cycle integration test should now exercise `poll_snmp()`, `store_metric_result()`, and `batch_update_events()` concurrently against the same triplet and assert exactly 1 Event CREATE per triplet.
+- Task 9 full suite verification: run `cd backend && uv run pytest backend/tests/...` and confirm 0 new failures. Pre-existing 139 failures on `main` are unrelated (RTU routers, MQTT subscriber) per issue #267.
+
+### PR link
+<filled in after `gh pr create`>


### PR DESCRIPTION
Closes #322 (chained-3, PR2 of 3)

## Summary

- All 3 production writers (`backend/engines/snmp_worker.py`, `backend/services/snmp_service.py`, `backend/polling/event_writer.py`) now acquire `pg_advisory_xact_lock(hashtext("ci|metric|type"))` BEFORE running their Neo4j Event writes.
- `poll_collector_id` (cached hostname) is persisted on every Event CREATE / SET for forensic correlation.
- New `get_poll_collector_id()` helper centralized in `backend/services/event_lock.py`.

This is PR2 of 3 chained PRs. PR1 (lock helper + concurrency test infra) merged as #328. PR3 (deadlock prevention tests + integration + full suite verification) is the next session.

## Chain context

| PR | Scope | Status | PR link |
|----|-------|--------|---------|
| PR1 | Test infra + lock helper + concurrency proof | ✅ Merged | #328 |
| **PR2** | **All 3 writers + poll_collector_id** | **📍 This PR** | — |
| PR3 | Deadlock prevention + integration + full suite | Next session | — |

**Base branch**: `main` (stacked-to-main).
**Out of scope (PR3)**: Task 3 deadlock tests, Task 8 full poll-cycle integration, Task 9 full suite verification.

## Changes

| File | Change |
|------|--------|
| `backend/engines/snmp_worker.py` | 3 refresh helpers gain `lock_db` param; sorted `pg_advisory_xact_lock` acquisition before `session.run`; `poll_collector_id` in CREATE / SET |
| `backend/services/snmp_service.py` | Session lifetime restructured: one `with SessionLocal() as pg_db:` wraps BOTH metric insert AND Neo4j write so the lock spans the Neo4j transaction |
| `backend/polling/event_writer.py` | `batch_update_events(driver, envelopes, lock_db=None)` signature; new `_acquire_sorted_locks` helper for lexicographic acquisition |
| `backend/polling/writer_pool.py` | Pass `lock_db=timescale_db` to `batch_update_events` |
| `backend/services/event_lock.py` | New `get_poll_collector_id()` + cached `POLL_COLLECTOR_ID` constant |
| `backend/tests/test_writer_advisory_lock.py` | 3 new tests for `get_poll_collector_id` (non-empty, cache, RuntimeError on empty hostname) |
| `backend/tests/test_snmp_worker.py` | Positive flipped assert: lock helper IS called with open PG session AND before Neo4j write |
| `backend/tests/test_snmp_service_collection_failures.py` | 3 new tests (pg lifetime, lock acquisition, `poll_collector_id` in CREATE clause) + `_make_context_mock` helper |
| `backend/tests/test_snmp_service_snapshots.py` | Existing tests patched with `_make_context_mock` for new `with SessionLocal() as pg_db:` pattern |
| `backend/tests/test_polling_event_writer.py` | 2 positive flipped asserts (original lines 195 + 507) + 2 new tests (sorted lexicographic acquisition, `poll_collector_id` in built row) |
| `backend/tests/test_polling_writer_pool.py` | Lambda mocks accept `**kwargs` for new `lock_db` parameter |
| `openspec/changes/fix-event-duplication-cross-writer/apply-progress.md` | PR2 progress appended |

## Test Plan

- [x] **Strict TDD**: every code change preceded by a failing test (see SDD artifacts for evidence table)
- [x] `cd backend && uv run pytest tests/test_writer_advisory_lock.py tests/test_snmp_worker.py tests/test_snmp_worker_correlation.py tests/test_polling_event_writer.py tests/test_snmp_service_collection_failures.py tests/test_snmp_service_snapshots.py tests/test_polling_safety_limits.py tests/test_polling_writer_pool.py tests/test_polling_runtime_scripts.py` — **122 passed, 0 failed** in writer-related scope
- [x] Full backend suite (excl. rtu_integration, subscriber_e2e): **1181 passed (+9 vs main), 139 failed (pre-existing on main, unrelated per issue #267)**. Zero new failures.
- [x] New positive flipped assertions at lines 195, 507, 866 of `test_polling_event_writer.py` / `test_snmp_worker.py` all GREEN
- [x] Sorted lexicographic acquisition test proves design §4 deterministic-ordering rule
- [x] `poll_collector_id` flows through all 3 writers' CREATE / SET clauses

## Reviewer checklist

- [ ] Linked approved issue (#322, closed by PR1 — this PR continues the chain)
- [ ] Added exactly one `type:*` label (`type:feature` per PR1 convention)
- [ ] Conventional commit format on all 4 feat commits + 1 docs commit
- [ ] No `Co-Authored-By` trailers

## Risk

- **Session-lifetime restructure (`snmp_service.py`)** is the most invasive change. If the Neo4j transaction fails AFTER the Timescale insert succeeds, the metric is now persisted without an associated Event (previously the two were decoupled too — but the new structure couples them via the lock lifecycle). Acceptable: the failure mode is observable via the existing `neo4j_pending` retry path in `writer_pool`, and the Timescale insert is idempotent on `idempotency_key`.
- **MagicMock `with` gotcha**: `with FakeMock() as x` does NOT bind `x is FakeMock` by default. Introduced `_make_context_mock` test helper to avoid the trap; tests that don't use it and rely on `is fake_pg` will break.

PR2/3 of #322.