### PR TITLE
fix(icmp): propagate latency threshold env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       - LM_STUDIO_TIMEOUT_SECONDS=${LM_STUDIO_TIMEOUT_SECONDS:-15}
       - LM_STUDIO_MAX_TOKENS=${LM_STUDIO_MAX_TOKENS:-800}
       - AI_PROMPTS_DIR=/data/ai
+      - ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}
+      - ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -161,6 +163,8 @@ services:
       - ICMP_TIMEOUT_MS=${ICMP_TIMEOUT_MS:-3000}
       - ICMP_RETRIES=${ICMP_RETRIES:-2}
       - ICMP_DEBOUNCE_COUNT=${ICMP_DEBOUNCE_COUNT:-3}
+      - ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}
+      - ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}
       # Scalable polling pipeline PR1 flags/defaults (behavior-changing flags remain off)
       - POLLING_PIPELINE_OBSERVE_ONLY=${POLLING_PIPELINE_OBSERVE_ONLY:-false}
       - POLLING_PG_QUEUE_ENABLED=${POLLING_PG_QUEUE_ENABLED:-false}

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/apply-progress.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/apply-progress.md
@@ -1,0 +1,94 @@
+# Apply Progress: fix-icmp-latency-threshold-env
+
+## Status
+
+- Artifact store: OpenSpec
+- Mode: Strict TDD
+- Runtime scope: Compose-only ICMP latency threshold environment propagation
+- Result: All tasks complete; runtime behavior verified; missing Strict TDD evidence artifact persisted
+
+## Completed Tasks
+
+### Phase 1: Baseline Evidence
+
+- [x] 1.1 RED: Render `docker-compose.yml` with configured threshold env values and confirm `backend`/`snmp-engine` currently miss `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS`.
+- [x] 1.2 RED: Render `docker-compose.yml` without threshold env values and confirm affected services do not explicitly receive default `100`/`500` values.
+
+### Phase 2: Compose Propagation
+
+- [x] 2.1 Add `ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}` to `backend.environment` in `docker-compose.yml`.
+- [x] 2.2 Add `ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}` to `backend.environment` in `docker-compose.yml`.
+- [x] 2.3 Add both ICMP latency threshold variables with matching defaults to `snmp-engine.environment` in `docker-compose.yml`.
+- [x] 2.4 Do not modify `backend/config.py` or ICMP threshold product semantics unless validation reveals an application defect.
+
+### Phase 3: Verification
+
+- [x] 3.1 GREEN: Run `docker compose config --quiet` to validate Compose syntax after the list-style environment edits.
+- [x] 3.2 GREEN: Inspect rendered `docker compose config` with configured env values and verify `backend` and `snmp-engine` receive both configured thresholds.
+- [x] 3.3 GREEN: Inspect rendered `docker compose config` with omitted env values and verify both affected services receive default `100`/`500` thresholds.
+- [x] 3.4 Verify non-consuming services are not required to receive the new variables.
+- [x] 3.5 Run targeted backend ICMP settings tests, e.g. `cd backend && python -m pytest backend/tests/test_snmp_worker.py -k ICMPSettings`, or document why unavailable.
+
+### Phase 4: Cleanup
+
+- [x] 4.1 REFACTOR: Keep the final diff limited to the focused Compose change plus necessary evidence notes.
+- [x] 4.2 Update `openspec/changes/fix-icmp-latency-threshold-env/tasks.md` task checkboxes during apply.
+
+## TDD Cycle Evidence
+
+| Task | Test File / Evidence | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR / Safety Net |
+|------|----------------------|-------|------------|-----|-------|-------------|------------------------|
+| 1.1 | `docker compose config --format json` render with `ICMP_LATENCY_WARNING_MS=123` and `ICMP_LATENCY_CRITICAL_MS=456` before the Compose propagation fix | Integration / config render | `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings` validates existing settings contract: 4 passed, 29 deselected | ✅ Written first as render evidence: affected services lacked explicit configured threshold env propagation before the fix | ✅ After Compose edit, configured render shows `backend` and `snmp-engine` receive `123` / `456` | ✅ Covered both affected services and verified non-consuming services do not receive the vars | ✅ No Python/runtime logic refactor required; scope stayed Compose-only |
+| 1.2 | `docker compose config --format json` render with threshold vars omitted before the Compose propagation fix | Integration / config render | Same ICMP settings safety net: 4 passed, 29 deselected via `uv run pytest` | ✅ Written first as render evidence: affected services lacked explicit default `100` / `500` env propagation before the fix | ✅ After Compose edit, default render shows `backend` and `snmp-engine` receive `100` / `500` | ✅ Triangulated configured values (`123` / `456`) against default values (`100` / `500`) | ✅ Defaults match `ICMPSettings` and `.env.example`; no product semantics changed |
+| 2.1 | `docker-compose.yml` render evidence for `backend.environment.ICMP_LATENCY_WARNING_MS` | Integration / config render | `docker compose config --quiet` validates YAML/Compose syntax | ✅ Failed render evidence existed before adding the backend warning env entry | ✅ Rendered backend environment contains `ICMP_LATENCY_WARNING_MS=123` when configured and `100` by default | ✅ Configured/default values both verified for backend | ✅ Minimal list-style environment entry only |
+| 2.2 | `docker-compose.yml` render evidence for `backend.environment.ICMP_LATENCY_CRITICAL_MS` | Integration / config render | `docker compose config --quiet` validates YAML/Compose syntax | ✅ Failed render evidence existed before adding the backend critical env entry | ✅ Rendered backend environment contains `ICMP_LATENCY_CRITICAL_MS=456` when configured and `500` by default | ✅ Configured/default values both verified for backend | ✅ Minimal list-style environment entry only |
+| 2.3 | `docker-compose.yml` render evidence for `snmp-engine.environment` threshold entries | Integration / config render | `docker compose config --quiet` validates YAML/Compose syntax | ✅ Failed render evidence existed before adding the snmp-engine threshold env entries | ✅ Rendered snmp-engine environment contains both configured `123` / `456` and default `100` / `500` values | ✅ Both threshold vars and both value modes verified for snmp-engine | ✅ Kept service-specific explicit entries; no Compose anchor/env refactor |
+| 2.4 | `backend/tests/test_snmp_worker.py -k ICMPSettings` | Unit | Existing ICMPSettings tests selected and run | ✅ Guard test intent established: preserve existing parsing, validation, ordering, and singleton behavior | ✅ `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings`: 4 passed, 29 deselected | ✅ Test set covers defaults, env overrides, invalid ordering, and singleton caching | ✅ Confirmed no `backend/config.py` or Python runtime logic changes were needed |
+| 3.1 | `docker compose config --quiet` | Integration / config render | N/A; command is the syntax safety net | ✅ Compose validation required before accepting list-style env edits | ✅ Passed with warnings only for unrelated unset existing env vars | ➖ Single syntax validation command; behavior triangulated in 3.2 and 3.3 | ✅ No additional config restructuring needed |
+| 3.2 | `docker compose config --format json` with configured threshold env values | Integration / config render | `docker compose config --quiet` passed | ✅ Configured render check established as acceptance evidence | ✅ `backend` and `snmp-engine` receive `ICMP_LATENCY_WARNING_MS=123` and `ICMP_LATENCY_CRITICAL_MS=456` | ✅ Compared against default render in 3.3 and unaffected services in 3.4 | ✅ Evidence confirms operator-configured propagation without Python changes |
+| 3.3 | `docker compose config --format json` with threshold vars unset | Integration / config render | `docker compose config --quiet` passed | ✅ Default render check established as acceptance evidence | ✅ `backend` and `snmp-engine` receive `ICMP_LATENCY_WARNING_MS=100` and `ICMP_LATENCY_CRITICAL_MS=500` | ✅ Compared against configured render in 3.2 and Python default tests in 3.5 | ✅ Evidence confirms defaults match existing settings contract |
+| 3.4 | `docker compose config --format json` service environment inspection | Integration / config render | `docker compose config --quiet` passed | ✅ Non-consuming service check established as scope guard | ✅ `neo4j`, `postgres`, and `frontend` do not receive the ICMP latency threshold vars | ✅ Verified unaffected services in both configured and default render modes | ✅ Scope remained limited to affected services only |
+| 3.5 | `backend/tests/test_snmp_worker.py -k ICMPSettings` | Unit | Targeted existing backend tests | ✅ Existing ICMP settings contract selected as the safety net for application behavior preservation | ✅ `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings`: 4 passed, 29 deselected | ✅ Covers defaults, env override, invalid threshold ordering, and singleton caching | ✅ System Python runner documented unavailable; no Python logic changed |
+| 4.1 | Final diff / artifact review | Review safety net | Runtime diff limited to `docker-compose.yml`; this remediation adds only `apply-progress.md` evidence | ✅ Cleanup task defined as focused-diff constraint | ✅ Current remediation changed no runtime code/config | ✅ Scope checked against proposal/design and verify report | ✅ Final implementation remains four Compose environment entries plus evidence notes |
+| 4.2 | `openspec/changes/fix-icmp-latency-threshold-env/tasks.md` | OpenSpec task artifact | Tasks were re-read before return | ✅ Task checkbox update required by apply protocol | ✅ All tasks in `tasks.md` are checked | ➖ Artifact bookkeeping task; no behavior branching | ✅ This `apply-progress.md` now provides the missing Strict TDD evidence artifact |
+
+## Test Summary
+
+- **Total tests/checks written or executed for evidence**: 7 checks
+- **Total tests passing**: 4 selected pytest tests passed via `uv run`; 3 Compose/render checks passed
+- **Layers used**: Unit (4 selected pytest tests), Integration/config render (3 Compose checks), E2E (0; not required by design)
+- **Approval tests**: None — no refactoring task changed application code behavior
+- **Pure functions created**: 0 — no Python/runtime logic was changed
+
+## Verification Commands and Outcomes
+
+| Command | Outcome | Notes |
+|---------|---------|-------|
+| `docker compose config --quiet` | ✅ PASS | Compose rendered successfully. Warnings were limited to unrelated existing unset variables such as `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `JWT_SECRET_KEY`, and `COOKIE_DOMAIN`. |
+| `docker compose config --format json` with `ICMP_LATENCY_WARNING_MS=123` and `ICMP_LATENCY_CRITICAL_MS=456` | ✅ PASS | `backend` and `snmp-engine` receive `123` / `456`; `neo4j`, `postgres`, and `frontend` do not receive the threshold vars. |
+| `docker compose config --format json` with threshold vars unset | ✅ PASS | `backend` and `snmp-engine` receive defaults `100` / `500`; non-consuming services remain unaffected. |
+| `python -m pytest backend/tests/test_snmp_worker.py -k ICMPSettings` | ❌ ENVIRONMENT FAILURE | `/usr/bin/python: No module named pytest`; system Python does not have pytest installed in this environment. |
+| `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings` | ✅ PASS | 4 passed, 29 deselected. This is the available project runner used for backend verification. |
+
+## Runtime Scope Confirmation
+
+- No Python/runtime logic was changed for this remediation.
+- `backend/config.py` remains the source of ICMP settings parsing, validation, defaults, and singleton caching.
+- The intended runtime implementation remains limited to `docker-compose.yml` env propagation for `backend` and `snmp-engine`.
+- This remediation adds only the missing OpenSpec evidence artifact: `openspec/changes/fix-icmp-latency-threshold-env/apply-progress.md`.
+
+## Deviations from Design
+
+None — implementation matches the design. The fix remains Compose-only and preserves existing Python settings behavior.
+
+## Issues Found
+
+- System Python cannot run the configured backend pytest command in this environment because pytest is missing: `/usr/bin/python: No module named pytest`.
+- The project `uv` runner is available and successfully runs the targeted ICMP settings tests.
+
+## Workload / PR Boundary
+
+- Mode: single PR
+- Current work unit: Unit 1 — Propagate existing ICMP latency threshold env vars to affected Compose services and verify render behavior
+- Boundary: This remediation persists missing Strict TDD evidence only; it does not alter runtime code/config.
+- Estimated review budget impact: Low; one evidence artifact added under the existing OpenSpec change root.

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/archive-report.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/archive-report.md
@@ -1,0 +1,56 @@
+# Archive Report — fix-icmp-latency-threshold-env
+
+## Status
+
+**Archive status:** PASS (no CRITICAL findings; verify-report is PASS WITH WARNINGS).
+
+**Archived on:** 2026-06-30
+**Mode:** OpenSpec
+**Change:** `fix-icmp-latency-threshold-env`
+
+## Goal
+
+Ensure containerized ICMP latency threshold consumers receive operator-configured warning and critical thresholds by propagating the existing env vars through Compose.
+
+## Artifacts read
+
+- `openspec/changes/fix-icmp-latency-threshold-env/proposal.md`
+- `openspec/changes/fix-icmp-latency-threshold-env/specs/icmp-latency-threshold-env/spec.md`
+- `openspec/changes/fix-icmp-latency-threshold-env/design.md`
+- `openspec/changes/fix-icmp-latency-threshold-env/tasks.md`
+- `openspec/changes/fix-icmp-latency-threshold-env/apply-progress.md`
+- `openspec/changes/fix-icmp-latency-threshold-env/verify-report.md`
+- `openspec/config.yaml`
+
+## Task completion / validation
+
+- `tasks.md` was fully checked before archive: 14/14 implementation tasks complete.
+- `verify-report.md` verdict: **PASS WITH WARNINGS**.
+- Warning accepted: system Python lacks pytest in this environment; `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings` passed.
+- No CRITICAL issues were present, so archive was allowed.
+
+## Specs synced
+
+- Root spec was created at `openspec/specs/icmp-latency-threshold-env/spec.md` because no main spec existed.
+- Delta spec was promoted directly as the source of truth.
+
+## Archived path
+
+- Source: `openspec/changes/fix-icmp-latency-threshold-env/`
+- Target: `openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/`
+
+## Files in archive
+
+- `proposal.md`
+- `design.md`
+- `tasks.md`
+- `verify-report.md`
+- `apply-progress.md`
+- `exploration.md`
+- `specs/icmp-latency-threshold-env/spec.md`
+- `archive-report.md`
+
+## Notes
+
+- Archive was purely filesystem-based; no runtime code changed during archiving.
+- Main spec and archived delta now reflect the same ICMP latency threshold environment behavior.

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/design.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/design.md
@@ -1,0 +1,69 @@
+# Design: Fix ICMP Latency Threshold Environment Propagation
+
+## Technical Approach
+
+Apply a Compose-only fix: explicitly pass `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS` into the two container services that execute backend Python code paths calling `get_icmp_settings()`: `backend` and `snmp-engine`. Keep `backend/config.py` as the source of parsing, validation, defaults, and singleton caching. This satisfies the delta spec by making operator-configured thresholds available to affected containers while preserving application behavior.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|--------|----------|----------|
+| Add threshold variables to `backend` and `snmp-engine` service `environment` lists | Duplicates two entries, but covers all known containerized `get_icmp_settings()` consumers | Chosen: explicit propagation is the smallest complete fix |
+| Add variables only to `snmp-engine` | Smaller patch, but leaves backend-side MetricDef initialization and writer paths on defaults | Rejected because the spec requires every containerized threshold evaluator |
+| Refactor Compose env handling with anchors or `env_file` | Reduces future duplication, but expands scope and risks unrelated Compose behavior changes | Rejected as out of scope for a focused bug fix |
+| Modify Python defaults/parsing | Could mask missing env propagation, but changes product semantics and validation surface | Rejected because existing Python tests show the settings contract already works |
+
+## Data Flow
+
+```text
+.env / shell env
+      │
+      ▼
+docker compose interpolation
+      │
+      ├── backend.environment ──────┐
+      │                             ▼
+      └── snmp-engine.environment → get_icmp_settings()
+                                    │
+          ┌─────────────────────────┼─────────────────────────┐
+          ▼                         ▼                         ▼
+writer_pool latency events   snmp_worker ICMP polling   topology MetricDef init
+```
+
+`get_icmp_settings()` remains process-cached, so changed values require container/process recreation before they take effect.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docker-compose.yml` | Modify | Add `ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}` and `ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}` to `backend.environment` and `snmp-engine.environment`. |
+| `backend/config.py` | Unchanged | Retains `ICMPSettings.from_env()`, validation, defaults, and singleton behavior. |
+| `backend/tests/test_snmp_worker.py` | Unchanged | Existing ICMP settings tests already cover env parsing, defaults, ordering validation, and caching. |
+
+## Interfaces / Contracts
+
+No Python interface changes. The Compose deployment contract is extended so affected services receive these existing variables:
+
+```yaml
+- ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}
+- ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}
+```
+
+Defaults intentionally match `ICMPSettings` (`100` warning, `500` critical) and `.env.example`.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Config render | Compose remains valid | Run `docker compose config --quiet`. |
+| Integration/config evidence | `backend` and `snmp-engine` render both threshold env vars with configured/default values | Inspect `docker compose config` output for service environments. |
+| Unit | Existing Python parsing and validation stay unchanged | Run targeted backend tests for `TestICMPSettings`, or document if unavailable. |
+| E2E | Not required | This is environment propagation; rendered Compose plus existing settings tests provide sufficient evidence. |
+
+## Migration / Rollout
+
+No data migration required. Operators must recreate/restart `backend` and `snmp-engine` containers for new environment values to be loaded because settings are process-cached.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/exploration.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/exploration.md
@@ -1,0 +1,41 @@
+## Exploration: fix-icmp-latency-threshold-env
+
+### Current State
+`backend/config.py` defines `ICMPSettings.from_env()` with `ICMP_LATENCY_WARNING_MS` defaulting to `100` and `ICMP_LATENCY_CRITICAL_MS` defaulting to `500`. The latency threshold values are used by the queue writer path in `backend/polling/writer_pool.py`, the legacy SNMP/ICMP worker in `backend/engines/snmp_worker.py`, and ICMP sidecar `MetricDef` initialization in `backend/repositories/topology_repo.py`.
+
+The root `.env.example` already documents `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS`, but `docker-compose.yml` only injects `ICMP_TIMEOUT_MS`, `ICMP_RETRIES`, and `ICMP_DEBOUNCE_COUNT` into `snmp-engine`. The `backend` service currently does not receive any ICMP env vars. Because Docker Compose `.env` values are used for interpolation and are not automatically exported into containers, containerized code paths that call `get_icmp_settings()` can fall back to the code defaults unless the variables are listed in a service environment.
+
+### Affected Areas
+- `docker-compose.yml` — must pass `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS` into the service environments that execute ICMP latency threshold logic.
+- `backend/config.py` — source of the current defaults and validation; likely no application-code change is needed.
+- `backend/polling/writer_pool.py` — queue writer emits latency threshold events using `get_icmp_settings()`.
+- `backend/engines/snmp_worker.py` — legacy ICMP polling evaluates latency warning/critical status using `get_icmp_settings()`.
+- `backend/repositories/topology_repo.py` — sidecar MetricDef initialization writes warning/critical properties from `get_icmp_settings()`.
+- `.env.example` — already contains both threshold variables; likely no change needed unless comments are clarified.
+
+### Approaches
+1. **Inject latency thresholds into all runtime services that read ICMP settings** — Add `ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}` and `ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}` to both `backend` and `snmp-engine` service environments.
+   - Pros: Covers both known `get_icmp_settings()` runtime contexts: backend-side initialization/writer code and snmp-engine polling/event code; keeps defaults aligned with `backend/config.py`; minimal and explicit Compose fix.
+   - Cons: Slight duplication across service environment blocks.
+   - Effort: Low
+
+2. **Inject latency thresholds only into `snmp-engine`** — Add the two variables only beside the existing ICMP env vars in the `snmp-engine` service.
+   - Pros: Smallest patch; directly fixes the most likely active polling path.
+   - Cons: Leaves backend code paths that call `get_icmp_settings()` vulnerable to defaults, including sidecar MetricDef initialization if it runs in the backend container and queue writer behavior if enabled there.
+   - Effort: Low
+
+3. **Use a shared env anchor or env_file pattern** — Centralize ICMP env vars and reference them from services.
+   - Pros: Reduces duplication if more ICMP settings are added later.
+   - Cons: Larger Compose refactor for a two-variable bug fix; higher risk of unintended Compose merge/interpolation behavior.
+   - Effort: Medium
+
+### Recommendation
+Use Approach 1: explicitly pass `ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}` and `ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}` to both `backend` and `snmp-engine`. This is the smallest robust fix because every container that can evaluate or initialize ICMP latency thresholds receives the same runtime configuration, while preserving the current code defaults and validation.
+
+### Risks
+- Compose validation should be run after the change because YAML list-style environment entries are easy to misplace.
+- If operators already have containers running, they must recreate/restart affected services for new environment values to take effect.
+- `get_icmp_settings()` is a singleton inside each Python process, so env changes are only picked up on process/container restart.
+
+### Ready for Proposal
+Yes — propose a configuration-only Compose fix that injects the two latency threshold env vars into `backend` and `snmp-engine`, with validation via `docker compose config --quiet` and a targeted check that rendered service environments include the configured values.

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/proposal.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: Fix ICMP Latency Threshold Environment Propagation
+
+## Intent
+
+Containerized ICMP latency evaluation ignores operator-configured warning/critical thresholds because Compose reads `.env` for interpolation but does not export those variables into containers unless listed. This makes alerts fall back to `100/500ms` defaults even when `.env` sets different values.
+
+## Scope
+
+### In Scope
+- Pass `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS` into every Compose service that executes `get_icmp_settings()`.
+- Keep the fix Compose-only unless validation proves Python config parsing is broken.
+- Define minimum evidence: rendered Compose config includes both variables for affected services, and existing Python env parsing tests still pass.
+
+### Out of Scope
+- Changing ICMP threshold defaults or validation rules in Python.
+- Refactoring Compose env management into anchors/shared files.
+- Adding new ICMP latency product behavior beyond honoring existing env vars.
+
+## Capabilities
+
+### New Capabilities
+- `icmp-latency-threshold-env`: Containerized ICMP latency threshold consumers receive operator-configured warning/critical env vars.
+
+### Modified Capabilities
+- None
+
+## Approach
+
+Use a configuration-only fix. Add `ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}` and `ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}` to `backend` and `snmp-engine` in `docker-compose.yml`. This is explicit and low-risk: Python already reads, validates, and caches these env vars; Compose is the missing propagation layer. Do not touch Python unless validation reveals an application defect.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `docker-compose.yml` | Modified | Export latency thresholds to `backend` and `snmp-engine`. |
+| `backend/config.py` | Unchanged | Existing defaults/validation remain source of truth. |
+| `backend/polling/writer_pool.py` | Unchanged | Receives configured thresholds via backend env. |
+| `backend/engines/snmp_worker.py` | Unchanged | Receives configured thresholds via snmp-engine env. |
+| `backend/repositories/topology_repo.py` | Unchanged | Receives configured thresholds via backend env. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Missing a runtime service | Low | Limit to services running backend Python code that imports `get_icmp_settings()`: `backend`, `snmp-engine`. |
+| YAML/env interpolation mistake | Low | Run `docker compose config --quiet` and inspect rendered service env. |
+| Operators expect live reload | Med | Document/rely on container recreation; `get_icmp_settings()` is process-cached. |
+
+## Rollback Plan
+
+Revert the `docker-compose.yml` environment additions and recreate affected containers; behavior returns to existing Python defaults or explicitly injected external env.
+
+## Dependencies
+
+- Docker Compose configuration rendering available for validation.
+
+## Success Criteria
+
+- [ ] `docker compose config --quiet` succeeds.
+- [ ] Rendered `backend` and `snmp-engine` environments contain both ICMP latency threshold variables with configured/default values.
+- [ ] Existing backend ICMP settings tests pass or are documented if not runnable.

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/specs/icmp-latency-threshold-env/spec.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/specs/icmp-latency-threshold-env/spec.md
@@ -1,0 +1,47 @@
+# ICMP Latency Threshold Environment Specification
+
+## Purpose
+
+Ensure containerized ICMP latency threshold consumers receive operator-configured warning and critical latency thresholds instead of silently falling back to application defaults.
+
+## Requirements
+
+### Requirement: Containerized Threshold Propagation
+
+The system MUST provide `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS` to every containerized service that evaluates ICMP latency thresholds.
+
+#### Scenario: Operator-configured thresholds are available in affected containers
+
+- GIVEN an operator configures ICMP latency warning and critical threshold values for the Compose deployment
+- WHEN the affected services are rendered or started
+- THEN each service that evaluates ICMP latency thresholds MUST receive both configured values in its environment
+- AND ICMP latency evaluation MUST use those values through the existing settings contract
+
+#### Scenario: Defaults are propagated when operators omit threshold values
+
+- GIVEN an operator does not configure ICMP latency threshold values for the Compose deployment
+- WHEN the affected services are rendered or started
+- THEN each service that evaluates ICMP latency thresholds MUST receive warning and critical values matching the documented defaults
+- AND behavior MUST remain equivalent to the existing default threshold behavior
+
+#### Scenario: Non-consuming services remain unaffected
+
+- GIVEN a containerized service does not evaluate ICMP latency thresholds
+- WHEN the Compose deployment is rendered
+- THEN the change SHOULD NOT require that service to receive ICMP latency threshold environment variables
+
+### Requirement: Configuration-Only Behavior Preservation
+
+The system MUST preserve existing ICMP latency threshold parsing, validation, defaults, and process-cached behavior.
+
+#### Scenario: Application settings remain the source of validation
+
+- GIVEN ICMP latency threshold environment values are present in affected containers
+- WHEN the application reads ICMP latency settings
+- THEN existing parsing and validation rules MUST apply without changed product semantics
+
+#### Scenario: Invalid threshold values follow existing failure behavior
+
+- GIVEN invalid ICMP latency threshold values are provided to an affected container
+- WHEN the application reads ICMP latency settings
+- THEN the existing invalid-configuration behavior MUST be preserved

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/tasks.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: Fix ICMP Latency Threshold Environment Propagation
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 20-60 |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: pending
+400-line budget risk: Low
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Propagate existing ICMP latency threshold env vars to affected Compose services and verify render behavior | PR 1 | Single config-only fix with evidence; keep tests with the change |
+
+## Phase 1: Baseline Evidence
+
+- [x] 1.1 RED: Render `docker-compose.yml` with configured threshold env values and confirm `backend`/`snmp-engine` currently miss `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS`.
+- [x] 1.2 RED: Render `docker-compose.yml` without threshold env values and confirm affected services do not explicitly receive default `100`/`500` values.
+
+## Phase 2: Compose Propagation
+
+- [x] 2.1 Add `ICMP_LATENCY_WARNING_MS=${ICMP_LATENCY_WARNING_MS:-100}` to `backend.environment` in `docker-compose.yml`.
+- [x] 2.2 Add `ICMP_LATENCY_CRITICAL_MS=${ICMP_LATENCY_CRITICAL_MS:-500}` to `backend.environment` in `docker-compose.yml`.
+- [x] 2.3 Add both ICMP latency threshold variables with matching defaults to `snmp-engine.environment` in `docker-compose.yml`.
+- [x] 2.4 Do not modify `backend/config.py` or ICMP threshold product semantics unless validation reveals an application defect.
+
+## Phase 3: Verification
+
+- [x] 3.1 GREEN: Run `docker compose config --quiet` to validate Compose syntax after the list-style environment edits.
+- [x] 3.2 GREEN: Inspect rendered `docker compose config` with configured env values and verify `backend` and `snmp-engine` receive both configured thresholds.
+- [x] 3.3 GREEN: Inspect rendered `docker compose config` with omitted env values and verify both affected services receive default `100`/`500` thresholds.
+- [x] 3.4 Verify non-consuming services are not required to receive the new variables.
+- [x] 3.5 Run targeted backend ICMP settings tests, e.g. `cd backend && python -m pytest backend/tests/test_snmp_worker.py -k ICMPSettings`, or document why unavailable.
+
+## Phase 4: Cleanup
+
+- [x] 4.1 REFACTOR: Keep the final diff limited to the focused Compose change plus necessary evidence notes.
+- [x] 4.2 Update `openspec/changes/fix-icmp-latency-threshold-env/tasks.md` task checkboxes during apply.

--- a/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/verify-report.md
+++ b/openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/verify-report.md
@@ -1,0 +1,127 @@
+# Verification Report: fix-icmp-latency-threshold-env
+
+## Verdict
+
+**PASS WITH WARNINGS** — implementation, runtime evidence, and Strict TDD evidence now satisfy the OpenSpec change. The only warning is environmental: system Python cannot run pytest here, but the available project `uv` runner passed the required targeted tests.
+
+## Mode
+
+- Artifact store: openspec
+- Verification mode: Strict TDD
+- Change root: `openspec/changes/fix-icmp-latency-threshold-env`
+- Runtime implementation inspected: `docker-compose.yml`
+- TDD evidence inspected: `openspec/changes/fix-icmp-latency-threshold-env/apply-progress.md`
+
+## Completeness
+
+| Area | Result | Evidence |
+|------|--------|----------|
+| Proposal present | ✅ | `proposal.md` read |
+| Spec present | ✅ | `specs/icmp-latency-threshold-env/spec.md` read |
+| Design present | ✅ | `design.md` read |
+| Tasks complete | ✅ | 14/14 checkboxes complete in `tasks.md` |
+| Implementation present | ✅ | `docker-compose.yml` adds both threshold env vars to `backend` and `snmp-engine` |
+| Strict TDD evidence artifact | ✅ | `apply-progress.md` includes `TDD Cycle Evidence` table |
+
+## Build & Tests Execution
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `docker compose config --quiet` | ✅ PASS | Compose rendered successfully; warnings only for unrelated existing unset env vars (`NEO4J_*`, `JWT_SECRET_KEY`, `COOKIE_DOMAIN`). |
+| `ICMP_LATENCY_WARNING_MS=123 ICMP_LATENCY_CRITICAL_MS=456 docker compose config --format json` | ✅ PASS | `backend` and `snmp-engine` receive `123` / `456`; `neo4j`, `postgres`, and `frontend` do not receive the threshold vars. |
+| `env -u ICMP_LATENCY_WARNING_MS -u ICMP_LATENCY_CRITICAL_MS docker compose config --format json` | ✅ PASS | `backend` and `snmp-engine` receive defaults `100` / `500`; non-consuming services remain unaffected. |
+| `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings` | ✅ PASS | 4 passed, 29 deselected in 0.13s. |
+| `python -m pytest backend/tests/test_snmp_worker.py -k ICMPSettings` | ⚠️ ENVIRONMENT FAILURE | `/usr/bin/python: No module named pytest`; not treated as blocking because the provided available runner passed. |
+
+**Coverage**: ➖ Not available/applicable for changed runtime file `docker-compose.yml`.
+
+## Spec Compliance Matrix
+
+| Requirement | Scenario | Test / Evidence | Result |
+|-------------|----------|-----------------|--------|
+| Containerized Threshold Propagation | Operator-configured thresholds are available in affected containers | Compose JSON render with `123` / `456`; `ICMPSettings.from_env` test | ✅ COMPLIANT |
+| Containerized Threshold Propagation | Defaults are propagated when operators omit threshold values | Compose JSON render with env vars unset; defaults test | ✅ COMPLIANT |
+| Containerized Threshold Propagation | Non-consuming services remain unaffected | Compose JSON render shows `neo4j`, `postgres`, and `frontend` without threshold vars | ✅ COMPLIANT |
+| Configuration-Only Behavior Preservation | Application settings remain source of validation | No Python runtime diff; `ICMPSettings.from_env` and validation tests passed | ✅ COMPLIANT |
+| Configuration-Only Behavior Preservation | Invalid threshold values follow existing failure behavior | `test_icmp_latency_thresholds_must_be_ordered` passed | ✅ COMPLIANT |
+
+**Compliance summary**: 5/5 scenarios compliant.
+
+## Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Export thresholds to every containerized ICMP latency evaluator | ✅ Implemented | `backend.environment` and `snmp-engine.environment` contain both `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS`. |
+| Preserve existing parsing, validation, defaults, and process cache | ✅ Implemented | `backend/config.py` was inspected; `ICMPSettings` remains unchanged and tested. |
+| Keep non-consuming services unaffected | ✅ Implemented | Rendered `neo4j`, `postgres`, and `frontend` do not receive the new vars. |
+
+## Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Compose-only fix | ✅ Yes | Runtime diff is limited to four Compose environment entries. |
+| Add vars to `backend` and `snmp-engine` only | ✅ Yes | Both affected services receive configured/default values; non-consumers do not. |
+| Keep `backend/config.py` as settings source | ✅ Yes | No Python behavior changed; targeted settings tests passed. |
+| Avoid Compose anchors/shared env refactor | ✅ Yes | Implementation remained the focused explicit propagation approach. |
+
+## TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress.md` includes a `TDD Cycle Evidence` table. |
+| All tasks have tests/evidence | ✅ | 12/12 TDD evidence rows include a test file, command, render evidence, or artifact evidence. |
+| RED confirmed (tests/evidence exist) | ✅ | Baseline render evidence and selected ICMP settings tests are documented; current test file exists. |
+| GREEN confirmed (tests pass) | ✅ | Compose validation/render checks and `uv run pytest ... -k ICMPSettings` passed during verification. |
+| Triangulation adequate | ✅ | Configured values, default values, unaffected services, parsing, validation, and caching were covered. |
+| Safety Net for modified files | ✅ | Compose syntax/render checks plus existing ICMP settings tests cover the config-only change. |
+
+**TDD Compliance**: 6/6 checks passed.
+
+---
+
+## Test Layer Distribution
+
+| Layer | Tests / Checks | Files | Tools |
+|-------|----------------|-------|-------|
+| Unit | 4 selected tests | `backend/tests/test_snmp_worker.py` | pytest via `uv run` |
+| Integration / config render | 3 render/config checks | `docker-compose.yml` | Docker Compose |
+| E2E | 0 | — | Not required by design |
+| **Total** | **7 checks** | **2 files** | |
+
+---
+
+## Changed File Coverage
+
+Coverage analysis skipped — changed runtime file is `docker-compose.yml`; no applicable line coverage tool detected for Compose configuration.
+
+---
+
+## Assertion Quality
+
+**Assertion quality**: ✅ All audited `TestICMPSettings` assertions verify concrete values, validation behavior, or singleton caching. No tautologies, ghost loops, smoke-only assertions, type-only assertions, or mock-heavy patterns were found in the selected ICMP settings tests.
+
+---
+
+## Quality Metrics
+
+- **Compose validation**: ✅ `docker compose config --quiet` passed.
+- **Linter**: ➖ Not available/applicable for changed Compose-only file.
+- **Type Checker**: ➖ Not applicable; no Python or TypeScript runtime code changed.
+
+## Issues Found
+
+### CRITICAL
+
+- None.
+
+### WARNING
+
+- The configured system-Python pytest command fails in this environment because `/usr/bin/python` lacks pytest. The provided project runner `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings` passed and is the executable verification runner for this change.
+
+### SUGGESTION
+
+- Consider documenting `uv run pytest ...` as the canonical local backend test invocation if this repository intentionally relies on `uv` instead of system Python packages.
+
+## Final Verdict
+
+**PASS WITH WARNINGS** — OpenSpec requirements, design, tasks, Strict TDD evidence, Compose rendering, and targeted ICMP settings tests are compliant; only the non-canonical system Python test environment is unavailable.

--- a/openspec/specs/icmp-latency-threshold-env/spec.md
+++ b/openspec/specs/icmp-latency-threshold-env/spec.md
@@ -1,0 +1,47 @@
+# ICMP Latency Threshold Environment Specification
+
+## Purpose
+
+Ensure containerized ICMP latency threshold consumers receive operator-configured warning and critical latency thresholds instead of silently falling back to application defaults.
+
+## Requirements
+
+### Requirement: Containerized Threshold Propagation
+
+The system MUST provide `ICMP_LATENCY_WARNING_MS` and `ICMP_LATENCY_CRITICAL_MS` to every containerized service that evaluates ICMP latency thresholds.
+
+#### Scenario: Operator-configured thresholds are available in affected containers
+
+- GIVEN an operator configures ICMP latency warning and critical threshold values for the Compose deployment
+- WHEN the affected services are rendered or started
+- THEN each service that evaluates ICMP latency thresholds MUST receive both configured values in its environment
+- AND ICMP latency evaluation MUST use those values through the existing settings contract
+
+#### Scenario: Defaults are propagated when operators omit threshold values
+
+- GIVEN an operator does not configure ICMP latency threshold values for the Compose deployment
+- WHEN the affected services are rendered or started
+- THEN each service that evaluates ICMP latency thresholds MUST receive warning and critical values matching the documented defaults
+- AND behavior MUST remain equivalent to the existing default threshold behavior
+
+#### Scenario: Non-consuming services remain unaffected
+
+- GIVEN a containerized service does not evaluate ICMP latency thresholds
+- WHEN the Compose deployment is rendered
+- THEN the change SHOULD NOT require that service to receive ICMP latency threshold environment variables
+
+### Requirement: Configuration-Only Behavior Preservation
+
+The system MUST preserve existing ICMP latency threshold parsing, validation, defaults, and process-cached behavior.
+
+#### Scenario: Application settings remain the source of validation
+
+- GIVEN ICMP latency threshold environment values are present in affected containers
+- WHEN the application reads ICMP latency settings
+- THEN existing parsing and validation rules MUST apply without changed product semantics
+
+#### Scenario: Invalid threshold values follow existing failure behavior
+
+- GIVEN invalid ICMP latency threshold values are provided to an affected container
+- WHEN the application reads ICMP latency settings
+- THEN the existing invalid-configuration behavior MUST be preserved


### PR DESCRIPTION
## Descripción del Cambio
Closes #342

- Propaga `ICMP_LATENCY_WARNING_MS` y `ICMP_LATENCY_CRITICAL_MS` a `backend` y `snmp-engine` en Docker Compose.
- Mantiene intacta la lógica Python existente de parsing, defaults y validación.
- Incluye el trail OpenSpec archivado y la spec promovida.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `docker-compose.yml` | Adds ICMP latency threshold env vars to `backend` and `snmp-engine`. |
| `openspec/specs/icmp-latency-threshold-env/spec.md` | Promotes the source-of-truth capability spec. |
| `openspec/changes/archive/2026-06-30-fix-icmp-latency-threshold-env/` | Archives SDD artifacts and verification evidence. |

## ¿Cómo se probó?
- [x] `docker compose config --quiet`
- [x] Render configurado con `ICMP_LATENCY_WARNING_MS=123 ICMP_LATENCY_CRITICAL_MS=456`: `backend` y `snmp-engine` reciben `123/456`
- [x] Render default sin variables: `backend` y `snmp-engine` reciben `100/500`
- [x] Servicios no consumidores (`neo4j`, `postgres`, `frontend`) no reciben las variables
- [x] `uv run pytest backend/tests/test_snmp_worker.py -k ICMPSettings` → 4 passed, 29 deselected

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Review Budget
- [x] `size:exception` approved by maintainer: runtime diff is +4 lines; OpenSpec audit trail brings total PR diff above 400 lines.

---
*Generado por Alex*