### PR TITLE
fix(frontend): stabilize DateTimeRangePicker calendar test

### DIFF
--- a/frontend/components/DateTimeRangePicker.test.tsx
+++ b/frontend/components/DateTimeRangePicker.test.tsx
@@ -1,96 +1,99 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import DateTimeRangePicker from "./DateTimeRangePicker";
 
 describe("DateTimeRangePicker", () => {
-	it("opens a calendar and time control from the start button", () => {
-		render(
-			<DateTimeRangePicker
-				startDate=""
-				endDate=""
-				onStartDateChange={vi.fn()}
-				onEndDateChange={vi.fn()}
-				onReset={vi.fn()}
-				availableDays={new Set(["2026-06-01"])}
-			/>,
-		);
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 15, 12, 0, 0));
+  });
 
-		fireEvent.click(
-			screen.getByRole("button", { name: /startchoose start date/i }),
-		);
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
-		expect(screen.getByLabelText("Time")).toBeInTheDocument();
-		expect(
-			screen.getByText("History markers not loaded yet."),
-		).toBeInTheDocument();
-		expect(screen.getByTitle("Metric history available")).toBeInTheDocument();
-	});
+  it("opens a calendar and time control from the start button", () => {
+    render(
+      <DateTimeRangePicker
+        startDate=""
+        endDate=""
+        onStartDateChange={vi.fn()}
+        onEndDateChange={vi.fn()}
+        onReset={vi.fn()}
+        availableDays={new Set(["2026-06-01"])}
+      />,
+    );
 
-	it("notifies when a visible month needs history markers", () => {
-		const onVisibleMonthChange = vi.fn();
-		render(
-			<DateTimeRangePicker
-				startDate="2026-06-10T08:30"
-				endDate=""
-				onStartDateChange={vi.fn()}
-				onEndDateChange={vi.fn()}
-				onReset={vi.fn()}
-				onVisibleMonthChange={onVisibleMonthChange}
-			/>,
-		);
+    fireEvent.click(screen.getByRole("button", { name: /startchoose start date/i }));
 
-		fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    expect(screen.getByLabelText("Time")).toBeInTheDocument();
+    expect(screen.getByText("History markers not loaded yet.")).toBeInTheDocument();
+    expect(screen.getByTitle("Metric history available")).toBeInTheDocument();
+  });
 
-		expect(onVisibleMonthChange).toHaveBeenCalledWith("2026-06");
-	});
+  it("notifies when a visible month needs history markers", () => {
+    const onVisibleMonthChange = vi.fn();
+    render(
+      <DateTimeRangePicker
+        startDate="2026-06-10T08:30"
+        endDate=""
+        onStartDateChange={vi.fn()}
+        onEndDateChange={vi.fn()}
+        onReset={vi.fn()}
+        onVisibleMonthChange={onVisibleMonthChange}
+      />,
+    );
 
-	it("distinguishes loading and confirmed-empty calendar marker states", () => {
-		const { rerender } = render(
-			<DateTimeRangePicker
-				startDate="2026-06-10T08:30"
-				endDate=""
-				onStartDateChange={vi.fn()}
-				onEndDateChange={vi.fn()}
-				onReset={vi.fn()}
-				loadingMonths={new Set(["2026-06"])}
-			/>,
-		);
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
 
-		fireEvent.click(screen.getByRole("button", { name: /start/i }));
-		expect(screen.getByText("Loading history markers…")).toBeInTheDocument();
+    expect(onVisibleMonthChange).toHaveBeenCalledWith("2026-06");
+  });
 
-		rerender(
-			<DateTimeRangePicker
-				startDate="2026-06-10T08:30"
-				endDate=""
-				onStartDateChange={vi.fn()}
-				onEndDateChange={vi.fn()}
-				onReset={vi.fn()}
-				loadedMonths={new Set(["2026-06"])}
-			/>,
-		);
+  it("distinguishes loading and confirmed-empty calendar marker states", () => {
+    const { rerender } = render(
+      <DateTimeRangePicker
+        startDate="2026-06-10T08:30"
+        endDate=""
+        onStartDateChange={vi.fn()}
+        onEndDateChange={vi.fn()}
+        onReset={vi.fn()}
+        loadingMonths={new Set(["2026-06"])}
+      />,
+    );
 
-		expect(
-			screen.getByText("Green days contain confirmed metric history."),
-		).toBeInTheDocument();
-	});
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    expect(screen.getByText("Loading history markers…")).toBeInTheDocument();
 
-	it("updates the selected date while preserving the time", () => {
-		const onStartDateChange = vi.fn();
-		render(
-			<DateTimeRangePicker
-				startDate="2026-06-10T08:30"
-				endDate=""
-				onStartDateChange={onStartDateChange}
-				onEndDateChange={vi.fn()}
-				onReset={vi.fn()}
-				availableDays={new Set(["2026-06-01"])}
-			/>,
-		);
+    rerender(
+      <DateTimeRangePicker
+        startDate="2026-06-10T08:30"
+        endDate=""
+        onStartDateChange={vi.fn()}
+        onEndDateChange={vi.fn()}
+        onReset={vi.fn()}
+        loadedMonths={new Set(["2026-06"])}
+      />,
+    );
 
-		fireEvent.click(screen.getByRole("button", { name: /start/i }));
-		fireEvent.click(screen.getByTitle("Metric history available"));
+    expect(screen.getByText("Green days contain confirmed metric history.")).toBeInTheDocument();
+  });
 
-		expect(onStartDateChange).toHaveBeenCalledWith("2026-06-01T08:30");
-	});
+  it("updates the selected date while preserving the time", () => {
+    const onStartDateChange = vi.fn();
+    render(
+      <DateTimeRangePicker
+        startDate="2026-06-10T08:30"
+        endDate=""
+        onStartDateChange={onStartDateChange}
+        onEndDateChange={vi.fn()}
+        onReset={vi.fn()}
+        availableDays={new Set(["2026-06-01"])}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    fireEvent.click(screen.getByTitle("Metric history available"));
+
+    expect(onStartDateChange).toHaveBeenCalledWith("2026-06-01T08:30");
+  });
 });


### PR DESCRIPTION
Closes #346

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Freezes the DateTimeRangePicker test clock to June 2026 so calendar marker expectations are deterministic.
- Restores real timers after each test to avoid timer leakage.

## Changes

| File | Change |
|------|--------|
| `frontend/components/DateTimeRangePicker.test.tsx` | Adds Vitest fake timer setup/teardown around the calendar tests. |

## Test Plan

- [x] `corepack pnpm exec vitest run components/DateTimeRangePicker.test.tsx`
- [x] `corepack pnpm run lint -- components/DateTimeRangePicker.test.tsx`
- [x] `corepack pnpm run format:check -- components/DateTimeRangePicker.test.tsx`
- [x] `corepack pnpm test:run`

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant checks
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
