### PR TITLE
feat(frontend): dedicated AI agent user management (#327)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -141,7 +141,7 @@ def schedule_daily_backup() -> None:
 
 
 # Router Imports
-from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai
+from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai, permissions
 
 app = FastAPI(
     title="NEX-GEN API",
@@ -213,6 +213,7 @@ app.include_router(dictionaries.router, prefix="/api")
 app.include_router(cis.router, prefix="/api")
 app.include_router(cli.router, prefix="/api")
 app.include_router(ai.router, prefix="/api")
+app.include_router(permissions.router, prefix="/api")
 
 
 @app.exception_handler(Exception)

--- a/backend/routers/permissions.py
+++ b/backend/routers/permissions.py
@@ -1,0 +1,18 @@
+from fastapi import APIRouter, Depends
+from models.user import User, UserPermission, AIPermission
+from services.auth_service import get_current_active_user
+
+router = APIRouter(
+    prefix="/permissions",
+    tags=["Permissions"],
+    responses={401: {"description": "Not authenticated"}},
+)
+
+
+@router.get("/")
+async def get_permissions(current_user: User = Depends(get_current_active_user)):
+    """Return all human and AI permission enum values."""
+    return {
+        "human": [p.value for p in UserPermission],
+        "ai": [p.value for p in AIPermission],
+    }

--- a/backend/tests/test_permissions_router.py
+++ b/backend/tests/test_permissions_router.py
@@ -1,0 +1,77 @@
+"""Router-level tests for the /api/permissions/ endpoint.
+
+Tests verify:
+- Authenticated users get a 200 response with human/ai keys
+- Returned values match UserPermission and AIPermission enum values
+- Unauthenticated requests get a 401
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub heavy infrastructure BEFORE importing main (conftest already stubs
+# neo4j/psycopg2, but we need the snmp_service stub to avoid import errors)
+# ---------------------------------------------------------------------------
+if "services.snmp_service" not in sys.modules:
+    _snmp_stub = types.ModuleType("services.snmp_service")
+    setattr(_snmp_stub, "snmp_collector_loop", lambda: None)
+    setattr(
+        _snmp_stub,
+        "get_collector_status",
+        lambda: {"last_run": None, "status": "STOPPED", "stats": {}},
+    )
+    setattr(_snmp_stub, "validate_snmp_oid", lambda *args, **kwargs: {"success": False})
+    setattr(_snmp_stub, "run_diagnostic", lambda *args, **kwargs: "diagnostic-ok")
+    sys.modules["services.snmp_service"] = _snmp_stub
+
+_mock_neo4j_driver = MagicMock()
+
+with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
+    from main import app
+
+from fastapi.testclient import TestClient
+from models.user import User, UserPermission, AIPermission
+from services.auth_service import get_current_active_user
+
+client = TestClient(app)
+
+
+def _mock_user():
+    return User(
+        username="testuser",
+        role="ADMIN",
+        permissions=[],
+        allowed_locations=[],
+    )
+
+
+def test_get_permissions_authenticated():
+    app.dependency_overrides[get_current_active_user] = _mock_user
+    resp = client.get("/api/permissions/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "human" in body
+    assert "ai" in body
+    app.dependency_overrides.pop(get_current_active_user, None)
+
+
+def test_human_permissions_match_enum():
+    app.dependency_overrides[get_current_active_user] = _mock_user
+    resp = client.get("/api/permissions/")
+    assert set(resp.json()["human"]) == {p.value for p in UserPermission}
+    app.dependency_overrides.pop(get_current_active_user, None)
+
+
+def test_ai_permissions_match_enum():
+    app.dependency_overrides[get_current_active_user] = _mock_user
+    resp = client.get("/api/permissions/")
+    assert set(resp.json()["ai"]) == {p.value for p in AIPermission}
+    app.dependency_overrides.pop(get_current_active_user, None)
+
+
+def test_get_permissions_unauthenticated():
+    app.dependency_overrides.clear()  # ensure no override leaks from prior tests
+    resp = client.get("/api/permissions/")
+    assert resp.status_code == 401

--- a/frontend/components/AdminPage.test.tsx
+++ b/frontend/components/AdminPage.test.tsx
@@ -21,6 +21,10 @@ vi.mock('../context/AuthContext', () => ({
     useAuth: () => ({ hasPermission: () => true }),
 }));
 
+vi.mock('../services/permissions', () => ({
+    usePermissions: vi.fn(() => ({ human: [], ai: [], loading: false, error: null })),
+}));
+
 vi.mock('./MetricsManager', () => ({ default: () => <div>Metrics Manager</div> }));
 vi.mock('./DictionaryManager', () => ({ default: () => <div>Dictionary Manager</div> }));
 vi.mock('./CIEditor', () => ({

--- a/frontend/components/RoleManager.test.tsx
+++ b/frontend/components/RoleManager.test.tsx
@@ -5,6 +5,7 @@ import RoleManager from './RoleManager';
 
 const mocks = vi.hoisted(() => ({
   useAuth: vi.fn(),
+  usePermissions: vi.fn(),
   api: {
     get: vi.fn(),
     post: vi.fn(),
@@ -19,6 +20,10 @@ vi.mock('../context/AuthContext', () => ({
 
 vi.mock('../services/api', () => ({
   api: mocks.api,
+}));
+
+vi.mock('../services/permissions', () => ({
+  usePermissions: mocks.usePermissions,
 }));
 
 type Role = {
@@ -49,10 +54,29 @@ const setAuth = (allowedPerms: string[] = ['ROLE_MANAGE']) => {
   });
 };
 
+const AI_ROLE = {
+  name: 'AI_DIAGNOSTIC',
+  description: 'AI agent',
+  permissions: ['AI_VIEW_ALL'],
+  is_system: true,
+};
+
 describe('RoleManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setAuth();
+    mocks.usePermissions.mockReturnValue({
+      human: [
+        'EVENT_VIEW', 'EVENT_ACK', 'EVENT_CLOSE', 'EVENT_FORCED_CLOSE',
+        'CI_VIEW', 'CI_EDIT', 'CI_DELETE',
+        'RUN_DIAGNOSTICS',
+        'USER_MANAGE', 'ROLE_MANAGE', 'AUDIT_VIEW',
+        'METRICS_VIEW',
+      ],
+      ai: ['AI_VIEW_ALL', 'AI_EVENT_ACK'],
+      loading: false,
+      error: null,
+    });
     mocks.api.get.mockResolvedValue([]);
     mocks.api.post.mockResolvedValue(undefined);
     mocks.api.put.mockResolvedValue(undefined);
@@ -370,5 +394,45 @@ describe('RoleManager', () => {
 
     expect(screen.getByText(/available roles/i)).toBeInTheDocument();
     expect(mocks.api.post).not.toHaveBeenCalled();
+  });
+
+  describe('AI expand/collapse — role list cards', () => {
+    // R-1: AI system role card must show expand toggle button
+    it('R-1: shows AI Permissions expand toggle for AI system roles', async () => {
+      mocks.api.get.mockResolvedValue([AI_ROLE]);
+
+      render(<RoleManager />);
+
+      await waitFor(() => {
+        expect(screen.getByText('AI_DIAGNOSTIC')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', { name: /toggle ai permissions for ai_diagnostic/i }),
+      ).toBeInTheDocument();
+    });
+
+    // R-2: clicking the toggle reveals disabled checkboxes for each AI permission
+    it('R-2: clicking expand toggle reveals disabled AI permission checkboxes', async () => {
+      mocks.api.get.mockResolvedValue([AI_ROLE]);
+
+      render(<RoleManager />);
+
+      await waitFor(() => {
+        expect(screen.getByText('AI_DIAGNOSTIC')).toBeInTheDocument();
+      });
+
+      const toggle = screen.getByRole('button', {
+        name: /toggle ai permissions for ai_diagnostic/i,
+      });
+      fireEvent.click(toggle);
+
+      // All checkboxes rendered must be disabled
+      const checkboxes = screen.getAllByRole('checkbox');
+      checkboxes.forEach(cb => expect(cb).toBeDisabled());
+
+      // The mocked ai permission label is visible
+      expect(screen.getByText('AI_VIEW_ALL')).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/components/RoleManager.tsx
+++ b/frontend/components/RoleManager.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import { usePermissions } from '../services/permissions';
 
 interface Role {
     name: string;
@@ -10,25 +11,36 @@ interface Role {
     is_system: boolean;
 }
 
-const ALL_PERMISSIONS = [
-    { category: "Event Management", perms: ["EVENT_VIEW", "EVENT_ACK", "EVENT_CLOSE", "EVENT_FORCED_CLOSE"] },
-    { category: "CI Management", perms: ["CI_VIEW", "CI_EDIT", "CI_DELETE"] },
-    { category: "Diagnostics", perms: ["RUN_DIAGNOSTICS"] },
-    { category: "System", perms: ["USER_MANAGE", "ROLE_MANAGE", "AUDIT_VIEW"] },
-    { category: "Visualization", perms: ["METRICS_VIEW"] }
-];
-
 const RoleManager: React.FC = () => {
     const { hasPermission } = useAuth();
+    const { human, ai } = usePermissions();
     const [roles, setRoles] = useState<Role[]>([]);
     const [view, setView] = useState<'list' | 'edit'>('list');
     const [currentRole, setCurrentRole] = useState<Role>({
         name: '', description: '', permissions: [], is_system: false
     });
     const [isNew, setIsNew] = useState(false);
+    const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set());
 
     const canViewRoles = hasPermission('USER_MANAGE') || hasPermission('ROLE_MANAGE') || hasPermission('ADMIN');
     const canMutateRoles = hasPermission('ROLE_MANAGE') || hasPermission('ADMIN');
+
+    const toggleExpand = (name: string) => {
+        setExpandedRoles(prev => {
+            const next = new Set(prev);
+            if (next.has(name)) next.delete(name);
+            else next.add(name);
+            return next;
+        });
+    };
+
+    const humanCategories = [
+        { category: 'Event Management', perms: human.filter(p => ['EVENT_VIEW', 'EVENT_ACK', 'EVENT_CLOSE', 'EVENT_FORCED_CLOSE'].includes(p)) },
+        { category: 'CI Management',    perms: human.filter(p => ['CI_VIEW', 'CI_EDIT', 'CI_DELETE'].includes(p)) },
+        { category: 'Diagnostics',      perms: human.filter(p => p === 'RUN_DIAGNOSTICS') },
+        { category: 'System',           perms: human.filter(p => ['USER_MANAGE', 'ROLE_MANAGE', 'AUDIT_VIEW'].includes(p)) },
+        { category: 'Visualization',    perms: human.filter(p => p === 'METRICS_VIEW') },
+    ];
 
     useEffect(() => {
         if (!canViewRoles) {
@@ -139,7 +151,7 @@ const RoleManager: React.FC = () => {
                     <div>
                         <label className="block text-xs font-bold text-neutral-500 uppercase tracking-widest mb-4">Permissions</label>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            {ALL_PERMISSIONS.map(cat => (
+                            {humanCategories.map(cat => (
                                 <div key={cat.category} className="bg-white/5 p-4 rounded-xl">
                                     <h4 className="text-sm font-bold text-neutral-300 uppercase mb-3 border-b border-white/10 pb-2">{cat.category}</h4>
                                     <div className="space-y-2">
@@ -202,6 +214,37 @@ const RoleManager: React.FC = () => {
                                 </span>
                             ))}
                         </div>
+
+                        {role.name.startsWith('AI_') && role.is_system && (
+                            <div className="mb-4">
+                                <button
+                                    onClick={() => toggleExpand(role.name)}
+                                    className="text-[10px] text-brand-400 hover:text-brand-200 flex items-center gap-1 font-bold uppercase"
+                                    aria-label={`Toggle AI permissions for ${role.name}`}
+                                >
+                                    <span className="material-symbols-outlined text-sm">
+                                        {expandedRoles.has(role.name) ? 'expand_less' : 'expand_more'}
+                                    </span>
+                                    AI Permissions
+                                </button>
+
+                                {expandedRoles.has(role.name) && (
+                                    <div className="mt-2 space-y-1 pl-2 border-l border-brand-500/20">
+                                        {ai.map(p => (
+                                            <label key={p} className="flex items-center gap-2">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={role.permissions.includes(p)}
+                                                    disabled
+                                                    className="w-3 h-3 rounded bg-black/40 border-white/10 cursor-not-allowed opacity-60"
+                                                />
+                                                <span className="text-[10px] text-brand-400">{p}</span>
+                                            </label>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        )}
 
                         <div className="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
                             {canMutateRoles && !role.is_system && (

--- a/frontend/components/UserManager.test.tsx
+++ b/frontend/components/UserManager.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import UserManager from './UserManager';
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+  usePermissions: vi.fn(),
+}));
+
+vi.mock('../services/api', () => ({
+  api: mocks.api,
+}));
+
+vi.mock('../services/permissions', () => ({
+  usePermissions: mocks.usePermissions,
+}));
+
+vi.mock('../context/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ hasPermission: () => true })),
+}));
+
+// RoleManager is rendered in a tab we never activate — mock it to avoid its api calls
+vi.mock('./RoleManager', () => ({ default: () => <div>Role Manager</div> }));
+
+const ROLES = [
+  { name: 'VIEWER', permissions: ['EVENT_VIEW'] },
+  { name: 'AI_DIAGNOSTIC', permissions: ['AI_VIEW_ALL', 'AI_EVENT_ACK'] },
+];
+
+const USERS_HUMAN = [
+  { username: 'alice', role: 'VIEWER', permissions: ['EVENT_VIEW'], allowed_locations: [] },
+];
+
+const USERS_AI = [
+  { username: 'bot-diag', role: 'AI_DIAGNOSTIC', permissions: ['AI_VIEW_ALL'], allowed_locations: [] },
+];
+
+function setupDefaultMocks() {
+  mocks.usePermissions.mockReturnValue({
+    human: ['EVENT_VIEW', 'EVENT_ACK', 'CI_VIEW'],
+    ai: ['AI_VIEW_ALL', 'AI_EVENT_ACK'],
+    loading: false,
+    error: null,
+  });
+}
+
+describe('UserManager — AI features', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaultMocks();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('shows AI Permissions section when an AI role is selected', async () => {
+    mocks.api.get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/roles/') return Promise.resolve(ROLES);
+      if (endpoint === '/users/') return Promise.resolve(USERS_HUMAN);
+      return Promise.resolve([]);
+    });
+
+    render(<UserManager />);
+
+    // Wait for roles to load
+    await waitFor(() => {
+      expect(mocks.api.get).toHaveBeenCalledWith('/roles/');
+    });
+
+    // Select an AI role
+    const roleSelect = await screen.findByRole('combobox');
+    fireEvent.change(roleSelect, { target: { value: 'AI_DIAGNOSTIC' } });
+
+    // Open the permissions panel
+    const permsToggle = screen.getByText(/Specific Permissions/);
+    fireEvent.click(permsToggle);
+
+    expect(screen.getByText('AI Permissions')).toBeInTheDocument();
+  });
+
+  it('does NOT show AI Permissions section when a human role is selected', async () => {
+    mocks.api.get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/roles/') return Promise.resolve(ROLES);
+      if (endpoint === '/users/') return Promise.resolve(USERS_HUMAN);
+      return Promise.resolve([]);
+    });
+
+    render(<UserManager />);
+
+    await waitFor(() => {
+      expect(mocks.api.get).toHaveBeenCalledWith('/roles/');
+    });
+
+    // VIEWER is the default role — open the permissions panel
+    const permsToggle = await screen.findByText(/Specific Permissions/);
+    fireEvent.click(permsToggle);
+
+    expect(screen.queryByText('AI Permissions')).toBeNull();
+  });
+
+  it('shows AI badge next to an AI user in the user list', async () => {
+    mocks.api.get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/roles/') return Promise.resolve(ROLES);
+      if (endpoint === '/users/') return Promise.resolve(USERS_AI);
+      return Promise.resolve([]);
+    });
+
+    render(<UserManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText('bot-diag')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('AI')).toBeInTheDocument();
+  });
+
+  it('does NOT show AI badge for a human user in the user list', async () => {
+    mocks.api.get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/roles/') return Promise.resolve(ROLES);
+      if (endpoint === '/users/') return Promise.resolve(USERS_HUMAN);
+      return Promise.resolve([]);
+    });
+
+    render(<UserManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText('alice')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('AI')).toBeNull();
+  });
+
+  it('shows service-account note when AI role is selected for a new user', async () => {
+    mocks.api.get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/roles/') return Promise.resolve(ROLES);
+      if (endpoint === '/users/') return Promise.resolve(USERS_HUMAN);
+      return Promise.resolve([]);
+    });
+
+    render(<UserManager />);
+
+    await waitFor(() => {
+      expect(mocks.api.get).toHaveBeenCalledWith('/roles/');
+    });
+
+    const roleSelect = await screen.findByRole('combobox');
+    fireEvent.change(roleSelect, { target: { value: 'AI_DIAGNOSTIC' } });
+
+    expect(screen.getByText(/This is a service account/)).toBeInTheDocument();
+  });
+
+  it('shows AI badge for AI_OPERATOR users (not just AI_DIAGNOSTIC)', async () => {
+    const USERS_OPERATOR = [
+      { username: 'bot-op', role: 'AI_OPERATOR', permissions: ['AI_VIEW_ALL', 'AI_EVENT_CLOSE'], allowed_locations: [] },
+    ];
+    mocks.api.get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/roles/') return Promise.resolve(ROLES);
+      if (endpoint === '/users/') return Promise.resolve(USERS_OPERATOR);
+      return Promise.resolve([]);
+    });
+
+    render(<UserManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText('bot-op')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('AI')).toBeInTheDocument();
+  });
+});

--- a/frontend/components/UserManager.tsx
+++ b/frontend/components/UserManager.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { api } from '../services/api';
 import { useAuth } from '../context/AuthContext';
+import { usePermissions } from '../services/permissions';
 import RoleManager from './RoleManager';
 
 interface User {
@@ -19,15 +20,11 @@ interface Role {
     permissions: string[];
 }
 
-const ALL_PERMISSIONS = [
-    { category: "Event Management", perms: ["EVENT_VIEW", "EVENT_ACK", "EVENT_CLOSE"] },
-    { category: "CI Management", perms: ["CI_VIEW", "CI_EDIT", "CI_DELETE"] },
-    { category: "Diagnostics", perms: ["RUN_DIAGNOSTICS"] },
-    { category: "System", perms: ["USER_MANAGE", "ROLE_MANAGE", "AUDIT_VIEW"] }
-];
+
 
 const UserManager: React.FC = () => {
     const { hasPermission } = useAuth();
+    const { human, ai } = usePermissions();
     const [activeTab, setActiveTab] = useState<'users' | 'roles'>('users');
     const [users, setUsers] = useState<User[]>([]);
     const [roles, setRoles] = useState<Role[]>([]);
@@ -168,6 +165,9 @@ const UserManager: React.FC = () => {
         return <div className="p-8 text-neutral-500">Access Denied.</div>;
     }
 
+    const activeRole = editingUser ? editingUser.role : newUser.role;
+    const isAiRole = activeRole.startsWith('AI_');
+
     const activeUser = editingUser || newUser;
 
     return (
@@ -250,6 +250,11 @@ const UserManager: React.FC = () => {
                                         <option key={r.name} value={r.name}>{r.name}</option>
                                     ))}
                                 </select>
+                                {isAiRole && !editingUser && (
+                                    <p className="text-[10px] text-brand-400 mt-1">
+                                        This is a service account. No password login.
+                                    </p>
+                                )}
                             </div>
 
                             {/* Granular Permissions Toggle */}
@@ -264,7 +269,13 @@ const UserManager: React.FC = () => {
 
                                 {showPerms && (
                                     <div className="p-3 bg-black/20 max-h-64 overflow-y-auto space-y-4">
-                                        {ALL_PERMISSIONS.map(cat => (
+                                        {([
+                                            { category: 'Event Management', perms: human.filter(p => ['EVENT_VIEW','EVENT_ACK','EVENT_CLOSE','EVENT_FORCED_CLOSE'].includes(p)) },
+                                            { category: 'CI Management',    perms: human.filter(p => ['CI_VIEW','CI_EDIT','CI_DELETE'].includes(p)) },
+                                            { category: 'Diagnostics',      perms: human.filter(p => p === 'RUN_DIAGNOSTICS') },
+                                            { category: 'System',           perms: human.filter(p => ['USER_MANAGE','ROLE_MANAGE','AUDIT_VIEW'].includes(p)) },
+                                            { category: 'Visualization',    perms: human.filter(p => p === 'METRICS_VIEW') },
+                                        ]).map(cat => (
                                             <div key={cat.category}>
                                                 <h5 className="text-[10px] text-neutral-500 font-bold uppercase mb-2">{cat.category}</h5>
                                                 <div className="space-y-1">
@@ -282,6 +293,24 @@ const UserManager: React.FC = () => {
                                                 </div>
                                             </div>
                                         ))}
+                                        {isAiRole && (
+                                            <div>
+                                                <h5 className="text-[10px] text-brand-400 font-bold uppercase mb-2">AI Permissions</h5>
+                                                <div className="space-y-1">
+                                                    {ai.map(p => (
+                                                        <label key={p} className="flex items-center gap-2 cursor-pointer">
+                                                            <input
+                                                                type="checkbox"
+                                                                checked={activeUser.permissions.includes(p)}
+                                                                onChange={() => togglePermission(p)}
+                                                                className="w-3 h-3 rounded bg-black/40 text-brand-500 border-white/10"
+                                                            />
+                                                            <span className="text-[10px] text-brand-300">{p}</span>
+                                                        </label>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
                                     </div>
                                 )}
                             </div>
@@ -312,7 +341,14 @@ const UserManager: React.FC = () => {
                             <tbody>
                                 {users.map(u => (
                                     <tr key={u.username} className="border-b border-white/5 hover:bg-white/5 transition-colors">
-                                        <td className="p-4 font-bold text-white">{u.username}</td>
+                                        <td className="p-4 font-bold text-white">
+                                            {u.username}
+                                            {u.role.startsWith('AI_') && (
+                                                <span className="ml-2 text-[9px] bg-brand-900/60 text-brand-300 border border-brand-500/30 px-1.5 py-0.5 rounded font-bold uppercase">
+                                                    AI
+                                                </span>
+                                            )}
+                                        </td>
                                         <td className="p-4">
                                             <span className="px-2 py-0.5 rounded text-[10px] font-bold uppercase bg-neutral-700 text-neutral-400">
                                                 {u.role}

--- a/frontend/services/permissions.ts
+++ b/frontend/services/permissions.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect } from 'react';
+import { api } from './api';
+
+export interface PermissionsResponse {
+  human: string[];
+  ai: string[];
+}
+
+export interface UsePermissionsResult extends PermissionsResponse {
+  loading: boolean;
+  error: string | null;
+}
+
+export function usePermissions(): UsePermissionsResult {
+  const [human, setHuman] = useState<string[]>([]);
+  const [ai, setAi] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get<PermissionsResponse>('/permissions/')
+      .then((data) => {
+        if (!cancelled) {
+          setHuman(data.human);
+          setAi(data.ai);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message ?? 'Failed to load permissions');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { human, ai, loading, error };
+}

--- a/openspec/changes/feat-327-ai-user-management/design.md
+++ b/openspec/changes/feat-327-ai-user-management/design.md
@@ -1,0 +1,372 @@
+# Design: feat-327-ai-user-management
+
+## Architecture Overview
+
+```
+backend/
+  routers/permissions.py      ← NEW: GET /permissions/ (enum introspection)
+  main.py                     ← ADD: import + app.include_router(permissions.router, prefix="/api")
+
+frontend/
+  services/permissions.ts     ← NEW: usePermissions hook (fetch + state)
+  components/UserManager.tsx  ← MOD: replace ALL_PERMISSIONS, add AI badge, AI perms block, service-account note
+  components/RoleManager.tsx  ← MOD: replace ALL_PERMISSIONS, add expandedRoles state, AI card expand/collapse
+```
+
+Data flow:
+```
+GET /api/permissions/
+       │
+       ▼
+  usePermissions()
+  ┌─────────────────────────────────────┐
+  │  { human[], ai[], loading, error }  │
+  └────────────┬────────────────────────┘
+               │
+       ┌───────┴───────┐
+       ▼               ▼
+  UserManager      RoleManager
+  (human cats +    (human cats +
+   AI block when    AI expand on
+   AI role)         AI cards)
+```
+
+## Backend Design
+
+### permissions router
+
+```python
+# backend/routers/permissions.py
+from fastapi import APIRouter, Depends
+from models.user import User, UserPermission, AIPermission
+from services.auth_service import get_current_active_user
+
+router = APIRouter(
+    prefix="/permissions",
+    tags=["Permissions"],
+    responses={401: {"description": "Not authenticated"}},
+)
+
+
+@router.get("/")
+async def get_permissions(current_user: User = Depends(get_current_active_user)):
+    """Return all human and AI permission enum values."""
+    return {
+        "human": [p.value for p in UserPermission],
+        "ai": [p.value for p in AIPermission],
+    }
+```
+
+No database calls. No Pydantic response model (plain dict is fine). The `get_current_active_user` dependency handles 401 for unauthenticated callers — this is exactly the same pattern used by `roles.py` (`list_roles`) and `users.py`.
+
+### main.py registration
+
+Current import line (line 144):
+```python
+from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai
+```
+
+Updated import line:
+```python
+from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai, permissions
+```
+
+Registration — append after `app.include_router(ai.router, prefix="/api")` (line 215):
+```python
+app.include_router(permissions.router, prefix="/api")
+```
+
+This follows the existing convention: one `include_router` call per router, all with `prefix="/api"`, ordered at startup registration.
+
+## Frontend Design
+
+### usePermissions hook / permissions service
+
+```typescript
+// frontend/services/permissions.ts
+import { useState, useEffect } from 'react';
+import { api } from './api';
+
+export interface PermissionsResponse {
+  human: string[];
+  ai: string[];
+}
+
+export interface UsePermissionsResult extends PermissionsResponse {
+  loading: boolean;
+  error: string | null;
+}
+
+export function usePermissions(): UsePermissionsResult {
+  const [human, setHuman] = useState<string[]>([]);
+  const [ai, setAi] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get<PermissionsResponse>('/permissions/')
+      .then((data) => {
+        if (!cancelled) {
+          setHuman(data.human);
+          setAi(data.ai);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err?.message ?? 'Failed to load permissions');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { human, ai, loading, error };
+}
+```
+
+Key decisions:
+- Single `useEffect` with empty deps — fetches once per component mount.
+- Cancellation flag prevents state updates after unmount.
+- Fallback to `[]` on error keeps callers safe (NFR-2).
+- Uses existing `api.get<T>()` pattern from `api.ts` (credentials handled automatically via HttpOnly cookie).
+
+### UserManager changes
+
+**Remove** the `ALL_PERMISSIONS` constant (lines 22-27).
+
+**Add** at top of component body:
+```typescript
+const { human, ai } = usePermissions();
+
+// Derived: is the currently-selected role an AI role?
+const activeRole = editingUser ? editingUser.role : newUser.role;
+const isAiRole = activeRole.startsWith('AI_');
+```
+
+**Build permission categories dynamically** (replaces hardcoded `ALL_PERMISSIONS` usage):
+```typescript
+const humanCategories = [
+  { category: 'Event Management', perms: human.filter(p => ['EVENT_VIEW','EVENT_ACK','EVENT_CLOSE','EVENT_FORCED_CLOSE'].includes(p)) },
+  { category: 'CI Management',    perms: human.filter(p => ['CI_VIEW','CI_EDIT','CI_DELETE'].includes(p)) },
+  { category: 'Diagnostics',      perms: human.filter(p => p === 'RUN_DIAGNOSTICS') },
+  { category: 'System',           perms: human.filter(p => ['USER_MANAGE','ROLE_MANAGE','AUDIT_VIEW'].includes(p)) },
+  { category: 'Visualization',    perms: human.filter(p => p === 'METRICS_VIEW') },
+];
+```
+
+> **Design note**: The category→perm mapping is still local because it is a UI concern (grouping labels), not business logic. The actual permission strings come from the API hook.
+
+**AI permissions block** — conditionally rendered inside the `showPerms` section after all human categories:
+```tsx
+{isAiRole && (
+  <div key="AI Permissions">
+    <h5 className="text-[10px] text-brand-400 font-bold uppercase mb-2">AI Permissions</h5>
+    <div className="space-y-1">
+      {ai.map(p => (
+        <label key={p} className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={activeUser.permissions.includes(p)}
+            onChange={() => togglePermission(p)}
+            className="w-3 h-3 rounded bg-black/40 text-brand-500 border-white/10"
+          />
+          <span className="text-[10px] text-brand-300">{p}</span>
+        </label>
+      ))}
+    </div>
+  </div>
+)}
+```
+
+**AI badge** in user list table row — rendered after `{u.username}`:
+```tsx
+<td className="p-4 font-bold text-white">
+  {u.username}
+  {u.role.startsWith('AI_') && (
+    <span className="ml-2 text-[9px] bg-brand-900/60 text-brand-300 border border-brand-500/30 px-1.5 py-0.5 rounded font-bold uppercase">
+      AI
+    </span>
+  )}
+</td>
+```
+
+**Service-account note** — rendered below the role `<select>` when `isAiRole` and `!editingUser`:
+```tsx
+{isAiRole && !editingUser && (
+  <p className="text-[10px] text-brand-400 mt-1">
+    This is a service account. No password login.
+  </p>
+)}
+```
+
+The `password` field is already hidden for `editingUser` — no additional guard needed for existing edit flow.
+
+### RoleManager changes
+
+**Remove** the `ALL_PERMISSIONS` constant (lines 13-19).
+
+**Add** at top of component body:
+```typescript
+const { human, ai } = usePermissions();
+const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set());
+
+const toggleExpand = (name: string) => {
+  setExpandedRoles(prev => {
+    const next = new Set(prev);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    return next;
+  });
+};
+```
+
+**Build human categories** (same pattern as UserManager — replaces `ALL_PERMISSIONS.map(...)` in the edit view):
+```typescript
+const humanCategories = [
+  { category: 'Event Management', perms: human.filter(p => ['EVENT_VIEW','EVENT_ACK','EVENT_CLOSE','EVENT_FORCED_CLOSE'].includes(p)) },
+  { category: 'CI Management',    perms: human.filter(p => ['CI_VIEW','CI_EDIT','CI_DELETE'].includes(p)) },
+  { category: 'Diagnostics',      perms: human.filter(p => p === 'RUN_DIAGNOSTICS') },
+  { category: 'System',           perms: human.filter(p => ['USER_MANAGE','ROLE_MANAGE','AUDIT_VIEW'].includes(p)) },
+  { category: 'Visualization',    perms: human.filter(p => p === 'METRICS_VIEW') },
+];
+```
+
+**AI system role card** — in the role list `map`, after the existing permission tags and before the action buttons:
+```tsx
+{role.name.startsWith('AI_') && role.is_system && (
+  <div className="mb-4">
+    <button
+      onClick={() => toggleExpand(role.name)}
+      className="text-[10px] text-brand-400 hover:text-brand-200 flex items-center gap-1 font-bold uppercase"
+      aria-label={`Toggle AI permissions for ${role.name}`}
+    >
+      <span className="material-symbols-outlined text-sm">
+        {expandedRoles.has(role.name) ? 'expand_less' : 'expand_more'}
+      </span>
+      AI Permissions
+    </button>
+
+    {expandedRoles.has(role.name) && (
+      <div className="mt-2 space-y-1 pl-2 border-l border-brand-500/20">
+        {ai.map(p => (
+          <label key={p} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={role.permissions.includes(p)}
+              disabled
+              className="w-3 h-3 rounded bg-black/40 border-white/10 cursor-not-allowed opacity-60"
+            />
+            <span className="text-[10px] text-brand-400">{p}</span>
+          </label>
+        ))}
+      </div>
+    )}
+  </div>
+)}
+```
+
+## Component State Changes
+
+| Component | New state | Type | Purpose |
+|-----------|-----------|------|---------|
+| `UserManager` | `human` | `string[]` (from hook) | Human permission values for category rendering |
+| `UserManager` | `ai` | `string[]` (from hook) | AI permission values for conditional AI block |
+| `RoleManager` | `human` | `string[]` (from hook) | Human permission values for edit-view categories |
+| `RoleManager` | `ai` | `string[]` (from hook) | AI permission values for read-only expand blocks |
+| `RoleManager` | `expandedRoles` | `Set<string>` | Tracks which AI role card names are expanded |
+
+`loading` and `error` from `usePermissions` are also available but both components can treat `loading: true` as an empty array (graceful no-op render).
+
+## Test Design
+
+### Backend (`backend/tests/test_permissions_router.py`)
+
+Uses the same `TestClient` + `app.dependency_overrides` pattern seen in existing backend tests. The `get_current_active_user` dependency is overridden with a fixture that returns a minimal `User` object.
+
+```python
+from fastapi.testclient import TestClient
+from main import app
+from models.user import User, UserPermission, AIPermission
+from services.auth_service import get_current_active_user
+
+def _mock_user():
+    return User(username="testuser", role="ADMIN", permissions=[], allowed_locations=[])
+
+client = TestClient(app)
+
+def test_get_permissions_authenticated():
+    app.dependency_overrides[get_current_active_user] = _mock_user
+    resp = client.get("/api/permissions/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "human" in body
+    assert "ai" in body
+
+def test_human_permissions_match_enum():
+    app.dependency_overrides[get_current_active_user] = _mock_user
+    resp = client.get("/api/permissions/")
+    assert set(resp.json()["human"]) == {p.value for p in UserPermission}
+
+def test_ai_permissions_match_enum():
+    app.dependency_overrides[get_current_active_user] = _mock_user
+    resp = client.get("/api/permissions/")
+    assert set(resp.json()["ai"]) == {p.value for p in AIPermission}
+
+def test_get_permissions_unauthenticated():
+    app.dependency_overrides.pop(get_current_active_user, None)
+    resp = client.get("/api/permissions/")
+    assert resp.status_code == 401
+```
+
+### Frontend (`frontend/components/__tests__/UserManager.test.tsx`)
+
+Pattern follows `AIAgentConsole.test.tsx`: `vi.mock` for dependencies, `render` + `screen` + `fireEvent`/`userEvent`, `waitFor` for async state.
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import UserManager from '../UserManager';
+
+// Mock api module
+vi.mock('../../services/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Mock usePermissions hook
+vi.mock('../../services/permissions', () => ({
+  usePermissions: vi.fn(() => ({
+    human: ['EVENT_VIEW', 'EVENT_ACK', 'CI_VIEW'],
+    ai: ['AI_VIEW_ALL', 'AI_EVENT_ACK'],
+    loading: false,
+    error: null,
+  })),
+}));
+
+// Mock useAuth
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ hasPermission: () => true })),
+}));
+```
+
+Key test structure: seed `api.get` to return a role list including an `AI_AGENT` role and a `VIEWER` role, then trigger `fireEvent.change` on the role selector to drive the `isAiRole` branch.
+
+### Frontend (`frontend/components/__tests__/RoleManager.test.tsx`)
+
+Same mock pattern. `api.get('/roles/')` returns a role with `is_system: true` and `name: 'AI_AGENT'`. Test clicks the expand button and asserts the AI permission checkboxes appear with `disabled` attribute.
+
+### Frontend (`frontend/pages/__tests__/AdminPage.test.tsx`)
+
+Add a module-level mock for `usePermissions` at the top of the test file:
+```typescript
+vi.mock('../../services/permissions', () => ({
+  usePermissions: vi.fn(() => ({ human: [], ai: [], loading: false, error: null })),
+}));
+```
+
+No other changes required — existing assertions still hold because the hook returns the same data shape as the old static constant.

--- a/openspec/changes/feat-327-ai-user-management/propose.md
+++ b/openspec/changes/feat-327-ai-user-management/propose.md
@@ -1,0 +1,91 @@
+# Proposal: feat-327-ai-user-management
+
+## Problem
+
+The frontend has no visibility into AI agent users or their permissions. Three concrete issues compound each other:
+
+1. `ALL_PERMISSIONS` is hardcoded as a local constant in two separate components (`UserManager.tsx` and `RoleManager.tsx`) and is missing all 7 `AIPermission` values — meaning AI-specific permissions never appear in any UI selection or role card.
+2. AI users appear visually identical to human users in the user list table — there is no badge, icon, or indicator to distinguish service accounts from human accounts.
+3. The password field is displayed even when an AI role is selected, creating a semantically misleading UX (AI agents use service-account credentials, not the same user-facing password concept).
+4. System AI role cards in `RoleManager` offer no way to expand or inspect their full permission set.
+5. The duplicated `ALL_PERMISSIONS` constant creates a maintenance hazard: any future permission added to the backend enums requires two separate frontend edits with no compile-time enforcement.
+
+The root cause is the absence of a backend endpoint that exposes the canonical permission lists. Without it, the frontend is forced to hardcode values derived from Python enums it cannot observe.
+
+## Approach
+
+Expose `AIPermission` and `UserPermission` enum values via a new lightweight backend endpoint (`GET /api/permissions/`) so the frontend derives its permission lists from the API, not from local constants. On the frontend, replace the duplicated `ALL_PERMISSIONS` constants with a shared `usePermissions` hook that fetches from this endpoint. Update `UserManager` and `RoleManager` to conditionally render AI permissions when an AI role is selected, add a visual AI badge to the user list, and suppress the misleading password hint for AI role selections. AI system role cards gain an expand/collapse detail view that shows the full AI permission set as read-only.
+
+No auth model, no guard system, no audit system, and no `roles.py` validator are touched.
+
+## Scope
+
+### In scope
+
+- **Backend**: New `GET /permissions/` endpoint returning `{human: string[], ai: string[]}` derived from `UserPermission` and `AIPermission` enums via pure enum introspection. Requires authentication (any active user). No database query.
+- **Frontend — shared layer**: New `usePermissions` hook (or `permissions.ts` service constant) that fetches from `GET /api/permissions/` and is consumed by both `UserManager` and `RoleManager`, eliminating the duplicate `ALL_PERMISSIONS` constants.
+- **Frontend — `UserManager.tsx`**:
+  - Conditional AI permissions category rendered when the selected role is an `AI_*` role.
+  - AI badge (visual indicator) added to the user list table row for AI-typed users.
+  - Label or description note clarifying service-account semantics when an AI role is selected.
+  - Suppress password field visual emphasis for AI role selections.
+- **Frontend — `RoleManager.tsx`**:
+  - AI permissions visible in the permission grid for system AI roles (read-only checkboxes).
+  - Expand/collapse detail view for AI system role cards so the full permission set is inspectable.
+- **Tests**:
+  - Update `RoleManager.test.tsx` and `AdminPage.test.tsx` for new AI rendering paths.
+  - Add `UserManager.test.tsx` covering AI permission display, AI badge, and role-conditional rendering.
+  - Backend: add test for `GET /permissions/` response shape and values.
+
+### Out of scope
+
+- Custom AI role creation (no changes to `roles.py` validator or `ALLOWED_PERMISSIONS` guard).
+- JWT token generation UI.
+- Guard dashboard.
+- Auth, audit, or session system changes.
+- Any changes to the `is_system` immutability guard on roles.
+
+## Changes
+
+### Backend
+
+| File | Change |
+|------|--------|
+| `backend/routers/permissions.py` *(new)* | `GET /permissions/` endpoint — returns `{human: [...], ai: [...]}` by iterating `UserPermission` and `AIPermission` enums. Requires authenticated user (existing auth dependency). Router registered in `backend/main.py`. |
+| `backend/main.py` | Include new `permissions` router under `/api/permissions`. |
+| `backend/tests/test_permissions_router.py` *(new)* | Unit tests for endpoint response shape, value correctness, and authentication requirement. |
+
+No changes to `backend/models/user.py`, `backend/routers/users.py`, `backend/routers/roles.py`, or `backend/models/roles.py`.
+
+### Frontend
+
+| File | Change |
+|------|--------|
+| `frontend/services/permissions.ts` *(new)* | API fetch for `GET /api/permissions/`; exports `usePermissions` hook (or plain async fetch). |
+| `frontend/components/UserManager.tsx` | Replace local `ALL_PERMISSIONS` with `usePermissions` hook; add conditional AI permissions block; add AI badge to table rows; add service-account label for AI roles. |
+| `frontend/components/RoleManager.tsx` | Replace local `ALL_PERMISSIONS` with `usePermissions` hook; show AI permissions in role card detail (read-only); add expand/collapse toggle for AI system role cards. |
+| `frontend/components/__tests__/UserManager.test.tsx` *(new)* | Tests: AI permission rendering, AI badge visibility, role-conditional display. |
+| `frontend/components/__tests__/RoleManager.test.tsx` | Update: AI role card expand/collapse, AI permissions visible in detail view. |
+| `frontend/pages/__tests__/AdminPage.test.tsx` | Update: mock `usePermissions`; verify no regression on existing paths. |
+
+## Constraints
+
+- **TDD-first** (`strict_tdd: true`): test files are written before implementation code in every phase.
+- **pnpm only** — no `npm` or `yarn` invocations.
+- No changes to the auth, guard, or audit systems.
+- AI system roles remain immutable — the `is_system` guard is not touched.
+- `roles.py` validator remains unchanged; `ALLOWED_PERMISSIONS` continues to exclude `AIPermission` values for custom roles.
+- The new `/permissions/` endpoint is **read-only** — no writes, no mutations.
+
+## Success Criteria
+
+1. `GET /api/permissions/` returns `{human: [...], ai: [...]}` with the correct enum values from `UserPermission` and `AIPermission`.
+2. Selecting `AI_DIAGNOSTIC` or `AI_OPERATOR` in `UserManager` shows the AI permission set (6 or 7 permissions) with checkboxes correctly pre-checked from the user's role data.
+3. AI users in the user list have a visible AI badge distinguishing them from human users.
+4. `RoleManager` AI role cards expose an expand/collapse detail view that displays the full AI permission set as read-only.
+5. `ALL_PERMISSIONS` no longer exists as a duplicated local constant in two components — a single `usePermissions` hook/service is the sole source of truth.
+6. All existing tests pass without modification to their assertions; new tests cover AI permission rendering, the AI badge, and the expand/collapse role card paths.
+
+## Linked Issue
+
+https://github.com/alexandervazquez98/next-gen/issues/327

--- a/openspec/changes/feat-327-ai-user-management/spec.md
+++ b/openspec/changes/feat-327-ai-user-management/spec.md
@@ -1,0 +1,132 @@
+# Spec: feat-327-ai-user-management
+
+## Functional Requirements
+
+- **FR-1**: `GET /api/permissions/` returns HTTP 200 with body `{"human": [...], "ai": [...]}` for any authenticated user.
+- **FR-2**: The `human` array contains exactly all string values from the `UserPermission` enum (`EVENT_VIEW`, `EVENT_ACK`, `EVENT_CLOSE`, `EVENT_FORCED_CLOSE`, `CI_VIEW`, `CI_EDIT`, `CI_DELETE`, `RUN_DIAGNOSTICS`, `USER_MANAGE`, `ROLE_MANAGE`, `AUDIT_VIEW`, `METRICS_VIEW`).
+- **FR-3**: The `ai` array contains exactly all string values from the `AIPermission` enum (`AI_RUN_DIAGNOSTIC`, `AI_VIEW_ALL`, `AI_EVENT_ACK`, `AI_EVENT_COMMENT`, `AI_CI_UPDATE_METADATA`, `AI_EVENT_CLOSE`, `AI_DICTIONARY_PREVIEW`).
+- **FR-4**: An unauthenticated request (no valid session cookie) to `GET /api/permissions/` returns HTTP 401.
+- **FR-5**: When a role whose name starts with `AI_` is selected in the UserManager create/edit form, an "AI Permissions" category section is displayed inside the permissions panel alongside the human categories.
+- **FR-6**: AI permission checkboxes are pre-checked based on the user's actual permissions list (sourced from role data on role change), not from static defaults.
+- **FR-7**: When a non-AI role is selected in UserManager, the AI permissions section is hidden — only the human permission categories are rendered.
+- **FR-8**: Users whose `role` starts with `AI_` display a visual AI badge (e.g. a small `AI` label) next to their username in the user list table.
+- **FR-9**: When an AI role is selected in the create form, a service-account descriptor note is shown beneath the role selector (e.g. "This is a service account. No password login.").
+- **FR-10**: In RoleManager list view, role cards for AI system roles (`is_system: true` and name starts with `AI_`) have an expand/collapse toggle that reveals the full AI permission set.
+- **FR-11**: AI permissions rendered inside expanded RoleManager cards use disabled checkboxes — they are read-only because system roles are immutable.
+- **FR-12**: Both `UserManager` and `RoleManager` import and use the `usePermissions` hook from `frontend/services/permissions.ts`; no local `ALL_PERMISSIONS` constant remains in either component.
+
+## Non-Functional Requirements
+
+- **NFR-1**: The `GET /api/permissions/` endpoint derives its payload entirely from enum introspection (`[p.value for p in UserPermission]` / `[p.value for p in AIPermission]`). No hardcoded string arrays exist in the router.
+- **NFR-2**: The `usePermissions` hook handles loading and error states gracefully: `human` and `ai` default to `[]` on fetch failure; a `loading` boolean is exposed to callers.
+- **NFR-3**: No breaking changes to existing `/api/users/` or `/api/roles/` endpoints. The new router is additive only.
+- **NFR-4**: All new and modified frontend code (`permissions.ts`, updated `UserManager.tsx`, updated `RoleManager.tsx`) is covered by Vitest/Testing Library tests.
+- **NFR-5**: All new backend code (`permissions.py` router, `main.py` registration) is covered by pytest tests.
+
+## API Contract
+
+### `GET /api/permissions/`
+
+| Field          | Value                                                                      |
+|----------------|----------------------------------------------------------------------------|
+| Method         | `GET`                                                                      |
+| Path           | `/api/permissions/`                                                        |
+| Authentication | Bearer token via HttpOnly cookie (`get_current_active_user` dependency)    |
+| Request body   | None                                                                       |
+| Query params   | None                                                                       |
+
+**Response 200 — OK**
+
+```json
+{
+  "human": [
+    "EVENT_VIEW",
+    "EVENT_ACK",
+    "EVENT_CLOSE",
+    "EVENT_FORCED_CLOSE",
+    "CI_VIEW",
+    "CI_EDIT",
+    "CI_DELETE",
+    "RUN_DIAGNOSTICS",
+    "USER_MANAGE",
+    "ROLE_MANAGE",
+    "AUDIT_VIEW",
+    "METRICS_VIEW"
+  ],
+  "ai": [
+    "AI_RUN_DIAGNOSTIC",
+    "AI_VIEW_ALL",
+    "AI_EVENT_ACK",
+    "AI_EVENT_COMMENT",
+    "AI_CI_UPDATE_METADATA",
+    "AI_EVENT_CLOSE",
+    "AI_DICTIONARY_PREVIEW"
+  ]
+}
+```
+
+**Response 401 — Unauthorized** (standard FastAPI form)
+
+```json
+{"detail": "Not authenticated"}
+```
+
+Array ordering follows the natural declaration order of each enum.
+
+## Data Contracts
+
+### TypeScript (frontend)
+
+```typescript
+// frontend/services/permissions.ts
+
+export interface PermissionsResponse {
+  human: string[];
+  ai: string[];
+}
+
+export interface UsePermissionsResult {
+  human: string[];
+  ai: string[];
+  loading: boolean;
+  error: string | null;
+}
+```
+
+### Python (backend — implicit, no Pydantic model needed)
+
+The response is a plain dict inferred by FastAPI. No `response_model` is required because the shape is trivial and enum-derived.
+
+## Test Requirements
+
+### Backend (`backend/tests/test_permissions_router.py`)
+
+| # | Test case | Expected outcome |
+|---|-----------|-----------------|
+| B-1 | Authenticated user calls `GET /api/permissions/` | HTTP 200, body is a JSON object with keys `human` and `ai` |
+| B-2 | `human` array in response | Contains exactly all `UserPermission` enum values (no extras, no omissions) |
+| B-3 | `ai` array in response | Contains exactly all `AIPermission` enum values (no extras, no omissions) |
+| B-4 | Unauthenticated call (no cookie / invalid token) | HTTP 401 |
+
+### Frontend — UserManager (`frontend/components/__tests__/UserManager.test.tsx`)
+
+| # | Test case | Expected outcome |
+|---|-----------|-----------------|
+| F-1 | AI role selected in create form | Element with text "AI Permissions" is visible in the DOM |
+| F-2 | Non-AI role selected in create form | Element with text "AI Permissions" is absent from the DOM |
+| F-3 | User list contains a user with `role` starting `AI_` | An element with text "AI" (the badge) is visible in that row |
+| F-4 | User list contains a user with non-AI role | No "AI" badge element is present |
+| F-5 | AI role selected in create form | Service-account note element is visible |
+
+### Frontend — RoleManager (`frontend/components/__tests__/RoleManager.test.tsx`)
+
+| # | Test case | Expected outcome |
+|---|-----------|-----------------|
+| R-1 | AI system role card rendered | An expand toggle button is present on that card |
+| R-2 | Expand toggle clicked on AI system role card | AI permission checkboxes become visible and are `disabled` |
+
+### Frontend — AdminPage (`frontend/pages/__tests__/AdminPage.test.tsx`)
+
+| # | Test case | Expected outcome |
+|---|-----------|-----------------|
+| A-1 | All existing AdminPage tests | Pass without modification beyond mocking `usePermissions` |

--- a/openspec/changes/feat-327-ai-user-management/tasks.md
+++ b/openspec/changes/feat-327-ai-user-management/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: feat-327-ai-user-management
+
+> **Convention**: `strict_tdd=true` — tests are written **before** implementation in every PR.
+> Package manager: `pnpm` only. Backend runner: `uv run pytest`.
+
+---
+
+## PR0 — Backend: permissions endpoint
+
+- [x] **T01** — Write `backend/tests/test_permissions_router.py` with all 4 backend test cases (TDD):
+  - `test_get_permissions_authenticated` → HTTP 200, keys `human` and `ai` present
+  - `test_human_permissions_match_enum` → `set(body["human"]) == {p.value for p in UserPermission}`
+  - `test_ai_permissions_match_enum` → `set(body["ai"]) == {p.value for p in AIPermission}`
+  - `test_get_permissions_unauthenticated` → HTTP 401
+  - Use `TestClient(app)` + `app.dependency_overrides[get_current_active_user]` pattern.
+  - Tests must **fail** at this point (router does not exist yet).
+
+- [x] **T02** — Create `backend/routers/permissions.py`:
+  - `router = APIRouter(prefix="/permissions", tags=["Permissions"])`
+  - `GET /` with `Depends(get_current_active_user)` dependency
+  - Return `{"human": [p.value for p in UserPermission], "ai": [p.value for p in AIPermission]}`
+  - No hardcoded strings; no Pydantic response model needed.
+
+- [x] **T03** — Register router in `backend/main.py`:
+  - Add `permissions` to the import line: `from routers import ..., permissions`
+  - Add `app.include_router(permissions.router, prefix="/api")` after the `ai` router registration.
+
+- [x] **T04** — Run backend tests and verify all pass:
+  ```bash
+  uv run pytest backend/tests/test_permissions_router.py -v
+  ```
+  All 4 tests must be GREEN. Fix any issues before proceeding.
+
+---
+
+## PR1 — Frontend: shared hook + UserManager
+
+- [x] **T05** — Write `frontend/components/__tests__/UserManager.test.tsx` with all 5 test cases (TDD):
+  - Mock `../../services/api` (`api.get` returns `[{name: 'AI_AGENT', permissions: ['AI_VIEW_ALL']}, {name: 'VIEWER', permissions: []}]` for roles, `[]` for users)
+  - Mock `../../services/permissions` → `usePermissions` returns `{ human: ['EVENT_VIEW'], ai: ['AI_VIEW_ALL','AI_EVENT_ACK'], loading: false, error: null }`
+  - Mock `../../context/AuthContext` → `useAuth` returns `{ hasPermission: () => true }`
+  - **F-1**: Select `AI_AGENT` role → `screen.getByText('AI Permissions')` found
+  - **F-2**: Select `VIEWER` role → `screen.queryByText('AI Permissions')` is null
+  - **F-3**: User list row with `role: 'AI_AGENT'` → badge with text `AI` visible
+  - **F-4**: User list row with `role: 'VIEWER'` → no `AI` badge
+  - **F-5**: Select `AI_AGENT` role → service-account note element visible
+  - Tests must **fail** at this point (hook not imported yet).
+
+- [x] **T06** — Create `frontend/services/permissions.ts`:
+  - Export `PermissionsResponse` and `UsePermissionsResult` interfaces.
+  - Export `usePermissions()` hook: `useState` for `human`, `ai`, `loading`, `error`; `useEffect` to `api.get<PermissionsResponse>('/permissions/')` once on mount with cancellation flag.
+  - On error: keep `human` and `ai` as `[]`, set `error` message.
+
+- [x] **T07** — Update `frontend/components/UserManager.tsx`:
+  - **Remove** `ALL_PERMISSIONS` constant (lines 22-27).
+  - **Add** `import { usePermissions } from '../services/permissions';`
+  - **Add** `const { human, ai } = usePermissions();` at top of component.
+  - **Add** `const isAiRole = (editingUser?.role ?? newUser.role).startsWith('AI_');`
+  - **Replace** `ALL_PERMISSIONS.map(...)` in the `showPerms` block with `humanCategories` derived from `human` array (grouped by category label, filtered from hook values).
+  - **Add** AI permissions block after human categories — conditionally rendered when `isAiRole`.
+  - **Add** AI badge in user list row — `{u.role.startsWith('AI_') && <span>AI</span>}` (with styling).
+  - **Add** service-account note below role selector — conditional on `isAiRole && !editingUser`.
+
+- [x] **T08** — Update `frontend/pages/__tests__/AdminPage.test.tsx`:
+  - Add module-level mock at top of file:
+    ```typescript
+    vi.mock('../services/permissions', () => ({
+      usePermissions: vi.fn(() => ({ human: [], ai: [], loading: false, error: null })),
+    }));
+    ```
+  - Adjust import path if AdminPage is under `pages/` — verify actual path.
+  - No other changes needed; existing assertions are unaffected.
+
+- [x] **T09** — Run full frontend test suite:
+  ```bash
+  pnpm --dir frontend run test:run
+  ```
+  All tests (new + existing) must be GREEN. Fix any regressions before proceeding.
+
+---
+
+## PR2 — Frontend: RoleManager AI cards
+
+- [x] **T10** — Update `frontend/components/__tests__/RoleManager.test.tsx` with AI expand/collapse test cases (TDD):
+  - Mock `../../services/api` → `api.get('/roles/')` returns `[{ name: 'AI_AGENT', description: 'AI service account', permissions: ['AI_VIEW_ALL'], is_system: true }]`
+  - Mock `../../services/permissions` → `usePermissions` returns `{ human: [], ai: ['AI_VIEW_ALL','AI_EVENT_ACK'], loading: false, error: null }`
+  - Mock `../../context/AuthContext` → `useAuth` returns `{ hasPermission: () => true }`
+  - **R-1**: Role card for `AI_AGENT` renders → expand toggle button is present (e.g. `getByRole('button', { name: /AI Permissions/i })`)
+  - **R-2**: Click expand toggle → `screen.getAllByRole('checkbox')` are all `disabled`; at least `AI_VIEW_ALL` label is visible
+  - Tests must **fail** at this point.
+
+- [x] **T11** — Update `frontend/components/RoleManager.tsx`:
+  - **Remove** `ALL_PERMISSIONS` constant (lines 13-19).
+  - **Add** `import { usePermissions } from '../services/permissions';`
+  - **Add** `const { human, ai } = usePermissions();` at top of component.
+  - **Add** `const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set());`
+  - **Add** `toggleExpand` function using immutable Set update.
+  - **Replace** `ALL_PERMISSIONS.map(...)` in edit view with `humanCategories` derived from `human`.
+  - **Add** AI expand/collapse block in role list card — conditional on `role.name.startsWith('AI_') && role.is_system`.
+  - Expand block renders AI permissions as `<input type="checkbox" disabled />` checkboxes.
+
+- [x] **T12** — Run full frontend test suite:
+  ```bash
+  pnpm --dir frontend run test:run
+  ```
+  All tests must be GREEN.
+
+- [ ] **T13** — Manual smoke test: <!-- T13: manual smoke test pending human review -->
+  - Navigate to Admin → User Management → Access Roles tab.
+  - Confirm AI system role cards (e.g. `AI_AGENT`) show the expand toggle.
+  - Click toggle → AI permissions appear as read-only checkboxes.
+  - Navigate to Users tab → create-form → select an `AI_*` role → confirm AI Permissions section and service-account note appear.
+  - Select a non-AI role → confirm AI section disappears.
+  - Confirm existing human-permission checkboxes still function (toggle on/off).


### PR DESCRIPTION
Closes #327

## Descripción del Cambio

Add full AI agent user visibility to the admin UI. The backend had two AI roles (`AI_DIAGNOSTIC`, `AI_OPERATOR`) with a separate `AIPermission` enum and guard system, but the frontend hardcoded `ALL_PERMISSIONS` with only human permissions in two components.

**What changed:**
- New `GET /api/permissions/` endpoint returning `{human: [...], ai: [...]}` from enum introspection — no DB query, pure enum values
- Shared `usePermissions` hook replaces all hardcoded `ALL_PERMISSIONS` constants
- `UserManager`: AI permissions section visible when AI role selected, AI badge in user list, service-account note below role selector
- `RoleManager`: AI system role cards now have an expand/collapse toggle showing read-only AI permission checkboxes

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)

## ¿Cómo se probó?

| Suite | Result |
|-------|--------|
| `uv run pytest backend/tests/test_permissions_router.py -v` | 4/4 ✅ |
| `pnpm --dir frontend run test:run` | 487/487 ✅ |

New tests: `UserManager.test.tsx` (6 cases), `RoleManager.test.tsx` (2 new cases), `test_permissions_router.py` (4 cases).

T13 (manual smoke test): navigate to Admin → Access Roles, verify AI role cards expand/collapse correctly.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.