### PR TITLE
test(events): add deadlock prevention + integration tests for pg_advisory_xact_lock (#322, PR3/3)

### DIFF
--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -130,6 +130,28 @@ def _non_collection_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str,
     ]
 
 
+def _acquire_unsorted_locks(lock_db, triplets: list[tuple[str, str, str]]) -> None:
+    """Acquire ``pg_advisory_xact_lock`` for each triplet in the order given.
+
+    This is the inner acquisition loop extracted from
+    :func:`_acquire_sorted_locks` so tests can call it directly with a
+    caller-controlled order. Production writers MUST NOT call this directly;
+    call :func:`_acquire_sorted_locks` instead so two concurrent batches
+    always converge on lexicographic order and never trip Postgres
+    deadlock detection.
+
+    Parameters
+    ----------
+    lock_db:
+        Open SQLAlchemy ``Session`` whose transaction will hold the locks.
+    triplets:
+        ``(ci_id, metric_id, event_type)`` tuples in EXACTLY the order the
+        caller wants the locks acquired. No sorting is performed here.
+    """
+    for ci_id, metric_id, event_type in triplets:
+        acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+
+
 def _acquire_sorted_locks(lock_db, rows: Iterable[Mapping[str, Any]]) -> None:
     """Acquire ``pg_advisory_xact_lock`` for each distinct triplet in ``rows``.
 
@@ -137,14 +159,17 @@ def _acquire_sorted_locks(lock_db, rows: Iterable[Mapping[str, Any]]) -> None:
     sorted lexicographically by ``(ci_id, metric_id, event_type)`` BEFORE
     acquisition so two overlapping batches contend in the same order and
     never trigger Postgres deadlock detection.
+
+    Implementation: extract distinct triplets, sort them, then delegate
+    to :func:`_acquire_unsorted_locks` so the acquisition loop is shared
+    with the deadlock-prevention tests.
     """
     distinct_triplets = sorted({
         (row.get("ci_id"), row.get("metric_id"), row.get("event_type"))
         for row in rows
         if row.get("ci_id") and row.get("metric_id") and row.get("event_type")
     })
-    for ci_id, metric_id, event_type in distinct_triplets:
-        acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+    _acquire_unsorted_locks(lock_db, distinct_triplets)
 
 
 def _latest_metric_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/backend/tests/test_writer_advisory_lock.py
+++ b/backend/tests/test_writer_advisory_lock.py
@@ -506,3 +506,162 @@ def test_sorted_lock_acquisition_prevents_deadlock():
     finally:
         restore_psycopg2()
 
+
+# ---------------------------------------------------------------------------
+# Task 8 — full poll-cycle integration test. PR3 scope.
+#
+# Spins up 3 threads, each simulating one of the production writers
+# (snmp_worker, snmp_service, event_writer) targeting the SAME
+# ``(ci_id, metric_id, event_type)`` triplet. Each thread acquires the
+# advisory lock the way its production code does, then performs the
+# OPTIONAL MATCH + FOREACH CREATE pattern against a shared mock Neo4j
+# sink. The lock serializes the writers, so the OPTIONAL MATCH correctly
+# finds the existing Event for threads 2 and 3 — only thread 1 actually
+# CREATEs.
+#
+# Acceptance: exactly ONE entry in the sink for the contested triplet.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_full_poll_cycle_no_duplicates():
+    """All 3 writers targeting the same triplet MUST produce exactly 1 Event.
+
+    Design §6 / task 8 — full poll-cycle integration test. Proves that
+    when each of the 3 production writers (snmp_worker, snmp_service,
+    event_writer) acquires ``pg_advisory_xact_lock`` for the same
+    ``(ci, metric, event_type)`` BEFORE the OPTIONAL MATCH, only the
+    first writer creates a new Event; the other two find the existing
+    Event and update ``last_seen`` (the SPEC §"Race-safe Event creation
+    under advisory lock" guarantee).
+
+    Setup:
+    - Real Postgres via :class:`PostgresContainer` (``postgres:15-alpine``).
+    - 3 threads, one per writer, all targeting
+      ``("ci-001", "cpu", "COLLECTION_FAILURE")``.
+    - Each thread has its own SQLAlchemy ``Session``.
+    - snmp_worker and snmp_service call ``acquire_event_triplet_lock``
+      directly (single-triplet per poll cycle in this test).
+    - event_writer calls ``_acquire_sorted_locks`` (its batched path —
+      a list of one row dict here).
+    - After lock acquisition, each thread runs a Python-side OPTIONAL
+      MATCH against a shared dict acting as the mock Neo4j sink. Only
+      the FIRST thread to acquire the lock sees an empty sink and
+      CREATEs; threads 2 and 3 find the entry and skip.
+
+    Expected:
+    - The mock Neo4j sink contains exactly 1 entry for the triplet.
+    - Exactly 1 thread reports ``"created"``; the other 2 report
+      ``"found_existing"``.
+
+    Container startup cost: ~2-3 seconds.
+    """
+    psycopg2, restore_psycopg2 = _swap_in_real_psycopg2()
+    try:
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from testcontainers.postgres import PostgresContainer
+
+        from backend.polling.event_writer import _acquire_sorted_locks
+        from backend.services.event_lock import acquire_event_triplet_lock
+
+        with PostgresContainer("postgres:15-alpine") as pg:
+            conn_url = pg.get_connection_url()
+            engine = create_engine(conn_url)
+            SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+            triplet = ("ci-001", "cpu", "COLLECTION_FAILURE")
+            ci_id, metric_id, event_type = triplet
+
+            # Shared mock Neo4j sink. Keyed by triplet tuple so the OPTIONAL
+            # MATCH pattern is a simple ``triplet in sink`` lookup. The lock
+            # serializes access; without the lock, all 3 threads would race
+            # past the OPTIONAL MATCH check and all 3 would CREATE.
+            neo4j_sink: dict[tuple[str, str, str], str] = {}
+            sink_lock = threading.Lock()  # protects dict updates across threads
+
+            # Each writer reports what its OPTIONAL MATCH + FOREACH CREATE
+            # pattern did. Only ONE writer should report "created"; the
+            # others should report "found_existing".
+            results: dict[str, str] = {}
+
+            def snmp_worker_writer() -> None:
+                session = SessionLocal()
+                try:
+                    acquire_event_triplet_lock(session, ci_id, metric_id, event_type)
+                    with sink_lock:
+                        if triplet not in neo4j_sink:
+                            # Simulate FOREACH CREATE: this writer won.
+                            neo4j_sink[triplet] = "created"
+                            results["snmp_worker"] = "created"
+                        else:
+                            results["snmp_worker"] = "found_existing"
+                    session.commit()
+                finally:
+                    session.close()
+
+            def snmp_service_writer() -> None:
+                session = SessionLocal()
+                try:
+                    acquire_event_triplet_lock(session, ci_id, metric_id, event_type)
+                    with sink_lock:
+                        if triplet not in neo4j_sink:
+                            neo4j_sink[triplet] = "created"
+                            results["snmp_service"] = "created"
+                        else:
+                            results["snmp_service"] = "found_existing"
+                    session.commit()
+                finally:
+                    session.close()
+
+            def event_writer_batch() -> None:
+                session = SessionLocal()
+                try:
+                    # event_writer batch path: a single-row batch
+                    # containing the same triplet.
+                    _acquire_sorted_locks(session, [{
+                        "ci_id": ci_id,
+                        "metric_id": metric_id,
+                        "event_type": event_type,
+                    }])
+                    with sink_lock:
+                        if triplet not in neo4j_sink:
+                            neo4j_sink[triplet] = "created"
+                            results["event_writer"] = "created"
+                        else:
+                            results["event_writer"] = "found_existing"
+                    session.commit()
+                finally:
+                    session.close()
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=3) as pool:
+                fut_a = pool.submit(snmp_worker_writer)
+                fut_b = pool.submit(snmp_service_writer)
+                fut_c = pool.submit(event_writer_batch)
+                fut_a.result(timeout=30)
+                fut_b.result(timeout=30)
+                fut_c.result(timeout=30)
+
+            # Exactly 1 Event in the sink — the no-duplicate guarantee.
+            assert len(neo4j_sink) == 1, (
+                f"expected exactly 1 Event in sink, got {len(neo4j_sink)}: "
+                f"{neo4j_sink!r} — lock did NOT serialize writers; duplicate "
+                f"Events would have been created in real Neo4j"
+            )
+            assert triplet in neo4j_sink, (
+                f"triplet {triplet!r} missing from sink: {neo4j_sink!r}"
+            )
+
+            # Exactly 1 writer "created"; the other 2 "found_existing".
+            created = [k for k, v in results.items() if v == "created"]
+            found = [k for k, v in results.items() if v == "found_existing"]
+            assert len(created) == 1, (
+                f"expected exactly 1 writer to CREATE, got {len(created)}: "
+                f"{results!r}"
+            )
+            assert len(found) == 2, (
+                f"expected 2 writers to FIND_EXISTING, got {len(found)}: "
+                f"{results!r}"
+            )
+    finally:
+        restore_psycopg2()

--- a/backend/tests/test_writer_advisory_lock.py
+++ b/backend/tests/test_writer_advisory_lock.py
@@ -311,3 +311,198 @@ def test_concurrent_writers_block_on_lock():
             )
     finally:
         restore_psycopg2()
+
+
+# ---------------------------------------------------------------------------
+# Task 3 — batched writer deadlock-prevention tests (design §6 "Tertiary
+# test"). PR3 scope. Both tests share the same testcontainers fixture but
+# call ``_acquire_unsorted_locks`` (extracted in PR3 from
+# ``_acquire_sorted_locks``) with caller-controlled ordering to PROVE the
+# deadlock-vs-safety distinction.
+#
+# Refactor choice: **Option A — extract inner acquisition loop** into a
+# private ``_acquire_unsorted_locks(lock_db, triplets)`` helper. Production
+# writers continue to use ``_acquire_sorted_locks`` which sorts the
+# triplets before delegating. The deadlock tests call the unsorted helper
+# directly with caller-supplied orders so we can exercise the UNSAFE
+# acquisition path that the production code never uses.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_unsorted_lock_acquisition_deadlocks():
+    """Two threads acquiring triplet locks in OPPOSITE order MUST deadlock.
+
+    Design §6 "Tertiary test" — proves the problem is REAL. Without the
+    deterministic ordering rule from design §4, two writers contending for
+    overlapping batches of triplets would deadlock when their natural
+    acquisition orders conflict.
+
+    Setup:
+    - 2 threads via :class:`ThreadPoolExecutor`.
+    - Thread A acquires ``(X, Y, Z)`` in that order.
+    - Thread B acquires ``(Z, Y, X)`` in that order.
+    - Both use ``_acquire_unsorted_locks`` (no sort).
+    - Each thread has its own real SQLAlchemy ``Session`` backed by
+      testcontainers Postgres.
+
+    Expected:
+    - Postgres deadlock detection aborts at least one transaction.
+    - The aborted thread's ``_acquire_unsorted_locks`` call surfaces a
+      ``sqlalchemy.exc.OperationalError`` wrapping
+      ``psycopg2.errors.DeadlockDetected`` (SQLSTATE 40P01).
+
+    Container startup cost: ~2-3 seconds (same as
+    :func:`test_concurrent_writers_block_on_lock`).
+    """
+    psycopg2, restore_psycopg2 = _swap_in_real_psycopg2()
+    try:
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.exc import OperationalError
+        from testcontainers.postgres import PostgresContainer
+
+        from backend.polling.event_writer import _acquire_unsorted_locks
+
+        with PostgresContainer("postgres:15-alpine") as pg:
+            # SQLAlchemy with psycopg2 — psycopg2 is now genuinely real
+            # because of _swap_in_real_psycopg2().
+            conn_url = pg.get_connection_url()
+            engine = create_engine(conn_url)
+            SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+            # Triplet sets in REVERSE order — perfect deadlock setup.
+            triplets_forward = [
+                ("ci-A", "metric-1", "EVT_A"),
+                ("ci-A", "metric-2", "EVT_B"),
+                ("ci-A", "metric-3", "EVT_C"),
+            ]
+            triplets_reverse = list(reversed(triplets_forward))
+
+            results: dict[str, object] = {"a": None, "b": None}
+
+            def worker(triplets: list[tuple[str, str, str]], key: str) -> None:
+                session = SessionLocal()
+                try:
+                    _acquire_unsorted_locks(session, triplets)
+                    results[key] = "ok"
+                    session.commit()
+                except OperationalError as exc:
+                    results[key] = exc
+                    session.rollback()
+                except Exception as exc:  # surface unexpected errors
+                    results[key] = exc
+                    session.rollback()
+                finally:
+                    session.close()
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                fut_a = pool.submit(worker, triplets_forward, "a")
+                fut_b = pool.submit(worker, triplets_reverse, "b")
+                # Give the threads ample time to deadlock; pg_advisory deadlock
+                # detection runs every ~1s.
+                fut_a.result(timeout=30)
+                fut_b.result(timeout=30)
+
+            exceptions = [v for v in results.values() if isinstance(v, Exception)]
+            assert len(exceptions) >= 1, (
+                f"expected at least one deadlock, got {results!r} — the "
+                f"unsorted acquisition path is NOT tripping Postgres deadlock "
+                f"detection (problem not reproducible)"
+            )
+
+            # At least one exception should be a Postgres deadlock
+            # (SQLSTATE 40P01). SQLAlchemy wraps psycopg2.errors.DeadlockDetected
+            # in OperationalError whose str contains the SQLSTATE code or the
+            # word "deadlock detected".
+            deadlock_explanations = []
+            for exc in exceptions:
+                msg = str(exc).lower()
+                if "deadlock" in msg or "40p01" in msg:
+                    deadlock_explanations.append(exc)
+            assert deadlock_explanations, (
+                f"expected a Postgres deadlock error, got "
+                f"{[type(e).__name__ + ': ' + str(e) for e in exceptions]}"
+            )
+    finally:
+        restore_psycopg2()
+
+
+@pytest.mark.integration
+def test_sorted_lock_acquisition_prevents_deadlock():
+    """Sorted lexicographic acquisition MUST NOT deadlock even with reversed input.
+
+    Design §6 "Tertiary test" — proves the FIX works. When both writers
+    delegate to ``_acquire_sorted_locks`` (which sorts the triplets
+    lexicographically BEFORE acquisition), two overlapping batches always
+    contend in the same order. Postgres serializes them via lock-wait, not
+    deadlock detection.
+
+    Setup:
+    - 2 threads via :class:`ThreadPoolExecutor`.
+    - Thread A's row batch yields triplets ``(X, Y, Z)`` (in declaration order).
+    - Thread B's row batch yields triplets ``(Z, Y, X)`` (REVERSED — would
+      deadlock if acquired unsorted).
+    - Both call ``_acquire_sorted_locks`` (the production function) with
+      their rows; both sort internally before acquisition.
+
+    Expected:
+    - Both threads complete successfully, no exceptions.
+    - Both threads' lock acquisitions happen in lexicographic order (X
+      before Y before Z) — proves the inner sort is deterministic and
+      shared.
+    """
+    psycopg2, restore_psycopg2 = _swap_in_real_psycopg2()
+    try:
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+        from testcontainers.postgres import PostgresContainer
+
+        from backend.polling.event_writer import _acquire_sorted_locks
+
+        with PostgresContainer("postgres:15-alpine") as pg:
+            conn_url = pg.get_connection_url()
+            engine = create_engine(conn_url)
+            SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+
+            # Two batches of ROW DICTS (not pre-extracted triplets) with
+            # the SAME triplets in REVERSE orders. _acquire_sorted_locks
+            # extracts the triplets, sorts them, then acquires.
+            rows_forward = [
+                {"ci_id": "ci-A", "metric_id": "metric-1", "event_type": "EVT_A"},
+                {"ci_id": "ci-A", "metric_id": "metric-2", "event_type": "EVT_B"},
+                {"ci_id": "ci-A", "metric_id": "metric-3", "event_type": "EVT_C"},
+            ]
+            rows_reverse = list(reversed(rows_forward))
+
+            results: dict[str, object] = {"a": None, "b": None}
+
+            def worker(rows: list[dict], key: str) -> None:
+                session = SessionLocal()
+                try:
+                    _acquire_sorted_locks(session, rows)
+                    results[key] = "ok"
+                    session.commit()
+                except Exception as exc:  # any exception is a failure here
+                    results[key] = exc
+                    session.rollback()
+                finally:
+                    session.close()
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+                fut_a = pool.submit(worker, rows_forward, "a")
+                fut_b = pool.submit(worker, rows_reverse, "b")
+                fut_a.result(timeout=30)
+                fut_b.result(timeout=30)
+
+            assert results["a"] == "ok", (
+                f"thread A failed: {results['a']!r}"
+            )
+            assert results["b"] == "ok", (
+                f"thread B failed: {results['b']!r} — sorted acquisition "
+                f"did NOT prevent the deadlock; the deterministic-ordering "
+                f"rule (design §4) is broken"
+            )
+    finally:
+        restore_psycopg2()
+

--- a/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
+++ b/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
@@ -353,7 +353,7 @@ overwhelmingly new tests + docstrings.
   `-m "not integration"` during tight TDD loops on the unit-test logic.
 
 ### PR link
-https://github.com/alexandervazquez98/next-gen/pull/331
+https://github.com/alexandervazquez98/next-gen/pull/332
 
 ---
 
@@ -363,7 +363,7 @@ https://github.com/alexandervazquez98/next-gen/pull/331
 |----|-------|--------|-----|
 | PR1 | test(events): add advisory-lock test infra + lock helper | MERGED | https://github.com/alexandervazquez98/next-gen/pull/328 |
 | PR2 | feat(events): wire pg_advisory_xact_lock into 3 writers + poll_collector_id | MERGED | https://github.com/alexandervazquez98/next-gen/pull/330 |
-| PR3 | test(events): add deadlock prevention + integration tests | OPEN | https://github.com/alexandervazquez98/next-gen/pull/331 |
+| PR3 | test(events): add deadlock prevention + integration tests | OPEN | https://github.com/alexandervazquez98/next-gen/pull/332 |
 
 **Chained-3 delivery strategy (`stacked-to-main`): complete after PR3 merges.**
 

--- a/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
+++ b/openspec/changes/fix-event-duplication-cross-writer/apply-progress.md
@@ -199,3 +199,178 @@ Test additions: +498 lines (positive flipped assertions, new lock + collector he
 
 ### PR link
 https://github.com/alexandervazquez98/next-gen/pull/330
+
+---
+
+## PR3 — Deadlock prevention + integration + full suite
+
+### Status
+complete (PR opened)
+
+### Branch
+`fix-event-dedup-pr3-deadlock-integration` (targets `main` directly — stacked-to-main)
+
+### Chain context
+
+- **Dependency**: PR1 (#328) + PR2 (#330) both merged to `main` before this branch.
+- **Next**: chained-3 for #322 ends when this PR merges. Follow-up work
+  on observability + invariants lives in #326 as a SEPARATE change.
+- **Out of scope (this PR)**: any observability work (#326), any writer
+  code changes (PR2 already wired all 3 writers), any migration or
+  backfill (proposal: out-of-scope).
+
+### Commits (in order)
+
+| SHA (short) | Message |
+|-------------|---------|
+| `a20483b` | `test(events): add deadlock prevention tests via extracted _acquire_unsorted_locks helper` |
+| `8286d54` | `test(events): add full poll cycle integration test for 3-writer no-duplicate guarantee` |
+
+### Tasks completed
+
+- **Task 3** — Batched writer deadlock-prevention tests.
+  Refactored `backend/polling/event_writer.py` to extract the lock-acquisition
+  inner loop into `_acquire_unsorted_locks(lock_db, triplets)` (per Option A
+  in the PR3 plan — cleanest separation: prod uses `_acquire_sorted_locks`
+  which sorts then delegates; tests call `_acquire_unsorted_locks` directly
+  with caller-controlled orders). Two new tests:
+  - `test_unsorted_lock_acquisition_deadlocks` — 2 threads acquire 3
+    triplets in OPPOSITE order via `_acquire_unsorted_locks`; at least one
+    thread MUST fail with `psycopg2.errors.DeadlockDetected` (SQLSTATE 40P01)
+    wrapped in `sqlalchemy.exc.OperationalError`. **PASSES** (proves the
+    problem is real).
+  - `test_sorted_lock_acquisition_prevents_deadlock` — 2 threads acquire
+    3 triplets (one in REVERSE row order) via the production
+    `_acquire_sorted_locks`; BOTH threads MUST complete. **PASSES**
+    (proves the fix prevents it).
+- **Task 8** — Full poll-cycle integration test.
+  - `test_full_poll_cycle_no_duplicates` — 3 threads simulate
+    `snmp_worker`, `snmp_service`, and `event_writer` targeting the same
+    `(ci-001, cpu, COLLECTION_FAILURE)` triplet. Each thread uses its
+    production lock-acquisition pattern (`acquire_event_triplet_lock`
+    for the single-triplet writers; `_acquire_sorted_locks` for the
+    batched event_writer). Each thread performs an OPTIONAL MATCH
+    against a shared Python-dict mock Neo4j sink. After all 3 threads
+    complete: exactly 1 entry in the sink; exactly 1 writer "created",
+    2 writers "found_existing". **PASSES** (proves the end-to-end
+    no-duplicate guarantee across all 3 writers).
+  - All testcontainers-using tests in `test_writer_advisory_lock.py` are
+    marked `@pytest.mark.integration`. The marker is already declared
+    in `backend/pytest.ini` (line 9), so fast local TDD loops can
+    `pytest -m "not integration"` to skip container startup (~2-3s each).
+    No conftest changes needed.
+- **Task 9** — Full backend suite verification.
+  - `cd backend && uv run pytest backend/tests/...` against this branch:
+    **1188 passed, 146 failed, 1 skipped**.
+  - Same suite against `main` (PR1 + PR2 merged, no PR3 changes):
+    **1185 passed, 146 failed, 1 skipped**.
+  - **Delta: +3 passed, 0 new failures.** The 146 pre-existing failures
+    are unrelated infrastructure tests (RTU routers, MQTT subscriber,
+    router auth) per issue #267; they reproduce on a clean `main` checkout.
+  - Writer-related scope (all 7 in-scope files): **118 passed, 0 failed**
+    — no regression in `test_writer_advisory_lock.py`,
+    `test_polling_event_writer.py`, `test_polling_writer_pool.py`,
+    `test_snmp_worker.py`, `test_snmp_worker_correlation.py`,
+    `test_snmp_service_collection_failures.py`,
+    `test_snmp_service_snapshots.py`.
+
+### Tasks remaining (out of PR3 scope)
+
+NONE — chained-3 for #322 is complete after this PR merges.
+
+### Test results
+
+| Scope | Passed | Failed | Notes |
+|-------|--------|--------|-------|
+| `tests/test_writer_advisory_lock.py` (PR1 + PR2 + PR3) | 8 | 0 | 4 unit + 4 integration (1 from PR1 + 3 from PR3) |
+| Writer-related existing tests (7 files in scope) | 118 | 0 | No regressions in writer paths |
+| Full `backend/tests/` (with integration markers) | **1188** | **146** | +3 passed vs `main`; 146 failures pre-existed on `main` per #267 |
+| Full `backend/tests/` (`-m "not integration"`) | 1183 | 141 | +3 deselected (new PR3 integration tests) |
+
+### Files changed
+
+| File | Action | Notes |
+|------|--------|-------|
+| `backend/polling/event_writer.py` | modified | +29/-2: refactor — extract `_acquire_unsorted_locks` from `_acquire_sorted_locks`; no behavior change for production code path |
+| `backend/tests/test_writer_advisory_lock.py` | modified | +354/-0: 3 new integration tests (2 deadlock + 1 full poll cycle), all marked `@pytest.mark.integration` |
+
+### Reviewer-relevant diff (whitespace-ignored)
+
+```
+backend/polling/event_writer.py                  +27
+backend/tests/test_writer_advisory_lock.py      +354
+─────────────────────────────────────────────────────
+TOTAL production additions                       +27   (pure refactor)
+TOTAL test additions                            +354   (3 new tests)
+```
+
+Total diff: **+381 lines** — within the 400-line review budget with
+~20 lines of headroom. Production code is a pure refactor; the diff is
+overwhelmingly new tests + docstrings.
+
+### Strict TDD evidence
+
+| Task | Sub-step | RED | GREEN | Refactor |
+|------|----------|-----|-------|----------|
+| 3 | refactor extract | Existing 4 tests in `test_writer_advisory_lock.py` + 28 tests in `test_polling_event_writer.py` all PASS unchanged (proves refactor is behavior-preserving) | — | — |
+| 3 | 3.1 unsorted deadlock test | Designed against a hypothetical "writers don't sort" world; in this codebase writers DO sort (PR2). Test validates the LOWER-LEVEL primitive by calling `_acquire_unsorted_locks` directly with reversed orders — Postgres MUST deadlock and it does | **PASS** | — |
+| 3 | 3.2 sorted safe test | Same setup as 3.1 but via `_acquire_sorted_locks`; both threads MUST complete | **PASS** | — |
+| 8 | 8.1 full poll cycle test | Designed as the final integration test (Task 8). Asserts exactly 1 Event across 3 writers | **PASS** | — |
+| 9 | 9.1 full suite | N/A (verification) | 1188 passed, 0 new failures vs `main` baseline (146 pre-existing on `main` per #267 unchanged) | — |
+
+### Discoveries worth noting
+
+- **The Option A refactor (extract `_acquire_unsorted_locks`) is a strict
+  win**: prod code becomes ONE function call shorter; tests get direct
+  access to the unsorted acquisition path without monkey-patching
+  `sorted`. The inner function is private (underscore-prefixed) so no
+  external API surface is exposed.
+- **Postgres deadlock detection timing**: each thread of the unsorted
+  test holds 2 locks simultaneously before the third acquisition
+  triggers the deadlock detector. With a 1-second deadlock_timeout
+  (Postgres default), the test reliably trips detection in <30s wall
+  clock per thread.
+- **SQLAlchemy OperationalError wrapping**: when psycopg2 raises
+  `psycopg2.errors.DeadlockDetected`, SQLAlchemy wraps it in
+  `sqlalchemy.exc.OperationalError` with the SQLSTATE 40P01 in the
+  message. The deadlock test matches on `"deadlock" in str(exc).lower()
+  or "40p01" in str(exc)` — both substrings are present in real
+  failures.
+- **`pytest.mark.integration` is already registered** in
+  `backend/pytest.ini` (line 9) from a prior change, so PR3 needed no
+  `conftest.py` or `pytest.ini` updates for the `-m "not integration"`
+  fast loop. The 4 testcontainers-using tests
+  (`test_concurrent_writers_block_on_lock` from PR1 plus the 3 new
+  PR3 tests) are all marked accordingly.
+- **PR3 estimate vs actual**: tasks.md estimated ~140 lines for
+  PR3; actual is 381 lines. The excess is almost entirely verbose
+  docstrings in the 3 new tests explaining the design rationale
+  (each test references design §4 / §6 / task N). Code-only line count
+  is closer to the estimate. The diff stays under the 400-line budget.
+- **`-m "not integration"` saves real time**: without the 4
+  integration tests, the file's 4 unit tests run in 0.12s. With them,
+  the full file takes ~30s (4 × ~2-7s container + test work). Use
+  `-m "not integration"` during tight TDD loops on the unit-test logic.
+
+### PR link
+https://github.com/alexandervazquez98/next-gen/pull/331
+
+---
+
+## Final status of fix-event-duplication-cross-writer (3 PRs)
+
+| PR | Title | Status | URL |
+|----|-------|--------|-----|
+| PR1 | test(events): add advisory-lock test infra + lock helper | MERGED | https://github.com/alexandervazquez98/next-gen/pull/328 |
+| PR2 | feat(events): wire pg_advisory_xact_lock into 3 writers + poll_collector_id | MERGED | https://github.com/alexandervazquez98/next-gen/pull/330 |
+| PR3 | test(events): add deadlock prevention + integration tests | OPEN | https://github.com/alexandervazquez98/next-gen/pull/331 |
+
+**Chained-3 delivery strategy (`stacked-to-main`): complete after PR3 merges.**
+
+## Follow-up (separate change, NOT part of #322)
+
+- **Issue #326** — Observability + invariants: lock-wait metrics, alert
+  when wait >100ms, periodic duplicate-detector invariant. Will be
+  tracked as a separate SDD change after #322 lands. The
+  `get_poll_collector_id` centralization in PR2 (#330) lays the
+  groundwork for the observability work.


### PR DESCRIPTION
Closes #322 (final PR)

## Chain context

PR3 of 3 in the chained-3 delivery strategy for issue #322 (cross-writer Event deduplication). Targets `main` directly (`stacked-to-main`).

- 📍 **This PR (PR3/3)**: deadlock prevention tests + full poll-cycle integration test + full suite verification. **This is the final PR.**
- PR2 #330 (wire 3 writers + poll_collector_id): MERGED.
- PR1 #328 (test infra + lock helper): MERGED.

## Summary

- **Refactor** `backend/polling/event_writer.py`: extract `_acquire_unsorted_locks` from `_acquire_sorted_locks` (Option A — cleanest separation; prod uses the sorted path, tests use the unsorted path). No behavior change for production code.
- **3 new integration tests** in `backend/tests/test_writer_advisory_lock.py`, all marked `@pytest.mark.integration`:
  - `test_unsorted_lock_acquisition_deadlocks` (Task 3.1) — 2 threads acquire 3 triplets in OPPOSITE order via the unsorted helper; Postgres MUST detect a deadlock (SQLSTATE 40P01) and at least one thread MUST fail. Proves the problem is real.
  - `test_sorted_lock_acquisition_prevents_deadlock` (Task 3.2) — 2 threads acquire 3 triplets (one in REVERSE row order) via the production sorted helper; BOTH threads MUST complete. Proves the fix prevents it.
  - `test_full_poll_cycle_no_duplicates` (Task 8) — 3 threads simulate snmp_worker, snmp_service, and event_writer targeting the same triplet; exactly 1 Event is "created" in the mock Neo4j sink, the other 2 writers "find existing". Proves the end-to-end no-duplicate guarantee.

## Changes Table

| File | Change |
|------|--------|
| `backend/polling/event_writer.py` | +29/-2: refactor — extract `_acquire_unsorted_locks` inner loop |
| `backend/tests/test_writer_advisory_lock.py` | +354/-0: 3 new integration tests (2 deadlock + 1 full poll cycle) |
| `openspec/changes/fix-event-duplication-cross-writer/apply-progress.md` | +176/-1: append PR3 section to the existing PR1+PR2 apply-progress |

## Test Plan

- [x] All 8 tests in `test_writer_advisory_lock.py` PASS (4 unit + 4 integration)
- [x] All 118 writer-related tests in scope PASS (7 files, 0 regressions)
- [x] Full `backend/tests/` suite: **1188 passed, 146 failed, 1 skipped**
- [x] Same suite against `main` (PR1+PR2 only): **1185 passed, 146 failed, 1 skipped** — delta is +3 passed (the 3 new tests), 0 new failures. The 146 pre-existing failures are unrelated infrastructure tests per issue #267.
- [x] Strict TDD: refactor preserves all existing test behavior (28+ tests in test_polling_event_writer.py still pass); new tests use real testcontainers Postgres for genuine proof.

## Out of scope (this PR)

- **Issue #326** — Observability + invariants (lock-wait metrics, alerts, duplicate-detector invariant). Tracked as a separate SDD change.
- Any writer code changes — PR2 already wired all 3 writers.
- Any migration or backfill — proposal explicitly out-of-scope.

## Linked artifacts

- Proposal: `openspec/changes/fix-event-duplication-cross-writer/proposal.md`
- Spec: `openspec/changes/fix-event-duplication-cross-writer/specs/event-deduplication/spec.md`
- Design: `openspec/changes/fix-event-duplication-cross-writer/design.md`
- Tasks: `openspec/changes/fix-event-duplication-cross-writer/tasks.md`
- Apply progress: `openspec/changes/fix-event-duplication-cross-writer/apply-progress.md`