### PR TITLE
fix(backend): clear full-suite baseline failures

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -141,7 +141,7 @@ def schedule_daily_backup() -> None:
 
 
 # Router Imports
-from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai, permissions
+from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai, permissions, rtus
 
 app = FastAPI(
     title="NEX-GEN API",
@@ -214,6 +214,7 @@ app.include_router(cis.router, prefix="/api")
 app.include_router(cli.router, prefix="/api")
 app.include_router(ai.router, prefix="/api")
 app.include_router(permissions.router, prefix="/api")
+app.include_router(rtus.router, prefix="/api/v1")
 
 
 @app.exception_handler(Exception)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,20 +1,19 @@
-from fastapi import FastAPI, HTTPException, Query, Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
-import logging
 import asyncio
+import logging
 import os
+import platform
 import re
 import shutil
-import platform
 import threading
-from datetime import datetime, timedelta, timezone
-from database import get_db, verify_connection
+from datetime import UTC, datetime, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
+from database import verify_connection
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 # Configure Logging
 logging.basicConfig(level=logging.INFO)
@@ -96,10 +95,11 @@ def _reload_system_status_env_settings() -> None:
         minimum=60,
     )
 
-from services.snmp_service import snmp_collector_loop, get_collector_status
-from seed_admin import seed_admin
-from seed_roles import seed_roles
-from middleware.rate_limit import RateLimitMiddleware
+
+from middleware.rate_limit import RateLimitMiddleware  # noqa: E402
+from seed_admin import seed_admin  # noqa: E402
+from seed_roles import seed_roles  # noqa: E402
+from services.snmp_service import get_collector_status, snmp_collector_loop  # noqa: E402
 
 # Global scheduler instance
 backup_scheduler = AsyncIOScheduler()
@@ -141,7 +141,24 @@ def schedule_daily_backup() -> None:
 
 
 # Router Imports
-from routers import audit, auth, users, roles, nodes, metrics, catalog, links, events, backup, dictionaries, cis, cli, ai, permissions, rtus
+from routers import (  # noqa: E402
+    ai,
+    audit,
+    auth,
+    backup,
+    catalog,
+    cis,
+    cli,
+    dictionaries,
+    events,
+    links,
+    metrics,
+    nodes,
+    permissions,
+    roles,
+    rtus,
+    users,
+)
 
 app = FastAPI(
     title="NEX-GEN API",
@@ -169,32 +186,82 @@ def _ensure_refresh_token_schema_migration(engine) -> None:
     try:
         with engine.connect() as conn:
             sql = __import__("sqlalchemy").text
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS session_id VARCHAR"))
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS policy_profile VARCHAR DEFAULT 'standard'"))
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMP"))
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS rotated_at TIMESTAMP"))
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS replaced_by_token_id INTEGER REFERENCES refresh_tokens(id)"))
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS revoked_reason VARCHAR"))
-            conn.execute(sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS stale_recovery_count INTEGER DEFAULT 0"))
+            conn.execute(
+                sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS session_id VARCHAR")
+            )
+            conn.execute(
+                sql(
+                    "ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS policy_profile VARCHAR DEFAULT 'standard'"
+                )
+            )
+            conn.execute(
+                sql(
+                    "ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMP"
+                )
+            )
+            conn.execute(
+                sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS rotated_at TIMESTAMP")
+            )
+            conn.execute(
+                sql(
+                    "ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS replaced_by_token_id INTEGER REFERENCES refresh_tokens(id)"
+                )
+            )
+            conn.execute(
+                sql("ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS revoked_reason VARCHAR")
+            )
+            conn.execute(
+                sql(
+                    "ALTER TABLE refresh_tokens ADD COLUMN IF NOT EXISTS stale_recovery_count INTEGER DEFAULT 0"
+                )
+            )
             # Backfill existing rows so runtime non-null assumptions are still safe.
-            conn.execute(sql("UPDATE refresh_tokens SET session_id = COALESCE(session_id, CONCAT('legacy-', id::text)) WHERE session_id IS NULL"))
-            conn.execute(sql("UPDATE refresh_tokens SET policy_profile = COALESCE(policy_profile, 'standard') WHERE policy_profile IS NULL"))
-            conn.execute(sql("UPDATE refresh_tokens SET last_activity_at = COALESCE(last_activity_at, created_at, NOW()) WHERE last_activity_at IS NULL"))
-            conn.execute(sql("UPDATE refresh_tokens SET stale_recovery_count = COALESCE(stale_recovery_count, 0) WHERE stale_recovery_count IS NULL"))
-            conn.execute(sql("CREATE INDEX IF NOT EXISTS ix_refresh_tokens_session_id ON refresh_tokens (session_id)"))
-            conn.execute(sql("CREATE INDEX IF NOT EXISTS ix_refresh_tokens_policy_profile ON refresh_tokens (policy_profile)"))
+            conn.execute(
+                sql(
+                    "UPDATE refresh_tokens SET session_id = COALESCE(session_id, CONCAT('legacy-', id::text)) WHERE session_id IS NULL"
+                )
+            )
+            conn.execute(
+                sql(
+                    "UPDATE refresh_tokens SET policy_profile = COALESCE(policy_profile, 'standard') WHERE policy_profile IS NULL"
+                )
+            )
+            conn.execute(
+                sql(
+                    "UPDATE refresh_tokens SET last_activity_at = COALESCE(last_activity_at, created_at, NOW()) WHERE last_activity_at IS NULL"
+                )
+            )
+            conn.execute(
+                sql(
+                    "UPDATE refresh_tokens SET stale_recovery_count = COALESCE(stale_recovery_count, 0) WHERE stale_recovery_count IS NULL"
+                )
+            )
+            conn.execute(
+                sql(
+                    "CREATE INDEX IF NOT EXISTS ix_refresh_tokens_session_id ON refresh_tokens (session_id)"
+                )
+            )
+            conn.execute(
+                sql(
+                    "CREATE INDEX IF NOT EXISTS ix_refresh_tokens_policy_profile ON refresh_tokens (policy_profile)"
+                )
+            )
             conn.commit()
     except Exception as migration_err:
-        logger.warning(f"Migration warning (refresh_tokens session-policy columns): {migration_err}")
+        logger.warning(
+            f"Migration warning (refresh_tokens session-policy columns): {migration_err}"
+        )
+
+
 """
 ROUTING ARCHITECTURE CONVENTIONS:
 1. Centralized Prefix: All routers are included with the '/api' prefix here in main.py.
 2. No Trailing Slashes: Routes are defined WITHOUT trailing slashes to maintain consistency.
-3. Pragmatic REST for Bulk Ops: 
+3. Pragmatic REST for Bulk Ops:
    - Single resource mutations use standard verbs (GET, POST, PUT, DELETE).
-   - Bulk/Mass operations use POST for compatibility with corporate proxies and firewalls 
+   - Bulk/Mass operations use POST for compatibility with corporate proxies and firewalls
      that often intercept or misinterpret PUT/DELETE on batch endpoints.
-4. Static vs Dynamic Priority: Static routes (like /bulk-update) MUST be registered 
+4. Static vs Dynamic Priority: Static routes (like /bulk-update) MUST be registered
    before dynamic routes (like /{id}) in their respective routers to prevent collisions.
 """
 
@@ -243,13 +310,8 @@ async def startup_event():
 
     # Initialize TimescaleDB Hypertables
     try:
-        from postgres_db import SessionLocal, engine, Base
+        from postgres_db import Base, SessionLocal, engine
         from repositories.metric_repo import create_hypertable
-        from models.timescale_models import MetricValue  # Import to register model
-        from models.audit_event import AuditEvent  # Import to register model
-        from models.rate_limit_attempt import RateLimitAttempt  # Import to register model
-        from models.system_status_history import SystemStatusSnapshot  # Import to register model
-        from models.ai_chat import AIChatMessage  # Import to register model
 
         # Create Tables (includes backup_config, backup_history, rate_limit_attempts, system status history, and audit events)
         Base.metadata.create_all(bind=engine)
@@ -298,12 +360,19 @@ async def startup_event():
         logger.error(f"Failed to seed AI prompts: {e}")
 
     # Start Background SNMP Collector
-    disable_collector = os.getenv("DISABLE_BACKEND_COLLECTOR", "false").lower() in ("true", "1", "yes", "on")
+    disable_collector = os.getenv("DISABLE_BACKEND_COLLECTOR", "false").lower() in (
+        "true",
+        "1",
+        "yes",
+        "on",
+    )
     if not disable_collector:
         asyncio.create_task(snmp_collector_loop())
         logger.info("Background SNMP Collector started in backend process")
     else:
-        logger.info("Background SNMP Collector in backend process is disabled (DISABLE_BACKEND_COLLECTOR=true)")
+        logger.info(
+            "Background SNMP Collector in backend process is disabled (DISABLE_BACKEND_COLLECTOR=true)"
+        )
 
     # Start Backup Scheduler
     schedule_daily_backup()
@@ -359,7 +428,7 @@ def _is_diskstats_device(device_name: str) -> bool:
         return True
     if re.fullmatch(r"nvme\d+n\d+", device_name):
         return True
-    if re.fullmatch(r"mmcblk\d+", device_name):
+    if re.fullmatch(r"mmcblk\d+", device_name):  # noqa: SIM103
         return True
     return False
 
@@ -371,7 +440,7 @@ def _collect_disk_io_sample(path: str = "/proc/diskstats", sampled_at: datetime 
     busy_ms = 0
 
     try:
-        with open(path, "r", encoding="utf-8") as diskstats:
+        with open(path, encoding="utf-8") as diskstats:
             lines = diskstats.readlines()
     except OSError:
         return None
@@ -444,9 +513,7 @@ def _build_disk_io_status(current, previous=None):
 
     status["read_bytes_per_sec"] = round(read_delta / elapsed_seconds, 2)
     status["write_bytes_per_sec"] = round(write_delta / elapsed_seconds, 2)
-    status["busy_percentage"] = round(
-        min((busy_delta / (elapsed_seconds * 1000)) * 100, 100), 1
-    )
+    status["busy_percentage"] = round(min((busy_delta / (elapsed_seconds * 1000)) * 100, 100), 1)
     return status
 
 
@@ -526,8 +593,8 @@ def _build_system_status_snapshot(status: dict, recorded_at: datetime):
 def _utc_isoformat(value: datetime) -> str:
     """Serialize stored UTC datetimes with an explicit timezone marker for clients."""
     if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _serialize_system_status_snapshot(snapshot):
@@ -571,25 +638,25 @@ def _build_system_status_payload() -> dict:
             load = os.getloadavg()
             # Approximation: Load / Cores * 100 (Simplified)
             cpu_percent = min((load[0] / os.cpu_count()) * 100, 100)
-    except:
+    except Exception:
         pass
 
     try:
         # Disk Usage
         total, used, free = shutil.disk_usage("/")
         disk_percent = (used / total) * 100
-    except:
+    except Exception:
         pass
 
     # RAM (Linux /proc/meminfo parsing)
     if platform.system() == "Linux":
         try:
-            with open("/proc/meminfo", "r") as f:
+            with open("/proc/meminfo") as f:
                 lines = f.readlines()
                 mem_total = int(lines[0].split()[1])
                 mem_available = int(lines[2].split()[1])  # MemAvailable usually
                 ram_percent = ((mem_total - mem_available) / mem_total) * 100
-        except:
+        except Exception:
             pass
 
     # 2. Service Status
@@ -597,17 +664,18 @@ def _build_system_status_payload() -> dict:
     try:
         verify_connection(max_retries=1, retry_delay=0)
         neo4j_status = "CONNECTED"
-    except:
+    except Exception:
         neo4j_status = "DISCONNECTED"
 
     postgres_status = "UNKNOWN"
     try:
         from postgres_db import engine
         from sqlalchemy import text
+
         with engine.connect() as conn:
             conn.execute(text("SELECT 1"))
         postgres_status = "CONNECTED"
-    except:
+    except Exception:
         postgres_status = "DISCONNECTED"
 
     collector = get_collector_status()
@@ -656,12 +724,12 @@ def _register_system_status_snapshot_job() -> bool:
 
 def _record_system_status_snapshot(status: dict, now: datetime | None = None) -> bool:
     """Persist a throttled operational snapshot and prune data older than configured retention."""
-    from postgres_db import SessionLocal
     from models.system_status_history import SystemStatusSnapshot
+    from postgres_db import SessionLocal
 
-    recorded_at = now or datetime.now(timezone.utc).replace(tzinfo=None)
+    recorded_at = now or datetime.now(UTC).replace(tzinfo=None)
     if recorded_at.tzinfo is not None:
-        recorded_at = recorded_at.astimezone(timezone.utc).replace(tzinfo=None)
+        recorded_at = recorded_at.astimezone(UTC).replace(tzinfo=None)
     with _SYSTEM_STATUS_HISTORY_LOCK:
         db = SessionLocal()
         try:
@@ -675,9 +743,9 @@ def _record_system_status_snapshot(status: dict, now: datetime | None = None) ->
 
             db.add(_build_system_status_snapshot(status, recorded_at))
             cutoff = recorded_at - timedelta(days=_SYSTEM_STATUS_HISTORY_RETENTION_DAYS)
-            db.query(SystemStatusSnapshot).filter(
-                SystemStatusSnapshot.recorded_at < cutoff
-            ).delete(synchronize_session=False)
+            db.query(SystemStatusSnapshot).filter(SystemStatusSnapshot.recorded_at < cutoff).delete(
+                synchronize_session=False
+            )
             db.commit()
             return True
         except Exception as exc:
@@ -690,12 +758,12 @@ def _record_system_status_snapshot(status: dict, now: datetime | None = None) ->
 
 def _fetch_system_status_history(hours: int, limit: int, now: datetime | None = None):
     """Read compact system status history rows newest-first."""
-    from postgres_db import SessionLocal
     from models.system_status_history import SystemStatusSnapshot
+    from postgres_db import SessionLocal
 
-    generated_at = now or datetime.now(timezone.utc).replace(tzinfo=None)
+    generated_at = now or datetime.now(UTC).replace(tzinfo=None)
     if generated_at.tzinfo is not None:
-        generated_at = generated_at.astimezone(timezone.utc).replace(tzinfo=None)
+        generated_at = generated_at.astimezone(UTC).replace(tzinfo=None)
     cutoff = generated_at - timedelta(hours=hours)
     db = SessionLocal()
     try:
@@ -719,7 +787,9 @@ def _fetch_system_status_history(hours: int, limit: int, now: datetime | None = 
             "retention_days": _SYSTEM_STATUS_HISTORY_RETENTION_DAYS,
             "snapshot_interval_seconds": _SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS,
             "stale_threshold_seconds": _SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS,
-            "latest_recorded_at": _utc_isoformat(latest_recorded_at) if latest_recorded_at else None,
+            "latest_recorded_at": (
+                _utc_isoformat(latest_recorded_at) if latest_recorded_at else None
+            ),
             "is_stale": is_stale,
             "rows": [_serialize_system_status_snapshot(row) for row in snapshots],
         }

--- a/backend/repositories/rtu_sensor_repo.py
+++ b/backend/repositories/rtu_sensor_repo.py
@@ -21,6 +21,23 @@ _MODBUS_REGISTER_COUNT_MIN = 1
 _MODBUS_REGISTER_COUNT_MAX = 4
 
 
+def _record_to_dict(record) -> Dict[str, Any]:
+    """Convert Neo4j records and lightweight test doubles to plain dictionaries."""
+    if hasattr(record, "data"):
+        out = record.data()
+    elif hasattr(record, "keys"):
+        out = {key: record[key] for key in record.keys()}
+    elif hasattr(record, "_data"):
+        out = dict(record._data)
+    else:
+        out = dict(record)
+
+    for key, value in out.items():
+        if hasattr(value, "isoformat"):
+            out[key] = value.isoformat()
+    return out
+
+
 def _validate_register_bounds(register_addr: int, register_count: int) -> None:
     """Validate Modbus register address and count against spec limits.
 
@@ -124,12 +141,7 @@ def get_rtu(tx, rtu_id: str) -> Optional[Dict[str, Any]]:
     record = result.single()
     if record is None:
         return None
-    # Serialize datetime objects
-    out = dict(record)
-    for key, value in out.items():
-        if hasattr(value, "isoformat"):
-            out[key] = value.isoformat()
-    return out
+    return _record_to_dict(record)
 
 
 def list_rtus(tx, location_id: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -177,11 +189,7 @@ def list_rtus(tx, location_id: Optional[str] = None) -> List[Dict[str, Any]]:
 
     rtus = []
     for record in result:
-        out = dict(record)
-        for key, value in out.items():
-            if hasattr(value, "isoformat"):
-                out[key] = value.isoformat()
-        rtus.append(out)
+        rtus.append(_record_to_dict(record))
     return rtus
 
 
@@ -325,11 +333,7 @@ def get_sensor(tx, sensor_id: str) -> Optional[Dict[str, Any]]:
     record = result.single()
     if record is None:
         return None
-    out = dict(record)
-    for key, value in out.items():
-        if hasattr(value, "isoformat"):
-            out[key] = value.isoformat()
-    return out
+    return _record_to_dict(record)
 
 
 def list_sensors(tx, rtu_id: str) -> List[Dict[str, Any]]:
@@ -354,11 +358,7 @@ def list_sensors(tx, rtu_id: str) -> List[Dict[str, Any]]:
     result = tx.run(cypher, rtu_id=rtu_id)
     sensors = []
     for record in result:
-        out = dict(record)
-        for key, value in out.items():
-            if hasattr(value, "isoformat"):
-                out[key] = value.isoformat()
-        sensors.append(out)
+        sensors.append(_record_to_dict(record))
     return sensors
 
 
@@ -423,11 +423,7 @@ def find_sensor_by_key(
     record = result.single()
     if record is None:
         return None
-    out = dict(record)
-    for key, value in out.items():
-        if hasattr(value, "isoformat"):
-            out[key] = value.isoformat()
-    return out
+    return _record_to_dict(record)
 
 
 def delete_sensor(tx, rtu_id: str, sensor_id: str) -> bool:

--- a/backend/repositories/rtu_sensor_repo.py
+++ b/backend/repositories/rtu_sensor_repo.py
@@ -7,11 +7,7 @@ Implements the data access pattern following `topology_repo.py` conventions:
 - Validates Modbus register bounds before any write
 """
 
-from datetime import datetime
-from typing import Dict, List, Optional, Any
-from uuid import uuid4
-
-from database import get_db
+from typing import Any
 
 # ── Modbus bounds ─────────────────────────────────────────────────────────────
 
@@ -21,12 +17,12 @@ _MODBUS_REGISTER_COUNT_MIN = 1
 _MODBUS_REGISTER_COUNT_MAX = 4
 
 
-def _record_to_dict(record) -> Dict[str, Any]:
+def _record_to_dict(record) -> dict[str, Any]:
     """Convert Neo4j records and lightweight test doubles to plain dictionaries."""
     if hasattr(record, "data"):
         out = record.data()
     elif hasattr(record, "keys"):
-        out = {key: record[key] for key in record.keys()}
+        out = {key: record[key] for key in record.keys()}  # noqa: SIM118
     elif hasattr(record, "_data"):
         out = dict(record._data)
     else:
@@ -72,9 +68,9 @@ def upsert_rtu(
     location_id: str,
     mqtt_topic: str,
     name: str,
-    ip: Optional[str],
+    ip: str | None,
     status: str,
-    mqtt_config: Optional[Dict[str, Any]],
+    mqtt_config: dict[str, Any] | None,
 ) -> None:
     """Upsert an RTU node with LOCATED_AT relationship to Location.
 
@@ -117,7 +113,7 @@ def upsert_rtu(
     )
 
 
-def get_rtu(tx, rtu_id: str) -> Optional[Dict[str, Any]]:
+def get_rtu(tx, rtu_id: str) -> dict[str, Any] | None:
     """Fetch a single RTU node by id.
 
     Returns:
@@ -144,7 +140,7 @@ def get_rtu(tx, rtu_id: str) -> Optional[Dict[str, Any]]:
     return _record_to_dict(record)
 
 
-def list_rtus(tx, location_id: Optional[str] = None) -> List[Dict[str, Any]]:
+def list_rtus(tx, location_id: str | None = None) -> list[dict[str, Any]]:
     """List all RTU nodes, optionally filtered by location_id.
 
     Args:
@@ -196,10 +192,10 @@ def list_rtus(tx, location_id: Optional[str] = None) -> List[Dict[str, Any]]:
 def update_rtu(
     tx,
     rtu_id: str,
-    name: Optional[str] = None,
-    ip: Optional[str] = None,
-    status: Optional[str] = None,
-    mqtt_config: Optional[Dict[str, Any]] = None,
+    name: str | None = None,
+    ip: str | None = None,
+    status: str | None = None,
+    mqtt_config: dict[str, Any] | None = None,
 ) -> bool:
     """Update RTU properties. Only non-None fields are written.
 
@@ -207,7 +203,7 @@ def update_rtu(
         True if RTU was found and updated, False if not found.
     """
     set_clauses = ["r.updated_at = datetime()"]
-    params: Dict[str, Any] = {"rtu_id": rtu_id}
+    params: dict[str, Any] = {"rtu_id": rtu_id}
 
     if name is not None:
         set_clauses.append("r.name = $name")
@@ -260,7 +256,7 @@ def upsert_sensor(
     register_addr: int,
     register_count: int,
     name: str,
-    unit: Optional[str],
+    unit: str | None,
     sensor_type: str,
 ) -> None:
     """Upsert a Sensor node with HAS_SENSOR relationship to parent RTU.
@@ -311,7 +307,7 @@ def upsert_sensor(
     )
 
 
-def get_sensor(tx, sensor_id: str) -> Optional[Dict[str, Any]]:
+def get_sensor(tx, sensor_id: str) -> dict[str, Any] | None:
     """Fetch a single Sensor node by id.
 
     Returns:
@@ -336,7 +332,7 @@ def get_sensor(tx, sensor_id: str) -> Optional[Dict[str, Any]]:
     return _record_to_dict(record)
 
 
-def list_sensors(tx, rtu_id: str) -> List[Dict[str, Any]]:
+def list_sensors(tx, rtu_id: str) -> list[dict[str, Any]]:
     """List all Sensor nodes for a given RTU.
 
     Returns:
@@ -366,8 +362,8 @@ def update_sensor(
     tx,
     rtu_id: str,
     sensor_id: str,
-    name: Optional[str] = None,
-    unit: Optional[str] = None,
+    name: str | None = None,
+    unit: str | None = None,
 ) -> bool:
     """Update Sensor properties. Only non-None fields are written.
 
@@ -375,7 +371,7 @@ def update_sensor(
         True if Sensor was found and updated, False if not found.
     """
     set_clauses = ["s.updated_at = datetime()"]
-    params: Dict[str, Any] = {"rtu_id": rtu_id, "sensor_id": sensor_id}
+    params: dict[str, Any] = {"rtu_id": rtu_id, "sensor_id": sensor_id}
 
     if name is not None:
         set_clauses.append("s.name = $name")
@@ -401,7 +397,7 @@ def find_sensor_by_key(
     rtu_id: str,
     register_addr: int,
     sensor_type: str,
-) -> Optional[Dict[str, Any]]:
+) -> dict[str, Any] | None:
     """Find a Sensor node by its composite key (rtu_id, register_addr, sensor_type).
 
     Returns:

--- a/backend/routers/cis.py
+++ b/backend/routers/cis.py
@@ -2,13 +2,14 @@
 CI Dictionary Exclusion Router — Per-CI exclusion endpoints.
 Handles AppliedDictionary customization at CI level.
 """
-from fastapi import APIRouter, Depends, HTTPException, status
-from typing import List, Dict, Any, Optional
-from pydantic import BaseModel
 
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from models.user import User
+from pydantic import BaseModel
 from services import dictionary_service
 from services.auth_service import get_current_active_user
-from models.user import User, UserPermission
 
 router = APIRouter(
     prefix="/cis",
@@ -32,8 +33,8 @@ def _require_editor(current_user: User):
 
 
 class ExclusionUpdateRequest(BaseModel):
-    excluded_metrics: Optional[List[str]] = None
-    extra_metrics: Optional[List[str]] = None
+    excluded_metrics: list[str] | None = None
+    extra_metrics: list[str] | None = None
 
 
 class AppliedDictionaryResponse(BaseModel):
@@ -41,16 +42,16 @@ class AppliedDictionaryResponse(BaseModel):
     dictionary_name: str
     dictionary_brand: str
     dictionary_model: str
-    dictionary_metric_ids: List[str]
-    excluded_metrics: List[str]
-    extra_metrics: List[str]
-    applied_at: Optional[str]
+    dictionary_metric_ids: list[str]
+    excluded_metrics: list[str]
+    extra_metrics: list[str]
+    applied_at: str | None
 
 
-@router.get("/{ci_id}/applied-dictionary", response_model=Optional[Dict[str, Any]])
+@router.get("/{ci_id}/applied-dictionary", response_model=Optional[dict[str, Any]])  # noqa: UP045
 async def get_applied_dictionary(
     ci_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     Get the AppliedDictionary for a CI with full details.
@@ -73,11 +74,11 @@ async def get_applied_dictionary(
     return result
 
 
-@router.put("/{ci_id}/dictionary-exclusions", response_model=Dict[str, Any])
+@router.put("/{ci_id}/dictionary-exclusions", response_model=dict[str, Any])
 async def update_dictionary_exclusions(
     ci_id: str,
     body: ExclusionUpdateRequest,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     Update excluded_metrics and/or extra_metrics for a CI's AppliedDictionary.
@@ -97,16 +98,18 @@ async def update_dictionary_exclusions(
     except ValueError as e:
         err_str = str(e)
         if "No AppliedDictionary found" in err_str:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_str)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=err_str)  # noqa: B904
         if "Invalid extra_metric_ids" in err_str:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=err_str)
-        raise HTTPException(status_code=status.HTTP_400, detail=err_str)
+            raise HTTPException(  # noqa: B904
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=err_str
+            )
+        raise HTTPException(status_code=status.HTTP_400, detail=err_str)  # noqa: B904
 
 
 @router.delete("/{ci_id}/applied-dictionary")
 async def remove_applied_dictionary(
     ci_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     Remove the AppliedDictionary from a CI (un-apply dictionary).

--- a/backend/routers/cis.py
+++ b/backend/routers/cis.py
@@ -67,7 +67,7 @@ async def get_applied_dictionary(
     result = dictionary_service.get_applied_dictionary(ci_id)
     if not result:
         raise HTTPException(
-            code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No dictionary applied to CI '{ci_id}'",
         )
     return result

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any, Optional
 from pydantic import BaseModel
 import services.event_service as event_service
 from services.auth_service import get_current_active_user, check_permission, get_current_ai_agent, AIAgentInfo
-from services.ai_guard_service import check_all_guards, record_operation
+from services.ai_guard_service import check_all_guards, record_operation, set_cooldown
 from services.escalation_notifier import notify_critical_event_escalation
 from models.core import (
     AvailabilityReportResponse,
@@ -14,7 +14,7 @@ from models.core import (
     EventDetailResponse,
     EventFeedSummary,
 )
-from models.user import User, UserPermission
+from models.user import AIPermission, User, UserPermission
 
 router = APIRouter(
     prefix="/events",
@@ -34,6 +34,14 @@ class AckRequest(BaseModel):
 class CloseRequest(BaseModel):
     forced: bool = False
     comment_message: Optional[str] = None
+
+
+def _is_ai_agent(current_user: User) -> bool:
+    return bool(current_user.role and str(current_user.role).startswith("AI_"))
+
+
+def _has_ai_permission(permission: AIPermission, current_user: User) -> bool:
+    return permission.value in current_user.permissions
 
 
 @router.get("", response_model=List[EventFeedSummary])
@@ -104,20 +112,21 @@ async def ack_event(
     """
     Acknowledge an Event.
     """
-    if not check_permission(UserPermission.EVENT_ACK, current_user):
+    is_ai_agent = _is_ai_agent(current_user)
+    if is_ai_agent:
+        if not _has_ai_permission(AIPermission.AI_EVENT_ACK, current_user):
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to acknowledge events",
+            )
+    elif not check_permission(UserPermission.EVENT_ACK, current_user):
         raise HTTPException(
             status_code=403, detail="Not authorized to acknowledge events"
         )
 
     # AI agent guard check
     ai_info = None
-    if current_user.role and str(current_user.role).startswith("AI_"):
-        # Extract AI agent info from JWT
-        from services.auth_service import SECRET_KEY, ALGORITHM
-        from jose import jwt
-        from fastapi.security import OAuth2PasswordBearer
-        oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/auth/token")
-        # Get token from request context is complex; use role-based check instead
+    if is_ai_agent:
         # The check_all_guards function needs ai_agent_id - use username as id
         guard_result = check_all_guards(current_user.username, "ack", [event_id])
         if not guard_result.allowed:
@@ -156,8 +165,17 @@ async def close_event(
     If forced=True, the caller must also hold EVENT_FORCED_CLOSE permission.
     AI agents cannot force-close events.
     """
-    if not check_permission(UserPermission.EVENT_CLOSE, current_user):
+    is_ai_agent = _is_ai_agent(current_user)
+    if is_ai_agent:
+        if not _has_ai_permission(AIPermission.AI_EVENT_CLOSE, current_user):
+            raise HTTPException(status_code=403, detail="Not authorized to close events")
+    elif not check_permission(UserPermission.EVENT_CLOSE, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to close events")
+    if close_req.forced and is_ai_agent:
+        raise HTTPException(
+            status_code=403,
+            detail="AI agents cannot force-close events",
+        )
     if close_req.forced and not check_permission(
         UserPermission.EVENT_FORCED_CLOSE, current_user
     ):
@@ -165,15 +183,10 @@ async def close_event(
             status_code=403,
             detail="Not authorized to force-close events (EVENT_FORCED_CLOSE required)",
         )
-    if close_req.forced and current_user.role and str(current_user.role).startswith("AI_"):
-        raise HTTPException(
-            status_code=403,
-            detail="AI agents cannot force-close events",
-        )
 
     # AI agent guard check
     ai_info = None
-    if current_user.role and str(current_user.role).startswith("AI_"):
+    if is_ai_agent:
         guard_result = check_all_guards(current_user.username, "close", [event_id])
         if not guard_result.allowed:
             raise HTTPException(status_code=403, detail=guard_result.reason)
@@ -208,7 +221,6 @@ async def close_event(
         )
         # C1 fix: still close the event (flagged as pending human review per spec)
         # C1 fix: set cooldown for CRITICAL events too
-        from services.ai_guard_service import set_cooldown
         set_cooldown(current_user.username, "close", event_id)
 
     result = event_service.close_event(
@@ -242,7 +254,13 @@ async def add_event_comment(
     """
     Append a user comment to the Event history.
     """
-    if not check_permission(UserPermission.EVENT_ACK, current_user):
+    is_ai_agent = _is_ai_agent(current_user)
+    if is_ai_agent:
+        authorized = _has_ai_permission(AIPermission.AI_EVENT_COMMENT, current_user)
+    else:
+        authorized = check_permission(UserPermission.EVENT_ACK, current_user)
+
+    if not authorized:
         raise HTTPException(
             status_code=403, detail="Not authorized to comment on events"
         )
@@ -367,12 +385,16 @@ async def run_event_diagnostic_endpoint(
     """
     Run an on-demand diagnostic (Ping/SNMP) for the CI related to this event.
     """
-    if not check_permission(UserPermission.RUN_DIAGNOSTICS, current_user):
+    is_ai_agent = _is_ai_agent(current_user)
+    if is_ai_agent:
+        if not _has_ai_permission(AIPermission.AI_RUN_DIAGNOSTIC, current_user):
+            raise HTTPException(status_code=403, detail="Not authorized to run diagnostics")
+    elif not check_permission(UserPermission.RUN_DIAGNOSTICS, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to run diagnostics")
 
     # AI agent guard check
     ai_info = None
-    if current_user.role and str(current_user.role).startswith("AI_"):
+    if is_ai_agent:
         guard_result = check_all_guards(current_user.username, "diagnose", [event_id])
         if not guard_result.allowed:
             raise HTTPException(status_code=403, detail=guard_result.reason)

--- a/backend/routers/events.py
+++ b/backend/routers/events.py
@@ -1,13 +1,9 @@
 from datetime import datetime
+from typing import Any
 
+import services.event_service as event_service
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
-from typing import List, Dict, Any, Optional
-from pydantic import BaseModel
-import services.event_service as event_service
-from services.auth_service import get_current_active_user, check_permission, get_current_ai_agent, AIAgentInfo
-from services.ai_guard_service import check_all_guards, record_operation, set_cooldown
-from services.escalation_notifier import notify_critical_event_escalation
 from models.core import (
     AvailabilityReportResponse,
     AvailabilitySnmpNoResponseResponse,
@@ -15,6 +11,13 @@ from models.core import (
     EventFeedSummary,
 )
 from models.user import AIPermission, User, UserPermission
+from pydantic import BaseModel
+from services.ai_guard_service import check_all_guards, record_operation, set_cooldown
+from services.auth_service import (
+    check_permission,
+    get_current_active_user,
+)
+from services.escalation_notifier import notify_critical_event_escalation
 
 router = APIRouter(
     prefix="/events",
@@ -28,12 +31,12 @@ class EventComment(BaseModel):
 
 
 class AckRequest(BaseModel):
-    comment_message: Optional[str] = None
+    comment_message: str | None = None
 
 
 class CloseRequest(BaseModel):
     forced: bool = False
-    comment_message: Optional[str] = None
+    comment_message: str | None = None
 
 
 def _is_ai_agent(current_user: User) -> bool:
@@ -44,8 +47,8 @@ def _has_ai_permission(permission: AIPermission, current_user: User) -> bool:
     return permission.value in current_user.permissions
 
 
-@router.get("", response_model=List[EventFeedSummary])
-async def get_events(status: Optional[str] = None):
+@router.get("", response_model=list[EventFeedSummary])
+async def get_events(status: str | None = None):
     """
     Fetch system events filtered by status.
     Args:
@@ -56,8 +59,8 @@ async def get_events(status: Optional[str] = None):
 
 @router.get("/availability-report", response_model=AvailabilityReportResponse)
 async def get_availability_report(
-    start: Optional[datetime] = Query(None, description="Inclusive report window start"),
-    end: Optional[datetime] = Query(None, description="Inclusive report window end"),
+    start: datetime | None = Query(None, description="Inclusive report window start"),  # noqa: B008
+    end: datetime | None = Query(None, description="Inclusive report window end"),  # noqa: B008
 ):
     """Fetch additive availability MTTR/MTBF metrics for the event dashboard."""
     return event_service.get_availability_report(start=start, end=end)
@@ -70,7 +73,7 @@ async def get_availability_report(
 async def get_availability_snmp_no_response(
     limit: int = Query(25, ge=1, le=100, description="Maximum affected CIs to return"),
     offset: int = Query(0, ge=0, description="Affected CI pagination offset"),
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """Fetch affected CIs with active SNMP no-response collection failures."""
     if not check_permission(UserPermission.EVENT_VIEW, current_user):
@@ -83,7 +86,7 @@ async def get_availability_snmp_no_response(
 
 @router.get("/{event_id}", response_model=EventDetailResponse)
 async def get_event_detail(
-    event_id: str, current_user: User = Depends(get_current_active_user)
+    event_id: str, current_user: User = Depends(get_current_active_user)  # noqa: B008
 ):
     """Fetch modal-specific event detail without bloating the summary feed."""
     if not check_permission(UserPermission.EVENT_VIEW, current_user):
@@ -91,9 +94,9 @@ async def get_event_detail(
     return event_service.get_event_detail(event_id)
 
 
-@router.get("/related/{ci_id}", response_model=List[Dict[str, Any]])
+@router.get("/related/{ci_id}", response_model=list[dict[str, Any]])
 async def get_related_events(
-    ci_id: str, current_user: User = Depends(get_current_active_user)
+    ci_id: str, current_user: User = Depends(get_current_active_user)  # noqa: B008
 ):
     """
     Fetch all ACTIVE (OPEN, ACK) events for a specific CI.
@@ -106,12 +109,13 @@ async def get_related_events(
 @router.post("/{event_id}/ack")
 async def ack_event(
     event_id: str,
-    ack_req: AckRequest = AckRequest(),
-    current_user: User = Depends(get_current_active_user),
+    ack_req: AckRequest | None = None,
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     Acknowledge an Event.
     """
+    ack_req = ack_req or AckRequest()
     is_ai_agent = _is_ai_agent(current_user)
     if is_ai_agent:
         if not _has_ai_permission(AIPermission.AI_EVENT_ACK, current_user):
@@ -120,9 +124,7 @@ async def ack_event(
                 detail="Not authorized to acknowledge events",
             )
     elif not check_permission(UserPermission.EVENT_ACK, current_user):
-        raise HTTPException(
-            status_code=403, detail="Not authorized to acknowledge events"
-        )
+        raise HTTPException(status_code=403, detail="Not authorized to acknowledge events")
 
     # AI agent guard check
     ai_info = None
@@ -157,14 +159,15 @@ async def ack_event(
 @router.post("/{event_id}/close")
 async def close_event(
     event_id: str,
-    close_req: CloseRequest = CloseRequest(),
-    current_user: User = Depends(get_current_active_user),
+    close_req: CloseRequest | None = None,
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     Close an Event manually.
     If forced=True, the caller must also hold EVENT_FORCED_CLOSE permission.
     AI agents cannot force-close events.
     """
+    close_req = close_req or CloseRequest()
     is_ai_agent = _is_ai_agent(current_user)
     if is_ai_agent:
         if not _has_ai_permission(AIPermission.AI_EVENT_CLOSE, current_user):
@@ -176,9 +179,7 @@ async def close_event(
             status_code=403,
             detail="AI agents cannot force-close events",
         )
-    if close_req.forced and not check_permission(
-        UserPermission.EVENT_FORCED_CLOSE, current_user
-    ):
+    if close_req.forced and not check_permission(UserPermission.EVENT_FORCED_CLOSE, current_user):
         raise HTTPException(
             status_code=403,
             detail="Not authorized to force-close events (EVENT_FORCED_CLOSE required)",
@@ -249,7 +250,7 @@ async def close_event(
 async def add_event_comment(
     event_id: str,
     comment: EventComment,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     Append a user comment to the Event history.
@@ -261,16 +262,14 @@ async def add_event_comment(
         authorized = check_permission(UserPermission.EVENT_ACK, current_user)
 
     if not authorized:
-        raise HTTPException(
-            status_code=403, detail="Not authorized to comment on events"
-        )
-    return event_service.add_event_comment(
-        event_id, current_user.username, comment.message
-    )
+        raise HTTPException(status_code=403, detail="Not authorized to comment on events")
+    return event_service.add_event_comment(event_id, current_user.username, comment.message)
 
 
 @router.post("/prune")
-async def prune_recovered_events(current_user: User = Depends(get_current_active_user)):
+async def prune_recovered_events(
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+):
     """
     Bulk Close all 'RECOVERED' events (sync version).
     """
@@ -281,8 +280,8 @@ async def prune_recovered_events(current_user: User = Depends(get_current_active
 
 async def _sse_event_generator(
     user: str,
-    batch_size: Optional[int] = None,
-    last_event_id: Optional[str] = None,
+    batch_size: int | None = None,
+    last_event_id: str | None = None,
 ):
     """
     Async generator that yields SSE-formatted progress events.
@@ -295,6 +294,7 @@ async def _sse_event_generator(
     Generator releases lock when stream ends (client disconnect or completion).
     """
     import json
+
     try:
         async for progress in event_service.event_batch_pruner(
             user=user,
@@ -307,13 +307,14 @@ async def _sse_event_generator(
         # WARNING #4 fix: explicit cleanup when client disconnects
         # Release distributed lock when SSE stream ends
         from services.event_service import release_prune_lock
+
         release_prune_lock(owner=user)
 
 
 @router.get("/bulk/stream-progress")
 async def stream_prune_progress(
     request: Request,
-    current_user: User = Depends(get_current_active_user),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
 ):
     """
     SSE endpoint that streams batch pruning progress in real-time.
@@ -332,6 +333,7 @@ async def stream_prune_progress(
 
     # Check distributed lock BEFORE starting SSE stream
     from services.event_service import acquire_prune_lock
+
     if not acquire_prune_lock(owner=current_user.username, ttl_seconds=300):
         raise HTTPException(
             status_code=409,
@@ -340,7 +342,7 @@ async def stream_prune_progress(
 
     # WARNING #6 fix: validate batch_size is a positive integer, cap at max 10000
     batch_size_str = request.query_params.get("batch_size")
-    batch_size: Optional[int] = None
+    batch_size: int | None = None
     if batch_size_str:
         try:
             batch_size = int(batch_size_str)
@@ -355,7 +357,7 @@ async def stream_prune_progress(
                     detail="batch_size must not exceed 10000",
                 )
         except ValueError:
-            raise HTTPException(
+            raise HTTPException(  # noqa: B904
                 status_code=400,
                 detail="batch_size must be a valid integer",
             )
@@ -380,7 +382,7 @@ async def stream_prune_progress(
 
 @router.post("/{event_id}/diagnose")
 async def run_event_diagnostic_endpoint(
-    event_id: str, current_user: User = Depends(get_current_active_user)
+    event_id: str, current_user: User = Depends(get_current_active_user)  # noqa: B008
 ):
     """
     Run an on-demand diagnostic (Ping/SNMP) for the CI related to this event.

--- a/backend/routers/rtus.py
+++ b/backend/routers/rtus.py
@@ -5,21 +5,19 @@ Router prefix: /api/v1 (applied in main.py)
 Tags: ["RTUs"]
 """
 
-from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, ValidationError
-
 from models.rtu_sensor import (
     RTUCreate,
-    RTUUpdate,
     RTUResponse,
+    RTUUpdate,
     SensorCreate,
-    SensorUpdate,
     SensorResponse,
+    SensorUpdate,
 )
 from models.user import User, UserPermission
+from pydantic import BaseModel
 from services.auth_service import check_permission, get_current_active_user
 from services.rtu_service import RTUService
 
@@ -55,7 +53,7 @@ def _require_permission(permission: UserPermission, current_user: User) -> None:
 class ErrorDetail(BaseModel):
     error: str
     message: str
-    details: Optional[List[dict]] = None
+    details: list[dict] | None = None
 
 
 class SensorCreateInternal(SensorCreate):
@@ -69,15 +67,15 @@ class SensorCreateInternal(SensorCreate):
 
 @router.get(
     "",
-    response_model=List[RTUResponse],
+    response_model=list[RTUResponse],
     summary="List all RTUs",
     description="Returns all RTU nodes, optionally filtered by location_id query param.",
 )
 async def list_rtus(
-    location_id: Optional[UUID] = Query(None, description="Filter by location UUID"),
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
-) -> List[RTUResponse]:
+    location_id: UUID | None = Query(None, description="Filter by location UUID"),  # noqa: B008
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
+) -> list[RTUResponse]:
     """GET /api/v1/rtus — list all RTUs (optionally filtered by location)."""
     _require_permission(UserPermission.CI_VIEW, current_user)
     rtus = service.list_rtus(location_id=location_id)
@@ -92,8 +90,8 @@ async def list_rtus(
 )
 async def get_rtu(
     rtu_id: UUID,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> RTUResponse:
     """GET /api/v1/rtus/{rtu_id} — get RTU by ID."""
     _require_permission(UserPermission.CI_VIEW, current_user)
@@ -112,8 +110,8 @@ async def get_rtu(
 )
 async def create_rtu(
     rtu_in: RTUCreate,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> RTUResponse:
     """POST /api/v1/rtus — create a new RTU node."""
     _require_permission(UserPermission.CI_EDIT, current_user)
@@ -135,8 +133,8 @@ async def create_rtu(
 async def update_rtu(
     rtu_id: UUID,
     rtu_in: RTUUpdate,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> RTUResponse:
     """PUT /api/v1/rtus/{rtu_id} — update RTU properties."""
     _require_permission(UserPermission.CI_EDIT, current_user)
@@ -160,8 +158,8 @@ async def update_rtu(
 )
 async def delete_rtu(
     rtu_id: UUID,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> None:
     """DELETE /api/v1/rtus/{rtu_id} — delete RTU (cascade sensors)."""
     _require_permission(UserPermission.CI_DELETE, current_user)
@@ -175,15 +173,15 @@ async def delete_rtu(
 
 @router.get(
     "/{rtu_id}/sensors",
-    response_model=List[SensorResponse],
+    response_model=list[SensorResponse],
     summary="List sensors for RTU",
     description="Returns all Sensor nodes attached to this RTU via HAS_SENSOR.",
 )
 async def list_sensors(
     rtu_id: UUID,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
-) -> List[SensorResponse]:
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
+) -> list[SensorResponse]:
     """GET /api/v1/rtus/{rtu_id}/sensors — list sensors for an RTU."""
     _require_permission(UserPermission.CI_VIEW, current_user)
     sensors = service.list_sensors(str(rtu_id))
@@ -200,8 +198,8 @@ async def list_sensors(
 async def create_sensor(
     rtu_id: UUID,
     sensor_in: SensorCreate,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> SensorResponse:
     """POST /api/v1/rtus/{rtu_id}/sensors — create sensor on RTU."""
     _require_permission(UserPermission.CI_EDIT, current_user)
@@ -226,8 +224,8 @@ async def update_sensor(
     rtu_id: UUID,
     sensor_id: UUID,
     sensor_in: SensorUpdate,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> SensorResponse:
     """PUT /api/v1/rtus/{rtu_id}/sensors/{sensor_id} — update sensor."""
     _require_permission(UserPermission.CI_EDIT, current_user)
@@ -251,8 +249,8 @@ async def update_sensor(
 async def delete_sensor(
     rtu_id: UUID,
     sensor_id: UUID,
-    current_user: User = Depends(get_current_active_user),
-    service: RTUService = Depends(get_rtu_service),
+    current_user: User = Depends(get_current_active_user),  # noqa: B008
+    service: RTUService = Depends(get_rtu_service),  # noqa: B008
 ) -> None:
     """DELETE /api/v1/rtus/{rtu_id}/sensors/{sensor_id} — delete sensor."""
     _require_permission(UserPermission.CI_DELETE, current_user)

--- a/backend/routers/rtus.py
+++ b/backend/routers/rtus.py
@@ -19,8 +19,8 @@ from models.rtu_sensor import (
     SensorUpdate,
     SensorResponse,
 )
-from models.user import User
-from services.auth_service import get_current_active_user
+from models.user import User, UserPermission
+from services.auth_service import check_permission, get_current_active_user
 from services.rtu_service import RTUService
 
 router = APIRouter(
@@ -39,6 +39,14 @@ def get_rtu_service() -> RTUService:
     Allows tests to inject a mock service.
     """
     return RTUService()
+
+
+def _require_permission(permission: UserPermission, current_user: User) -> None:
+    if not check_permission(permission, current_user):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied: {permission.value} required",
+        )
 
 
 # ── Request/Response schemas ─────────────────────────────────────────────────
@@ -71,6 +79,7 @@ async def list_rtus(
     service: RTUService = Depends(get_rtu_service),
 ) -> List[RTUResponse]:
     """GET /api/v1/rtus — list all RTUs (optionally filtered by location)."""
+    _require_permission(UserPermission.CI_VIEW, current_user)
     rtus = service.list_rtus(location_id=location_id)
     return [RTUResponse(**rtu) for rtu in rtus]
 
@@ -87,6 +96,7 @@ async def get_rtu(
     service: RTUService = Depends(get_rtu_service),
 ) -> RTUResponse:
     """GET /api/v1/rtus/{rtu_id} — get RTU by ID."""
+    _require_permission(UserPermission.CI_VIEW, current_user)
     rtu = service.get_rtu(str(rtu_id))
     if rtu is None:
         raise HTTPException(status_code=404, detail=f"RTU {rtu_id} not found")
@@ -106,6 +116,7 @@ async def create_rtu(
     service: RTUService = Depends(get_rtu_service),
 ) -> RTUResponse:
     """POST /api/v1/rtus — create a new RTU node."""
+    _require_permission(UserPermission.CI_EDIT, current_user)
     rtu = service.create_rtu(
         name=rtu_in.name,
         location_id=rtu_in.location_id,
@@ -128,6 +139,7 @@ async def update_rtu(
     service: RTUService = Depends(get_rtu_service),
 ) -> RTUResponse:
     """PUT /api/v1/rtus/{rtu_id} — update RTU properties."""
+    _require_permission(UserPermission.CI_EDIT, current_user)
     rtu = service.update_rtu(
         rtu_id=str(rtu_id),
         name=rtu_in.name,
@@ -152,6 +164,7 @@ async def delete_rtu(
     service: RTUService = Depends(get_rtu_service),
 ) -> None:
     """DELETE /api/v1/rtus/{rtu_id} — delete RTU (cascade sensors)."""
+    _require_permission(UserPermission.CI_DELETE, current_user)
     deleted = service.delete_rtu(str(rtu_id))
     if not deleted:
         raise HTTPException(status_code=404, detail=f"RTU {rtu_id} not found")
@@ -172,6 +185,7 @@ async def list_sensors(
     service: RTUService = Depends(get_rtu_service),
 ) -> List[SensorResponse]:
     """GET /api/v1/rtus/{rtu_id}/sensors — list sensors for an RTU."""
+    _require_permission(UserPermission.CI_VIEW, current_user)
     sensors = service.list_sensors(str(rtu_id))
     return [SensorResponse(**s) for s in sensors]
 
@@ -190,6 +204,7 @@ async def create_sensor(
     service: RTUService = Depends(get_rtu_service),
 ) -> SensorResponse:
     """POST /api/v1/rtus/{rtu_id}/sensors — create sensor on RTU."""
+    _require_permission(UserPermission.CI_EDIT, current_user)
     sensor = service.create_sensor(
         rtu_id=str(rtu_id),
         name=sensor_in.name,
@@ -215,6 +230,7 @@ async def update_sensor(
     service: RTUService = Depends(get_rtu_service),
 ) -> SensorResponse:
     """PUT /api/v1/rtus/{rtu_id}/sensors/{sensor_id} — update sensor."""
+    _require_permission(UserPermission.CI_EDIT, current_user)
     sensor = service.update_sensor(
         rtu_id=str(rtu_id),
         sensor_id=str(sensor_id),
@@ -239,6 +255,7 @@ async def delete_sensor(
     service: RTUService = Depends(get_rtu_service),
 ) -> None:
     """DELETE /api/v1/rtus/{rtu_id}/sensors/{sensor_id} — delete sensor."""
+    _require_permission(UserPermission.CI_DELETE, current_user)
     deleted = service.delete_sensor(rtu_id=str(rtu_id), sensor_id=str(sensor_id))
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Sensor {sensor_id} not found")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -213,11 +213,16 @@ class MockNeo4jSession:
     def __init__(self):
         self.queries: List[Dict[str, Any]] = []
         self._response_map: Dict[str, List[Dict[str, Any]]] = {}
+        self._response_sequences: Dict[str, List[List[Dict[str, Any]]]] = {}
         self._default_response: List[Dict[str, Any]] = []
 
     def set_response(self, query_contains: str, records: List[Dict[str, Any]]):
         """Set a canned response for queries containing the given substring."""
         self._response_map[query_contains.lower()] = records
+
+    def set_sequence_response(self, query_contains: str, record_batches: List[List[Dict[str, Any]]]):
+        """Set ordered canned responses for repeated queries containing the substring."""
+        self._response_sequences[query_contains.lower()] = list(record_batches)
 
     def set_default_response(self, records: List[Dict[str, Any]]):
         """Set a fallback response for any unmatched query."""
@@ -227,6 +232,11 @@ class MockNeo4jSession:
         """Capture the query and return the matching canned response."""
         self.queries.append({"query": query, "params": params})
         query_lower = query.lower()
+        for key, batches in self._response_sequences.items():
+            if key in query_lower:
+                if batches:
+                    return MockNeo4jResult(batches.pop(0))
+                return MockNeo4jResult([])
         for key, records in self._response_map.items():
             if key in query_lower:
                 return MockNeo4jResult(records)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -15,12 +15,13 @@ Also provides shared pytest fixtures and configuration for NEX-GEN backend tests
 - Helpers for creating test users/tokens without hitting the DB
 """
 
-import sys
 import os
-import pytest
-from unittest.mock import MagicMock, patch
+import sys
 from datetime import datetime, timedelta
-from typing import List, Dict, Any, Optional
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Set test JWT secret BEFORE importing auth_service modules
 os.environ["JWT_SECRET_KEY"] = "test-secret-key-for-unit-tests"
@@ -169,7 +170,7 @@ def valid_test_token(create_test_token: callable) -> str:
 class MockNeo4jResult:
     """Helper to simulate Neo4j query results in tests."""
 
-    def __init__(self, records: List[Dict[str, Any]]):
+    def __init__(self, records: list[dict[str, Any]]):
         self._records = records
         self._index = 0
 
@@ -194,7 +195,7 @@ class MockNeo4jResult:
 class MockNeo4jRecord:
     """Simulates a Neo4j record dict-like access."""
 
-    def __init__(self, data: Dict[str, Any]):
+    def __init__(self, data: dict[str, Any]):
         self._data = data
 
     def __getitem__(self, key):
@@ -211,20 +212,22 @@ class MockNeo4jSession:
     """Simulates a Neo4j session with controllable query responses."""
 
     def __init__(self):
-        self.queries: List[Dict[str, Any]] = []
-        self._response_map: Dict[str, List[Dict[str, Any]]] = {}
-        self._response_sequences: Dict[str, List[List[Dict[str, Any]]]] = {}
-        self._default_response: List[Dict[str, Any]] = []
+        self.queries: list[dict[str, Any]] = []
+        self._response_map: dict[str, list[dict[str, Any]]] = {}
+        self._response_sequences: dict[str, list[list[dict[str, Any]]]] = {}
+        self._default_response: list[dict[str, Any]] = []
 
-    def set_response(self, query_contains: str, records: List[Dict[str, Any]]):
+    def set_response(self, query_contains: str, records: list[dict[str, Any]]):
         """Set a canned response for queries containing the given substring."""
         self._response_map[query_contains.lower()] = records
 
-    def set_sequence_response(self, query_contains: str, record_batches: List[List[Dict[str, Any]]]):
+    def set_sequence_response(
+        self, query_contains: str, record_batches: list[list[dict[str, Any]]]
+    ):
         """Set ordered canned responses for repeated queries containing the substring."""
         self._response_sequences[query_contains.lower()] = list(record_batches)
 
-    def set_default_response(self, records: List[Dict[str, Any]]):
+    def set_default_response(self, records: list[dict[str, Any]]):
         """Set a fallback response for any unmatched query."""
         self._default_response = records
 
@@ -315,7 +318,7 @@ def mock_neo4j_driver():
     driver = MockNeo4jDriver()
 
     # Patch at the database module level (where driver global lives)
-    with patch("database.driver", driver):
+    with patch("database.driver", driver):  # noqa: SIM117
         with patch("database.verify_connection", return_value=None):
             yield driver
 

--- a/backend/tests/test_auth_extended.py
+++ b/backend/tests/test_auth_extended.py
@@ -619,6 +619,7 @@ class TestPermissionSecurity:
             UserPermission.RUN_DIAGNOSTICS,
             UserPermission.USER_MANAGE,
             UserPermission.ROLE_MANAGE,
+            UserPermission.AUDIT_VIEW,
             UserPermission.METRICS_VIEW,
         }
 

--- a/backend/tests/test_auth_extended.py
+++ b/backend/tests/test_auth_extended.py
@@ -8,29 +8,27 @@ Focus areas:
 - Permission enforcement patterns (role hierarchy, explicit vs implicit permissions)
 """
 
-import pytest
-from datetime import timedelta, datetime
-from jose import jwt, JWTError
-from pydantic import ValidationError
+from datetime import datetime, timedelta
 
-from services.auth_service import (
-    create_access_token,
-    check_permission,
-    get_current_active_user,
-    SECRET_KEY,
-    ALGORITHM,
-)
+import pytest
+from jose import JWTError, jwt
 from models.user import (
+    PasswordChangeRequest,
+    TokenData,
     User,
-    UserInDB,
-    UserUpdate,
+    UserPermission,
     UserResetRequest,
     UserRole,
-    UserPermission,
-    TokenData,
-    PasswordChangeRequest,
+    UserUpdate,
 )
-
+from pydantic import ValidationError
+from services.auth_service import (
+    ALGORITHM,
+    SECRET_KEY,
+    check_permission,
+    create_access_token,
+    get_current_active_user,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures — extended Phase 2
@@ -493,17 +491,13 @@ class TestPasswordChangeFlow:
 
     def test_valid_password_change_request(self):
         """PasswordChangeRequest should accept valid old and new passwords."""
-        req = PasswordChangeRequest(
-            old_password="OldP@ss123", new_password="NewP@ss456"
-        )
+        req = PasswordChangeRequest(old_password="OldP@ss123", new_password="NewP@ss456")
         assert req.old_password == "OldP@ss123"
         assert req.new_password == "NewP@ss456"
 
     def test_same_old_and_new_password_is_valid_model(self):
         """Model allows same old/new password (business logic should reject)."""
-        req = PasswordChangeRequest(
-            old_password="SamePass123", new_password="SamePass123"
-        )
+        req = PasswordChangeRequest(old_password="SamePass123", new_password="SamePass123")
         assert req.old_password == req.new_password
 
     def test_empty_old_password_is_valid_model(self):

--- a/backend/tests/test_backup_service.py
+++ b/backend/tests/test_backup_service.py
@@ -320,13 +320,16 @@ class TestPgDump:
         """_run_pg_dump returns a path string when pg_dump succeeds."""
         backup_service = _load_backup_service_module()
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            with patch("os.path.getsize", return_value=2048000):
-                result = backup_service._run_pg_dump(
-                    output_path="/backups",
-                    db_name="nexgen_auth",
-                )
+        with patch("os.makedirs") as mock_makedirs:
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0)
+                with patch("os.path.getsize", return_value=2048000):
+                    result = backup_service._run_pg_dump(
+                        output_path="/backups",
+                        db_name="nexgen_auth",
+                    )
+
+        mock_makedirs.assert_called_once_with("/backups", exist_ok=True)
 
         # Normalize path for cross-platform comparison
         result_normalized = result.replace("\\", "/")
@@ -355,9 +358,10 @@ class TestPgDump:
                 "POSTGRES_DB": "custom_db",
             },
         ):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0)
-                backup_service._run_pg_dump(output_path="/backups")
+            with patch("os.makedirs"):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    backup_service._run_pg_dump(output_path="/backups")
 
         call_args = mock_run.call_args[0][0]
         assert "postgresql://" not in " ".join(str(a) for a in call_args)
@@ -381,9 +385,10 @@ class TestPgDump:
                 "POSTGRES_DB": "custom_db",
             },
         ):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0)
-                backup_service._run_pg_dump(output_path="/backups")
+            with patch("os.makedirs"):
+                with patch("subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0)
+                    backup_service._run_pg_dump(output_path="/backups")
 
         call_args = mock_run.call_args[0][0]
         call_kwargs = mock_run.call_args.kwargs
@@ -394,10 +399,11 @@ class TestPgDump:
         """_run_pg_dump raises RuntimeError when pg_dump fails."""
         backup_service = _load_backup_service_module()
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=1, stderr=b"connection refused")
-            with pytest.raises(RuntimeError, match="pg_dump failed"):
-                backup_service._run_pg_dump(output_path="/backups", db_name="nexgen_auth")
+        with patch("os.makedirs"):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=1, stderr=b"connection refused")
+                with pytest.raises(RuntimeError, match="pg_dump failed"):
+                    backup_service._run_pg_dump(output_path="/backups", db_name="nexgen_auth")
 
 
 class TestCleanupOldBackups:
@@ -412,19 +418,20 @@ class TestCleanupOldBackups:
         def fake_remove(path):
             deleted_files.append(path)
 
-        with patch("os.listdir") as mock_listdir:
-            with patch("os.path.getmtime") as mock_getmtime:
-                with patch("os.remove", fake_remove):
-                    # Simulate two files: one old (deleted), one recent (kept)
-                    import time
-                    now = time.time()
-                    mock_listdir.return_value = ["old.dump", "recent.dump"]
-                    mock_getmtime.side_effect = lambda p: now - (8 * 86400) if "old" in p else now - (1 * 86400)
+        with patch("os.path.exists", return_value=True):
+            with patch("os.listdir") as mock_listdir:
+                with patch("os.path.getmtime") as mock_getmtime:
+                    with patch("os.remove", fake_remove):
+                        # Simulate two files: one old (deleted), one recent (kept)
+                        import time
+                        now = time.time()
+                        mock_listdir.return_value = ["old.dump", "recent.dump"]
+                        mock_getmtime.side_effect = lambda p: now - (8 * 86400) if "old" in p else now - (1 * 86400)
 
-                    removed_count = backup_service._cleanup_old_backups(
-                        backup_dir="/backups",
-                        retention_days=7,
-                    )
+                        removed_count = backup_service._cleanup_old_backups(
+                            backup_dir="/backups",
+                            retention_days=7,
+                        )
 
         assert removed_count == 1
         assert any("old.dump" in f for f in deleted_files)
@@ -434,7 +441,7 @@ class TestCleanupOldBackups:
         """_cleanup_old_backups returns 0 when backup dir doesn't exist."""
         backup_service = _load_backup_service_module()
 
-        with patch("os.listdir", side_effect=FileNotFoundError()):
+        with patch("os.path.exists", return_value=False):
             count = backup_service._cleanup_old_backups("/nonexistent", retention_days=7)
 
         assert count == 0

--- a/backend/tests/test_backup_service.py
+++ b/backend/tests/test_backup_service.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 import importlib
-import subprocess
 import sys
 import types
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -134,9 +133,9 @@ class TestBackupConfigOperations:
 
         saved_config = {}
         # Patch both the read (to avoid DB) and write (to capture)
-        with patch.object(backup_service, "_get_config_from_db", return_value=None):
+        with patch.object(backup_service, "_get_config_from_db", return_value=None):  # noqa: SIM117
             with patch.object(backup_service, "_save_config_to_db", saved_config.update):
-                result = backup_service.update_backup_config(
+                backup_service.update_backup_config(
                     schedule_type="manual",
                     scheduled_time="04:00",
                     enabled=True,
@@ -164,7 +163,7 @@ class TestBackupConfigOperations:
             "updated_by": "admin",
         }
 
-        with patch.object(backup_service, "_get_config_from_db", return_value=None):
+        with patch.object(backup_service, "_get_config_from_db", return_value=None):  # noqa: SIM117
             with patch.object(backup_service, "_save_config_to_db", return_value=expected_result):
                 result = backup_service.update_backup_config(
                     schedule_type="daily",
@@ -188,12 +187,16 @@ class TestManualBackup:
         """trigger_manual_backup returns a success dict on success."""
         backup_service = _load_backup_service_module()
 
-        with patch.object(backup_service, "_get_config_from_db", return_value=DEFAULT_CONFIG):
-            with patch.object(backup_service, "_run_pg_dump", return_value="/backups/manual_20260502_120000.dump"):
-                with patch.object(backup_service, "_record_backup_history", return_value=None):
-                    with patch.object(backup_service, "_cleanup_old_backups", return_value=0):
-                        with patch.object(backup_service, "_emit_backup_event", return_value=None):
-                            result = backup_service.trigger_manual_backup(triggered_by="admin")
+        with (
+            patch.object(backup_service, "_get_config_from_db", return_value=DEFAULT_CONFIG),
+            patch.object(
+                backup_service, "_run_pg_dump", return_value="/backups/manual_20260502_120000.dump"
+            ),
+            patch.object(backup_service, "_record_backup_history", return_value=None),
+            patch.object(backup_service, "_cleanup_old_backups", return_value=0),
+            patch.object(backup_service, "_emit_backup_event", return_value=None),
+        ):
+            result = backup_service.trigger_manual_backup(triggered_by="admin")
 
         assert result["status"] == "SUCCESS"
         assert "filename" in result
@@ -204,15 +207,17 @@ class TestManualBackup:
         """trigger_manual_backup returns FAILURE status when pg_dump fails."""
         backup_service = _load_backup_service_module()
 
-        with patch.object(backup_service, "_get_config_from_db", return_value=DEFAULT_CONFIG):
-            with patch.object(
+        with (
+            patch.object(backup_service, "_get_config_from_db", return_value=DEFAULT_CONFIG),
+            patch.object(
                 backup_service,
                 "_run_pg_dump",
                 side_effect=RuntimeError("pg_dump failed: connection refused"),
-            ):
-                with patch.object(backup_service, "_record_backup_history", return_value=None):
-                    with patch.object(backup_service, "_emit_backup_event", return_value=None) as mock_event:
-                        result = backup_service.trigger_manual_backup(triggered_by="admin")
+            ),
+            patch.object(backup_service, "_record_backup_history", return_value=None),
+            patch.object(backup_service, "_emit_backup_event", return_value=None) as mock_event,
+        ):
+            result = backup_service.trigger_manual_backup(triggered_by="admin")
 
         assert result["status"] == "FAILURE"
         assert "pg_dump failed" in result["error_message"]
@@ -226,7 +231,7 @@ class TestBackupHistory:
     def test_get_backup_history_returns_list(self, mock_neo4j_session):
         """get_backup_history returns a list of history records."""
         backup_service = _load_backup_service_module()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         stored_records = [
             {
@@ -268,6 +273,7 @@ class TestBackupHistory:
         backup_service = _load_backup_service_module()
 
         captured_limit = {}
+
         def fake_get_history(limit=None):
             captured_limit["value"] = limit
             return []
@@ -284,7 +290,7 @@ class TestBackupMetrics:
     def test_get_backup_metrics_returns_stats(self, mock_neo4j_session):
         """get_backup_metrics aggregates statistics from history."""
         backup_service = _load_backup_service_module()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         stored_records = [
             {
@@ -320,14 +326,13 @@ class TestPgDump:
         """_run_pg_dump returns a path string when pg_dump succeeds."""
         backup_service = _load_backup_service_module()
 
-        with patch("os.makedirs") as mock_makedirs:
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0)
-                with patch("os.path.getsize", return_value=2048000):
-                    result = backup_service._run_pg_dump(
-                        output_path="/backups",
-                        db_name="nexgen_auth",
-                    )
+        with patch("os.makedirs") as mock_makedirs, patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            with patch("os.path.getsize", return_value=2048000):
+                result = backup_service._run_pg_dump(
+                    output_path="/backups",
+                    db_name="nexgen_auth",
+                )
 
         mock_makedirs.assert_called_once_with("/backups", exist_ok=True)
 
@@ -342,53 +347,57 @@ class TestPgDump:
         assert "-Fc" in call_args
         assert "-f" in call_args
         assert any(str(arg).replace("\\", "/").startswith("/backups/backup_") for arg in call_args)
-        assert ["-d", "nexgen_auth"] == call_args[-2:]
+        assert call_args[-2:] == ["-d", "nexgen_auth"]
 
     def test_run_pg_dump_uses_postgres_env_vars(self):
         """_run_pg_dump passes Compose-compatible env vars as pg_dump args."""
         backup_service = _load_backup_service_module()
 
-        with patch.dict(
-            "os.environ",
-            {
-                "POSTGRES_USER": "custom_user",
-                "POSTGRES_PASSWORD": "custom_password",
-                "POSTGRES_HOST": "custom_postgres",
-                "POSTGRES_PORT": "15432",
-                "POSTGRES_DB": "custom_db",
-            },
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "POSTGRES_USER": "custom_user",
+                    "POSTGRES_PASSWORD": "custom_password",
+                    "POSTGRES_HOST": "custom_postgres",
+                    "POSTGRES_PORT": "15432",
+                    "POSTGRES_DB": "custom_db",
+                },
+            ),
+            patch("os.makedirs"),
+            patch("subprocess.run") as mock_run,
         ):
-            with patch("os.makedirs"):
-                with patch("subprocess.run") as mock_run:
-                    mock_run.return_value = MagicMock(returncode=0)
-                    backup_service._run_pg_dump(output_path="/backups")
+            mock_run.return_value = MagicMock(returncode=0)
+            backup_service._run_pg_dump(output_path="/backups")
 
         call_args = mock_run.call_args[0][0]
         assert "postgresql://" not in " ".join(str(a) for a in call_args)
-        assert ["-h", "custom_postgres"] == call_args[4:6]
-        assert ["-p", "15432"] == call_args[6:8]
-        assert ["-U", "custom_user"] == call_args[8:10]
-        assert ["-d", "custom_db"] == call_args[10:12]
+        assert call_args[4:6] == ["-h", "custom_postgres"]
+        assert call_args[6:8] == ["-p", "15432"]
+        assert call_args[8:10] == ["-U", "custom_user"]
+        assert call_args[10:12] == ["-d", "custom_db"]
 
     def test_run_pg_dump_keeps_special_character_password_out_of_args(self):
         """_run_pg_dump sends passwords through PGPASSWORD, not argv."""
         backup_service = _load_backup_service_module()
         password = "p@ss:word/with?special&chars='\"$"
 
-        with patch.dict(
-            "os.environ",
-            {
-                "POSTGRES_USER": "custom_user",
-                "POSTGRES_PASSWORD": password,
-                "POSTGRES_HOST": "custom_postgres",
-                "POSTGRES_PORT": "15432",
-                "POSTGRES_DB": "custom_db",
-            },
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "POSTGRES_USER": "custom_user",
+                    "POSTGRES_PASSWORD": password,
+                    "POSTGRES_HOST": "custom_postgres",
+                    "POSTGRES_PORT": "15432",
+                    "POSTGRES_DB": "custom_db",
+                },
+            ),
+            patch("os.makedirs"),
+            patch("subprocess.run") as mock_run,
         ):
-            with patch("os.makedirs"):
-                with patch("subprocess.run") as mock_run:
-                    mock_run.return_value = MagicMock(returncode=0)
-                    backup_service._run_pg_dump(output_path="/backups")
+            mock_run.return_value = MagicMock(returncode=0)
+            backup_service._run_pg_dump(output_path="/backups")
 
         call_args = mock_run.call_args[0][0]
         call_kwargs = mock_run.call_args.kwargs
@@ -399,11 +408,10 @@ class TestPgDump:
         """_run_pg_dump raises RuntimeError when pg_dump fails."""
         backup_service = _load_backup_service_module()
 
-        with patch("os.makedirs"):
-            with patch("subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=1, stderr=b"connection refused")
-                with pytest.raises(RuntimeError, match="pg_dump failed"):
-                    backup_service._run_pg_dump(output_path="/backups", db_name="nexgen_auth")
+        with patch("os.makedirs"), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr=b"connection refused")
+            with pytest.raises(RuntimeError, match="pg_dump failed"):
+                backup_service._run_pg_dump(output_path="/backups", db_name="nexgen_auth")
 
 
 class TestCleanupOldBackups:
@@ -418,15 +426,18 @@ class TestCleanupOldBackups:
         def fake_remove(path):
             deleted_files.append(path)
 
-        with patch("os.path.exists", return_value=True):
+        with patch("os.path.exists", return_value=True):  # noqa: SIM117
             with patch("os.listdir") as mock_listdir:
                 with patch("os.path.getmtime") as mock_getmtime:
                     with patch("os.remove", fake_remove):
                         # Simulate two files: one old (deleted), one recent (kept)
                         import time
+
                         now = time.time()
                         mock_listdir.return_value = ["old.dump", "recent.dump"]
-                        mock_getmtime.side_effect = lambda p: now - (8 * 86400) if "old" in p else now - (1 * 86400)
+                        mock_getmtime.side_effect = lambda p: (
+                            now - (8 * 86400) if "old" in p else now - (1 * 86400)
+                        )
 
                         removed_count = backup_service._cleanup_old_backups(
                             backup_dir="/backups",

--- a/backend/tests/test_cli_worker.py
+++ b/backend/tests/test_cli_worker.py
@@ -13,7 +13,7 @@ import sys
 import os
 import math
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "engines"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "engines"))
 
 from unittest.mock import MagicMock, patch
 

--- a/backend/tests/test_cli_worker.py
+++ b/backend/tests/test_cli_worker.py
@@ -9,9 +9,9 @@ Covers:
 Uses paramiko mock to avoid requiring live SSH connectivity.
 """
 
-import sys
-import os
 import math
+import os
+import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "engines"))
 
@@ -210,6 +210,7 @@ class TestResolveCredential:
         """Given a credential ref, resolves USER and PASS from env."""
         with patch.dict(os.environ, {"MYDEV_USER": "admin", "MYDEV_PASS": "secret123"}):
             from cli_worker import resolve_credential
+
             username, password = resolve_credential("MYDEV")
 
             assert username == "admin"
@@ -224,11 +225,20 @@ class TestResolveCredential:
             os.environ["CLI_DEFAULT_USER"] = "default_user"
             os.environ["CLI_DEFAULT_PASS"] = "default_pass"
             # MYDEV_* not set
-            with patch.dict(os.environ, {"CLI_DEFAULT_USER": "default_user", "CLI_DEFAULT_PASS": "default_pass"}, clear=False):
+            with patch.dict(
+                os.environ,
+                {"CLI_DEFAULT_USER": "default_user", "CLI_DEFAULT_PASS": "default_pass"},
+                clear=False,
+            ):
                 # Ensure MYDEV_* are not present
-                env = {k: v for k, v in os.environ.items() if k != "CLI_DEFAULT_USER" and k != "CLI_DEFAULT_PASS"}
+                env = {
+                    k: v
+                    for k, v in os.environ.items()
+                    if k != "CLI_DEFAULT_USER" and k != "CLI_DEFAULT_PASS"
+                }
                 with patch.dict(os.environ, env, clear=False):
                     from cli_worker import resolve_credential
+
                     username, password = resolve_credential("MYDEV")
 
                     assert username == "default_user"
@@ -245,8 +255,13 @@ class TestResolveCredential:
 
     def test_none_ref_defaults_to_cli_default(self):
         """When cli_credential_ref is None, uses CLI_DEFAULT_*."""
-        with patch.dict(os.environ, {"CLI_DEFAULT_USER": "fallback_user", "CLI_DEFAULT_PASS": "fallback_pass"}, clear=False):
+        with patch.dict(
+            os.environ,
+            {"CLI_DEFAULT_USER": "fallback_user", "CLI_DEFAULT_PASS": "fallback_pass"},
+            clear=False,
+        ):
             from cli_worker import resolve_credential
+
             username, password = resolve_credential(None)
 
             assert username == "fallback_user"
@@ -254,8 +269,13 @@ class TestResolveCredential:
 
     def test_partial_env_falls_back_correctly(self):
         """If only USER is set, PASS falls back even if specific ref provided."""
-        with patch.dict(os.environ, {"MYDEV_USER": "specific_user", "CLI_DEFAULT_PASS": "fallback_pass"}, clear=False):
+        with patch.dict(
+            os.environ,
+            {"MYDEV_USER": "specific_user", "CLI_DEFAULT_PASS": "fallback_pass"},
+            clear=False,
+        ):
             from cli_worker import resolve_credential
+
             username, password = resolve_credential("MYDEV")
 
             assert username == "specific_user"
@@ -306,6 +326,7 @@ class TestApplyEscalation:
 
         result = apply_escalation(mock_client, "enable\nsecret_password")
 
+        assert result is True
         assert mock_client.send.call_count == 2
         mock_client.send.assert_any_call("enable\r")
         mock_client.send.assert_any_call("secret_password\r")
@@ -321,6 +342,7 @@ class TestApplyEscalation:
 
         result = apply_escalation(mock_client, "  enable  \n  secret_password  ")
 
+        assert result is True
         assert mock_client.send.call_count == 2
         mock_client.send.assert_any_call("enable\r")
 
@@ -335,6 +357,7 @@ class TestApplyEscalation:
 
         result = apply_escalation(mock_client, "enable\n\nsecret_password\n")
 
+        assert result is True
         assert mock_client.send.call_count == 2
 
     def test_no_hash_in_response_returns_false(self):
@@ -368,7 +391,7 @@ class TestNanRateLimiter:
     """Tests for NaN rate limiting logic."""
 
     def test_consecutive_nan_increments_counter(self):
-        from cli_worker import _nan_tracker, check_nan_threshold, nan_rate_limiter
+        from cli_worker import _nan_tracker, nan_rate_limiter
 
         # Reset tracker
         _nan_tracker.clear()
@@ -376,11 +399,11 @@ class TestNanRateLimiter:
         metric_id = "test-cli-metric"
 
         # First NaN
-        nan_rate_limiter(metric_id, float('nan'), "raw output", "Router-01")
+        nan_rate_limiter(metric_id, float("nan"), "raw output", "Router-01")
         assert _nan_tracker.get(metric_id, 0) == 1
 
         # Second NaN
-        nan_rate_limiter(metric_id, float('nan'), "raw output 2", "Router-01")
+        nan_rate_limiter(metric_id, float("nan"), "raw output 2", "Router-01")
         assert _nan_tracker.get(metric_id, 0) == 2
 
     def test_valid_value_resets_counter(self):
@@ -407,7 +430,7 @@ class TestNanRateLimiter:
             mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
 
             for i in range(3):
-                check_nan_threshold(metric_id, float('nan'), f"raw-{i}", "Router-01")
+                check_nan_threshold(metric_id, float("nan"), f"raw-{i}", "Router-01")
 
             # After 3rd NaN, should have emitted alert
             mock_session.run.assert_called()

--- a/backend/tests/test_dictionary_service.py
+++ b/backend/tests/test_dictionary_service.py
@@ -2,10 +2,10 @@
 Unit tests for dictionary_service.py — CRUD operations for MetricDictionary nodes.
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
-from models.core import MetricDictionary, DictionaryCreate, DictionaryUpdate
+import pytest
+from models.core import DictionaryUpdate, MetricDictionary
 
 
 class TestDictionaryServiceImports:
@@ -162,17 +162,20 @@ class TestDictionaryServiceCRUD:
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary_by_brand_model calls get_dictionary
             mock_neo4j_session.set_response("metricdictionary {brand", [{"id": "existing-dict"}])
-            mock_neo4j_session.set_response("return md.id as id, md.name", [
-                {
-                    "id": "existing-dict",
-                    "name": "Existing Dictionary",
-                    "brand": "Cisco",
-                    "model": "Catalyst-2960",
-                    "polling_interval": 60,
-                    "created_at": None,
-                    "updated_at": None,
-                }
-            ])
+            mock_neo4j_session.set_response(
+                "return md.id as id, md.name",
+                [
+                    {
+                        "id": "existing-dict",
+                        "name": "Existing Dictionary",
+                        "brand": "Cisco",
+                        "model": "Catalyst-2960",
+                        "polling_interval": 60,
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ],
+            )
             mock_neo4j_session.set_response("has_metric", [])
 
             from services.dictionary_service import create_dictionary
@@ -203,17 +206,20 @@ class TestDictionaryServiceCRUD:
                 [[{"id": "cpu-load"}], [{"id": "mem-used"}]],
             )
             # Final get_dictionary after creation
-            mock_neo4j_session.set_response("return md.id as id, md.name", [
-                {
-                    "id": "new-dict",
-                    "name": "New Dictionary",
-                    "brand": "Cisco",
-                    "model": "Catalyst-2960",
-                    "polling_interval": 60,
-                    "created_at": None,
-                    "updated_at": None,
-                }
-            ])
+            mock_neo4j_session.set_response(
+                "return md.id as id, md.name",
+                [
+                    {
+                        "id": "new-dict",
+                        "name": "New Dictionary",
+                        "brand": "Cisco",
+                        "model": "Catalyst-2960",
+                        "polling_interval": 60,
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ],
+            )
             mock_neo4j_session.set_response("has_metric", [{"metric_id": "cpu-load"}])
 
             from services.dictionary_service import create_dictionary
@@ -241,31 +247,36 @@ class TestDictionaryServiceCRUD:
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary existing
-            mock_neo4j_session.set_sequence_response("return md.id as id, md.name", [
+            mock_neo4j_session.set_sequence_response(
+                "return md.id as id, md.name",
                 [
-                    {
-                        "id": "dict-1",
-                        "name": "Old Name",
-                        "brand": "Cisco",
-                        "model": "Catalyst-2960",
-                        "polling_interval": 60,
-                        "created_at": None,
-                        "updated_at": None,
-                    }
+                    [
+                        {
+                            "id": "dict-1",
+                            "name": "Old Name",
+                            "brand": "Cisco",
+                            "model": "Catalyst-2960",
+                            "polling_interval": 60,
+                            "created_at": None,
+                            "updated_at": None,
+                        }
+                    ],
+                    [
+                        {
+                            "id": "dict-1",
+                            "name": "New Name",
+                            "brand": "Cisco",
+                            "model": "Catalyst-2960",
+                            "polling_interval": 90,
+                            "created_at": None,
+                            "updated_at": None,
+                        }
+                    ],
                 ],
-                [
-                    {
-                        "id": "dict-1",
-                        "name": "New Name",
-                        "brand": "Cisco",
-                        "model": "Catalyst-2960",
-                        "polling_interval": 90,
-                        "created_at": None,
-                        "updated_at": None,
-                    }
-                ],
-            ])
-            mock_neo4j_session.set_sequence_response("has_metric", [[], [{"metric_id": "new-metric"}]])
+            )
+            mock_neo4j_session.set_sequence_response(
+                "has_metric", [[], [{"metric_id": "new-metric"}]]
+            )
             # Check brand+model conflict — no conflict
             mock_neo4j_session.set_response("where md.id <>", [])
             # Update SET query
@@ -295,17 +306,20 @@ class TestDictionaryServiceCRUD:
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary existing
-            mock_neo4j_session.set_response("return md.id as id, md.name", [
-                {
-                    "id": "dict-to-delete",
-                    "name": "To Delete",
-                    "brand": "Cisco",
-                    "model": "Catalyst-2960",
-                    "polling_interval": 60,
-                    "created_at": None,
-                    "updated_at": None,
-                }
-            ])
+            mock_neo4j_session.set_response(
+                "return md.id as id, md.name",
+                [
+                    {
+                        "id": "dict-to-delete",
+                        "name": "To Delete",
+                        "brand": "Cisco",
+                        "model": "Catalyst-2960",
+                        "polling_interval": 60,
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ],
+            )
             mock_neo4j_session.set_response("has_metric", [])
             # Cascade delete AppliedDictionary
             mock_neo4j_session.set_response("applieddictionary", [])

--- a/backend/tests/test_dictionary_service.py
+++ b/backend/tests/test_dictionary_service.py
@@ -77,7 +77,7 @@ class TestDictionaryServiceCRUD:
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # Query 1: get_dictionary node query
             mock_neo4j_session.set_response(
-                "dict_node_query",
+                "return md.id as id, md.name",
                 [
                     {
                         "id": "cisco-2960-v1",
@@ -92,7 +92,7 @@ class TestDictionaryServiceCRUD:
             )
             # Query 2: get_metrics_from_dictionary (HAS_METRIC relationships)
             mock_neo4j_session.set_response(
-                "dict_metrics_query",
+                "has_metric",
                 [
                     {"metric_id": "cpu-load"},
                     {"metric_id": "mem-used"},
@@ -118,7 +118,7 @@ class TestDictionaryServiceCRUD:
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # Query 1: list_dictionaries node query
             mock_neo4j_session.set_response(
-                "dict_list_query",
+                "match (md:metricdictionary)",
                 [
                     {
                         "id": "dict-1",
@@ -141,9 +141,9 @@ class TestDictionaryServiceCRUD:
                 ],
             )
             # Query 2: get_metrics_from_dictionary for dict-1
-            mock_neo4j_session.set_response("dict1_metrics", [])
+            mock_neo4j_session.set_sequence_response("has_metric", [[], []])
             # Query 3: get_metrics_from_dictionary for dict-2
-            mock_neo4j_session.set_response("dict2_metrics", [])
+            mock_neo4j_session.set_response("has_metric", [])
 
             from services.dictionary_service import list_dictionaries
 
@@ -161,8 +161,19 @@ class TestDictionaryServiceCRUD:
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary_by_brand_model calls get_dictionary
-            mock_neo4j_session.set_response("dict_brand_model_node", [{"id": "existing-dict"}])
-            mock_neo4j_session.set_response("dict_brand_model_metrics", [])
+            mock_neo4j_session.set_response("metricdictionary {brand", [{"id": "existing-dict"}])
+            mock_neo4j_session.set_response("return md.id as id, md.name", [
+                {
+                    "id": "existing-dict",
+                    "name": "Existing Dictionary",
+                    "brand": "Cisco",
+                    "model": "Catalyst-2960",
+                    "polling_interval": 60,
+                    "created_at": None,
+                    "updated_at": None,
+                }
+            ])
+            mock_neo4j_session.set_response("has_metric", [])
 
             from services.dictionary_service import create_dictionary
 
@@ -185,13 +196,14 @@ class TestDictionaryServiceCRUD:
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary_by_brand_model → get_dictionary (node query returns nothing)
-            mock_neo4j_session.set_response("dict_brand_model_node", [])
-            mock_neo4j_session.set_response("dict_brand_model_metrics", [])
+            mock_neo4j_session.set_response("metricdictionary {brand", [])
             # MetricDef checks for cpu-load and mem-used
-            mock_neo4j_session.set_response("metricdef_cpu", [{"id": "cpu-load"}])
-            mock_neo4j_session.set_response("metricdef_mem", [{"id": "mem-used"}])
+            mock_neo4j_session.set_sequence_response(
+                "metricdef {id",
+                [[{"id": "cpu-load"}], [{"id": "mem-used"}]],
+            )
             # Final get_dictionary after creation
-            mock_neo4j_session.set_response("dict_brand_model_node", [
+            mock_neo4j_session.set_response("return md.id as id, md.name", [
                 {
                     "id": "new-dict",
                     "name": "New Dictionary",
@@ -202,7 +214,7 @@ class TestDictionaryServiceCRUD:
                     "updated_at": None,
                 }
             ])
-            mock_neo4j_session.set_response("dict_brand_model_metrics", [{"metric_id": "cpu-load"}])
+            mock_neo4j_session.set_response("has_metric", [{"metric_id": "cpu-load"}])
 
             from services.dictionary_service import create_dictionary
 
@@ -229,39 +241,40 @@ class TestDictionaryServiceCRUD:
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary existing
-            mock_neo4j_session.set_response("dict_update_get_node", [
-                {
-                    "id": "dict-1",
-                    "name": "Old Name",
-                    "brand": "Cisco",
-                    "model": "Catalyst-2960",
-                    "polling_interval": 60,
-                    "created_at": None,
-                    "updated_at": None,
-                }
+            mock_neo4j_session.set_sequence_response("return md.id as id, md.name", [
+                [
+                    {
+                        "id": "dict-1",
+                        "name": "Old Name",
+                        "brand": "Cisco",
+                        "model": "Catalyst-2960",
+                        "polling_interval": 60,
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ],
+                [
+                    {
+                        "id": "dict-1",
+                        "name": "New Name",
+                        "brand": "Cisco",
+                        "model": "Catalyst-2960",
+                        "polling_interval": 90,
+                        "created_at": None,
+                        "updated_at": None,
+                    }
+                ],
             ])
-            mock_neo4j_session.set_response("dict_update_get_metrics", [])
+            mock_neo4j_session.set_sequence_response("has_metric", [[], [{"metric_id": "new-metric"}]])
             # Check brand+model conflict — no conflict
-            mock_neo4j_session.set_response("dict_update_conflict_check", [])
+            mock_neo4j_session.set_response("where md.id <>", [])
             # Update SET query
-            mock_neo4j_session.set_response("dict_update_set_props", [])
+            mock_neo4j_session.set_response("set md.name", [])
             # Delete existing HAS_METRIC
-            mock_neo4j_session.set_response("dict_update_delete_metrics", [])
+            mock_neo4j_session.set_response("delete r", [])
             # Create new HAS_METRIC
-            mock_neo4j_session.set_response("dict_update_new_metric", [{"id": "new-metric"}])
+            mock_neo4j_session.set_response("metricdef {id", [{"id": "new-metric"}])
             # Final get_dictionary
-            mock_neo4j_session.set_response("dict_update_get_node", [
-                {
-                    "id": "dict-1",
-                    "name": "New Name",
-                    "brand": "Cisco",
-                    "model": "Catalyst-2960",
-                    "polling_interval": 90,
-                    "created_at": None,
-                    "updated_at": None,
-                }
-            ])
-            mock_neo4j_session.set_response("dict_update_get_metrics", [{"metric_id": "new-metric"}])
 
             from services.dictionary_service import update_dictionary
 
@@ -282,7 +295,7 @@ class TestDictionaryServiceCRUD:
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
             # get_dictionary existing
-            mock_neo4j_session.set_response("dict_delete_get_node", [
+            mock_neo4j_session.set_response("return md.id as id, md.name", [
                 {
                     "id": "dict-to-delete",
                     "name": "To Delete",
@@ -293,11 +306,11 @@ class TestDictionaryServiceCRUD:
                     "updated_at": None,
                 }
             ])
-            mock_neo4j_session.set_response("dict_delete_get_metrics", [])
+            mock_neo4j_session.set_response("has_metric", [])
             # Cascade delete AppliedDictionary
-            mock_neo4j_session.set_response("dict_delete_cascade", [])
+            mock_neo4j_session.set_response("applieddictionary", [])
             # DETACH DELETE MetricDictionary
-            mock_neo4j_session.set_response("dict_delete_detach", [])
+            mock_neo4j_session.set_response("detach delete md", [])
 
             from services.dictionary_service import delete_dictionary
 
@@ -314,7 +327,7 @@ class TestDictionaryServiceCRUD:
         mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
-            mock_neo4j_session.set_response("dict_delete_get_node", [])
+            mock_neo4j_session.set_response("return md.id as id, md.name", [])
 
             from services.dictionary_service import delete_dictionary
 
@@ -329,14 +342,10 @@ class TestDictionaryServiceCRUD:
         mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
-            # validate_metric_ids uses "MATCH (m:MetricDef {id: $mid})"
+            # validate_metric_ids uses a single IN query over MetricDef ids.
             mock_neo4j_session.set_response(
-                "metricdef {id",
-                [{"id": "cpu-load"}],
-            )
-            mock_neo4j_session.set_response(
-                "metricdef {id",
-                [{"id": "mem-used"}],
+                "match (m:metricdef)",
+                [{"id": "cpu-load"}, {"id": "mem-used"}],
             )
 
             from services.dictionary_service import validate_metric_ids
@@ -353,10 +362,8 @@ class TestDictionaryServiceCRUD:
         mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
 
         with patch("services.dictionary_service.get_db", return_value=mock_driver):
-            # cpu-load not found
-            mock_neo4j_session.set_response("metricdef {id", [])
-            # mem-used found
-            mock_neo4j_session.set_response("metricdef {id", [{"id": "mem-used"}])
+            # cpu-load not found, mem-used found
+            mock_neo4j_session.set_response("match (m:metricdef)", [{"id": "mem-used"}])
 
             from services.dictionary_service import validate_metric_ids
 

--- a/backend/tests/test_event_batch_pruner.py
+++ b/backend/tests/test_event_batch_pruner.py
@@ -10,7 +10,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 _SNMP_SERVICE_SENTINEL = object()
 
 
@@ -27,7 +26,7 @@ def _load_event_service_module():
     sys.modules.pop("services.event_service", None)
     sys.modules.pop("services.snmp_service", None)
     stub = types.ModuleType("services.snmp_service")
-    setattr(stub, "run_diagnostic", lambda ci, metric: "diagnostic-ok")
+    stub.run_diagnostic = lambda ci, metric: "diagnostic-ok"
     sys.modules["services.snmp_service"] = stub
     return importlib.import_module("services.event_service")
 
@@ -46,8 +45,10 @@ def restore_snmp_service_stub():
 # Mock infrastructure — mirrors conftest.py MockNeo4j* classes
 # ---------------------------------------------------------------------------
 
+
 class MockNeo4jRecord:
     """Simulates a Neo4j record dict-like access."""
+
     def __init__(self, data):
         self._data = data if isinstance(data, dict) else {}
 
@@ -184,6 +185,7 @@ def _patch_get_db(mock_driver, event_service):
     to the database module so get_db() returns our custom driver.
     """
     import database
+
     original_driver = database.driver
     database.driver = mock_driver  # driver.session() will return our mock session
     original_get_db = event_service.get_db
@@ -194,6 +196,7 @@ def _patch_get_db(mock_driver, event_service):
 
 def _restore_get_db(original_driver, original_get_db, event_service):
     import database
+
     database.driver = original_driver
     event_service.get_db = original_get_db
 
@@ -221,11 +224,13 @@ class TestEventBatchPrunerChunkCounting:
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
             chunks = []
+
             async def consume():
                 async for progress in event_service.event_batch_pruner(
                     user="system", batch_delay_ms=0
                 ):
                     chunks.append(progress)
+
             _run_async(consume())
 
             # Initial (batch=0) + one processing chunk (batch=1)
@@ -255,11 +260,13 @@ class TestEventBatchPrunerChunkCounting:
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
             chunks = []
+
             async def consume():
                 async for progress in event_service.event_batch_pruner(
                     user="system", batch_size=500, batch_delay_ms=0
                 ):
                     chunks.append(progress)
+
             _run_async(consume())
 
             # Initial (batch=0) + 3 batches = 4
@@ -283,11 +290,13 @@ class TestEventBatchPrunerChunkCounting:
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
             chunks = []
+
             async def consume():
                 async for progress in event_service.event_batch_pruner(
                     user="system", batch_delay_ms=0
                 ):
                     chunks.append(progress)
+
             _run_async(consume())
 
             assert len(chunks) == 1
@@ -318,9 +327,11 @@ class TestEventBatchPrunerIdempotency:
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
             progress_list = []
+
             async def consume():
                 async for p in event_service.event_batch_pruner(user="system", batch_delay_ms=0):
                     progress_list.append(p)
+
             _run_async(consume())
 
             # Initial + one batch
@@ -346,6 +357,7 @@ class TestEventBatchPrunerTimeout:
 
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
+
             async def consume():
                 progress_list = []
                 async for progress in event_service.event_batch_pruner(
@@ -378,17 +390,15 @@ class TestEventBatchPrunerSafetyGuards:
 
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
+
             async def consume():
-                async for _ in event_service.event_batch_pruner(
-                    user="system", batch_delay_ms=0
-                ):
+                async for _ in event_service.event_batch_pruner(user="system", batch_delay_ms=0):
                     pass
+
             _run_async(consume())
 
             close_queries = [
-                q["query"]
-                for q in session.queries
-                if "RETURN e.id AS closed_id" in q["query"]
+                q["query"] for q in session.queries if "RETURN e.id AS closed_id" in q["query"]
             ]
             assert close_queries, "Expected guarded close query to run"
             close_query = close_queries[0]
@@ -413,20 +423,24 @@ class TestEventBatchPrunerSafetyGuards:
                 [{"event_id": "evt-3", "status": "RECOVERED"}],
             ],
         )
-        session.set_close_results([
-            [{"closed_id": "first-page-close"}],
-            [],
-            [{"closed_id": "evt-3"}],
-        ])
+        session.set_close_results(
+            [
+                [{"closed_id": "first-page-close"}],
+                [],
+                [{"closed_id": "evt-3"}],
+            ]
+        )
 
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
             progress_list = []
+
             async def consume():
                 async for p in event_service.event_batch_pruner(
                     user="system", batch_size=2, batch_delay_ms=0
                 ):
                     progress_list.append(p)
+
             _run_async(consume())
 
             assert [p["batch"] for p in progress_list] == [0, 1, 2]
@@ -459,11 +473,11 @@ class TestEventBatchPrunerProgressShape:
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
             progress_list = []
+
             async def consume():
-                async for p in event_service.event_batch_pruner(
-                    user="system", batch_delay_ms=0
-                ):
+                async for p in event_service.event_batch_pruner(user="system", batch_delay_ms=0):
                     progress_list.append(p)
+
             _run_async(consume())
 
             assert len(progress_list) == 2  # initial + one chunk

--- a/backend/tests/test_event_batch_pruner.py
+++ b/backend/tests/test_event_batch_pruner.py
@@ -11,6 +11,9 @@ from unittest.mock import MagicMock
 import pytest
 
 
+_SNMP_SERVICE_SENTINEL = object()
+
+
 # ---------------------------------------------------------------------------
 # Stubs — must match conftest.py pattern so event_service imports cleanly
 # ---------------------------------------------------------------------------
@@ -27,6 +30,16 @@ def _load_event_service_module():
     setattr(stub, "run_diagnostic", lambda ci, metric: "diagnostic-ok")
     sys.modules["services.snmp_service"] = stub
     return importlib.import_module("services.event_service")
+
+
+@pytest.fixture(autouse=True)
+def restore_snmp_service_stub():
+    previous = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
+    yield
+    if previous is _SNMP_SERVICE_SENTINEL:
+        sys.modules.pop("services.snmp_service", None)
+    else:
+        sys.modules["services.snmp_service"] = previous
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -11,12 +11,25 @@ import pytest
 from fastapi import HTTPException
 
 
+_SNMP_SERVICE_SENTINEL = object()
+
+
 def _load_event_service_module():
     sys.modules.pop("services.event_service", None)
     stub = types.ModuleType("services.snmp_service")
     setattr(stub, "run_diagnostic", lambda ci, metric: "diagnostic-ok")
     sys.modules["services.snmp_service"] = stub
     return importlib.import_module("services.event_service")
+
+
+@pytest.fixture(autouse=True)
+def restore_snmp_service_stub():
+    previous = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
+    yield
+    if previous is _SNMP_SERVICE_SENTINEL:
+        sys.modules.pop("services.snmp_service", None)
+    else:
+        sys.modules["services.snmp_service"] = previous
 
 
 class TestEventServiceImports:

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import importlib
 import sys
 import types
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi import HTTPException
-
 
 _SNMP_SERVICE_SENTINEL = object()
 
@@ -17,7 +16,7 @@ _SNMP_SERVICE_SENTINEL = object()
 def _load_event_service_module():
     sys.modules.pop("services.event_service", None)
     stub = types.ModuleType("services.snmp_service")
-    setattr(stub, "run_diagnostic", lambda ci, metric: "diagnostic-ok")
+    stub.run_diagnostic = lambda ci, metric: "diagnostic-ok"
     sys.modules["services.snmp_service"] = stub
     return importlib.import_module("services.event_service")
 
@@ -84,7 +83,9 @@ class TestEventServiceSmoke:
         assert "$status = 'ACTIVE' AND e.status IN ['OPEN', 'ACK']" in query
         assert "$status = 'CONSOLE' AND e.status IN ['OPEN', 'ACK', 'RECOVERED']" in query
         assert "$status <> 'ACTIVE' AND $status <> 'CONSOLE' AND e.status = $status" in query
-        assert query.index("WHERE (\n                $status IS NULL") < query.index("OPTIONAL MATCH")
+        assert query.index("WHERE (\n                $status IS NULL") < query.index(
+            "OPTIONAL MATCH"
+        )
 
     def test_get_events_console_filter_includes_recovered(self, mock_neo4j_session):
         """CONSOLE feed should keep recovered events visible until close/prune logic runs."""
@@ -108,8 +109,8 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 5, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "not e.status in ['open', 'ack']",
             [
@@ -120,8 +121,8 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 0, 10, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
                 },
@@ -132,8 +133,8 @@ class TestEventServiceSmoke:
                         "status": "CLOSED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 2, 20, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 2, 20, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
                 },
@@ -144,7 +145,7 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=UTC),
                         "recovered_at": None,
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
@@ -161,7 +162,7 @@ class TestEventServiceSmoke:
                         "status": "OPEN",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 4, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 4, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
                 }
@@ -185,12 +186,10 @@ class TestEventServiceSmoke:
         assert row["active_downtime_seconds"] == 3600
         assert row["availability_percentage"] == 70.0
 
-    def test_get_availability_report_includes_snmp_coverage_summary(
-        self, mock_neo4j_session
-    ):
+    def test_get_availability_report_includes_snmp_coverage_summary(self, mock_neo4j_session):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "return count(ci) as total_ci_with_snmp",
             [
@@ -219,10 +218,8 @@ class TestEventServiceSmoke:
     def test_get_availability_snmp_no_response_drilldown_returns_affected_cis(
         self, mock_neo4j_session
     ):
-        get_drilldown = (
-            _load_event_service_module().get_availability_snmp_no_response_drilldown
-        )
-        now = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+        get_drilldown = _load_event_service_module().get_availability_snmp_no_response_drilldown
+        now = datetime(2026, 1, 2, 12, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "return count(distinct ci) as total_ci_with_no_response",
             [
@@ -306,9 +303,7 @@ class TestEventServiceSmoke:
     def test_get_availability_snmp_no_response_drilldown_bounds_pagination(
         self, mock_neo4j_session
     ):
-        get_drilldown = (
-            _load_event_service_module().get_availability_snmp_no_response_drilldown
-        )
+        get_drilldown = _load_event_service_module().get_availability_snmp_no_response_drilldown
 
         report = get_drilldown(limit=500, offset=-4)
 
@@ -320,8 +315,8 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 5, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "not e.status in ['open', 'ack']",
             [
@@ -332,8 +327,8 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 0, 10, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
                 },
@@ -349,7 +344,7 @@ class TestEventServiceSmoke:
                         "status": "ACK",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
                 },
@@ -368,8 +363,8 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "not e.status in ['open', 'ack']",
             [
@@ -380,8 +375,8 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 0, 15, tzinfo=UTC),
                     },
                     "ci": {
                         "id": "ci-1",
@@ -407,7 +402,7 @@ class TestEventServiceSmoke:
                         "snmp_community": "public",
                         "credentials": {"username": "admin", "password": "secret"},
                         "api_token": "token-value",
-                        "installed_at": datetime(2025, 12, 1, 10, 0, tzinfo=timezone.utc),
+                        "installed_at": datetime(2025, 12, 1, 10, 0, tzinfo=UTC),
                         "location": object(),
                     },
                     "category": "Routers",
@@ -457,8 +452,8 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=UTC)
 
         get_availability_report(start=start, end=end, now=end)
 
@@ -479,12 +474,10 @@ class TestEventServiceSmoke:
         assert "RETURN e, ci, category" in recovered_query
         assert "RETURN e, ci, category" in active_query
 
-    def test_get_availability_report_queries_scope_to_availability_events(
-        self, mock_neo4j_session
-    ):
+    def test_get_availability_report_queries_scope_to_availability_events(self, mock_neo4j_session):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
 
         get_availability_report(start=start, end=end, now=end)
 
@@ -500,9 +493,7 @@ class TestEventServiceSmoke:
             and "NOT e.status IN ['OPEN', 'ACK']" not in query["query"]
         )["query"]
         snmp_query = next(
-            query
-            for query in mock_neo4j_session.queries
-            if "total_ci_with_snmp" in query["query"]
+            query for query in mock_neo4j_session.queries if "total_ci_with_snmp" in query["query"]
         )["query"]
 
         assert "e.event_type = 'AVAILABILITY'" in recovered_query
@@ -522,8 +513,8 @@ class TestEventServiceSmoke:
     ):
         """Only availability incidents should drive MTTR/MTBF/availability rows."""
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 4, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 4, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "not e.status in ['open', 'ack']",
             [
@@ -534,8 +525,8 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 0, 30, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01", "status": "OK"},
                 },
@@ -545,8 +536,8 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "RECOVERED",
                         "event_type": "THRESHOLD_BREACH",
-                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01", "status": "DEGRADED"},
                 },
@@ -556,8 +547,8 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-2",
                         "status": "CLOSED",
                         "event_type": "COLLECTION_FAILURE",
-                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 1, 15, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 1, 15, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-2", "name": "Switch-01", "status": "OK"},
                 },
@@ -569,8 +560,8 @@ class TestEventServiceSmoke:
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
                         "correlation_type": "PROPAGATED",
-                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 1, 30, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 1, 30, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-3", "name": "Propagated Switch", "status": "OK"},
                 },
@@ -586,7 +577,7 @@ class TestEventServiceSmoke:
                         "status": "ACK",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 3, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01", "status": "DOWN"},
                 },
@@ -596,7 +587,7 @@ class TestEventServiceSmoke:
                         "ci_id": "ci-1",
                         "status": "OPEN",
                         "event_type": "COLLECTION_FAILURE",
-                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01", "status": "UNKNOWN"},
                 },
@@ -608,7 +599,7 @@ class TestEventServiceSmoke:
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
                         "correlation_type": "propagated",
-                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-4", "name": "Impacted Radio", "status": "DOWN"},
                 },
@@ -631,8 +622,8 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "not e.status in ['open', 'ack']",
             [
@@ -644,8 +635,8 @@ class TestEventServiceSmoke:
                         "event_type": "AVAILABILITY",
                         "availability_source": "PING",
                         "metric_id": "PING-CHECK",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 0, 30, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01", "status": "OK"},
                 },
@@ -657,8 +648,8 @@ class TestEventServiceSmoke:
                         "event_type": "AVAILABILITY",
                         "source_protocol": "ICMP",
                         "metric_id": "PING-CHECK",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-2", "name": "Legacy Ping", "status": "OK"},
                 },
@@ -669,8 +660,8 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "metric_id": "mariadb-GS",
-                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 0, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-3", "name": "MariaDB", "status": "OK"},
                 },
@@ -687,8 +678,8 @@ class TestEventServiceSmoke:
     ):
         """CI state at event time should not change event-status availability math."""
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 6, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 6, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "not e.status in ['open', 'ack']",
             [
@@ -699,8 +690,8 @@ class TestEventServiceSmoke:
                         "status": "RECOVERED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 1, 20, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 1, 20, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-online", "name": "Router Online", "status": "OK"},
                 },
@@ -711,8 +702,8 @@ class TestEventServiceSmoke:
                         "status": "CLOSED",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc),
-                        "recovered_at": datetime(2026, 1, 1, 2, 45, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 2, 0, tzinfo=UTC),
+                        "recovered_at": datetime(2026, 1, 1, 2, 45, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-maint", "name": "Router Maintenance", "status": "MAINTENANCE"},
                 },
@@ -728,7 +719,7 @@ class TestEventServiceSmoke:
                         "status": "OPEN",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2026, 1, 1, 5, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 1, 1, 5, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-down", "name": "Router Down", "status": "DOWN"},
                 }
@@ -751,12 +742,10 @@ class TestEventServiceSmoke:
         assert rows["ci-down"]["active_downtime_seconds"] == 3600
         assert rows["ci-down"]["availability_percentage"] == 83.3333
 
-    def test_get_availability_report_queries_filter_window_in_cypher(
-        self, mock_neo4j_session
-    ):
+    def test_get_availability_report_queries_filter_window_in_cypher(self, mock_neo4j_session):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
 
         get_availability_report(start=start, end=end, now=end)
 
@@ -788,8 +777,8 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
-        start = datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 1, 2, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+        end = datetime(2026, 1, 1, 2, 0, tzinfo=UTC)
         mock_neo4j_session.set_response("not e.status in ['open', 'ack']", [])
         mock_neo4j_session.set_response(
             "e.status in ['open', 'ack']",
@@ -801,7 +790,7 @@ class TestEventServiceSmoke:
                         "status": "OPEN",
                         "event_type": "AVAILABILITY",
                         "availability_source": "ICMP",
-                        "created_at": datetime(2025, 12, 31, 23, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2025, 12, 31, 23, 0, tzinfo=UTC),
                     },
                     "ci": {"id": "ci-1", "name": "Router-01"},
                 }
@@ -820,7 +809,7 @@ class TestEventServiceSmoke:
 
     def test_get_availability_report_defaults_to_last_30_days(self, mock_neo4j_session):
         get_availability_report = _load_event_service_module().get_availability_report
-        now = datetime(2026, 2, 1, 12, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 2, 1, 12, 0, tzinfo=UTC)
 
         report = get_availability_report(now=now)
 
@@ -828,11 +817,9 @@ class TestEventServiceSmoke:
         assert report["window_start"] == (now - timedelta(days=30)).isoformat()
         assert report["window_days"] == 30
 
-    def test_get_events_returns_legacy_event_without_metric_relationship(
-        self, mock_neo4j_session
-    ):
+    def test_get_events_returns_legacy_event_without_metric_relationship(self, mock_neo4j_session):
         get_events = _load_event_service_module().get_events
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         mock_neo4j_session.set_response(
             "return e, ci, m",
             [
@@ -884,7 +871,7 @@ class TestEventServiceSmoke:
         self, mock_neo4j_session
     ):
         get_events = _load_event_service_module().get_events
-        last_seen = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+        last_seen = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
         mock_neo4j_session.set_response(
             "return e, ci, m",
             [
@@ -939,11 +926,9 @@ class TestEventServiceSmoke:
         assert "metric_name" not in result[0]
         assert "metric_protocol" not in result[0]
 
-    def test_get_events_strips_audit_heavy_fields_from_public_summary(
-        self, mock_neo4j_session
-    ):
+    def test_get_events_strips_audit_heavy_fields_from_public_summary(self, mock_neo4j_session):
         get_events = _load_event_service_module().get_events
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         mock_neo4j_session.set_response(
             "return e, ci, m",
             [
@@ -978,9 +963,7 @@ class TestEventServiceSmoke:
     def test_ack_event_sets_ack_status(self, mock_neo4j_session):
         """ack_event should set status to ACK."""
         ack_event = _load_event_service_module().ack_event
-        mock_neo4j_session.set_response(
-            "return e.id as event_id", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("return e.id as event_id", [{"event_id": "evt-001"}])
 
         ack_event("evt-001", "testuser")
 
@@ -997,9 +980,7 @@ class TestEventServiceSmoke:
             "match (e:event {id: $eid}) return e.status", [{"status": "OPEN"}]
         )
         # 2. Update query
-        mock_neo4j_session.set_response(
-            "set e.status = 'closed'", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("set e.status = 'closed'", [{"event_id": "evt-001"}])
 
         close_event(
             "evt-001",
@@ -1015,9 +996,7 @@ class TestEventServiceSmoke:
     def test_add_event_comment_appends_comment(self, mock_neo4j_session):
         """add_event_comment should append to comments array."""
         add_event_comment = _load_event_service_module().add_event_comment
-        mock_neo4j_session.set_response(
-            "return e.id as event_id", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("return e.id as event_id", [{"event_id": "evt-001"}])
 
         add_event_comment("evt-001", "testuser", "Investigating...")
 
@@ -1040,7 +1019,7 @@ class TestEventServiceSmoke:
 
     def test_build_event_detail_prefers_snapshot_values_and_sla_math(self):
         event_service = _load_event_service_module()
-        now = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
         created_at = now - timedelta(minutes=35)
 
         detail = event_service.build_event_detail_response(
@@ -1073,7 +1052,6 @@ class TestEventServiceSmoke:
                     "ip": "10.0.0.1",
                     "location_name": "Sede Central",
                 },
-
                 "m": {"id": "cpu-load", "protocol": "SNMP"},
                 "bs": {
                     "id": "svc-live",
@@ -1095,10 +1073,7 @@ class TestEventServiceSmoke:
 
         assert detail["event"]["ci_ref"]["id"] == "ci-001"
         assert detail["business_context"]["source"] == "snapshot"
-        assert (
-            detail["business_context"]["business_service"]["name"]
-            == "Corp-WAN Snapshot"
-        )
+        assert detail["business_context"]["business_service"]["name"] == "Corp-WAN Snapshot"
         assert "tier" not in detail["business_context"]["business_service"]
         assert detail["business_context"]["service_catalog"]["id"] == "sla-snapshot"
         assert detail["business_context"]["service_catalog"]["service_tier"] == "Gold"
@@ -1110,7 +1085,7 @@ class TestEventServiceSmoke:
         self,
     ):
         event_service = _load_event_service_module()
-        now = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
         created_at = now - timedelta(minutes=5)
 
         detail = event_service.build_event_detail_response(
@@ -1133,7 +1108,6 @@ class TestEventServiceSmoke:
                     "ip": "10.0.0.1",
                     "location_name": "Sede Central",
                 },
-
                 "m": {"id": "ping", "protocol": "ICMP"},
                 "bs": {
                     "id": "svc-live",
@@ -1157,9 +1131,7 @@ class TestEventServiceSmoke:
         assert detail["business_context"]["source"] == "resolved"
         assert detail["business_context"]["business_service"]["name"] == "Payments"
         assert detail["business_context"]["business_service"]["tier"] == "T2"
-        assert (
-            detail["business_context"]["service_catalog"]["service_tier"] == "Platinum"
-        )
+        assert detail["business_context"]["service_catalog"]["service_tier"] == "Platinum"
         assert detail["business_context"]["service_catalog"]["sla_minutes"] == 30
         assert detail["business_context"]["sla_remaining_minutes"] == 25
         assert detail["itsm_context"]["assignment_state"] == "assigned"
@@ -1167,7 +1139,7 @@ class TestEventServiceSmoke:
 
     def test_build_event_detail_marks_mixed_source_for_partial_snapshot(self):
         event_service = _load_event_service_module()
-        now = datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
         created_at = now - timedelta(minutes=10)
 
         detail = event_service.build_event_detail_response(
@@ -1190,7 +1162,6 @@ class TestEventServiceSmoke:
                     "ip": "10.0.0.1",
                     "location_name": "Sede Central",
                 },
-
                 "m": {"id": "latency", "protocol": "HTTP"},
                 "bs": {
                     "id": "svc-live",
@@ -1259,8 +1230,8 @@ class TestEventServiceSmoke:
                     "status": "OPEN",
                     "severity": "WARNING",
                     "message": "Ticket sync degraded",
-                    "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
-                    "last_seen": datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+                    "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+                    "last_seen": datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
                     "ack": False,
                     "external_ticket_status": "Open",
                 },
@@ -1295,27 +1266,19 @@ class TestEventServiceSmoke:
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Event not found: missing-event"
 
-    def test_close_event_rejects_normal_close_without_root_cause_and_note(
-        self, mock_neo4j_session
-    ):
+    def test_close_event_rejects_normal_close_without_root_cause_and_note(self, mock_neo4j_session):
         close_event = _load_event_service_module().close_event
-        mock_neo4j_session.set_response(
-            "return e.id as event_id", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("return e.id as event_id", [{"event_id": "evt-001"}])
 
         with pytest.raises(HTTPException) as exc_info:
-            close_event(
-                "evt-001", "testuser", forced=False, comment_message="Nota: corto"
-            )
+            close_event("evt-001", "testuser", forced=False, comment_message="Nota: corto")
 
         assert exc_info.value.status_code == 400
         assert "Causa raíz" in exc_info.value.detail
 
     def test_close_event_rejects_normal_close_with_short_note(self, mock_neo4j_session):
         close_event = _load_event_service_module().close_event
-        mock_neo4j_session.set_response(
-            "return e.id as event_id", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("return e.id as event_id", [{"event_id": "evt-001"}])
 
         with pytest.raises(HTTPException) as exc_info:
             close_event(
@@ -1330,9 +1293,7 @@ class TestEventServiceSmoke:
 
     def test_close_event_rejects_forced_close_without_reason(self, mock_neo4j_session):
         close_event = _load_event_service_module().close_event
-        mock_neo4j_session.set_response(
-            "return e.id as event_id", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("return e.id as event_id", [{"event_id": "evt-001"}])
 
         with pytest.raises(HTTPException) as exc_info:
             close_event("evt-001", "testuser", forced=True, comment_message="   ")
@@ -1340,9 +1301,7 @@ class TestEventServiceSmoke:
         assert exc_info.value.status_code == 400
         assert "Forced close requires a reason" in exc_info.value.detail
 
-    def test_add_event_comment_raises_404_when_event_is_missing(
-        self, mock_neo4j_session
-    ):
+    def test_add_event_comment_raises_404_when_event_is_missing(self, mock_neo4j_session):
         add_event_comment = _load_event_service_module().add_event_comment
 
         with pytest.raises(HTTPException) as exc_info:
@@ -1353,9 +1312,7 @@ class TestEventServiceSmoke:
 
     def test_ack_event_writes_ownership_comment_atomically(self, mock_neo4j_session):
         ack_event = _load_event_service_module().ack_event
-        mock_neo4j_session.set_response(
-            "return e.id as event_id", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("return e.id as event_id", [{"event_id": "evt-001"}])
 
         ack_event(
             "evt-001",
@@ -1374,9 +1331,7 @@ class TestEventServiceSmoke:
             "match (e:event {id: $eid}) return e.status", [{"status": "OPEN"}]
         )
         # 2. Update
-        mock_neo4j_session.set_response(
-            "set e.status = 'closed'", [{"event_id": "evt-001"}]
-        )
+        mock_neo4j_session.set_response("set e.status = 'closed'", [{"event_id": "evt-001"}])
 
         close_event(
             "evt-001",
@@ -1392,18 +1347,14 @@ class TestEventServiceSmoke:
             "Nota: Se reemplazó el módulo principal"
         )
 
-    def test_close_event_forced_writes_single_canonical_audit_entry(
-        self, mock_neo4j_session
-    ):
+    def test_close_event_forced_writes_single_canonical_audit_entry(self, mock_neo4j_session):
         close_event = _load_event_service_module().close_event
         # 1. State check
         mock_neo4j_session.set_response(
             "match (e:event {id: $eid}) return e.status", [{"status": "OPEN"}]
         )
         # 2. Update
-        mock_neo4j_session.set_response(
-            "set e.status = 'closed'", [{"event_id": "evt-002"}]
-        )
+        mock_neo4j_session.set_response("set e.status = 'closed'", [{"event_id": "evt-002"}])
 
         close_event(
             "evt-002",
@@ -1414,14 +1365,11 @@ class TestEventServiceSmoke:
 
         params = mock_neo4j_session.queries[1]["params"]
         assert params["audit_message"] == (
-            "[AUDIT][FORCED_CLOSE] Cierre forzado por testuser\n"
-            "Motivo: Ventana de mantenimiento"
+            "[AUDIT][FORCED_CLOSE] Cierre forzado por testuser\n" "Motivo: Ventana de mantenimiento"
         )
         assert "forced" not in params
 
-    def test_get_event_detail_query_collapses_multiple_sla_matches(
-        self, mock_neo4j_session
-    ):
+    def test_get_event_detail_query_collapses_multiple_sla_matches(self, mock_neo4j_session):
         mock_neo4j_session.set_response(
             "return e, ci, m, bs, sc",
             [
@@ -1432,7 +1380,7 @@ class TestEventServiceSmoke:
                         "status": "OPEN",
                         "severity": "WARNING",
                         "message": "Latency spike",
-                        "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=timezone.utc),
+                        "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
                         "ack": False,
                     },
                     "ci": {"id": "ci-010", "name": "Router-10", "ip": "10.0.0.10"},
@@ -1449,13 +1397,9 @@ class TestEventServiceSmoke:
 
         assert detail["business_context"]["service_catalog"]["id"] == "sla-010"
         query = mock_neo4j_session.queries[0]["query"]
-        assert (
-            "head([item in collect(sc) where item is not null]) as sc" in query.lower()
-        )
+        assert "head([item in collect(sc) where item is not null]) as sc" in query.lower()
 
-    def test_get_event_detail_raises_404_when_event_is_missing(
-        self, mock_neo4j_session
-    ):
+    def test_get_event_detail_raises_404_when_event_is_missing(self, mock_neo4j_session):
         mock_neo4j_session.set_response("match (e:event {id: $event_id})", [])
 
         get_event_detail = _load_event_service_module().get_event_detail

--- a/backend/tests/test_permissions_router.py
+++ b/backend/tests/test_permissions_router.py
@@ -19,14 +19,10 @@ _previous_snmp_service = sys.modules.get("services.snmp_service", _SNMP_SERVICE_
 
 if "services.snmp_service" not in sys.modules:
     _snmp_stub = types.ModuleType("services.snmp_service")
-    setattr(_snmp_stub, "snmp_collector_loop", lambda: None)
-    setattr(
-        _snmp_stub,
-        "get_collector_status",
-        lambda: {"last_run": None, "status": "STOPPED", "stats": {}},
-    )
-    setattr(_snmp_stub, "validate_snmp_oid", lambda *args, **kwargs: {"success": False})
-    setattr(_snmp_stub, "run_diagnostic", lambda *args, **kwargs: "diagnostic-ok")
+    _snmp_stub.snmp_collector_loop = lambda: None
+    _snmp_stub.get_collector_status = lambda: {"last_run": None, "status": "STOPPED", "stats": {}}
+    _snmp_stub.validate_snmp_oid = lambda *args, **kwargs: {"success": False}
+    _snmp_stub.run_diagnostic = lambda *args, **kwargs: "diagnostic-ok"
     sys.modules["services.snmp_service"] = _snmp_stub
 
 _mock_neo4j_driver = MagicMock()
@@ -39,9 +35,9 @@ if _previous_snmp_service is _SNMP_SERVICE_SENTINEL:
 else:
     sys.modules["services.snmp_service"] = _previous_snmp_service
 
-from fastapi.testclient import TestClient
-from models.user import User, UserPermission, AIPermission
-from services.auth_service import get_current_active_user
+from fastapi.testclient import TestClient  # noqa: E402
+from models.user import AIPermission, User, UserPermission  # noqa: E402
+from services.auth_service import get_current_active_user  # noqa: E402
 
 client = TestClient(app)
 

--- a/backend/tests/test_permissions_router.py
+++ b/backend/tests/test_permissions_router.py
@@ -14,6 +14,9 @@ from unittest.mock import MagicMock, patch
 # Stub heavy infrastructure BEFORE importing main (conftest already stubs
 # neo4j/psycopg2, but we need the snmp_service stub to avoid import errors)
 # ---------------------------------------------------------------------------
+_SNMP_SERVICE_SENTINEL = object()
+_previous_snmp_service = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
+
 if "services.snmp_service" not in sys.modules:
     _snmp_stub = types.ModuleType("services.snmp_service")
     setattr(_snmp_stub, "snmp_collector_loop", lambda: None)
@@ -30,6 +33,11 @@ _mock_neo4j_driver = MagicMock()
 
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
+
+if _previous_snmp_service is _SNMP_SERVICE_SENTINEL:
+    sys.modules.pop("services.snmp_service", None)
+else:
+    sys.modules["services.snmp_service"] = _previous_snmp_service
 
 from fastapi.testclient import TestClient
 from models.user import User, UserPermission, AIPermission

--- a/backend/tests/test_routers_auth_users_roles.py
+++ b/backend/tests/test_routers_auth_users_roles.py
@@ -170,15 +170,20 @@ def _make_mock_pg_user(
     return mock
 
 
-def _assert_audit_request_context(kwargs: dict, user_agent: str | None = None, request_id: str | None = None) -> None:
+def _assert_audit_request_context(
+    kwargs: dict,
+    user_agent: str | None = None,
+    request_id: str | None = None,
+    forwarded_for: str | None = None,
+) -> None:
     """Assert auth audit calls receive a Request with context needed for IP/UA enrichment."""
     request = kwargs["request"]
     if user_agent:
         assert request.headers["user-agent"] == user_agent
     if request_id:
         assert request.headers["x-request-id"] == request_id
-    assert request.client is not None
-    assert request.client.host
+    if forwarded_for:
+        assert request.headers["x-forwarded-for"] == forwarded_for
 
 
 # ---------------------------------------------------------------------------
@@ -370,7 +375,11 @@ class TestAuthToken:
             response = client.post(
                 "/api/auth/token",
                 data={"username": "testuser", "password": "wrong_password"},
-                headers={"User-Agent": "pytest-agent", "X-Request-ID": "req-auth-1"},
+                headers={
+                    "User-Agent": "pytest-agent",
+                    "X-Request-ID": "req-auth-1",
+                    "X-Forwarded-For": "203.0.113.10",
+                },
             )
 
         assert response.status_code == 401
@@ -380,7 +389,12 @@ class TestAuthToken:
         assert kwargs["outcome"] == AUDIT_OUTCOME_FAILURE
         assert kwargs["actor_username"] == "testuser"
         assert kwargs["reason"] == AUTH_REASON_INCORRECT_CREDENTIALS
-        _assert_audit_request_context(kwargs, user_agent="pytest-agent", request_id="req-auth-1")
+        _assert_audit_request_context(
+            kwargs,
+            user_agent="pytest-agent",
+            request_id="req-auth-1",
+            forwarded_for="203.0.113.10",
+        )
         context = kwargs.get("context") or {}
         assert "password" not in context
         assert "token" not in context
@@ -405,7 +419,11 @@ class TestAuthToken:
             response = client.post(
                 "/api/auth/token",
                 data={"username": "testuser", "password": "wrong_password"},
-                headers={"User-Agent": "pytest-agent", "X-Request-ID": "req-auth-precheck"},
+                headers={
+                    "User-Agent": "pytest-agent",
+                    "X-Request-ID": "req-auth-precheck",
+                    "X-Forwarded-For": "203.0.113.11",
+                },
             )
 
         assert response.status_code == 429
@@ -415,7 +433,12 @@ class TestAuthToken:
         assert kwargs["outcome"] == AUDIT_OUTCOME_DENIED
         assert kwargs["actor_username"] == "testuser"
         assert kwargs["reason"] == AUTH_REASON_RATE_LIMITED
-        _assert_audit_request_context(kwargs, user_agent="pytest-agent", request_id="req-auth-precheck")
+        _assert_audit_request_context(
+            kwargs,
+            user_agent="pytest-agent",
+            request_id="req-auth-precheck",
+            forwarded_for="203.0.113.11",
+        )
 
         app.dependency_overrides.pop(get_pg_db, None)
 

--- a/backend/tests/test_routers_auth_users_roles.py
+++ b/backend/tests/test_routers_auth_users_roles.py
@@ -21,10 +21,11 @@ Strategy:
 - Override Neo4j driver (database.get_db) for roles router
 """
 
-import pytest
 from datetime import datetime, timedelta
-from fastapi import HTTPException
 from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
@@ -36,39 +37,32 @@ _mock_neo4j_driver = MagicMock()
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     # Import the main app (which imports database.py)
     from main import app
-    from database import get_db
 
-from models.user import (
-    User,
-    UserInDB,
+from middleware import rate_limit  # noqa: E402
+from models.rate_limit_attempt import RateLimitAttempt  # noqa: E402
+from models.user import (  # noqa: E402
     CurrentUser,
     CurrentUserSessionPolicy,
-    UserCreate,
-    UserUpdate,
+    User,
+    UserInDB,
     UserPermission,
-    PasswordChangeRequest,
-    UserResetRequest,
-    Role,
-    RoleCreate,
 )
-from postgres_db import Base, get_pg_db
-from services.auth_service import get_current_active_user
-from repositories import user_repo
-from middleware import rate_limit
-from models.rate_limit_attempt import RateLimitAttempt
-from routers.auth import (
+from postgres_db import Base, get_pg_db  # noqa: E402
+from repositories import user_repo  # noqa: E402
+from routers.auth import (  # noqa: E402
     AUDIT_OUTCOME_DENIED,
     AUDIT_OUTCOME_FAILURE,
     AUDIT_OUTCOME_SUCCESS,
     AUTH_EVENT_LOGIN_FAILURE,
     AUTH_EVENT_LOGIN_SUCCESS,
     AUTH_EVENT_LOGOUT,
-    AUTH_REASON_INCORRECT_CREDENTIALS,
     AUTH_REASON_INACTIVE_USER,
-    AUTH_REASON_RATE_LIMITED,
+    AUTH_REASON_INCORRECT_CREDENTIALS,
     AUTH_REASON_LOGIN_SUCCESS,
     AUTH_REASON_LOGOUT_SUCCESS,
+    AUTH_REASON_RATE_LIMITED,
 )
+from services.auth_service import get_current_active_user  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # TestClient
@@ -125,6 +119,7 @@ def _make_pydantic_current_user(
             persistent=persistent,
         ),
     )
+
 
 def _make_pydantic_user_in_db(
     username: str = "testuser",
@@ -199,7 +194,7 @@ def rate_limit_db(monkeypatch):
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)  # noqa: N806
     Base.metadata.create_all(bind=engine, tables=[RateLimitAttempt.__table__])
     monkeypatch.setattr(rate_limit, "SessionLocal", TestingSessionLocal)
     yield TestingSessionLocal
@@ -412,7 +407,9 @@ class TestAuthToken:
         with (
             patch(
                 "routers.auth.check_rate_limit",
-                side_effect=HTTPException(status_code=429, detail="Too many failed login attempts."),
+                side_effect=HTTPException(
+                    status_code=429, detail="Too many failed login attempts."
+                ),
             ),
             patch("routers.auth.audit_service.record_auth_event") as mock_record,
         ):
@@ -465,7 +462,11 @@ class TestAuthToken:
             patch("routers.auth.audit_service.record_auth_event") as mock_record,
             patch(
                 "routers.auth.raise_rate_limit_locked",
-                side_effect=HTTPException(status_code=429, detail="Too many failed login attempts. Account temporarily locked.", headers={"Retry-After": "900"}),
+                side_effect=HTTPException(
+                    status_code=429,
+                    detail="Too many failed login attempts. Account temporarily locked.",
+                    headers={"Retry-After": "900"},
+                ),
             ),
         ):
             response = client.post(
@@ -643,9 +644,7 @@ class TestAuthUsersMe:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/auth/users/me")
 
@@ -670,9 +669,7 @@ class TestAuthUsersMe:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/auth/users/me")
 
@@ -701,9 +698,7 @@ class TestAuthUsersMe:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/auth/users/me")
 
@@ -732,9 +727,7 @@ class TestAuthUsersMe:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/auth/users/me")
 
@@ -760,9 +753,7 @@ class TestAuthUsersMe:
                 raise HTTPException(status_code=400, detail="Inactive user")
             return disabled_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/auth/users/me")
 
@@ -780,9 +771,10 @@ class TestAuthUsersMe:
         """`get_current_user` must call record_session_activity with the JWT sid
         and the resolved DB user id when a valid access token is presented."""
         import asyncio
-        from services import auth_service as auth_service_module
+
         from jose import jwt
-        from services.auth_service import SECRET_KEY, ALGORITHM
+        from services import auth_service as auth_service_module
+        from services.auth_service import ALGORITHM, SECRET_KEY
 
         # Build a real access token carrying `sid` (the get_current_user flow
         # decodes the JWT to read the sid claim).
@@ -822,19 +814,20 @@ class TestAuthUsersMe:
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = mock_db_user
 
-        with patch.object(
-            auth_service_module,
-            "record_session_activity",
-            return_value=True,
-        ) as mock_record, patch.object(
-            auth_service_module,
-            "user_repo",
-        ) as mock_user_repo:
+        with (
+            patch.object(
+                auth_service_module,
+                "record_session_activity",
+                return_value=True,
+            ) as mock_record,
+            patch.object(
+                auth_service_module,
+                "user_repo",
+            ) as mock_user_repo,
+        ):
             mock_user_repo.get_user_by_username.return_value = mock_db_user
             # get_current_user is async — run it to completion.
-            result = asyncio.run(
-                auth_service_module.get_current_user(request=request, db=mock_db)
-            )
+            result = asyncio.run(auth_service_module.get_current_user(request=request, db=mock_db))
 
         assert result.username == "testuser"
         mock_record.assert_called_once()
@@ -847,9 +840,10 @@ class TestAuthUsersMe:
         NOT be invoked (it is a no-op, but we still avoid the call to keep
         the hot path tight)."""
         import asyncio
-        from services import auth_service as auth_service_module
+
         from jose import jwt
-        from services.auth_service import SECRET_KEY, ALGORITHM
+        from services import auth_service as auth_service_module
+        from services.auth_service import ALGORITHM, SECRET_KEY
 
         token = jwt.encode(
             {
@@ -886,18 +880,19 @@ class TestAuthUsersMe:
         mock_db = MagicMock()
         mock_db.query.return_value.filter.return_value.first.return_value = mock_db_user
 
-        with patch.object(
-            auth_service_module,
-            "record_session_activity",
-            return_value=True,
-        ) as mock_record, patch.object(
-            auth_service_module,
-            "user_repo",
-        ) as mock_user_repo:
+        with (
+            patch.object(
+                auth_service_module,
+                "record_session_activity",
+                return_value=True,
+            ) as mock_record,
+            patch.object(
+                auth_service_module,
+                "user_repo",
+            ) as mock_user_repo,
+        ):
             mock_user_repo.get_user_by_username.return_value = mock_db_user
-            asyncio.run(
-                auth_service_module.get_current_user(request=request, db=mock_db)
-            )
+            asyncio.run(auth_service_module.get_current_user(request=request, db=mock_db))
 
         mock_record.assert_not_called()
 
@@ -925,9 +920,7 @@ class TestAuthChangePassword:
         def override_get_db():
             yield mock_db
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.auth.verify_password", return_value=True):
@@ -958,9 +951,7 @@ class TestAuthChangePassword:
         def override_get_db():
             yield mock_db
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.auth.verify_password", return_value=False):
@@ -985,9 +976,7 @@ class TestAuthChangePassword:
         def override_get_db():
             yield mock_db
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.auth.verify_password", return_value=True):
@@ -1028,9 +1017,7 @@ class TestUsersList:
         def override_get_db():
             yield mock_db
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         response = client.get("/api/users/")
@@ -1055,9 +1042,7 @@ class TestUsersList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/users/")
 
@@ -1093,14 +1078,12 @@ class TestUsersCreate:
         # user_repo.create_user has a pre-existing bug: it accesses
         # user.disabled and user.force_password_change which don't exist
         # on UserCreate. We must mock the repo call entirely.
-        with patch.object(user_repo, "get_user_by_username", return_value=None):
+        with patch.object(user_repo, "get_user_by_username", return_value=None):  # noqa: SIM117
             with (
                 patch.object(user_repo, "create_user", return_value=new_pg_user),
                 patch("routers.users.audit_service.record_critical_change") as mock_record,
             ):
-                app.dependency_overrides[get_current_active_user] = (
-                    override_get_current_active_user
-                )
+                app.dependency_overrides[get_current_active_user] = override_get_current_active_user
                 app.dependency_overrides[get_pg_db] = override_get_db
 
                 response = client.post(
@@ -1125,6 +1108,7 @@ class TestUsersCreate:
 
         app.dependency_overrides.pop(get_current_active_user, None)
         app.dependency_overrides.pop(get_pg_db, None)
+
     def test_create_user_duplicate_username(self, mock_db):
         """Creating a user with existing username should return 400."""
         fake_user = _make_pydantic_user(username="admin", role="ADMIN")
@@ -1136,13 +1120,9 @@ class TestUsersCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-            existing_pg_user
-        )
+        mock_db.query.return_value.filter.return_value.first.return_value = existing_pg_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1174,9 +1154,7 @@ class TestUsersCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.users.audit_service.record_denied") as mock_record:
             response = client.post(
@@ -1212,13 +1190,9 @@ class TestUsersUpdate:
             return fake_user
 
         # update_user calls get_user_by_username internally
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-            updated_pg_user
-        )
+        mock_db.query.return_value.filter.return_value.first.return_value = updated_pg_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1248,9 +1222,7 @@ class TestUsersUpdate:
 
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1279,9 +1251,7 @@ class TestUsersUpdate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.users.audit_service.record_denied") as mock_record:
             response = client.put(
@@ -1309,13 +1279,11 @@ class TestUsersDelete:
             return fake_user
 
         # delete_user calls get_user_by_username
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-            _make_mock_pg_user(username="testuser")
+        mock_db.query.return_value.filter.return_value.first.return_value = _make_mock_pg_user(
+            username="testuser"
         )
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1344,9 +1312,7 @@ class TestUsersDelete:
 
         mock_db.query.return_value.filter.return_value.first.return_value = None
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1372,9 +1338,7 @@ class TestUsersDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.users.audit_service.record_denied") as mock_record:
             response = client.delete("/api/users/testuser")
@@ -1402,13 +1366,9 @@ class TestUsersResetPassword:
         async def override_get_current_active_user():
             return fake_user
 
-        mock_db.query.return_value.filter.return_value.first.return_value = (
-            target_pg_user
-        )
+        mock_db.query.return_value.filter.return_value.first.return_value = target_pg_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1438,9 +1398,7 @@ class TestUsersResetPassword:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         # Sending empty JSON body triggers Pydantic validation error (422)
@@ -1465,9 +1423,7 @@ class TestUsersResetPassword:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
         app.dependency_overrides[get_pg_db] = override_get_db
 
         with patch("routers.users.audit_service.record_critical_change") as mock_record:
@@ -1495,9 +1451,7 @@ class TestUsersResetPassword:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.users.audit_service.record_denied") as mock_record:
             response = client.post(
@@ -1548,9 +1502,7 @@ class TestRolesList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         # roles.py calls get_db_driver() directly, not via Depends()
         # so we must patch the function at the router module level
@@ -1588,9 +1540,7 @@ class TestRolesList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/roles/")
 
@@ -1609,9 +1559,7 @@ class TestRolesList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.roles.get_db_driver", return_value=mock_neo4j_driver):
             mock_neo4j_driver.execute_query.return_value = ([], None, None)
@@ -1644,9 +1592,7 @@ class TestRolesCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         # First execute_query: check exists (empty results)
         # Second execute_query: create (with result)
@@ -1701,9 +1647,7 @@ class TestRolesCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_neo4j_driver.execute_query.return_value = ([], None, None)
 
@@ -1741,9 +1685,7 @@ class TestRolesCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_neo4j_driver.execute_query.return_value = ([], None, None)
 
@@ -1769,9 +1711,7 @@ class TestRolesCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_existing_node = _FakeNeo4jNode({"name": "ExistingRole"})
         mock_record = {"r": mock_existing_node}
@@ -1805,9 +1745,7 @@ class TestRolesCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.roles.audit_service.record_denied") as mock_record:
             response = client.post(
@@ -1832,24 +1770,28 @@ class TestRolesUpdate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
-        mock_record = {"r": _FakeNeo4jNode(
-            {
-                "name": "CustomRole",
-                "description": "Updated description",
-                "permissions": ["EVENT_ACK", "METRICS_VIEW"],
-                "is_system": False,
-            }
-        )}
+        mock_record = {
+            "r": _FakeNeo4jNode(
+                {
+                    "name": "CustomRole",
+                    "description": "Updated description",
+                    "permissions": ["EVENT_ACK", "METRICS_VIEW"],
+                    "is_system": False,
+                }
+            )
+        }
 
         def mock_execute(*args, **kwargs):
             # First call: lookup by name; second call: update
             if mock_execute.call_count == 0:
                 mock_execute.call_count += 1
-                return ([{"r": _FakeNeo4jNode({"name": "CustomRole", "is_system": False})}], None, None)
+                return (
+                    [{"r": _FakeNeo4jNode({"name": "CustomRole", "is_system": False})}],
+                    None,
+                    None,
+                )
             mock_execute.call_count += 1
             return ([mock_record], None, None)
 
@@ -1888,9 +1830,7 @@ class TestRolesUpdate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_node = _FakeNeo4jNode(
             {"name": "CustomRole", "description": "Existing", "is_system": False}
@@ -1931,9 +1871,7 @@ class TestRolesUpdate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.roles.audit_service.record_denied") as mock_record:
             response = client.put(
@@ -1953,9 +1891,7 @@ class TestRolesUpdate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_node = _FakeNeo4jNode(
             {
@@ -1995,9 +1931,7 @@ class TestRolesUpdate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_neo4j_driver.execute_query.return_value = ([], None, None)
 
@@ -2031,9 +1965,7 @@ class TestRolesDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         call_count = [0]
 
@@ -2076,9 +2008,7 @@ class TestRolesDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_node = _FakeNeo4jNode({"name": "ADMIN", "is_system": True})
         mock_record = {"r": mock_node}
@@ -2106,9 +2036,7 @@ class TestRolesDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         call_count = [0]
 
@@ -2151,9 +2079,7 @@ class TestRolesDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_neo4j_driver.execute_query.return_value = ([], None, None)
 
@@ -2183,9 +2109,7 @@ class TestRolesDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.roles.audit_service.record_denied") as mock_record:
             response = client.delete("/api/roles/CustomRole")

--- a/backend/tests/test_routers_events.py
+++ b/backend/tests/test_routers_events.py
@@ -24,6 +24,8 @@ from fastapi.testclient import TestClient
 _mock_neo4j_driver = MagicMock()
 
 # Stub out snmp_service before it gets imported
+_SNMP_SERVICE_SENTINEL = object()
+_previous_snmp_service = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
 _snmp_service_stub = types.ModuleType("services.snmp_service")
 setattr(_snmp_service_stub, "snmp_collector_loop", lambda: None)
 setattr(
@@ -39,7 +41,12 @@ with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
     from database import get_db
 
-from models.user import User, UserPermission
+if _previous_snmp_service is _SNMP_SERVICE_SENTINEL:
+    sys.modules.pop("services.snmp_service", None)
+else:
+    sys.modules["services.snmp_service"] = _previous_snmp_service
+
+from models.user import AIPermission, User, UserPermission
 from services.auth_service import get_current_active_user
 
 # ---------------------------------------------------------------------------
@@ -48,17 +55,32 @@ from services.auth_service import get_current_active_user
 client = TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def restore_dependency_overrides_and_snmp_stub():
+    yield
+    app.dependency_overrides.pop(get_current_active_user, None)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
-def _ai_user(username: str = "ai-agent-1", role: str = "AI_DIAGNOSTIC") -> User:
+def _ai_user(
+    username: str = "ai-agent-1",
+    role: str = "AI_DIAGNOSTIC",
+    permissions: list[AIPermission | str] | None = None,
+) -> User:
     """Create a fake AI agent user."""
     return User(
         username=username,
         role=role,
-        permissions=[],
+        permissions=[
+            AIPermission.AI_EVENT_ACK,
+            AIPermission.AI_EVENT_CLOSE,
+            AIPermission.AI_EVENT_COMMENT,
+            AIPermission.AI_RUN_DIAGNOSTIC,
+        ] if permissions is None else permissions,
         allowed_locations=[],
     )
 
@@ -149,6 +171,21 @@ class TestAckEvent:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
+    def test_ai_agent_ack_without_ai_event_ack_denied_before_guard(self):
+        """AI agent without AI_EVENT_ACK must not reach ack guard logic."""
+        async def override():
+            return _ai_user(permissions=[AIPermission.AI_RUN_DIAGNOSTIC])
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards:
+            response = client.post("/api/events/evt-001/ack", json={})
+
+            assert response.status_code == 403
+            mock_guards.assert_not_called()
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
     def test_ai_agent_ack_records_operation_on_success(self):
         """When ack succeeds, record_operation is called with result='success'."""
         async def override():
@@ -169,6 +206,74 @@ class TestAckEvent:
             call_kwargs = mock_record.call_args
             assert call_kwargs[1]["result"] == "success"
             assert call_kwargs[1]["operation"] == "ack"
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/events/{event_id}/comment
+# ---------------------------------------------------------------------------
+
+
+class TestCommentEvent:
+    """Tests for POST /api/events/{event_id}/comment endpoint permissions."""
+
+    def test_human_event_ack_can_comment(self):
+        async def override():
+            return _operator_user(permissions=[UserPermission.EVENT_ACK])
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.event_service") as mock_service:
+            mock_service.add_event_comment.return_value = {"message": "Comment added"}
+
+            response = client.post(
+                "/api/events/evt-001/comment",
+                json={"message": "Checking this event"},
+            )
+
+            assert response.status_code == 200
+            mock_service.add_event_comment.assert_called_once_with(
+                "evt-001", "operator", "Checking this event"
+            )
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_without_ai_event_comment_denied(self):
+        async def override():
+            return _ai_user(permissions=[AIPermission.AI_EVENT_ACK])
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.event_service") as mock_service:
+            response = client.post(
+                "/api/events/evt-001/comment",
+                json={"message": "Checking this event"},
+            )
+
+            assert response.status_code == 403
+            mock_service.add_event_comment.assert_not_called()
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_with_ai_event_comment_can_comment(self):
+        async def override():
+            return _ai_user(permissions=[AIPermission.AI_EVENT_COMMENT])
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.event_service") as mock_service:
+            mock_service.add_event_comment.return_value = {"message": "Comment added"}
+
+            response = client.post(
+                "/api/events/evt-001/comment",
+                json={"message": "AI note"},
+            )
+
+            assert response.status_code == 200
+            mock_service.add_event_comment.assert_called_once_with(
+                "evt-001", "ai-agent-1", "AI note"
+            )
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -265,6 +370,21 @@ class TestCloseEvent:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
+    def test_ai_agent_close_without_ai_event_close_denied_before_guard(self):
+        """AI_DIAGNOSTIC with only AI_RUN_DIAGNOSTIC must not close events."""
+        async def override():
+            return _ai_user(permissions=[AIPermission.AI_RUN_DIAGNOSTIC])
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards:
+            response = client.post("/api/events/evt-001/close", json={})
+
+            assert response.status_code == 403
+            mock_guards.assert_not_called()
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
     def test_critical_event_close_triggers_escalation(self):
         """Closing a CRITICAL event must trigger escalation notification for all users."""
         async def override():
@@ -291,7 +411,7 @@ class TestCloseEvent:
             # notify_critical_event_escalation must have been called
             mock_notify.assert_called_once()
             call_kwargs = mock_notify.call_args[1]
-            assert call_kwargs["severity"] == "CRITICAL" or "event_message" in call_kwargs
+            assert "event_message" in call_kwargs
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -404,6 +524,21 @@ class TestDiagnoseEvent:
 
             assert response.status_code == 403
             assert "Cooldown active" in response.json()["detail"]
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
+    def test_ai_agent_diagnose_without_ai_run_diagnostic_denied_before_guard(self):
+        """AI agent without AI_RUN_DIAGNOSTIC must not reach diagnostic guards."""
+        async def override():
+            return _ai_user(permissions=[AIPermission.AI_EVENT_ACK])
+
+        app.dependency_overrides[get_current_active_user] = override
+
+        with patch("routers.events.check_all_guards") as mock_guards:
+            response = client.post("/api/events/evt-001/diagnose")
+
+            assert response.status_code == 403
+            mock_guards.assert_not_called()
 
         app.dependency_overrides.pop(get_current_active_user, None)
 

--- a/backend/tests/test_routers_events.py
+++ b/backend/tests/test_routers_events.py
@@ -12,10 +12,11 @@ Strategy:
 - Mock ai_guard_service functions and event_service functions
 """
 
-import pytest
-import types
 import sys
+import types
 from unittest.mock import MagicMock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------
@@ -27,27 +28,26 @@ _mock_neo4j_driver = MagicMock()
 _SNMP_SERVICE_SENTINEL = object()
 _previous_snmp_service = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
 _snmp_service_stub = types.ModuleType("services.snmp_service")
-setattr(_snmp_service_stub, "snmp_collector_loop", lambda: None)
-setattr(
-    _snmp_service_stub,
-    "get_collector_status",
-    lambda: {"last_run": None, "status": "STOPPED", "stats": {}},
-)
-setattr(_snmp_service_stub, "validate_snmp_oid", lambda *args, **kwargs: {"success": False})
-setattr(_snmp_service_stub, "run_diagnostic", lambda *args, **kwargs: "diagnostic-ok")
+_snmp_service_stub.snmp_collector_loop = lambda: None
+_snmp_service_stub.get_collector_status = lambda: {
+    "last_run": None,
+    "status": "STOPPED",
+    "stats": {},
+}
+_snmp_service_stub.validate_snmp_oid = lambda *args, **kwargs: {"success": False}
+_snmp_service_stub.run_diagnostic = lambda *args, **kwargs: "diagnostic-ok"
 sys.modules["services.snmp_service"] = _snmp_service_stub
 
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
-    from database import get_db
 
 if _previous_snmp_service is _SNMP_SERVICE_SENTINEL:
     sys.modules.pop("services.snmp_service", None)
 else:
     sys.modules["services.snmp_service"] = _previous_snmp_service
 
-from models.user import AIPermission, User, UserPermission
-from services.auth_service import get_current_active_user
+from models.user import AIPermission, User, UserPermission  # noqa: E402
+from services.auth_service import get_current_active_user  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # TestClient
@@ -75,12 +75,16 @@ def _ai_user(
     return User(
         username=username,
         role=role,
-        permissions=[
-            AIPermission.AI_EVENT_ACK,
-            AIPermission.AI_EVENT_CLOSE,
-            AIPermission.AI_EVENT_COMMENT,
-            AIPermission.AI_RUN_DIAGNOSTIC,
-        ] if permissions is None else permissions,
+        permissions=(
+            [
+                AIPermission.AI_EVENT_ACK,
+                AIPermission.AI_EVENT_CLOSE,
+                AIPermission.AI_EVENT_COMMENT,
+                AIPermission.AI_RUN_DIAGNOSTIC,
+            ]
+            if permissions is None
+            else permissions
+        ),
         allowed_locations=[],
     )
 
@@ -93,7 +97,8 @@ def _operator_user(
     return User(
         username=username,
         role="OPERATOR",
-        permissions=permissions or [UserPermission.EVENT_ACK, UserPermission.EVENT_CLOSE, UserPermission.RUN_DIAGNOSTICS],
+        permissions=permissions
+        or [UserPermission.EVENT_ACK, UserPermission.EVENT_CLOSE, UserPermission.RUN_DIAGNOSTICS],
         allowed_locations=[],
     )
 
@@ -113,6 +118,7 @@ class TestAckEvent:
 
     def test_ack_no_permission(self):
         """User without EVENT_ACK should get 403."""
+
         async def override():
             return User(
                 username="viewer",
@@ -131,14 +137,17 @@ class TestAckEvent:
 
     def test_ai_agent_ack_passes_guard_check(self):
         """AI agent can acknowledge when check_all_guards returns allowed=True."""
+
         async def override():
             return _ai_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.check_all_guards") as mock_guards, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service:
+        with (
+            patch("routers.events.check_all_guards") as mock_guards,
+            patch("routers.events.record_operation") as mock_record,
+            patch("routers.events.event_service") as mock_service,
+        ):
             mock_guards.return_value = MagicMock(allowed=True)
             mock_service.ack_event.return_value = {"message": "Event acknowledged"}
 
@@ -152,6 +161,7 @@ class TestAckEvent:
 
     def test_ai_agent_ack_blocked_by_guard(self):
         """AI agent gets 403 when check_all_guards returns allowed=False (cooldown active)."""
+
         async def override():
             return _ai_user()
 
@@ -173,6 +183,7 @@ class TestAckEvent:
 
     def test_ai_agent_ack_without_ai_event_ack_denied_before_guard(self):
         """AI agent without AI_EVENT_ACK must not reach ack guard logic."""
+
         async def override():
             return _ai_user(permissions=[AIPermission.AI_RUN_DIAGNOSTIC])
 
@@ -188,14 +199,17 @@ class TestAckEvent:
 
     def test_ai_agent_ack_records_operation_on_success(self):
         """When ack succeeds, record_operation is called with result='success'."""
+
         async def override():
             return _ai_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.check_all_guards") as mock_guards, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service:
+        with (
+            patch("routers.events.check_all_guards") as mock_guards,
+            patch("routers.events.record_operation") as mock_record,
+            patch("routers.events.event_service") as mock_service,
+        ):
             mock_guards.return_value = MagicMock(allowed=True)
             mock_service.ack_event.return_value = {"message": "Event acknowledged"}
 
@@ -293,6 +307,7 @@ class TestCloseEvent:
 
     def test_close_no_permission(self):
         """User without EVENT_CLOSE should get 403."""
+
         async def override():
             return User(
                 username="viewer",
@@ -311,6 +326,7 @@ class TestCloseEvent:
 
     def test_ai_agent_cannot_force_close(self):
         """AI agent with forced=True should get 403 — AI cannot force-close."""
+
         async def override():
             return _ai_user()
 
@@ -328,18 +344,25 @@ class TestCloseEvent:
 
     def test_ai_agent_close_passes_guard_check(self):
         """AI agent can close when check_all_guards returns allowed=True (non-CRITICAL event)."""
+
         async def override():
             return _ai_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.check_all_guards") as mock_guards, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service, \
-             patch("routers.events.set_cooldown") as mock_set_cooldown:
+        with (
+            patch("routers.events.check_all_guards") as mock_guards,
+            patch("routers.events.record_operation"),
+            patch("routers.events.event_service") as mock_service,
+            patch("routers.events.set_cooldown"),
+        ):
             mock_guards.return_value = MagicMock(allowed=True)
             mock_service.get_event_detail.return_value = {
-                "event": {"severity": "WARNING", "message": "Test", "ci": {"id": "ci-001", "label": "Router-01"}},
+                "event": {
+                    "severity": "WARNING",
+                    "message": "Test",
+                    "ci": {"id": "ci-001", "label": "Router-01"},
+                },
             }
             mock_service.close_event.return_value = {"message": "Event closed"}
 
@@ -352,6 +375,7 @@ class TestCloseEvent:
 
     def test_ai_agent_close_blocked_by_guard(self):
         """AI agent gets 403 when check_all_guards returns allowed=False."""
+
         async def override():
             return _ai_user()
 
@@ -372,6 +396,7 @@ class TestCloseEvent:
 
     def test_ai_agent_close_without_ai_event_close_denied_before_guard(self):
         """AI_DIAGNOSTIC with only AI_RUN_DIAGNOSTIC must not close events."""
+
         async def override():
             return _ai_user(permissions=[AIPermission.AI_RUN_DIAGNOSTIC])
 
@@ -387,15 +412,18 @@ class TestCloseEvent:
 
     def test_critical_event_close_triggers_escalation(self):
         """Closing a CRITICAL event must trigger escalation notification for all users."""
+
         async def override():
             return _operator_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.notify_critical_event_escalation") as mock_notify, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service, \
-             patch("routers.events.set_cooldown") as mock_set_cooldown:
+        with (
+            patch("routers.events.notify_critical_event_escalation") as mock_notify,
+            patch("routers.events.record_operation"),
+            patch("routers.events.event_service") as mock_service,
+            patch("routers.events.set_cooldown"),
+        ):
             mock_service.get_event_detail.return_value = {
                 "event": {
                     "severity": "CRITICAL",
@@ -417,16 +445,19 @@ class TestCloseEvent:
 
     def test_ai_agent_close_critical_event_records_escalated(self):
         """AI agent closing CRITICAL event should record result='escalated'."""
+
         async def override():
             return _ai_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.check_all_guards") as mock_guards, \
-             patch("routers.events.notify_critical_event_escalation") as mock_notify, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service, \
-             patch("routers.events.set_cooldown") as mock_set_cooldown:
+        with (
+            patch("routers.events.check_all_guards") as mock_guards,
+            patch("routers.events.notify_critical_event_escalation"),
+            patch("routers.events.record_operation") as mock_record,
+            patch("routers.events.event_service") as mock_service,
+            patch("routers.events.set_cooldown"),
+        ):
             mock_guards.return_value = MagicMock(allowed=True)
             mock_service.get_event_detail.return_value = {
                 "event": {
@@ -443,8 +474,7 @@ class TestCloseEvent:
             # record_operation should be called twice: once for escalation, once for success
             # Find the escalated call
             escalated_calls = [
-                c for c in mock_record.call_args_list
-                if c[1].get("result") == "escalated"
+                c for c in mock_record.call_args_list if c[1].get("result") == "escalated"
             ]
             assert len(escalated_calls) >= 1
 
@@ -466,6 +496,7 @@ class TestDiagnoseEvent:
 
     def test_diagnose_no_permission(self):
         """User without RUN_DIAGNOSTICS should get 403."""
+
         async def override():
             return User(
                 username="viewer",
@@ -484,17 +515,24 @@ class TestDiagnoseEvent:
 
     def test_ai_agent_diagnose_passes_guard_check(self):
         """AI agent can run diagnostic when check_all_guards returns allowed=True."""
+
         async def override():
             return _ai_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.check_all_guards") as mock_guards, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service:
+        with (
+            patch("routers.events.check_all_guards") as mock_guards,
+            patch("routers.events.record_operation") as mock_record,
+            patch("routers.events.event_service") as mock_service,
+        ):
             mock_guards.return_value = MagicMock(allowed=True)
             mock_service.get_event_detail.return_value = {
-                "event": {"severity": "WARNING", "message": "Test", "ci": {"id": "ci-001", "label": "Router-01"}},
+                "event": {
+                    "severity": "WARNING",
+                    "message": "Test",
+                    "ci": {"id": "ci-001", "label": "Router-01"},
+                },
             }
             mock_service.run_event_diagnostic.return_value = {"message": "Diagnostic complete"}
 
@@ -508,6 +546,7 @@ class TestDiagnoseEvent:
 
     def test_ai_agent_diagnose_blocked_by_guard(self):
         """AI agent gets 403 when check_all_guards returns allowed=False."""
+
         async def override():
             return _ai_user()
 
@@ -529,6 +568,7 @@ class TestDiagnoseEvent:
 
     def test_ai_agent_diagnose_without_ai_run_diagnostic_denied_before_guard(self):
         """AI agent without AI_RUN_DIAGNOSTIC must not reach diagnostic guards."""
+
         async def override():
             return _ai_user(permissions=[AIPermission.AI_EVENT_ACK])
 
@@ -544,14 +584,17 @@ class TestDiagnoseEvent:
 
     def test_ai_agent_diagnose_records_operation_on_success(self):
         """When diagnose succeeds, record_operation is called with operation='diagnose'."""
+
         async def override():
             return _ai_user()
 
         app.dependency_overrides[get_current_active_user] = override
 
-        with patch("routers.events.check_all_guards") as mock_guards, \
-             patch("routers.events.record_operation") as mock_record, \
-             patch("routers.events.event_service") as mock_service:
+        with (
+            patch("routers.events.check_all_guards") as mock_guards,
+            patch("routers.events.record_operation") as mock_record,
+            patch("routers.events.event_service") as mock_service,
+        ):
             mock_guards.return_value = MagicMock(allowed=True)
             mock_service.get_event_detail.return_value = {
                 "event": {"severity": "WARNING", "ci": {"label": "Router-01"}},

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -30,6 +30,8 @@ from sqlalchemy.orm import Session
 # The driver is created at module import time and tries to connect immediately
 # ---------------------------------------------------------------------------
 _mock_neo4j_driver = MagicMock()
+_SNMP_SERVICE_SENTINEL = object()
+_previous_snmp_service = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
 _snmp_service_stub = types.ModuleType("services.snmp_service")
 setattr(_snmp_service_stub, "snmp_collector_loop", lambda: None)
 setattr(
@@ -49,6 +51,11 @@ sys.modules["services.snmp_service"] = _snmp_service_stub
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
     from database import get_db
+
+if _previous_snmp_service is _SNMP_SERVICE_SENTINEL:
+    sys.modules.pop("services.snmp_service", None)
+else:
+    sys.modules["services.snmp_service"] = _previous_snmp_service
 
 from models.user import User, UserPermission
 from postgres_db import get_pg_db

--- a/backend/tests/test_routers_metrics_events.py
+++ b/backend/tests/test_routers_metrics_events.py
@@ -15,14 +15,15 @@ Strategy:
 """
 
 import asyncio
-from datetime import datetime, timezone
-import pytest
 import sys
 import threading
 import types
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
-from fastapi.testclient import TestClient
+
+import pytest
 from fastapi import HTTPException
+from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 # ---------------------------------------------------------------------------
@@ -33,33 +34,26 @@ _mock_neo4j_driver = MagicMock()
 _SNMP_SERVICE_SENTINEL = object()
 _previous_snmp_service = sys.modules.get("services.snmp_service", _SNMP_SERVICE_SENTINEL)
 _snmp_service_stub = types.ModuleType("services.snmp_service")
-setattr(_snmp_service_stub, "snmp_collector_loop", lambda: None)
-setattr(
-    _snmp_service_stub,
-    "get_collector_status",
-    lambda: {
-        "last_run": None,
-        "status": "STOPPED",
-        "stats": {},
-    },
-)
-setattr(
-    _snmp_service_stub, "validate_snmp_oid", lambda *args, **kwargs: {"success": False}
-)
-setattr(_snmp_service_stub, "run_diagnostic", lambda *args, **kwargs: "diagnostic-ok")
+_snmp_service_stub.snmp_collector_loop = lambda: None
+_snmp_service_stub.get_collector_status = lambda: {
+    "last_run": None,
+    "status": "STOPPED",
+    "stats": {},
+}
+_snmp_service_stub.validate_snmp_oid = lambda *args, **kwargs: {"success": False}
+_snmp_service_stub.run_diagnostic = lambda *args, **kwargs: "diagnostic-ok"
 sys.modules["services.snmp_service"] = _snmp_service_stub
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
-    from database import get_db
 
 if _previous_snmp_service is _SNMP_SERVICE_SENTINEL:
     sys.modules.pop("services.snmp_service", None)
 else:
     sys.modules["services.snmp_service"] = _previous_snmp_service
 
-from models.user import User, UserPermission
-from postgres_db import get_pg_db
-from services.auth_service import get_current_active_user
+from models.user import User, UserPermission  # noqa: E402
+from postgres_db import get_pg_db  # noqa: E402
+from services.auth_service import get_current_active_user  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # TestClient
@@ -158,9 +152,7 @@ class TestMetricsList:
         """Should return empty list when no metrics exist."""
         mock_session = MagicMock()
         mock_session.run.return_value = []
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/metrics")
@@ -207,9 +199,7 @@ class TestMetricsList:
 
         mock_session = MagicMock()
         mock_session.run.return_value = FakeResult()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/metrics")
@@ -272,7 +262,7 @@ class TestMetricsList:
         """Metrics list should NOT require authentication (documented gap)."""
         # No auth headers, no overrides — should still succeed (200, not 401)
         # Since Neo4j isn't mocked here, it will fail with 500, but NOT 401
-        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):  # noqa: SIM117
             with patch("database.driver", MagicMock()):
                 response = client.get("/api/metrics")
         # 200 or 500 are acceptable — the key is it's NOT 401/403
@@ -286,8 +276,8 @@ class TestMetricsCreate:
     @pytest.mark.asyncio
     async def test_create_metric_offloads_sync_service_work(self):
         """The async route should not block unrelated coroutine startup."""
-        from routers import metrics as metrics_router
         from models.core import MetricDef
+        from routers import metrics as metrics_router
 
         fake_user = _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
         started = threading.Event()
@@ -303,7 +293,9 @@ class TestMetricsCreate:
 
         with (
             patch("routers.metrics.check_permission", return_value=True),
-            patch.object(metrics_router.metric_service, "create_metric", side_effect=blocking_create),
+            patch.object(
+                metrics_router.metric_service, "create_metric", side_effect=blocking_create
+            ),
         ):
             metric = MetricDef(id="slow-metric", protocol="SNMP")
             marker_task = None
@@ -332,13 +324,13 @@ class TestMetricsCreate:
 
     @pytest.mark.asyncio
     async def test_create_metric_duplicate_operation_maps_to_409(self):
-        from routers import metrics as metrics_router
         from models.core import MetricDef
+        from routers import metrics as metrics_router
         from services.metric_operation_guard import MetricOperationInProgress
 
         fake_user = _make_pydantic_user(permissions=[UserPermission.CI_EDIT])
 
-        with (
+        with (  # noqa: SIM117
             patch("routers.metrics.check_permission", return_value=True),
             patch.object(
                 metrics_router.metric_service,
@@ -347,7 +339,9 @@ class TestMetricsCreate:
             ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await metrics_router.create_metric(MetricDef(id="slow-metric", protocol="SNMP"), fake_user)
+                await metrics_router.create_metric(
+                    MetricDef(id="slow-metric", protocol="SNMP"), fake_user
+                )
 
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail == {
@@ -366,14 +360,10 @@ class TestMetricsCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_session = MagicMock()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with (
             patch("database.driver", mock_neo4j_driver),
@@ -409,7 +399,7 @@ class TestMetricsCreate:
 
     def test_create_metric_unauthenticated(self):
         """Create metric requires authentication."""
-        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):  # noqa: SIM117
             with patch("database.driver", MagicMock()):
                 response = client.post(
                     "/api/metrics",
@@ -431,9 +421,7 @@ class TestMetricsCreate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post(
             "/api/metrics",
@@ -468,7 +456,9 @@ class TestMetricsDelete:
 
         with (
             patch("routers.metrics.check_permission", return_value=True),
-            patch.object(metrics_router.metric_service, "delete_metric", side_effect=blocking_delete),
+            patch.object(
+                metrics_router.metric_service, "delete_metric", side_effect=blocking_delete
+            ),
         ):
             marker_task = None
             route_task = asyncio.create_task(metrics_router.delete_metric("slow-metric", fake_user))
@@ -508,9 +498,9 @@ class TestMetricsDelete:
                 "delete_metric",
                 side_effect=MetricOperationInProgress("slow-metric"),
             ),
+            pytest.raises(HTTPException) as exc_info,
         ):
-            with pytest.raises(HTTPException) as exc_info:
-                await metrics_router.delete_metric("slow-metric", fake_user)
+            await metrics_router.delete_metric("slow-metric", fake_user)
 
         assert exc_info.value.status_code == 409
         assert exc_info.value.detail == {
@@ -531,9 +521,7 @@ class TestMetricsDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with (
             patch("routers.metrics.check_permission", return_value=True),
@@ -561,7 +549,7 @@ class TestMetricsDelete:
 
     def test_delete_metric_unauthenticated(self):
         """Delete metric requires authentication."""
-        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):  # noqa: SIM117
             with patch("database.driver", MagicMock()):
                 response = client.delete("/api/metrics/any-metric")
         assert response.status_code == 401
@@ -577,9 +565,7 @@ class TestMetricsDelete:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.delete("/api/metrics/forbidden-metric")
 
@@ -628,9 +614,7 @@ class TestMetricsUsage:
 
         mock_session = MagicMock()
         mock_session.run.side_effect = mock_run
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/metrics/cpu-load/usage")
@@ -712,14 +696,10 @@ class TestMetricsPromote:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_session = MagicMock()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with (
             patch("database.driver", mock_neo4j_driver),
@@ -752,9 +732,7 @@ class TestMetricsPromote:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post(
             "/api/metrics/promote",
@@ -778,9 +756,7 @@ class TestMetricsValidate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.metrics.validate_snmp_oid") as mock_validate:
             mock_validate.return_value = {
@@ -810,9 +786,7 @@ class TestMetricsValidate:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         # Patch at the router module level where the function is imported
         with patch("routers.metrics.validate_snmp_oid") as mock_validate:
@@ -1114,9 +1088,7 @@ class TestEventsList:
                 )
             )
         )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/events")
@@ -1129,12 +1101,8 @@ class TestEventsList:
     def test_list_events_with_status_filter(self, mock_neo4j_driver):
         """Should pass status filter to the query."""
         mock_session = MagicMock()
-        mock_session.run.return_value = MagicMock(
-            __iter__=MagicMock(return_value=iter([]))
-        )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_session.run.return_value = MagicMock(__iter__=MagicMock(return_value=iter([])))
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/events?status=OPEN")
@@ -1148,12 +1116,8 @@ class TestEventsList:
     def test_list_events_active_filter(self, mock_neo4j_driver):
         """ACTIVE status should request unresolved OPEN/ACK events from the service."""
         mock_session = MagicMock()
-        mock_session.run.return_value = MagicMock(
-            __iter__=MagicMock(return_value=iter([]))
-        )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_session.run.return_value = MagicMock(__iter__=MagicMock(return_value=iter([])))
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/events?status=ACTIVE")
@@ -1164,7 +1128,7 @@ class TestEventsList:
 
     def test_list_events_no_auth_required(self):
         """Events list should NOT require authentication (by design)."""
-        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):
+        with patch("neo4j.GraphDatabase.driver", return_value=MagicMock()):  # noqa: SIM117
             with patch("database.driver", MagicMock()):
                 response = client.get("/api/events")
         assert response.status_code != 401
@@ -1189,9 +1153,7 @@ class TestEventsList:
                 "ack": False,
                 "ack_by": "operator-1",
                 "closed_by": "operator-2",
-                "comments": [
-                    "[AUDIT][CLOSE] Evento cerrado por operator-2\nNota: detalle interno"
-                ],
+                "comments": ["[AUDIT][CLOSE] Evento cerrado por operator-2\nNota: detalle interno"],
             }
         ]
 
@@ -1236,8 +1198,8 @@ class TestEventsList:
         assert event["source_protocol"] == "ICMP"
 
     def test_availability_report_endpoint_is_additive_and_accepts_custom_window(self):
-        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        end = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, tzinfo=UTC)
+        end = datetime(2026, 1, 31, tzinfo=UTC)
         payload = {
             "window_start": start.isoformat(),
             "window_end": end.isoformat(),
@@ -1322,11 +1284,9 @@ class TestEventsList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
-        generated_at = datetime(2026, 1, 31, tzinfo=timezone.utc)
+        generated_at = datetime(2026, 1, 31, tzinfo=UTC)
         payload = {
             "generated_at": generated_at.isoformat(),
             "limit": 25,
@@ -1389,9 +1349,7 @@ class TestEventsList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/events/availability-report/snmp-no-response")
 
@@ -1408,9 +1366,7 @@ class TestEventsList:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get(
             "/api/events/availability-report/snmp-no-response",
@@ -1420,7 +1376,7 @@ class TestEventsList:
         assert response.status_code == 422
 
     def test_availability_report_endpoint_keeps_old_rows_valid(self):
-        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        start = datetime(2026, 1, 1, tzinfo=UTC)
         payload = {
             "window_start": start.isoformat(),
             "window_end": start.isoformat(),
@@ -1445,9 +1401,7 @@ class TestEventsList:
             ],
         }
 
-        with patch(
-            "routers.events.event_service.get_availability_report", return_value=payload
-        ):
+        with patch("routers.events.event_service.get_availability_report", return_value=payload):
             response = client.get("/api/events/availability-report")
 
         assert response.status_code == 200
@@ -1469,9 +1423,7 @@ class TestEventsDetail:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         payload = {
             "event": {
@@ -1522,9 +1474,7 @@ class TestEventsDetail:
             },
         }
 
-        with patch(
-            "routers.events.event_service.get_event_detail", return_value=payload
-        ):
+        with patch("routers.events.event_service.get_event_detail", return_value=payload):
             response = client.get("/api/events/evt-001")
 
         assert response.status_code == 200
@@ -1549,18 +1499,14 @@ class TestEventsDetail:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/events/evt-001")
 
         assert response.status_code == 403
         assert response.json()["detail"] == "Not authorized to view events"
 
-    def test_get_event_detail_real_contract_handles_partial_snapshot(
-        self, mock_neo4j_driver
-    ):
+    def test_get_event_detail_real_contract_handles_partial_snapshot(self, mock_neo4j_driver):
         fake_user = _make_pydantic_user(
             username="viewer",
             role="VIEWER",
@@ -1570,9 +1516,7 @@ class TestEventsDetail:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         class FakeRecord(dict):
             def __getitem__(self, key):
@@ -1611,9 +1555,7 @@ class TestEventsDetail:
                 "sc": _FakeNeo4jNode({"id": "sla-legacy", "category": "NETWORK"}),
             }
         )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/events/evt-legacy")
@@ -1636,9 +1578,7 @@ class TestEventsDetail:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch(
             "routers.events.event_service.get_event_detail",
@@ -1664,9 +1604,7 @@ class TestEventsRelated:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         class FakeEventNode:
             def __init__(self, data):
@@ -1716,9 +1654,7 @@ class TestEventsRelated:
                 )
             )
         )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.get("/api/events/related/ci-001")
@@ -1744,9 +1680,7 @@ class TestEventsRelated:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.get("/api/events/related/ci-001")
 
@@ -1769,9 +1703,7 @@ class TestEventsAck:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.events.event_service.ack_event") as mock_ack_event:
             mock_ack_event.return_value = {"message": "Event Acknowledged"}
@@ -1780,9 +1712,7 @@ class TestEventsAck:
         assert response.status_code == 200
         data = response.json()
         assert "Acknowledged" in data["message"]
-        mock_ack_event.assert_called_once_with(
-            "evt-001", "operator", comment_message=None
-        )
+        mock_ack_event.assert_called_once_with("evt-001", "operator", comment_message=None)
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
@@ -1796,17 +1726,13 @@ class TestEventsAck:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.events.event_service.ack_event") as mock_ack_event:
             mock_ack_event.return_value = {"message": "Event Acknowledged"}
             response = client.post(
                 "/api/events/evt-001/ack",
-                json={
-                    "comment_message": "[OWNERSHIP] Caso tomado por operator - Tier T2"
-                },
+                json={"comment_message": "[OWNERSHIP] Caso tomado por operator - Tier T2"},
             )
 
         assert response.status_code == 200
@@ -1833,9 +1759,7 @@ class TestEventsAck:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post("/api/events/evt-001/ack")
 
@@ -1856,9 +1780,7 @@ class TestEventsClose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.events.event_service.close_event") as mock_close_event:
             mock_close_event.return_value = {"message": "Event Closed"}
@@ -1883,9 +1805,7 @@ class TestEventsClose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("routers.events.event_service.close_event") as mock_close_event:
             mock_close_event.return_value = {"message": "Event Closed"}
@@ -1922,17 +1842,13 @@ class TestEventsClose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post("/api/events/evt-001/close")
 
         assert response.status_code == 403
 
-    def test_close_event_requires_structured_root_cause_and_note(
-        self, mock_neo4j_driver
-    ):
+    def test_close_event_requires_structured_root_cause_and_note(self, mock_neo4j_driver):
         fake_user = _make_pydantic_user(
             username="operator",
             role="OPERATOR",
@@ -1942,9 +1858,7 @@ class TestEventsClose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.post(
@@ -1966,9 +1880,7 @@ class TestEventsClose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.post(
@@ -2002,13 +1914,9 @@ class TestEventsComment:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
-        with patch(
-            "routers.events.event_service.add_event_comment"
-        ) as mock_add_comment:
+        with patch("routers.events.event_service.add_event_comment") as mock_add_comment:
             mock_add_comment.return_value = {"message": "Comment added"}
 
             response = client.post(
@@ -2018,9 +1926,7 @@ class TestEventsComment:
 
         assert response.status_code == 200
         assert response.json()["message"] == "Comment added"
-        mock_add_comment.assert_called_once_with(
-            "evt-001", "operator", "Investigating the issue"
-        )
+        mock_add_comment.assert_called_once_with("evt-001", "operator", "Investigating the issue")
 
     def test_add_comment_forbidden_without_event_permission(self):
         fake_user = _make_pydantic_user(
@@ -2032,9 +1938,7 @@ class TestEventsComment:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post(
             "/api/events/evt-001/comment",
@@ -2060,9 +1964,7 @@ class TestEventsPrune:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         class FakeRecord:
             def __init__(self, data):
@@ -2078,9 +1980,7 @@ class TestEventsPrune:
         mock_session.run.return_value = MagicMock(
             single=MagicMock(return_value=FakeRecord({"closed_count": 5}))
         )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.post("/api/events/prune")
@@ -2107,9 +2007,7 @@ class TestEventsPrune:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post("/api/events/prune")
 
@@ -2130,15 +2028,11 @@ class TestEventsDiagnose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         mock_session = MagicMock()
         mock_session.run.return_value = MagicMock(single=MagicMock(return_value=None))
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.post("/api/events/nonexistent/diagnose")
@@ -2162,9 +2056,7 @@ class TestEventsDiagnose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         response = client.post("/api/events/evt-001/diagnose")
 
@@ -2181,9 +2073,7 @@ class TestEventsDiagnose:
         async def override_get_current_active_user():
             return fake_user
 
-        app.dependency_overrides[get_current_active_user] = (
-            override_get_current_active_user
-        )
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
 
         class FakeNode:
             def __init__(self, data):
@@ -2235,9 +2125,7 @@ class TestEventsDiagnose:
                 )
             )
         )
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with (
             patch("database.driver", mock_neo4j_driver),
@@ -2278,9 +2166,7 @@ class TestEventsForcedCloseAuthorization:
         app.dependency_overrides[get_current_active_user] = override
 
         mock_session = MagicMock()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.post(
@@ -2334,9 +2220,7 @@ class TestEventsForcedCloseAuthorization:
         app.dependency_overrides[get_current_active_user] = override
 
         mock_session = MagicMock()
-        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(
-            return_value=mock_session
-        )
+        mock_neo4j_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
 
         with patch("database.driver", mock_neo4j_driver):
             response = client.post(

--- a/backend/tests/test_rtus_router.py
+++ b/backend/tests/test_rtus_router.py
@@ -18,10 +18,11 @@ Strategy:
 - Mock RTUService for service-layer isolation
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
-from fastapi.testclient import TestClient
 from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
 
 # ---------------------------------------------------------------------------
 # Patch Neo4j driver BEFORE importing anything that touches database.py
@@ -29,10 +30,9 @@ from uuid import uuid4
 _mock_neo4j_driver = MagicMock()
 with patch("neo4j.GraphDatabase.driver", return_value=_mock_neo4j_driver):
     from main import app
-    from database import get_db
 
-from models.user import User, UserPermission
-from services.auth_service import get_current_active_user
+from models.user import User, UserPermission  # noqa: E402
+from services.auth_service import get_current_active_user  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # TestClient (real app)
@@ -474,9 +474,7 @@ class TestSensorsRouter:
                 f"/api/v1/rtus/{rtu_id}/sensors/{sensor_id}",
                 json={"name": "Sensor Updated"},
             )
-            delete_response = client.delete(
-                f"/api/v1/rtus/{rtu_id}/sensors/{sensor_id}"
-            )
+            delete_response = client.delete(f"/api/v1/rtus/{rtu_id}/sensors/{sensor_id}")
 
             assert create_response.status_code == 403
             assert update_response.status_code == 403

--- a/backend/tests/test_rtus_router.py
+++ b/backend/tests/test_rtus_router.py
@@ -62,6 +62,17 @@ def _make_pydantic_user(
     )
 
 
+def _override_auth_and_service(user: User, mock_rtu_service):
+    from routers import rtus as rtus_module
+
+    async def override_get_current_active_user():
+        return user
+
+    app.dependency_overrides[get_current_active_user] = override_get_current_active_user
+    app.dependency_overrides[rtus_module.get_rtu_service] = lambda: mock_rtu_service
+    return rtus_module
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -79,7 +90,11 @@ def fake_user():
     return _make_pydantic_user(
         username="testuser",
         role="ADMIN",
-        permissions=[],
+        permissions=[
+            UserPermission.CI_VIEW,
+            UserPermission.CI_EDIT,
+            UserPermission.CI_DELETE,
+        ],
     )
 
 
@@ -173,6 +188,27 @@ class TestRTUsRouter:
 
         assert response.status_code == 404
 
+    def test_read_rtu_routes_reject_low_privilege_user(self, mock_rtu_service):
+        """RTU read endpoints require CI_VIEW permission."""
+        rtus_module = _override_auth_and_service(
+            _make_pydantic_user(role="VIEWER", permissions=[]),
+            mock_rtu_service,
+        )
+
+        try:
+            rtu_id = str(uuid4())
+
+            list_response = client.get("/api/v1/rtus")
+            get_response = client.get(f"/api/v1/rtus/{rtu_id}")
+
+            assert list_response.status_code == 403
+            assert get_response.status_code == 403
+            mock_rtu_service.list_rtus.assert_not_called()
+            mock_rtu_service.get_rtu.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_current_active_user, None)
+            app.dependency_overrides.pop(rtus_module.get_rtu_service, None)
+
     def test_post_rtu_creates_rtu(self, auth_override, mock_rtu_service):
         """POST /api/v1/rtus creates a new RTU."""
         location_id = uuid4()
@@ -262,6 +298,37 @@ class TestRTUsRouter:
 
         assert response.status_code == 404
 
+    def test_mutating_rtu_routes_reject_low_privilege_user(self, mock_rtu_service):
+        """RTU create/update/delete require CI edit/delete permissions."""
+        rtus_module = _override_auth_and_service(
+            _make_pydantic_user(role="VIEWER", permissions=[UserPermission.CI_VIEW]),
+            mock_rtu_service,
+        )
+
+        try:
+            rtu_id = str(uuid4())
+            location_id = str(uuid4())
+
+            create_response = client.post(
+                "/api/v1/rtus",
+                json={"name": "RTU-New", "location_id": location_id},
+            )
+            update_response = client.put(
+                f"/api/v1/rtus/{rtu_id}",
+                json={"name": "RTU-Updated"},
+            )
+            delete_response = client.delete(f"/api/v1/rtus/{rtu_id}")
+
+            assert create_response.status_code == 403
+            assert update_response.status_code == 403
+            assert delete_response.status_code == 403
+            mock_rtu_service.create_rtu.assert_not_called()
+            mock_rtu_service.update_rtu.assert_not_called()
+            mock_rtu_service.delete_rtu.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_current_active_user, None)
+            app.dependency_overrides.pop(rtus_module.get_rtu_service, None)
+
 
 # ---------------------------------------------------------------------------
 # Sensor Endpoint Tests
@@ -324,6 +391,24 @@ class TestSensorsRouter:
         assert response.status_code == 201
         mock_rtu_service.create_sensor.assert_called_once()
 
+    def test_read_sensor_routes_reject_low_privilege_user(self, mock_rtu_service):
+        """Sensor read endpoints require CI_VIEW permission."""
+        rtus_module = _override_auth_and_service(
+            _make_pydantic_user(role="VIEWER", permissions=[]),
+            mock_rtu_service,
+        )
+
+        try:
+            rtu_id = str(uuid4())
+
+            response = client.get(f"/api/v1/rtus/{rtu_id}/sensors")
+
+            assert response.status_code == 403
+            mock_rtu_service.list_sensors.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_current_active_user, None)
+            app.dependency_overrides.pop(rtus_module.get_rtu_service, None)
+
     def test_post_sensor_returns_422_on_invalid_register_bounds(self, auth_override):
         """POST with register_addr > 319 returns 422."""
         rtu_id = str(uuid4())
@@ -369,6 +454,39 @@ class TestSensorsRouter:
         response = client.delete(f"/api/v1/rtus/{uuid4()}/sensors/{sensor_id}")
 
         assert response.status_code == 204
+
+    def test_mutating_sensor_routes_reject_low_privilege_user(self, mock_rtu_service):
+        """Sensor create/update/delete require CI edit/delete permissions."""
+        rtus_module = _override_auth_and_service(
+            _make_pydantic_user(role="VIEWER", permissions=[UserPermission.CI_VIEW]),
+            mock_rtu_service,
+        )
+
+        try:
+            rtu_id = str(uuid4())
+            sensor_id = str(uuid4())
+
+            create_response = client.post(
+                f"/api/v1/rtus/{rtu_id}/sensors",
+                json={"name": "Sensor", "register_addr": 1, "sensor_type": "temperature"},
+            )
+            update_response = client.put(
+                f"/api/v1/rtus/{rtu_id}/sensors/{sensor_id}",
+                json={"name": "Sensor Updated"},
+            )
+            delete_response = client.delete(
+                f"/api/v1/rtus/{rtu_id}/sensors/{sensor_id}"
+            )
+
+            assert create_response.status_code == 403
+            assert update_response.status_code == 403
+            assert delete_response.status_code == 403
+            mock_rtu_service.create_sensor.assert_not_called()
+            mock_rtu_service.update_sensor.assert_not_called()
+            mock_rtu_service.delete_sensor.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_current_active_user, None)
+            app.dependency_overrides.pop(rtus_module.get_rtu_service, None)
 
 
 # Mark entire module as api tests


### PR DESCRIPTION
Closes #347

## Description
- Clear the backend full-suite baseline failures that were blocking unrelated PRs/releases.
- Register the RTU API router with explicit backend permissions for read/write/delete operations.
- Tighten AI event authorization so AI ack/close/comment/diagnose actions require explicit AI permissions before guard logic.
- Stabilize backend test harness issues around backup paths, CLI worker imports, dictionary mocks, SNMP service stubs, audit request context, and Neo4j record conversion.

## Type of Change
- [x] Bug fix

## Changes

| File | Change |
|------|--------|
| `backend/main.py` | Registers RTU router under `/api/v1`. |
| `backend/routers/rtus.py` | Enforces `CI_VIEW`, `CI_EDIT`, and `CI_DELETE` on RTU/sensor endpoints. |
| `backend/routers/events.py` | Requires explicit AI permissions for AI event actions and fixes guard ordering. |
| `backend/routers/cis.py` | Fixes `HTTPException` usage to pass `status_code`. |
| `backend/repositories/rtu_sensor_repo.py` | Adds Neo4j record conversion compatible with real records and mocks. |
| `backend/tests/*` | Repairs deterministic mocks, import isolation, permission coverage, and denial-path coverage. |

## How It Was Tested
- [x] Targeted cluster: `253 passed, 57 warnings`
- [x] Event/RTU/auth targeted suite after security fixes: `99 passed`
- [x] Full backend suite: `1394 passed, 1 skipped`
- [x] Fresh risk review: PASS
- [x] Fresh reliability review: PASS
- [x] `git diff --check` passed

## Size Exception
This cleanup exceeds the standard 400-line review budget because it fixes multiple independent baseline blockers in one pass, as requested, and adds authorization denial coverage for newly registered RTU endpoints and AI event actions. The production changes are small; most of the diff is test stabilization and regression coverage.

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No secrets or credentials added
- [x] Tests updated for changed behavior