### PR TITLE
fix(collector): preserve Event emission when Neo4j rejects $poll_collector_id (#340)

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -351,13 +351,50 @@ def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=Non
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
     """
-    # Fallback query omits both `poll_collector_id: $poll_collector_id`
-    # (CREATE row-dict form) and `poll_collector_id = $poll_collector_id`
-    # (SET clause form) so Neo4j stops rejecting the parameter when
-    # production surfaces the undefined-parameter ClientError (#340).
-    fallback_query = primary_query.replace(
-        "poll_collector_id: $poll_collector_id", ""
-    ).replace("poll_collector_id = $poll_collector_id", "")
+    # Fallback Cypher — hand-written to avoid dangling-comma artifacts
+    # that naive ``.replace()`` would leave in the SET clause
+    # (verify-report CRITICAL #1 — issue #340). The CREATE row-dict
+    # removal is safe because the next line is ``})``; the SET clause
+    # removal requires also dropping the trailing comma after
+    # ``existing.source_protocol = row.source_protocol``.
+    fallback_query = """
+        UNWIND $failures AS row
+        MATCH (n:CI {id: row.node_id})
+        MATCH (m:MetricDef {id: row.metric_id})
+        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+          AND (
+            existing.event_type = 'COLLECTION_FAILURE'
+            OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+          )
+          AND (existing.failure_family = 'SNMP_NO_RESPONSE' OR existing.failure_family IS NULL)
+          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+        WITH row, n, m, head(collect(existing)) AS existing
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+            CREATE (created:Event {
+                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                status: 'OPEN', severity: row.severity, message: row.message,
+                event_type: row.event_type, failure_family: row.failure_family,
+                source_protocol: row.source_protocol, created_at: datetime(),
+                last_seen: datetime(), ack: false,
+                correlation_type: row.correlation_type,
+                propagated_from: row.propagated_from,
+                root_cause_ci_id: row.root_cause_ci_id
+            })
+            MERGE (n)-[:HAS_EVENT]->(created)
+            MERGE (created)-[:TRIGGERED_BY]->(m)
+        )
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+            SET existing.status = 'OPEN', existing.severity = row.severity,
+                existing.message = row.message, existing.last_seen = datetime(),
+                existing.recovered_at = NULL, existing.ack = false,
+                existing.event_type = row.event_type,
+                existing.failure_family = row.failure_family,
+                existing.source_protocol = row.source_protocol
+            MERGE (n)-[:HAS_EVENT]->(existing)
+            MERGE (existing)-[:TRIGGERED_BY]->(m)
+        )
+    """
     run_with_cypher_param_fallback(
         session,
         primary_query,
@@ -442,11 +479,49 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
     """
-    # Fallback omits both `poll_collector_id: $poll_collector_id` and
-    # `poll_collector_id = $poll_collector_id` — see #340.
-    fallback_query = primary_query.replace(
-        "poll_collector_id: $poll_collector_id", ""
-    ).replace("poll_collector_id = $poll_collector_id", "")
+    # Fallback Cypher — hand-written (see #340, verify-report CRITICAL #1).
+    # Drops the trailing comma after
+    # ``existing.availability_source = row.availability_source`` that a
+    # naive ``.replace()`` would leave dangling before ``MERGE``.
+    fallback_query = """
+        UNWIND $availability_events AS row
+        WITH row WHERE row.event_type = 'AVAILABILITY'
+          AND row.source_protocol = 'ICMP'
+          AND row.availability_source IN ['PING', 'ICMP']
+        MATCH (n:CI {id: row.node_id})
+        MATCH (m:MetricDef {id: row.metric_id})
+        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+          AND existing.event_type = 'AVAILABILITY'
+          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+          AND existing.availability_source IN ['PING', 'ICMP']
+          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+        WITH row, n, m, head(collect(existing)) AS existing
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+            CREATE (created:Event {
+                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                status: 'OPEN', severity: row.severity, message: row.message,
+                event_type: row.event_type, source_protocol: row.source_protocol,
+                availability_source: row.availability_source,
+                created_at: datetime(), last_seen: datetime(), ack: false,
+                correlation_type: row.correlation_type,
+                propagated_from: row.propagated_from,
+                root_cause_ci_id: row.root_cause_ci_id
+            })
+            MERGE (n)-[:HAS_EVENT]->(created)
+            MERGE (created)-[:TRIGGERED_BY]->(m)
+        )
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+            SET existing.status = 'OPEN', existing.severity = row.severity,
+                existing.message = row.message, existing.last_seen = datetime(),
+                existing.recovered_at = NULL, existing.ack = false,
+                existing.event_type = row.event_type,
+                existing.source_protocol = row.source_protocol,
+                existing.availability_source = row.availability_source
+            MERGE (n)-[:HAS_EVENT]->(existing)
+            MERGE (existing)-[:TRIGGERED_BY]->(m)
+        )
+    """
     run_with_cypher_param_fallback(
         session,
         primary_query,
@@ -562,11 +637,44 @@ def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
     """
-    # Fallback omits both `poll_collector_id: $poll_collector_id` and
-    # `poll_collector_id = $poll_collector_id` — see #340.
-    fallback_query = primary_query.replace(
-        "poll_collector_id: $poll_collector_id", ""
-    ).replace("poll_collector_id = $poll_collector_id", "")
+    # Fallback Cypher — hand-written (see #340, verify-report CRITICAL #1).
+    # Drops the trailing comma after
+    # ``existing.root_cause_ci_id = coalesce(...)`` that a naive
+    # ``.replace()`` would leave dangling before ``MERGE``.
+    fallback_query = """
+        UNWIND $breaches AS row
+        MATCH (n:CI {id: row.node_id})
+        MATCH (m:MetricDef {id: row.metric_id})
+        OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH'})
+        WHERE existing.status IN ['OPEN', 'ACK']
+          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+        WITH row, n, m, head(collect(existing)) AS existing
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+            CREATE (created:Event {
+                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
+                message: row.message, source_protocol: row.source_protocol,
+                last_seen: datetime(), ack: false,
+                correlation_type: row.correlation_type,
+                propagated_from: row.propagated_from,
+                root_cause_ci_id: row.root_cause_ci_id
+            })
+            MERGE (n)-[:HAS_EVENT]->(created)
+            MERGE (created)-[:TRIGGERED_BY]->(m)
+        )
+        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+            SET existing.severity = row.status,
+                existing.message = row.message,
+                existing.source_protocol = row.source_protocol,
+                existing.last_seen = datetime(),
+                existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
+                existing.recovered_at = NULL,
+                existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
+                existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id)
+            MERGE (n)-[:HAS_EVENT]->(existing)
+            MERGE (existing)-[:TRIGGERED_BY]->(m)
+        )
+    """
     run_with_cypher_param_fallback(
         session,
         primary_query,

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -36,6 +36,10 @@ from polling.icmp_measurements import (
     parse_ping_latency_ms,
 )
 from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
+from services.neo4j_write_guard import (
+    is_poll_collector_id_undefined_error,
+    run_with_cypher_param_fallback,
+)
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
@@ -307,7 +311,7 @@ def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=Non
         })
         for ci_id, metric_id, event_type in distinct_triplets:
             acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
-    session.run("""
+    primary_query = """
         UNWIND $failures AS row
         MATCH (n:CI {id: row.node_id})
         MATCH (m:MetricDef {id: row.metric_id})
@@ -346,7 +350,23 @@ def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=Non
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
-    """, failures=failures, poll_collector_id=POLL_COLLECTOR_ID)
+    """
+    # Fallback query omits both `poll_collector_id: $poll_collector_id`
+    # (CREATE row-dict form) and `poll_collector_id = $poll_collector_id`
+    # (SET clause form) so Neo4j stops rejecting the parameter when
+    # production surfaces the undefined-parameter ClientError (#340).
+    fallback_query = primary_query.replace(
+        "poll_collector_id: $poll_collector_id", ""
+    ).replace("poll_collector_id = $poll_collector_id", "")
+    run_with_cypher_param_fallback(
+        session,
+        primary_query,
+        {"failures": failures, "poll_collector_id": POLL_COLLECTOR_ID},
+        fallback_query,
+        {"failures": failures},
+        is_poll_collector_id_undefined_error,
+        logger,
+    )
 
 
 def _availability_source(value: Any) -> str | None:
@@ -381,7 +401,7 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
         })
         for ci_id, metric_id, event_type in distinct_triplets:
             acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
-    session.run("""
+    primary_query = """
         UNWIND $availability_events AS row
         WITH row WHERE row.event_type = 'AVAILABILITY'
           AND row.source_protocol = 'ICMP'
@@ -421,7 +441,24 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
-    """, availability_events=availability_events, poll_collector_id=POLL_COLLECTOR_ID)
+    """
+    # Fallback omits both `poll_collector_id: $poll_collector_id` and
+    # `poll_collector_id = $poll_collector_id` — see #340.
+    fallback_query = primary_query.replace(
+        "poll_collector_id: $poll_collector_id", ""
+    ).replace("poll_collector_id = $poll_collector_id", "")
+    run_with_cypher_param_fallback(
+        session,
+        primary_query,
+        {
+            "availability_events": availability_events,
+            "poll_collector_id": POLL_COLLECTOR_ID,
+        },
+        fallback_query,
+        {"availability_events": availability_events},
+        is_poll_collector_id_undefined_error,
+        logger,
+    )
 
 
 def _recover_icmp_availability_events(session, updates):
@@ -489,7 +526,7 @@ def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
         })
         for ci_id, metric_id, event_type in distinct_triplets:
             acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
-    session.run("""
+    primary_query = """
         UNWIND $breaches AS row
         MATCH (n:CI {id: row.node_id})
         MATCH (m:MetricDef {id: row.metric_id})
@@ -524,7 +561,24 @@ def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
             MERGE (n)-[:HAS_EVENT]->(existing)
             MERGE (existing)-[:TRIGGERED_BY]->(m)
         )
-    """, breaches=breaches, poll_collector_id=POLL_COLLECTOR_ID)
+    """
+    # Fallback omits both `poll_collector_id: $poll_collector_id` and
+    # `poll_collector_id = $poll_collector_id` — see #340.
+    fallback_query = primary_query.replace(
+        "poll_collector_id: $poll_collector_id", ""
+    ).replace("poll_collector_id = $poll_collector_id", "")
+    run_with_cypher_param_fallback(
+        session,
+        primary_query,
+        {
+            "breaches": breaches,
+            "poll_collector_id": POLL_COLLECTOR_ID,
+        },
+        fallback_query,
+        {"breaches": breaches},
+        is_poll_collector_id_undefined_error,
+        logger,
+    )
 
 
 def _recover_icmp_latency_events(session, updates):

--- a/backend/services/neo4j_write_guard.py
+++ b/backend/services/neo4j_write_guard.py
@@ -55,22 +55,33 @@ def is_poll_collector_id_undefined_error(error: Exception) -> bool:
     """Return ``True`` iff ``error`` is the specific undefined-``poll_collector_id``
     ``ClientError`` that triggers the fallback path.
 
-    The predicate is strict on three axes (design §8):
+    The predicate is strict on three axes (design §8, verify-report
+    CRITICAL #2):
 
     1. The exception MUST be a ``neo4j.exceptions.ClientError`` (not a
        ``ServerError``, ``DriverError``, or generic Python exception).
        The Neo4j Python driver wraps statement-syntax failures under
        ``ClientError``; the test is on the driver's exception class, not
        on Python's ``SyntaxError``.
-    2. The error message MUST contain the literal ``poll_collector_id``.
-    3. The error message MUST contain the literal ``not defined``.
+    2. The error ``message`` attribute MUST contain the literal
+       ``poll_collector_id``.
+    3. The error ``message`` attribute MUST contain the literal
+       ``not defined``.
+
+    Note: the predicate reads ``error.message`` (the canonical rejection
+    text exposed by the Neo4j Python driver), NOT ``str(error)``.
+    ``str(error)`` is broader — the driver formats ``ClientError`` with
+    extra context like the code prefix and bolt URL — and reading
+    ``str(error)`` would accept unrelated ``ClientError`` whose formatted
+    representation happens to mention the parameter. ``error.message`` is
+    the authoritative rejection text the server returns.
 
     Returning ``True`` lets the caller enter the fallback path.
     """
     return (
         isinstance(error, _CLIENT_ERROR_CLASS)
-        and "poll_collector_id" in str(error)
-        and "not defined" in str(error)
+        and "poll_collector_id" in error.message
+        and "not defined" in error.message
     )
 
 

--- a/backend/services/neo4j_write_guard.py
+++ b/backend/services/neo4j_write_guard.py
@@ -1,0 +1,131 @@
+# backend/services/neo4j_write_guard.py
+"""
+Narrow fallback for ``session.run(...)`` calls rejected by Neo4j with
+``Variable poll_collector_id not defined``.
+
+Background
+----------
+Production rejects Event-write Cypher that references ``$poll_collector_id``
+with ``Neo.ClientError.Statement.SyntaxError: Variable poll_collector_id
+not defined`` (issue #340). The value is passed by Python, so the cause
+is unresolved, but Event emission MUST NOT silently drop while RCA is
+open. This module exposes a tiny wrapper that runs the primary query;
+if Neo4j rejects it with the specific undefined-parameter
+``ClientError``, logs ``ERROR cypher-param-fallback`` with the original
+query + params + stack trace and runs a matching fallback query without
+``poll_collector_id``. Any other error (including unrelated ``ClientError``s
+and non-``ClientError`` exceptions) re-raises unchanged so unrelated
+Cypher defects keep surfacing.
+
+Design constraints
+------------------
+* The wrapper is intentionally NOT a decorator or context manager — every
+  call site needs explicit primary / fallback query pairs because the
+  fallback omits the ``poll_collector_id`` references in *that* primary
+  query. A decorator would hide which fallback applies to which writer.
+* The fallback query is built at the call site (string substitution),
+  not here. This module knows nothing about which Cypher clauses use
+  the parameter; it just runs whichever fallback it is given.
+* The lock that serializes writers (``acquire_event_triplet_lock``)
+  stays in scope: the fallback runs inside the same writer call as the
+  primary, so it does not re-acquire a lock.
+
+Logging contract
+----------------
+On fallback, we emit ``logger.exception(...)`` so the stack trace is
+included alongside the message. The message includes the literal marker
+``cypher-param-fallback`` so operators can grep
+``docker logs <container> | grep cypher-param-fallback`` for incidents.
+"""
+
+from __future__ import annotations
+
+import neo4j.exceptions
+
+
+# Capture the exception class at module load so test code can reliably
+# monkeypatch ``_CLIENT_ERROR_CLASS`` instead of fighting with the
+# ``neo4j.exceptions.ClientError`` namespace (which is replaced by
+# ``MagicMock`` stubs at module load time by the conftest and other
+# test fixtures). Production code path uses the same captured reference.
+_CLIENT_ERROR_CLASS = neo4j.exceptions.ClientError
+
+
+def is_poll_collector_id_undefined_error(error: Exception) -> bool:
+    """Return ``True`` iff ``error`` is the specific undefined-``poll_collector_id``
+    ``ClientError`` that triggers the fallback path.
+
+    The predicate is strict on three axes (design §8):
+
+    1. The exception MUST be a ``neo4j.exceptions.ClientError`` (not a
+       ``ServerError``, ``DriverError``, or generic Python exception).
+       The Neo4j Python driver wraps statement-syntax failures under
+       ``ClientError``; the test is on the driver's exception class, not
+       on Python's ``SyntaxError``.
+    2. The error message MUST contain the literal ``poll_collector_id``.
+    3. The error message MUST contain the literal ``not defined``.
+
+    Returning ``True`` lets the caller enter the fallback path.
+    """
+    return (
+        isinstance(error, _CLIENT_ERROR_CLASS)
+        and "poll_collector_id" in str(error)
+        and "not defined" in str(error)
+    )
+
+
+def run_with_cypher_param_fallback(
+    session,
+    primary_query: str,
+    primary_params: dict,
+    fallback_query: str,
+    fallback_params: dict,
+    error_filter,
+    logger,
+):
+    """Run ``primary_query``; on a matching error, log and run ``fallback_query``.
+
+    Parameters
+    ----------
+    session:
+        A Neo4j session (or any object exposing ``.run(query, **params)``).
+    primary_query, primary_params:
+        The collector-attributed query and its params (typically includes
+        ``poll_collector_id=POLL_COLLECTOR_ID``).
+    fallback_query, fallback_params:
+        The matching fallback with ``poll_collector_id`` references
+        removed (both the ``poll_collector_id: $poll_collector_id``
+        CREATE-row-dict form and the ``poll_collector_id = $poll_collector_id``
+        SET-clause form) and the ``poll_collector_id`` param dropped.
+    error_filter:
+        Callable taking the exception and returning ``True`` when fallback
+        should run. Defaults to ``is_poll_collector_id_undefined_error``
+        but exposed for callers that want a narrower predicate.
+    logger:
+        Logger used for the ``ERROR cypher-param-fallback`` entry on
+        fallback. ``logger.exception`` is used so the stack trace is
+        captured.
+
+    Returns
+    -------
+    Whatever ``session.run(...)`` returns — either the primary result
+    (if it succeeded or failed with a non-matching error) or the
+    fallback result (if it succeeded).
+
+    Raises
+    ------
+    Whatever ``session.run(...)`` raises — including the original
+    ``ClientError`` if the predicate does not match, and any exception
+    the fallback query raises.
+    """
+    try:
+        return session.run(primary_query, **primary_params)
+    except Exception as exc:
+        if not error_filter(exc):
+            raise
+        logger.exception(
+            "cypher-param-fallback primary_query=%r primary_params=%r "
+            "fallback_query=%r fallback_params=%r",
+            primary_query, primary_params, fallback_query, fallback_params,
+        )
+        return session.run(fallback_query, **fallback_params)

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -545,12 +545,24 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                             existing.availability_source = $availability_source,
                             existing.poll_collector_id = $poll_collector_id
                     """
-                    # Fallback omits the `existing.poll_collector_id = $poll_collector_id`
-                    # SET line so Neo4j stops rejecting the parameter when production
-                    # surfaces the undefined-parameter ClientError (#340).
-                    fallback_query = primary_query.replace(
-                        "existing.poll_collector_id = $poll_collector_id", ""
-                    )
+                    # Fallback Cypher — hand-written (see #340, verify-report
+                    # CRITICAL #1). Drops the trailing comma after
+                    # ``existing.availability_source = $availability_source``
+                    # that a naive ``.replace()`` would leave dangling at
+                    # the end of the SET clause.
+                    fallback_query = """
+                        MATCH (existing:Event)
+                        WHERE elementId(existing) = $existing_element_id
+                        SET existing.status = 'OPEN',
+                            existing.last_seen = datetime(),
+                            existing.message = $msg,
+                            existing.severity = $sev,
+                            existing.recovered_at = NULL,
+                            existing.event_type = $event_type,
+                            existing.failure_family = $failure_family,
+                            existing.source_protocol = $source_protocol,
+                            existing.availability_source = $availability_source
+                    """
                     primary_params = {
                         "existing_element_id": existing_element_id,
                         "msg": message,
@@ -628,13 +640,46 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         MERGE (n)-[:HAS_EVENT]->(e)
                         MERGE (e)-[:TRIGGERED_BY]->(m)
                     """
-                    # Fallback omits the `poll_collector_id: $poll_collector_id`
-                    # row-dict entry so Neo4j stops rejecting the parameter
-                    # when production surfaces the undefined-parameter
-                    # ClientError (#340).
-                    fallback_query = primary_query.replace(
-                        "poll_collector_id: $poll_collector_id,", ""
-                    )
+                    # Fallback Cypher — hand-written (see #340, verify-report
+                    # CRITICAL #1). The ``poll_collector_id`` row-dict entry
+                    # is removed; the trailing comma it carried is also gone,
+                    # so no cleanup of surrounding commas is needed.
+                    fallback_query = """
+                        MATCH (n:CI {id: $nid})
+                        MATCH (m:MetricDef {id: $mid})
+                        CREATE (e:Event {
+                            id: randomUUID(),
+                            ci_id: $nid,
+                            metric_id: $mid,
+                            status: 'OPEN',
+                            severity: $sev,
+                            message: $msg,
+                            event_type: $event_type,
+                            failure_family: $failure_family,
+                            source_protocol: $source_protocol,
+                            availability_source: $availability_source,
+                            created_at: datetime(),
+                            last_seen: datetime(),
+                            ack: false,
+                            business_service_id: $business_service_id,
+                            business_service_name: $business_service_name,
+                            business_service_tier: $business_service_tier,
+                            owner_t1: $owner_t1,
+                            owner_t2: $owner_t2,
+                            owner_t3: $owner_t3,
+                            impacted_users: $impacted_users,
+                            site: $site,
+                            service_catalog_id: $service_catalog_id,
+                            service_category: $service_category,
+                            service_tier: $service_tier,
+                            sla_minutes: $sla_minutes,
+                            propagated_from: $propagated_from,
+                            correlation_type: $correlation_type,
+                            root_cause_ci_id: $root_cause_ci_id
+                        })
+                        MERGE (n)-[:HAS_EVENT]->(e)
+                        MERGE (e)-[:TRIGGERED_BY]->(m)
+                    """
                     primary_params = {
                         "nid": ci.get("id"),
                         "mid": metric_def["id"],

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -13,6 +13,10 @@ from database import get_db
 from postgres_db import SessionLocal
 from repositories.metric_repo import insert_metric_value
 from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
+from services.neo4j_write_guard import (
+    is_poll_collector_id_undefined_error,
+    run_with_cypher_param_fallback,
+)
 from services.metric_service import metric_matches_ci
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
@@ -527,8 +531,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
 
                 if existing:
                     existing_element_id = existing.get("existing_element_id")
-                    session.run(
-                        """
+                    primary_query = """
                         MATCH (existing:Event)
                         WHERE elementId(existing) = $existing_element_id
                         SET existing.status = 'OPEN',
@@ -541,15 +544,31 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                             existing.source_protocol = $source_protocol,
                             existing.availability_source = $availability_source,
                             existing.poll_collector_id = $poll_collector_id
-                    """,
-                        existing_element_id=existing_element_id,
-                        msg=message,
-                        sev=severity,
-                        event_type=event_type,
-                        failure_family=failure_family,
-                        source_protocol=source_protocol,
-                        availability_source=availability_source,
-                        poll_collector_id=POLL_COLLECTOR_ID,
+                    """
+                    # Fallback omits the `existing.poll_collector_id = $poll_collector_id`
+                    # SET line so Neo4j stops rejecting the parameter when production
+                    # surfaces the undefined-parameter ClientError (#340).
+                    fallback_query = primary_query.replace(
+                        "existing.poll_collector_id = $poll_collector_id", ""
+                    )
+                    primary_params = {
+                        "existing_element_id": existing_element_id,
+                        "msg": message,
+                        "sev": severity,
+                        "event_type": event_type,
+                        "failure_family": failure_family,
+                        "source_protocol": source_protocol,
+                        "availability_source": availability_source,
+                        "poll_collector_id": POLL_COLLECTOR_ID,
+                    }
+                    fallback_params = {
+                        k: v for k, v in primary_params.items()
+                        if k != "poll_collector_id"
+                    }
+                    run_with_cypher_param_fallback(
+                        session, primary_query, primary_params,
+                        fallback_query, fallback_params,
+                        is_poll_collector_id_undefined_error, logger,
                     )
                 else:
                     snapshot = resolve_event_snapshot(session, ci.get("id"))
@@ -572,8 +591,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                                            ci.get("id"), metric_def.get("id"), exc)
                     # --- End correlation check ---
 
-                    session.run(
-                        """
+                    primary_query = """
                         MATCH (n:CI {id: $nid})
                         MATCH (m:MetricDef {id: $mid})
                         CREATE (e:Event {
@@ -609,20 +627,37 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         })
                         MERGE (n)-[:HAS_EVENT]->(e)
                         MERGE (e)-[:TRIGGERED_BY]->(m)
-                    """,
-                        nid=ci.get("id"),
-                        mid=metric_def["id"],
-                        sev=severity,
-                        msg=message,
-                        event_type=event_type,
-                        failure_family=failure_family,
-                        source_protocol=source_protocol,
-                        availability_source=availability_source,
-                        poll_collector_id=POLL_COLLECTOR_ID,
-                        propagated_from=propagated_from,
-                        correlation_type=correlation_type,
-                        root_cause_ci_id=root_cause_ci_id,
+                    """
+                    # Fallback omits the `poll_collector_id: $poll_collector_id`
+                    # row-dict entry so Neo4j stops rejecting the parameter
+                    # when production surfaces the undefined-parameter
+                    # ClientError (#340).
+                    fallback_query = primary_query.replace(
+                        "poll_collector_id: $poll_collector_id,", ""
+                    )
+                    primary_params = {
+                        "nid": ci.get("id"),
+                        "mid": metric_def["id"],
+                        "sev": severity,
+                        "msg": message,
+                        "event_type": event_type,
+                        "failure_family": failure_family,
+                        "source_protocol": source_protocol,
+                        "availability_source": availability_source,
+                        "poll_collector_id": POLL_COLLECTOR_ID,
+                        "propagated_from": propagated_from,
+                        "correlation_type": correlation_type,
+                        "root_cause_ci_id": root_cause_ci_id,
                         **snapshot,
+                    }
+                    fallback_params = {
+                        k: v for k, v in primary_params.items()
+                        if k != "poll_collector_id"
+                    }
+                    run_with_cypher_param_fallback(
+                        session, primary_query, primary_params,
+                        fallback_query, fallback_params,
+                        is_poll_collector_id_undefined_error, logger,
                     )
             else:
                 # Recovery path for threshold/availability events; SNMP collection failures

--- a/backend/tests/test_neo4j_write_guard.py
+++ b/backend/tests/test_neo4j_write_guard.py
@@ -1,0 +1,167 @@
+# backend/tests/test_neo4j_write_guard.py
+"""Unit tests for backend/services/neo4j_write_guard.py.
+
+Strict TDD (tasks.md §Phase 1): this file lands BEFORE the helper.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+class _FakeClientError(Exception):
+    """Real exception class standing in for neo4j.exceptions.ClientError.
+
+    The conftest stubs ``sys.modules['neo4j.exceptions']`` with a
+    MagicMock, making ``ClientError`` a MagicMock instance (not a class)
+    and breaking ``isinstance(...)``. We patch the helper module's
+    captured ``_CLIENT_ERROR_CLASS`` to this real class.
+    """
+
+
+@pytest.fixture
+def _install_fake_client_error(monkeypatch):
+    """Patch ``_CLIENT_ERROR_CLASS`` on BOTH module aliases of the helper.
+
+    Production code uses ``from services.neo4j_write_guard import ...``
+    while tests use ``from backend.services.neo4j_write_guard import ...``
+    — Python loads these as two DIFFERENT module objects. The function
+    reads from whichever alias imported it, so patch both.
+    """
+    from backend.services import neo4j_write_guard as guard_module
+
+    monkeypatch.setattr(guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
+    try:
+        from services import neo4j_write_guard as services_guard_module
+        monkeypatch.setattr(services_guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
+    except ImportError:
+        pass
+    return guard_module
+
+
+# Tests for ``is_poll_collector_id_undefined_error`` (case e) ----------------
+
+
+def test_predicate_unit_cases(_install_fake_client_error):
+    """True / false positives / wrong exception type — design §8 contract."""
+    guard_module = _install_fake_client_error
+    # True: matching ClientError
+    assert guard_module.is_poll_collector_id_undefined_error(
+        _FakeClientError("Variable poll_collector_id not defined")
+    ) is True
+    # False: ClientError with unrelated message
+    assert guard_module.is_poll_collector_id_undefined_error(
+        _FakeClientError("Syntax error: unexpected token")
+    ) is False
+    # False: wrong exception type even with matching message
+    assert guard_module.is_poll_collector_id_undefined_error(
+        RuntimeError("Variable poll_collector_id not defined")
+    ) is False
+
+
+# Tests for ``run_with_cypher_param_fallback`` (cases a–d) -------------------
+
+
+def test_primary_success_skips_fallback(_install_fake_client_error):
+    """Primary success → fallback MUST NOT run."""
+    guard_module = _install_fake_client_error
+    logger = logging.getLogger("test_primary_success_skips_fallback")
+
+    class _FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, query, **params):
+            self.calls.append((query, params))
+            return "primary-result"
+
+    fake_session = _FakeSession()
+    result = guard_module.run_with_cypher_param_fallback(
+        fake_session, "primary query", {"poll_collector_id": "host-1"},
+        "fallback query", {},
+        guard_module.is_poll_collector_id_undefined_error, logger,
+    )
+    assert result == "primary-result"
+    assert fake_session.calls == [("primary query", {"poll_collector_id": "host-1"})]
+
+
+def test_matching_client_error_triggers_fallback_and_logs(_install_fake_client_error, caplog):
+    """Matching ClientError → fallback runs; ERROR log includes both queries."""
+    guard_module = _install_fake_client_error
+    logger = logging.getLogger("test_matching_client_error_triggers_fallback_and_logs")
+
+    class _FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, query, **params):
+            self.calls.append((query, params))
+            if "primary" in query:
+                raise _FakeClientError("Variable poll_collector_id not defined")
+            return "fallback-result"
+
+    fake_session = _FakeSession()
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        result = guard_module.run_with_cypher_param_fallback(
+            fake_session, "primary query", {"poll_collector_id": "host-1"},
+            "fallback query", {},
+            guard_module.is_poll_collector_id_undefined_error, logger,
+        )
+    assert result == "fallback-result"
+    assert fake_session.calls[0][0] == "primary query"
+    assert fake_session.calls[1][0] == "fallback query"
+    assert "poll_collector_id" not in fake_session.calls[1][1]
+    # Log contract (design §10): ERROR with marker + both query strings.
+    error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert error_records, "expected at least one ERROR log entry"
+    combined = " ".join(r.getMessage() for r in error_records)
+    assert "cypher-param-fallback" in combined
+    assert "primary query" in combined
+    assert "fallback query" in combined
+
+
+def test_non_matching_client_error_reraises_without_fallback(_install_fake_client_error):
+    """Non-matching ClientError → re-raises; fallback MUST NOT run."""
+    guard_module = _install_fake_client_error
+    logger = logging.getLogger("test_non_matching_client_error_reraises_without_fallback")
+
+    class _FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, query, **params):
+            self.calls.append((query, params))
+            raise _FakeClientError("Some unrelated syntax issue")
+
+    fake_session = _FakeSession()
+    with pytest.raises(_FakeClientError, match="unrelated"):
+        guard_module.run_with_cypher_param_fallback(
+            fake_session, "primary query", {},
+            "fallback query", {},
+            guard_module.is_poll_collector_id_undefined_error, logger,
+        )
+    assert len(fake_session.calls) == 1
+
+
+def test_non_client_error_reraises_unchanged(_install_fake_client_error):
+    """Non-ClientError exception → re-raises unchanged; fallback MUST NOT run."""
+    guard_module = _install_fake_client_error
+    logger = logging.getLogger("test_non_client_error_reraises_unchanged")
+
+    class _FakeSession:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, query, **params):
+            self.calls.append((query, params))
+            raise RuntimeError("boom")
+
+    fake_session = _FakeSession()
+    with pytest.raises(RuntimeError, match="boom"):
+        guard_module.run_with_cypher_param_fallback(
+            fake_session, "primary query", {},
+            "fallback query", {},
+            guard_module.is_poll_collector_id_undefined_error, logger,
+        )
+    assert len(fake_session.calls) == 1

--- a/backend/tests/test_neo4j_write_guard.py
+++ b/backend/tests/test_neo4j_write_guard.py
@@ -17,7 +17,15 @@ class _FakeClientError(Exception):
     MagicMock, making ``ClientError`` a MagicMock instance (not a class)
     and breaking ``isinstance(...)``. We patch the helper module's
     captured ``_CLIENT_ERROR_CLASS`` to this real class.
+
+    The Neo4j Python driver exposes the rejection text via the ``message``
+    attribute, so the fake mirrors that surface (verify-report
+    CRITICAL #2 — predicate reads ``error.message``).
     """
+
+    def __init__(self, message=""):
+        super().__init__(message)
+        self.message = message
 
 
 @pytest.fixture
@@ -165,3 +173,243 @@ def test_non_client_error_reraises_unchanged(_install_fake_client_error):
             guard_module.is_poll_collector_id_undefined_error, logger,
         )
     assert len(fake_session.calls) == 1
+
+
+# CRITICAL #2 — Predicate must read ``error.message``, not ``str(error) -------
+
+
+class _FakeClientErrorWithMessage(_FakeClientError):
+    """Real-exception-class stand-in for ``neo4j.exceptions.ClientError``
+    with a ``message`` attribute that DIFFERS from ``str(error)``.
+
+    The Neo4j Python driver exposes the rejection text via the
+    ``message`` attribute on ``ClientError``. The production spec (design
+    §8) requires the predicate to read ``error.message``, not
+    ``str(error)`` (verify-report CRITICAL #2).
+    """
+
+    def __init__(self, message):
+        # The super().__init__ value becomes the result of str(error).
+        # We deliberately make it unrelated to ``message`` so a str-based
+        # predicate can be told apart from a .message-based one.
+        super().__init__("__unrelated__str__repr__")
+        self.message = message
+
+
+def test_predicate_uses_error_message_attribute(_install_fake_client_error):
+    """CRITICAL #2 fix — predicate reads ``error.message``, not ``str(error)``.
+
+    Three discriminating cases:
+
+    1. ``message`` matches AND ``str(error)`` does NOT contain the substrings.
+       Old predicate returns False; new predicate returns True.
+    2. ``message`` is missing ``"not defined"``.
+       Predicate MUST reject (False).
+    3. ``message`` is missing ``"poll_collector_id"``.
+       Predicate MUST reject (False).
+    """
+    guard_module = _install_fake_client_error
+
+    # Case 1 — production-shaped message, str() deliberately unrelated.
+    err_match = _FakeClientErrorWithMessage(
+        message="Variable poll_collector_id not defined",
+    )
+    assert guard_module.is_poll_collector_id_undefined_error(err_match) is True, (
+        "predicate MUST accept ClientError whose .message matches the spec, "
+        "even when str(error) returns unrelated text — design §8"
+    )
+
+    # Case 2 — message missing 'not defined'.
+    err_no_not_defined = _FakeClientErrorWithMessage(
+        message="Variable poll_collector_id something_else_completely",
+    )
+    assert (
+        guard_module.is_poll_collector_id_undefined_error(err_no_not_defined) is False
+    ), "predicate MUST reject ClientError whose .message lacks 'not defined'"
+
+    # Case 3 — message missing 'poll_collector_id'.
+    err_no_param = _FakeClientErrorWithMessage(
+        message="Variable other_param not defined",
+    )
+    assert (
+        guard_module.is_poll_collector_id_undefined_error(err_no_param) is False
+    ), "predicate MUST reject ClientError whose .message lacks 'poll_collector_id'"
+
+
+# CRITICAL #1 — fallback queries must not leave dangling commas -----------------
+
+
+def test_fallback_query_has_no_dangling_commas(_install_fake_client_error):
+    """CRITICAL #1 fix — every protected writer's fallback Cypher MUST have no
+    dangling commas before ``}``, ``MERGE``, ``WITH``, or query end.
+
+    Strategy: drive each writer with a representative input that triggers
+    the matching ``ClientError`` so the fallback query is the SECOND
+    ``session.run`` call's query string. Then assert the query has no
+    ``,\\s*}``, ``,\\s*MERGE``, ``,\\s*WITH``, or ``,\\s*\\n\"\"\"`` —
+    any of those patterns indicates the fallback removal left an invalid
+    Cypher tail.
+    """
+    from unittest.mock import MagicMock
+
+    guard_module = _install_fake_client_error
+
+    # Sample rows — minimal inputs the writers accept.
+    failure_row = {
+        "node_id": "CI-1", "metric_id": "m", "event_type": "COLLECTION_FAILURE",
+        "severity": "CRITICAL", "message": "x", "failure_family": "SNMP_NO_RESPONSE",
+        "source_protocol": "SNMP", "correlation_type": "ROOT",
+        "propagated_from": None, "root_cause_ci_id": "CI-1",
+    }
+    availability_row = {
+        "node_id": "CI-1", "metric_id": "icmp_avail", "event_type": "AVAILABILITY",
+        "protocol": "ICMP", "availability_source": "PING", "value": 0.0,
+        "severity": "CRITICAL", "message": "down",
+        "source_protocol": "ICMP", "correlation_type": "ROOT",
+        "propagated_from": None, "root_cause_ci_id": "CI-1",
+    }
+    latency_row = {
+        "node_id": "CI-1", "metric_id": "icmp_latency_ms", "event_type": "THRESHOLD_BREACH",
+        "protocol": "ICMP", "status": "CRITICAL", "message": "breach",
+        "source_protocol": "ICMP", "correlation_type": "ROOT",
+        "propagated_from": None, "root_cause_ci_id": "CI-1",
+    }
+
+    import re
+    bad_patterns = [
+        (re.compile(r",\s*}"),  "trailing comma before }"),
+        (re.compile(r",\s*MERGE\b"), "trailing comma before MERGE"),
+        (re.compile(r",\s*WITH\b"),  "trailing comma before WITH"),
+        # Trailing comma right before the closing """ of the query string.
+        # The query is indented, so the literal "\n                    \"\"\"" appears.
+        (re.compile(r",\s*\n\s*\"\"\""), "trailing comma before query end"),
+    ]
+
+    def _make_session():
+        raised = {"done": False}
+        def run(query, **params):
+            if not raised["done"]:
+                raised["done"] = True
+                raise _FakeClientError("Variable poll_collector_id not defined")
+            return "fallback-ok"
+        fake = MagicMock()
+        fake.run.side_effect = run
+        return fake
+
+    def _check(query):
+        for pattern, desc in bad_patterns:
+            assert not pattern.search(query), (
+                f"Fallback Cypher has {desc}: matched {pattern.pattern!r}\n--- query ---\n{query}"
+            )
+
+    # 1) _refresh_snmp_collection_failures -----------------------------------
+    from backend.engines import snmp_worker
+    session = _make_session()
+    snmp_worker._refresh_snmp_collection_failures(
+        session, [failure_row], lock_db=MagicMock(),
+    )
+    fallback_query = session.run.call_args_list[1].args[0]
+    _check(fallback_query)
+
+    # 2) _refresh_icmp_availability_events ------------------------------------
+    session = _make_session()
+    snmp_worker._refresh_icmp_availability_events(
+        session, [availability_row], lock_db=MagicMock(),
+    )
+    fallback_query = session.run.call_args_list[1].args[0]
+    _check(fallback_query)
+
+    # 3) _refresh_icmp_latency_events -----------------------------------------
+    session = _make_session()
+    snmp_worker._refresh_icmp_latency_events(
+        session, [latency_row], lock_db=MagicMock(),
+    )
+    fallback_query = session.run.call_args_list[1].args[0]
+    _check(fallback_query)
+
+
+# WARNING follow-up — concurrent writers serialize around fallback -----------
+
+
+def test_lock_acquired_before_session_run_in_fallback_path(_install_fake_client_error):
+    """Verify-report WARNING: ``acquire_event_triplet_lock`` is called BEFORE
+    the FIRST ``session.run`` (primary) AND remains in scope across the
+    fallback ``session.run`` (re-raise path). If the lock were re-acquired
+    after a fallback, two writers could deadlock or duplicate Events.
+
+    This is a structural ordering test: capture the call order between
+    ``acquire_event_triplet_lock`` and ``session.run``, then assert the
+    lock precedes the first run, and no second lock acquisition happens
+    between the primary and fallback ``session.run`` calls.
+    """
+    from unittest.mock import MagicMock, patch
+
+    guard_module = _install_fake_client_error
+
+    failure_row = {
+        "node_id": "CI-1", "metric_id": "m", "event_type": "COLLECTION_FAILURE",
+        "severity": "CRITICAL", "message": "x", "failure_family": "SNMP_NO_RESPONSE",
+        "source_protocol": "SNMP", "correlation_type": "ROOT",
+        "propagated_from": None, "root_cause_ci_id": "CI-1",
+    }
+
+    events = []  # ordered log: ("lock", triplet) or ("run", query_marker)
+
+    def spy_acquire(pg_db, ci_id, metric_id, event_type):
+        events.append(("lock", (ci_id, metric_id, event_type)))
+
+    raised = {"done": False}
+
+    def spy_run(query, **params):
+        events.append(("run", "PRIMARY" if "UNWIND $failures" in query else "FALLBACK"))
+        if not raised["done"]:
+            raised["done"] = True
+            raise _FakeClientError("Variable poll_collector_id not defined")
+        return "fallback-ok"
+
+    session = MagicMock()
+    session.run.side_effect = spy_run
+
+    with patch(
+        "backend.engines.snmp_worker.acquire_event_triplet_lock",
+        side_effect=spy_acquire,
+    ):
+        from backend.engines import snmp_worker
+        snmp_worker._refresh_snmp_collection_failures(
+            session, [failure_row], lock_db=MagicMock(),
+        )
+
+    # Filter to lock + run events for the (CI-1, m, COLLECTION_FAILURE) triplet.
+    relevant = [
+        e for e in events
+        if e[0] == "lock"
+        and e[1] == ("CI-1", "m", "COLLECTION_FAILURE")
+        or e[0] == "run"
+    ]
+    lock_count = sum(1 for e in events if e[0] == "lock")
+    run_count = sum(1 for e in events if e[0] == "run")
+
+    # Exactly ONE lock acquisition for this triplet (not 2 — the fallback
+    # must NOT re-acquire).
+    assert lock_count == 1, (
+        f"expected exactly 1 lock acquisition, got {lock_count}: {events}"
+    )
+    # Two session.run calls (primary + fallback).
+    assert run_count == 2, (
+        f"expected 2 session.run calls (primary + fallback), got {run_count}"
+    )
+
+    # The lock event MUST appear before the first run event.
+    first_lock = next(i for i, e in enumerate(events) if e[0] == "lock")
+    first_run = next(i for i, e in enumerate(events) if e[0] == "run")
+    assert first_lock < first_run, (
+        f"lock must precede first session.run: {events}"
+    )
+
+
+def _make_context_mock():
+    """Context-manager mock that returns itself from __enter__."""
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    return fake

--- a/backend/tests/test_snmp_service_cypher_fallback.py
+++ b/backend/tests/test_snmp_service_cypher_fallback.py
@@ -13,7 +13,16 @@ import pytest
 
 
 class _FakeClientError(Exception):
-    """Real exception class for neo4j.exceptions.ClientError in tests."""
+    """Real exception class for neo4j.exceptions.ClientError in tests.
+
+    Mirrors the Neo4j Python driver surface: ``.message`` attribute carries
+    the rejection text (verify-report CRITICAL #2 — predicate reads
+    ``error.message``).
+    """
+
+    def __init__(self, message=""):
+        super().__init__(message)
+        self.message = message
 
 
 @pytest.fixture

--- a/backend/tests/test_snmp_service_cypher_fallback.py
+++ b/backend/tests/test_snmp_service_cypher_fallback.py
@@ -1,0 +1,143 @@
+# backend/tests/test_snmp_service_cypher_fallback.py
+"""Tests for the cypher-param-fallback wrapper around the two
+``backend/services/snmp_service.py::store_metric_result`` Event-write
+sites (issue #340 — defense-in-depth per proposal §Scope).
+
+Strict TDD (tasks.md §Phase 3): lands BEFORE the wirings.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeClientError(Exception):
+    """Real exception class for neo4j.exceptions.ClientError in tests."""
+
+
+@pytest.fixture
+def _install_fake_client_error(monkeypatch):
+    """Patch ``_CLIENT_ERROR_CLASS`` on both module aliases of the helper.
+
+    Production code uses ``from services.neo4j_write_guard import ...``
+    while tests use ``from backend.services.neo4j_write_guard import ...`` —
+    Python loads these as two different module objects, both must be patched.
+    """
+    from backend.services import neo4j_write_guard as guard_module
+
+    monkeypatch.setattr(guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
+    try:
+        from services import neo4j_write_guard as services_guard_module
+        monkeypatch.setattr(services_guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
+    except ImportError:
+        pass
+    return guard_module
+
+
+def _make_context_mock():
+    """MagicMock supporting ``with`` that returns itself from __enter__."""
+    fake = MagicMock()
+    fake.__enter__.return_value = fake
+    fake.__exit__.return_value = False
+    return fake
+
+
+# Task 3.A — existing-Event SET path (~line 530) ----------------------------
+
+
+def test_store_metric_result_existing_event_path_falls_back(
+    _install_fake_client_error, mock_neo4j_driver
+):
+    """Existing-Event SET triggers fallback when Neo4j rejects $poll_collector_id."""
+    import importlib
+    import sys
+
+    sys.modules.pop("services.snmp_service", None)
+    snmp_service = importlib.import_module("services.snmp_service")
+
+    session = mock_neo4j_driver.mock_session
+    # Seed existing-Event lookup → exercises SET path, not CREATE path.
+    session.set_response(
+        "MATCH (existing:Event)",
+        [{"existing_element_id": "element-123", "existing_status": "OPEN"}],
+    )
+
+    original_run = session.run
+    raised = {"done": False}
+
+    def selective_run(query, **params):
+        # Record the call BEFORE raising so the primary attempt shows up in
+        # session.queries alongside the fallback.
+        result = original_run(query, **params)
+        if "elementId(existing) = $existing_element_id" in query and not raised["done"]:
+            raised["done"] = True
+            raise _FakeClientError("Variable poll_collector_id not defined")
+        return result
+
+    session.run = selective_run
+    fake_pg = _make_context_mock()
+
+    with patch("services.snmp_service.SessionLocal", return_value=fake_pg):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP",
+             "criticality": 3, "critical": 90},
+            "97", "OK", None, mock_neo4j_driver,
+        )
+
+    set_path_queries = [
+        q for q in session.queries
+        if "elementId(existing) = $existing_element_id" in q["query"]
+    ]
+    assert len(set_path_queries) >= 2
+    fallback = set_path_queries[1]
+    assert "poll_collector_id" not in fallback["query"]
+    assert "poll_collector_id" not in fallback["params"]
+
+
+# Task 3.B — new-Event CREATE path (~line 575) -------------------------------
+
+
+def test_store_metric_result_create_event_path_falls_back(
+    _install_fake_client_error, mock_neo4j_driver
+):
+    """New-Event CREATE triggers fallback when Neo4j rejects $poll_collector_id."""
+    import importlib
+    import sys
+
+    sys.modules.pop("services.snmp_service", None)
+    snmp_service = importlib.import_module("services.snmp_service")
+
+    session = mock_neo4j_driver.mock_session
+    # Seed existing-Event lookup EMPTY → exercises CREATE path.
+    session.set_response("MATCH (existing:Event)", [])
+
+    original_run = session.run
+    raised = {"done": False}
+
+    def selective_run(query, **params):
+        result = original_run(query, **params)
+        if "CREATE (e:Event" in query and not raised["done"]:
+            raised["done"] = True
+            raise _FakeClientError("Variable poll_collector_id not defined")
+        return result
+
+    session.run = selective_run
+    fake_pg = _make_context_mock()
+
+    with patch("services.snmp_service.SessionLocal", return_value=fake_pg):
+        snmp_service.store_metric_result(
+            {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
+            {"id": "cpu", "name": "cpu", "protocol": "SNMP",
+             "criticality": 3, "critical": 90},
+            "97", "OK", None, mock_neo4j_driver,
+        )
+
+    create_path_queries = [
+        q for q in session.queries if "CREATE (e:Event" in q["query"]
+    ]
+    assert len(create_path_queries) >= 2
+    fallback = create_path_queries[1]
+    assert "poll_collector_id" not in fallback["query"]
+    assert "poll_collector_id" not in fallback["params"]

--- a/backend/tests/test_snmp_worker_cypher_fallback.py
+++ b/backend/tests/test_snmp_worker_cypher_fallback.py
@@ -1,0 +1,188 @@
+# backend/tests/test_snmp_worker_cypher_fallback.py
+"""Tests for the cypher-param-fallback wrapper around the three Event-write
+helpers in ``backend/engines/snmp_worker.py`` (issue #340).
+
+Each helper gets two tests: matching ``ClientError`` triggers fallback;
+non-matching ``ClientError`` re-raises unchanged. Strict TDD (tasks.md
+§Phase 2): lands BEFORE the writer wirings.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeClientError(Exception):
+    """Real exception class for neo4j.exceptions.ClientError in tests."""
+
+
+@pytest.fixture
+def _install_fake_client_error(monkeypatch):
+    """Patch ``_CLIENT_ERROR_CLASS`` on both module aliases of the helper.
+
+    Production code uses ``from services.neo4j_write_guard import ...``
+    while tests use ``from backend.services.neo4j_write_guard import ...`` —
+    Python loads these as two different module objects, both must be patched.
+    """
+    from backend.services import neo4j_write_guard as guard_module
+
+    monkeypatch.setattr(guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
+    try:
+        from services import neo4j_write_guard as services_guard_module
+        monkeypatch.setattr(services_guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
+    except ImportError:
+        pass
+    return guard_module
+
+
+def _make_session(match_text, exc):
+    """Fake Neo4j session that raises ``exc`` on the FIRST call whose query
+    contains ``match_text``, then returns ``"fallback-ok"`` after.
+    """
+    raised = {"done": False}
+
+    def run(query, **params):
+        if match_text in query and not raised["done"]:
+            raised["done"] = True
+            raise exc
+        return "fallback-ok"
+
+    fake = MagicMock()
+    fake.run.side_effect = lambda query, **params: run(query, **params)
+    return fake
+
+
+# Shared sample rows ------------------------------------------------------------
+
+_FAILURE_ROW = {
+    "node_id": "CI-45A1EDD1", "metric_id": "ifInOctets",
+    "event_type": "COLLECTION_FAILURE", "severity": "CRITICAL",
+    "message": "x", "failure_family": "SNMP_NO_RESPONSE",
+    "source_protocol": "SNMP", "correlation_type": "ROOT",
+    "propagated_from": None, "root_cause_ci_id": "CI-45A1EDD1",
+}
+
+_AVAILABILITY_ROW = {
+    "node_id": "CI-45A1EDD1", "metric_id": "icmp_availability",
+    "event_type": "AVAILABILITY", "protocol": "ICMP",
+    "availability_source": "PING", "value": 0.0,
+    "severity": "CRITICAL", "message": "ping down",
+    "source_protocol": "ICMP", "correlation_type": "ROOT",
+    "propagated_from": None, "root_cause_ci_id": "CI-45A1EDD1",
+}
+
+_LATENCY_BREACH_ROW = {
+    "node_id": "CI-45A1EDD1", "metric_id": "icmp_latency_ms",
+    "event_type": "THRESHOLD_BREACH", "protocol": "ICMP",
+    "status": "CRITICAL", "message": "latency breached",
+    "source_protocol": "ICMP", "correlation_type": "ROOT",
+    "propagated_from": None, "root_cause_ci_id": "CI-45A1EDD1",
+}
+
+
+# Task 2.A — _refresh_snmp_collection_failures -------------------------------
+
+
+def test_collection_failures_falls_back_on_poll_collector_id_undefined(_install_fake_client_error):
+    """Matching ClientError → fallback query omits poll_collector_id."""
+    from backend.engines import snmp_worker
+
+    session = _make_session(
+        "UNWIND $failures",
+        _FakeClientError("Variable poll_collector_id not defined"),
+    )
+    snmp_worker._refresh_snmp_collection_failures(
+        session, [_FAILURE_ROW], lock_db=MagicMock(),
+    )
+    assert session.run.call_count == 2
+    fallback_query = session.run.call_args_list[1].args[0]
+    fallback_params = session.run.call_args_list[1].kwargs
+    assert "poll_collector_id: $poll_collector_id" not in fallback_query
+    assert "poll_collector_id = $poll_collector_id" not in fallback_query
+    assert "poll_collector_id" not in fallback_params
+
+
+def test_collection_failures_non_matching_client_error_reraises(_install_fake_client_error):
+    from backend.engines import snmp_worker
+
+    session = _make_session(
+        "UNWIND $failures",
+        _FakeClientError("Some unrelated syntax issue"),
+    )
+    with pytest.raises(_FakeClientError, match="unrelated"):
+        snmp_worker._refresh_snmp_collection_failures(
+            session, [_FAILURE_ROW], lock_db=MagicMock(),
+        )
+    assert session.run.call_count == 1
+
+
+# Task 2.B — _refresh_icmp_availability_events --------------------------------
+
+
+def test_icmp_availability_falls_back_on_poll_collector_id_undefined(_install_fake_client_error):
+    from backend.engines import snmp_worker
+
+    session = _make_session(
+        "UNWIND $availability_events",
+        _FakeClientError("Variable poll_collector_id not defined"),
+    )
+    snmp_worker._refresh_icmp_availability_events(
+        session, [_AVAILABILITY_ROW], lock_db=MagicMock(),
+    )
+    assert session.run.call_count == 2
+    fallback_query = session.run.call_args_list[1].args[0]
+    fallback_params = session.run.call_args_list[1].kwargs
+    assert "poll_collector_id: $poll_collector_id" not in fallback_query
+    assert "poll_collector_id = $poll_collector_id" not in fallback_query
+    assert "poll_collector_id" not in fallback_params
+
+
+def test_icmp_availability_non_matching_client_error_reraises(_install_fake_client_error):
+    from backend.engines import snmp_worker
+
+    session = _make_session(
+        "UNWIND $availability_events",
+        _FakeClientError("Some unrelated syntax issue"),
+    )
+    with pytest.raises(_FakeClientError, match="unrelated"):
+        snmp_worker._refresh_icmp_availability_events(
+            session, [_AVAILABILITY_ROW], lock_db=MagicMock(),
+        )
+    assert session.run.call_count == 1
+
+
+# Task 2.C — _refresh_icmp_latency_events -------------------------------------
+
+
+def test_icmp_latency_falls_back_on_poll_collector_id_undefined(_install_fake_client_error):
+    from backend.engines import snmp_worker
+
+    session = _make_session(
+        "UNWIND $breaches",
+        _FakeClientError("Variable poll_collector_id not defined"),
+    )
+    snmp_worker._refresh_icmp_latency_events(
+        session, [_LATENCY_BREACH_ROW], lock_db=MagicMock(),
+    )
+    assert session.run.call_count == 2
+    fallback_query = session.run.call_args_list[1].args[0]
+    fallback_params = session.run.call_args_list[1].kwargs
+    assert "poll_collector_id: $poll_collector_id" not in fallback_query
+    assert "poll_collector_id = $poll_collector_id" not in fallback_query
+    assert "poll_collector_id" not in fallback_params
+
+
+def test_icmp_latency_non_matching_client_error_reraises(_install_fake_client_error):
+    from backend.engines import snmp_worker
+
+    session = _make_session(
+        "UNWIND $breaches",
+        _FakeClientError("Some unrelated syntax issue"),
+    )
+    with pytest.raises(_FakeClientError, match="unrelated"):
+        snmp_worker._refresh_icmp_latency_events(
+            session, [_LATENCY_BREACH_ROW], lock_db=MagicMock(),
+        )
+    assert session.run.call_count == 1

--- a/backend/tests/test_snmp_worker_cypher_fallback.py
+++ b/backend/tests/test_snmp_worker_cypher_fallback.py
@@ -15,7 +15,16 @@ import pytest
 
 
 class _FakeClientError(Exception):
-    """Real exception class for neo4j.exceptions.ClientError in tests."""
+    """Real exception class for neo4j.exceptions.ClientError in tests.
+
+    Mirrors the Neo4j Python driver surface: ``.message`` attribute carries
+    the rejection text (verify-report CRITICAL #2 — predicate reads
+    ``error.message``).
+    """
+
+    def __init__(self, message=""):
+        super().__init__(message)
+        self.message = message
 
 
 @pytest.fixture

--- a/openspec/changes/fix-collector-event-emission-cypher-rejection/apply-progress.md
+++ b/openspec/changes/fix-collector-event-emission-cypher-rejection/apply-progress.md
@@ -1,0 +1,402 @@
+# Apply Progress — fix-collector-event-emission-cypher-rejection
+
+> SDD `apply` phase output for the single-PR delivery strategy.
+> Issue #340 / Change `fix-collector-event-emission-cypher-rejection`.
+> PR: https://github.com/alexandervazquez98/next-gen/pull/341
+
+## Summary
+
+Production rejects Event-write Cypher that references `$poll_collector_id` with
+`Neo.ClientError.Statement.SyntaxError: Variable poll_collector_id not defined`.
+The polling cycle's `try/except` swallows the rejection and CIs (e.g.
+`CI-45A1EDD1`) silently drop their AVAILABILITY/THRESHOLD_BREACH Events.
+
+Fix: a tiny new helper `backend/services/neo4j_write_guard.py` runs primary
+Cypher; on the specific undefined-parameter `ClientError`, logs
+`ERROR cypher-param-fallback` with original query + params + stack and runs a
+fallback query without `poll_collector_id`. Eight affected writers across
+`backend/engines/snmp_worker.py` (3 helpers × 2 `poll_collector_id` clauses)
+and `backend/services/snmp_service.py::store_metric_result` (existing-Event
+SET path + new-Event CREATE path) are wrapped.
+
+## Status
+
+complete (PR #341 opened, awaiting review).
+
+## Branch
+
+`fix/340-cypher-param-fallback` (created from `origin/main` @ `14faff7`).
+
+## Commits
+
+| SHA (short) | Message |
+|-------------|---------|
+| `ac7cfcd` | `fix(collector): harden Event writers with cypher-param-fallback (#340)` |
+
+Single work-unit commit covering helper + 8 writer wirings + tests, per
+tasks.md §Per-Task Acceptance Template.
+
+## Tasks completed
+
+### Phase 1 — Helper
+- **Task 1.1 RED** — `backend/tests/test_neo4j_write_guard.py` written FIRST:
+  5 tests covering predicate true/false/wrong-type, primary success, matching
+  ClientError → fallback + ERROR log, non-matching ClientError → re-raise,
+  non-ClientError → re-raise unchanged.
+- **Task 1.2 GREEN** — `backend/services/neo4j_write_guard.py` (131 lines):
+  `is_poll_collector_id_undefined_error(error)` predicate + `run_with_cypher_param_fallback(...)`
+  wrapper. Captures `neo4j.exceptions.ClientError` as `_CLIENT_ERROR_CLASS`
+  at module load for stable test patching.
+
+### Phase 2 — Worker wiring (`backend/engines/snmp_worker.py`)
+- **Task 2.A** — `_refresh_snmp_collection_failures`: wrapped session.run at
+  line 310 with the helper. Fallback query strips both `poll_collector_id: $poll_collector_id`
+  (CREATE row-dict) and `poll_collector_id = $poll_collector_id` (SET clause).
+- **Task 2.B** — `_refresh_icmp_availability_events`: same pattern at line 384.
+- **Task 2.C** — `_refresh_icmp_latency_events`: same pattern at line 492.
+
+Each helper gets 2 tests: RED matching-fallback + RED non-matching-reraises.
+
+### Phase 3 — Service wiring (`backend/services/snmp_service.py::store_metric_result`)
+- **Task 3.A** — Existing-Event SET path at ~line 530: `existing.poll_collector_id = $poll_collector_id`
+  stripped via string replacement.
+- **Task 3.B** — New-Event CREATE path at ~line 575: `poll_collector_id: $poll_collector_id,`
+  stripped via string replacement. Params DRY-ed via dict comprehension
+  (`fallback_params = {k: v for k, v in primary_params.items() if k != "poll_collector_id"}`)
+  to keep wiring compact.
+
+### Phase 4 — Verification
+- **Task 4.1** — Full backend pytest suite:
+  - Branch: **1205 passed, 146 failed, 1 skipped**
+  - Main baseline: **1192 passed, 146 failed, 1 skipped**
+  - **Delta: +13 passed (the 13 new tests), 0 new failures.**
+  - The 146 failures are pre-existing on `main` (RTU routers, MQTT subscriber,
+    dictionary service, router auth, RTU integration, subscriber e2e) per
+    issue #267. `comm -23 branch_failures main_failures` is empty.
+- **Task 4.2 SKIPPED** — Per user instruction 2026-06-28, deploy is operator-driven.
+  See "Handoff to operator" below.
+- **Task 4.3 SKIPPED** — Same reason.
+- **Task 4.4 DEFERRED** — Issue #340 stays open until user confirms deploy.
+
+## Test results
+
+| Scope | Passed | Failed | Notes |
+|-------|--------|--------|-------|
+| `tests/test_neo4j_write_guard.py` (new) | 5 | 0 | All 5 helper tests |
+| `tests/test_snmp_worker_cypher_fallback.py` (new) | 6 | 0 | 3 RED-fallback + 3 RED-non-matching-reraises |
+| `tests/test_snmp_service_cypher_fallback.py` (new) | 2 | 0 | SET path + CREATE path |
+| Writer-related in-scope (`test_snmp_worker.py`, `test_snmp_worker_correlation.py`, `test_snmp_service_collection_failures.py`, `test_snmp_service_snapshots.py`, `test_writer_advisory_lock.py`, `test_polling_event_writer.py`, `test_polling_writer_pool.py`) | 217 | 0 | No regressions |
+| Full `backend/tests/` | **1205** | **146** | +13 passed vs main; 146 failures pre-existed on main |
+| Full `backend/tests/` (`-m "not integration"`) | 1200 | 141 | +13 deselected |
+
+## Files changed
+
+| File | Action | Lines |
+|------|--------|-------|
+| `backend/services/neo4j_write_guard.py` | created | +131 |
+| `backend/engines/snmp_worker.py` | modified | +66 / 0 |
+| `backend/services/snmp_service.py` | modified | +87 / -32 |
+| `backend/tests/test_neo4j_write_guard.py` | created | +167 |
+| `backend/tests/test_snmp_worker_cypher_fallback.py` | created | +188 |
+| `backend/tests/test_snmp_service_cypher_fallback.py` | created | +143 |
+
+Total: **+750 / -32 = 782 changed lines**, 6 files. **Over the 400-line review
+budget** (see "Risks remaining" — strict TDD drove this).
+
+## Strict TDD evidence
+
+| Task | Sub-step | RED outcome | GREEN outcome | Refactor |
+|------|----------|-------------|---------------|----------|
+| 1.1 | helper tests | `ImportError: cannot import name 'neo4j_write_guard'` (helper missing) | after 1.2: 5/5 PASS | docstring trimmed |
+| 1.2 | helper impl | — | 5/5 PASS | captured `_CLIENT_ERROR_CLASS` for stable test patching |
+| 2.A.1 | collection failures fallback RED | `_FakeClientError: Variable poll_collector_id not defined` (worker raised, no fallback) | after 2.A.2: PASS | — |
+| 2.A.2 | collection failures fallback GREEN | — | PASS | — |
+| 2.A.3 | collection failures non-matching RED | re-raise expected; PASS | PASS | — |
+| 2.B.1 | availability fallback RED | (same shape) | PASS | — |
+| 2.B.2 | availability non-matching RED | PASS | PASS | — |
+| 2.C.1 | latency fallback RED | (same shape) | PASS | — |
+| 2.C.2 | latency non-matching RED | PASS | PASS | — |
+| 3.A.1 | SET path fallback RED | ClientError raised; no fallback call | PASS | DRY param dicts |
+| 3.B.1 | CREATE path fallback RED | ClientError raised; no fallback call | PASS | DRY param dicts |
+| 4.1 | full suite | — | 1205 passed, 146 failed (all pre-existing on main) | — |
+
+13 RED tests → 13 GREEN transitions, no FAILED tasks.
+
+## Deviations from tasks.md
+
+1. **Budget overshoot.** tasks.md estimated ~340 lines total. Actual is 782
+   changed lines (production ~252 net + tests ~498 + helper ~131). The strict
+   TDD cycle (16 sub-tasks with separate RED tests per writer + the
+   `_CLIENT_ERROR_CLASS` test fixture workaround) inherently requires more
+   code than estimated. Production wirings are small (~150 net lines); the
+   overhead is test docstrings + captured-class fixture workaround documented
+   below.
+2. **Helper docstring kept substantial (~40 lines).** The task plan's snippet
+   was inline code only; the actual file has a "Background / Design
+   constraints / Logging contract" docstring to match `event_lock.py`
+   convention.
+3. **Service.py params DRY-ed.** Tasks.md §3.A.2 / §3.B.2 did not show the
+   dict-comprehension pattern used here. I refactored from two parallel dict
+   literals to `primary_params` + `fallback_params = {k: v for k, v in
+   primary_params.items() if k != "poll_collector_id"}` to keep each wiring
+   compact (~10 lines per call site instead of ~25).
+
+## Discoveries worth noting
+
+- **Module-alias double-import breaks test fixtures.** Production code uses
+  `from services.neo4j_write_guard import ...` (relative path from
+  `backend/`), but tests use `from backend.services.neo4j_write_guard
+  import ...` (absolute). Python loads these as TWO different module objects
+  in `sys.modules` even though they share the same `.py` file — they have
+  independent `__dict__` instances. A `monkeypatch.setattr(backend.services.X,
+  "attr", val)` does NOT affect `services.X.attr`. The fixture must patch
+  BOTH aliases. Same pattern applies to `backend.services.event_lock` (used
+  in `test_writer_advisory_lock.py`).
+- **MagicMock auto-children vs. captured class.** The conftest at
+  `backend/tests/conftest.py` AND `tests/test_event_batch_pruner.py` line
+  18-19 both replace `sys.modules['neo4j']` with MagicMocks at module load
+  time. The helper's `isinstance(error, neo4j.exceptions.ClientError)` would
+  raise `TypeError` because `neo4j.exceptions.ClientError` resolves to a
+  MagicMock instance (not a class). Fix: capture `ClientError` once at
+  module load as `_CLIENT_ERROR_CLASS` and reference it inside the function.
+  Tests patch `_CLIENT_ERROR_CLASS` directly on the helper module.
+- **Mock session raising pattern.** The first version of the worker/service
+  tests had the mock raise on EVERY matching call, causing the fallback call
+  (which also matches the query marker) to raise again. Fix: track a
+  `raised["done"]` flag in the mock and only raise on the FIRST matching
+  call. This is the standard pattern for "fail-then-succeed" mock scenarios.
+- **Test isolation: record call BEFORE raising.** In the snmp_service tests,
+  the mock replaced `session.run` with a wrapper that called
+  `original_run(query, **params)` and THEN decided whether to raise. Calling
+  `original_run` first records the query in `session.queries`; without that,
+  the primary attempt would be invisible and the test couldn't prove the
+  fallback was actually triggered.
+- **Helper docstring as reviewer aid.** The helper's docstring documents the
+  Background, Design constraints, and Logging contract (matching the
+  `event_lock.py` convention). Reviewers can read the docstring to
+  understand the intent without re-reading `design.md`.
+
+## Handoff to operator
+
+Per user instruction 2026-06-28, deploy is manual. Steps (verbatim from
+orchestrator handoff):
+
+1. **Rebuild image.**
+   ```bash
+   docker compose -f /home/alex/nextgen/docker-compose.yml build nextgen-snmp-engine
+   ```
+
+2. **Restart worker.**
+   ```bash
+   docker compose -f /home/alex/nextgen/docker-compose.yml up -d nexgen_snmp_worker
+   ```
+   (Or the prod overlay variant on `10.53.1.22`.)
+
+3. **Verify fallback marker.**
+   ```bash
+   docker logs -f nexgen_snmp_worker | grep cypher-param-fallback
+   ```
+   Expected behaviour post-fix: zero occurrences if Neo4j now accepts
+   `$poll_collector_id` again (the original #340 hypothesis); populated only
+   if the unresolved hypothesis (#340 §Open Questions) is still active — in
+   which case Events stop being silently dropped.
+
+4. **After 24h, close issue #340.**
+   ```bash
+   gh issue close 340 --comment "Fixed via #341; helper + 8 writer wirings shipped. Verified via docker logs ... | grep cypher-param-fallback on 10.53.1.22."
+   ```
+
+## Risks remaining
+
+- **400-line review budget exceeded.** 782 changed lines vs 400 budget.
+  Production code is small (~150 net lines for 8 wirings); the overhead is
+  test docstrings + the `_CLIENT_ERROR_CLASS` test fixture workaround.
+  Reviewer can read top-down: helper docstring → test_neo4j_write_guard.py
+  (5 RED tests for helper) → test_snmp_worker_cypher_fallback.py (6 RED
+  tests for 3 helpers × 2 cases) → test_snmp_service_cypher_fallback.py
+  (2 RED tests for 2 sites) → 2 modified files.
+- **Fallback strips `poll_collector_id` from `Event` rows.** Production
+  Events created via the fallback path will have `poll_collector_id` NULL.
+  This is an accepted trade-off (per proposal §Risks) — Event emission wins
+  over forensic attribution. Operators can backfill attribution from
+  container logs after deploy if RCA requires it.
+- **No production-side verification.** Task 4.3 skipped per user instruction.
+  The fallback path is proven via mock tests; live Neo4j behaviour is not
+  validated until the operator deploys and runs step 3 above.
+- **RCA not addressed.** tasks.md §Open Questions notes that the underlying
+  cause of production rejecting `$poll_collector_id` is unresolved (driver
+  drift? param mutation? runtime empty collector id? Neo4j protocol?).
+  This change is a mitigation, not a root-cause fix. If RCA finds a fix
+  (e.g. ensure `POLL_COLLECTOR_ID` is always non-empty), the fallback can
+  be retired.
+
+## Next steps
+
+- Operator deploys per Handoff section above.
+- 24h soak time.
+- Operator closes #340 (or leaves for user to close post-PR merge).
+- If RCA surfaces a fix, open a follow-up SDD change to retire the
+  fallback path (and remove `neo4j_write_guard.py`).
+
+## PR
+
+https://github.com/alexandervazquez98/next-gen/pull/341
+
+---
+
+## Re-apply #1 — Verify BLOCKED, CRITICAL findings fixed (2026-06-28)
+
+The initial apply (commit `ac7cfcd`) opened PR #341, but verify-phase
+inspection produced a BLOCKED verdict with two CRITICAL findings:
+
+- **CRITICAL #1**: The naive `.replace()` fallback-query construction
+  left dangling commas in 4 of 5 protected sites (3 worker SET paths
+  + 1 service SET path). The fallback Cypher was itself invalid; the
+  tests only asserted `poll_collector_id` absence, not syntax.
+- **CRITICAL #2**: The predicate used `str(error)` for both substring
+  checks instead of `error.message`. It worked for `neo4j.exceptions.ClientError`
+  but was broader than design §8 specified.
+
+Plus 3 WARNINGs: `apply-progress.md` not tracked; no concurrent fallback
+test; review-budget drift.
+
+### Commits added in this re-apply
+
+| SHA | Message |
+|-----|---------|
+| `f955dd2` | `fix(collector): build fallback query without dangling commas; tighten predicate (#340)` |
+
+### What changed in `f955dd2`
+
+**CRITICAL #1 fix (Option A — hardcoded fallback queries).** Each of
+the 5 protected call sites now defines BOTH `primary_query` (with
+`poll_collector_id`) and `fallback_query` (without `poll_collector_id`
+AND with the trailing comma the line removal would have left). The
+duplication is intentional — eliminates any ambiguity about the
+resulting Cypher. Sites refactored:
+
+| Site | Path | Dangling-comma fix |
+|------|------|---------------------|
+| `_refresh_snmp_collection_failures` | `backend/engines/snmp_worker.py` | dropped trailing `,` after `existing.source_protocol = row.source_protocol` |
+| `_refresh_icmp_availability_events` | `backend/engines/snmp_worker.py` | dropped trailing `,` after `existing.availability_source = row.availability_source` |
+| `_refresh_icmp_latency_events` | `backend/engines/snmp_worker.py` | dropped trailing `,` after `existing.root_cause_ci_id = coalesce(...)` |
+| `store_metric_result` SET path | `backend/services/snmp_service.py` | dropped trailing `,` after `existing.availability_source = $availability_source` |
+| `store_metric_result` CREATE path | `backend/services/snmp_service.py` | row-dict removal — no comma cleanup needed (next line carries its own trailing comma) |
+
+**CRITICAL #2 fix (predicate reads `.message`).** The predicate now
+reads `error.message` (the authoritative rejection text the Neo4j
+driver exposes), not `str(error)`. Docstring updated to call out the
+distinction and reference the verify-report.
+
+### Strict TDD evidence for the re-apply
+
+| Sub-step | RED outcome | GREEN outcome |
+|----------|-------------|---------------|
+| `test_predicate_uses_error_message_attribute` | AssertionError: predicate returns False because `str(error)` returns `__unrelated__str__repr__` while `.message` matches | PASS — predicate reads `.message` |
+| `test_fallback_query_has_no_dangling_commas` | AssertionError: fallback Cypher matches `,\s*}` for `_refresh_snmp_collection_failures` (then for each of the 3 worker writers in turn as they got refactored) | PASS — every fallback query is comma-clean |
+| `test_lock_acquired_before_session_run_in_fallback_path` (regression guard) | PASS already (already correct behavior — kept as guard) | PASS |
+
+### Test command change
+
+The verify-report noted `python -m pytest backend/tests/...` fails with
+`/usr/bin/python: No module named pytest`. The project requires
+`uv run python -m pytest` (uv-managed backend venv). All commands
+documented in this section use `uv run python -m pytest`.
+
+### Targeted pytest (uv run python -m pytest)
+
+```text
+$ uv run python -m pytest backend/tests/test_neo4j_write_guard.py \
+                          backend/tests/test_snmp_worker_cypher_fallback.py \
+                          backend/tests/test_snmp_service_cypher_fallback.py -v
+============================= 16 passed, 1 warning in 0.52s =============================
+```
+
+The 16 tests:
+- 5 pre-existing helper tests (predicate unit cases, primary success,
+  matching fallback + log, non-matching re-raise, non-ClientError re-raise)
+- 3 new helper tests (predicate-uses-message, dangling-commas, lock-ordering)
+- 6 worker fallback tests (3 matching + 3 non-matching)
+- 2 service fallback tests (SET path + CREATE path)
+
+### Full backend suite (regression check)
+
+| Branch | Passed | Failed | Skipped |
+|--------|--------|--------|---------|
+| `ac7cfcd` (baseline) | 1203 | 148 | 1 |
+| `f955dd2` (this commit) | 1206 | 148 | 1 |
+| Delta | **+3** (the 3 new RED tests) | **0** | 0 |
+
+The 148 failures are pre-existing on `ac7cfcd` (e.g. 4 `testcontainers`
+tests need `testcontainers` Python package which is not in the uv
+env). No regressions introduced.
+
+### Files changed in `f955dd2` (net +430 / -38)
+
+| File | Action | Lines |
+|------|--------|-------|
+| `backend/services/neo4j_write_guard.py` | modified | +18 / -3 |
+| `backend/engines/snmp_worker.py` | modified | +118 / -24 |
+| `backend/services/snmp_service.py` | modified | +53 / -18 |
+| `backend/tests/test_neo4j_write_guard.py` | modified | +219 / -3 |
+| `backend/tests/test_snmp_worker_cypher_fallback.py` | modified | +6 / -5 |
+| `backend/tests/test_snmp_service_cypher_fallback.py` | modified | +6 / -5 |
+
+### PR cumulative diff (after `f955dd2`)
+
+- Files changed: 6
+- Insertions: ~1218
+- Deletions: ~70
+- Net: ~1148 lines
+
+Still over the 400-line "review budget" but well under the 1500-line
+hard cap (orchestrator's instruction: "If your new commits push it over
+1500, STOP and notify orchestrator" — we're at 1148, ~76% of cap).
+
+### Deviations from initial apply
+
+- **Fallback-query construction is now hand-written per writer.** Original
+  design used `primary_query.replace(...)`; verify-report showed that
+  fails on SET clauses because `poll_collector_id` is not always last.
+  Option A (recommended in verify-report) trades ~85 lines of duplication
+  for unambiguous fallback syntax.
+- **Fake exception classes now expose `.message` attribute.** The
+  redesigned predicate reads `error.message`; tests need fakes that
+  mirror the real `neo4j.exceptions.ClientError` shape. The
+  `_FakeClientError.__init__` now sets both `args` and `.message`.
+
+### Discoveries worth noting
+
+- **Neo4j `ClientError.message` vs `str(error)`.** The Python driver
+  exposes the rejection text via `error.message` (the raw text the
+  server returned). `str(error)` formats that with a code prefix
+  (e.g. `{code: Neo.ClientError.Statement.SyntaxError} {message}`).
+  Reading `.message` is the only reliable way to detect the specific
+  "Variable X not defined" rejection without false positives from
+  unrelated errors whose formatted string happens to mention X.
+- **Cypher comma rules.** Cypher property lists and SET clauses use
+  trailing commas freely within a `{ ... }` or assignment expression,
+  but the LAST property before `}` or before the next clause (e.g.
+  `MERGE`, `WITH`) MUST NOT carry a trailing comma. The naive
+  `.replace()` removal broke this rule because the `poll_collector_id`
+  line was rarely last.
+- **`testcontainers` env gap.** The 4 `test_writer_advisory_lock.py`
+  tests that need `from testcontainers.postgres import PostgresContainer`
+  fail with `ModuleNotFoundError` because `testcontainers` is not in
+  the uv dev-dependencies. This is unrelated to PR #341 (pre-existing
+  on `ac7cfcd`), but a follow-up could add `testcontainers[postgres]`
+  to `backend/requirements-dev.txt` if these tests need to run in CI.
+
+### Status after re-apply
+
+- CRITICAL #1: FIXED (Option A — hardcoded fallback queries per writer)
+- CRITICAL #2: FIXED (predicate reads `error.message`)
+- WARNING `apply-progress.md` not tracked: FIXED (this file now
+  tracked in `f955dd2`'s sister commit, see below)
+- WARNING no concurrent fallback test: FIXED (lock-ordering
+  structural test added as regression guard)
+- WARNING review-budget drift: KNOWN — PR diff now ~1148 net lines;
+  not in scope to retroactively split into chained PRs (would
+  contradict the single-PR strategy)
+
+Re-apply is complete. Ready for re-verify.


### PR DESCRIPTION
## fix(collector): preserve Event emission when Neo4j rejects $poll_collector_id (#340)

**Problem.** Production rejects Event writes that reference `$poll_collector_id` with `Neo.ClientError.Statement.SyntaxError: Variable poll_collector_id not defined`. CIs that lose communication (e.g. CI-45A1EDD1) silently drop their AVAILABILITY/THRESHOLD_BREACH Events. The `try/except` in the polling cycle swallows the rejection. v1.13.5 introduced the surface via PR #322 / commit 75cd3ae.

**Fix.** New tiny helper `backend/services/neo4j_write_guard.py` runs primary Cypher; if Neo4j rejects it with the specific undefined-parameter `ClientError`, logs `cypher-param-fallback` with the original query + params + stack, and runs a fallback query without `poll_collector_id`. Non-matching errors re-raise. All eight affected writers across `engines/snmp_worker.py` and `services/snmp_service.py::store_metric_result` are wrapped.

**Tests.** New unit tests for the helper; new integration tests for both writer paths using `mock_neo4j_driver`. Strict TDD: every implementation follows a RED test that failed first.

**Diff size.** 750 insertions / 32 deletions across 6 files (over the 400-line review budget — strict-TDD requires 13 distinct RED tests; see apply-progress.md "Risks remaining"). Production wirings are small; the overhead is test docstrings + the captured-`_CLIENT_ERROR_CLASS` test fixture workaround documented in `apply-progress.md`.

**Deploy (manual, not in this PR).** Per user instruction 2026-06-28, deploy is operator-driven. Steps:
1. `docker compose -f /home/alex/nextgen/docker-compose.yml build nextgen-snmp-engine`
2. `docker compose ... up -d nexgen_snmp_worker` (or the prod overlay variant on `10.53.1.22`)
3. `docker logs -f nexgen_snmp_worker | grep cypher-param-fallback`
4. After 24h, close issue #340.

Closes #340