### PR TITLE
feat(events): add lock observability core

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -34,6 +34,111 @@ def _env_float_bounded(name: str, default: float, *, minimum: float, maximum: fl
     return default
 
 
+def _env_int_bounded(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    """Parse a bounded integer environment variable with a safe fallback."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    if minimum <= value <= maximum:
+        return value
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Event Lock Observability Settings
+# ---------------------------------------------------------------------------
+
+
+EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE = 500
+EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS = 20
+EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS = 250.0
+EVENT_LOCK_DEFAULT_WARNING_P95_MS = 1000.0
+EVENT_LOCK_DEFAULT_CRITICAL_P99_MS = 5000.0
+EVENT_LOCK_MIN_THRESHOLD_MS = 0.0
+EVENT_LOCK_MAX_SLOW_LOG_INFO_MS = 60_000.0
+EVENT_LOCK_MAX_ALERT_THRESHOLD_MS = 600_000.0
+EVENT_LOCK_MIN_SAMPLE_WINDOW_SIZE = 1
+EVENT_LOCK_MAX_SAMPLE_WINDOW_SIZE = 10_000
+EVENT_LOCK_MIN_WRITER_CONTEXTS = 1
+EVENT_LOCK_MAX_WRITER_CONTEXTS = 100
+EVENT_LOCK_TOTAL_WRITER_SAMPLE_BUDGET = 10_000
+
+
+class EventLockSettings(BaseModel):
+    """Runtime observability thresholds for Event advisory-lock acquisition."""
+
+    slow_log_info_ms: float = Field(default=EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS, ge=0)
+    warning_p95_ms: float = Field(default=EVENT_LOCK_DEFAULT_WARNING_P95_MS, ge=0)
+    critical_p99_ms: float = Field(default=EVENT_LOCK_DEFAULT_CRITICAL_P99_MS, ge=0)
+    sample_window_size: int = Field(
+        default=EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE,
+        ge=EVENT_LOCK_MIN_SAMPLE_WINDOW_SIZE,
+        le=EVENT_LOCK_MAX_SAMPLE_WINDOW_SIZE,
+    )
+    max_writer_contexts: int = Field(
+        default=EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS,
+        ge=EVENT_LOCK_MIN_WRITER_CONTEXTS,
+        le=EVENT_LOCK_MAX_WRITER_CONTEXTS,
+    )
+
+    @classmethod
+    def from_env(cls) -> "EventLockSettings":
+        """Load Event lock observability settings from environment variables."""
+        sample_window_size = _env_int_bounded(
+            "EVENT_LOCK_SAMPLE_WINDOW_SIZE",
+            EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE,
+            minimum=EVENT_LOCK_MIN_SAMPLE_WINDOW_SIZE,
+            maximum=EVENT_LOCK_MAX_SAMPLE_WINDOW_SIZE,
+        )
+        max_writer_contexts = _env_int_bounded(
+            "EVENT_LOCK_MAX_WRITER_CONTEXTS",
+            EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS,
+            minimum=EVENT_LOCK_MIN_WRITER_CONTEXTS,
+            maximum=EVENT_LOCK_MAX_WRITER_CONTEXTS,
+        )
+        max_contexts_for_budget = max(
+            EVENT_LOCK_MIN_WRITER_CONTEXTS,
+            EVENT_LOCK_TOTAL_WRITER_SAMPLE_BUDGET // sample_window_size,
+        )
+        return cls(
+            slow_log_info_ms=_env_float_bounded(
+                "EVENT_LOCK_SLOW_LOG_INFO_MS",
+                EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS,
+                minimum=EVENT_LOCK_MIN_THRESHOLD_MS,
+                maximum=EVENT_LOCK_MAX_SLOW_LOG_INFO_MS,
+            ),
+            warning_p95_ms=_env_float_bounded(
+                "EVENT_LOCK_WARNING_P95_MS",
+                EVENT_LOCK_DEFAULT_WARNING_P95_MS,
+                minimum=EVENT_LOCK_MIN_THRESHOLD_MS,
+                maximum=EVENT_LOCK_MAX_ALERT_THRESHOLD_MS,
+            ),
+            critical_p99_ms=_env_float_bounded(
+                "EVENT_LOCK_CRITICAL_P99_MS",
+                EVENT_LOCK_DEFAULT_CRITICAL_P99_MS,
+                minimum=EVENT_LOCK_MIN_THRESHOLD_MS,
+                maximum=EVENT_LOCK_MAX_ALERT_THRESHOLD_MS,
+            ),
+            sample_window_size=sample_window_size,
+            max_writer_contexts=min(max_writer_contexts, max_contexts_for_budget),
+        )
+
+
+_event_lock_settings: Optional[EventLockSettings] = None
+
+
+def get_event_lock_settings() -> EventLockSettings:
+    """Return cached Event lock observability settings (singleton)."""
+    global _event_lock_settings
+    if _event_lock_settings is None:
+        _event_lock_settings = EventLockSettings.from_env()
+    return _event_lock_settings
+
+
 # ---------------------------------------------------------------------------
 # Event Batch Pruner Settings
 # ---------------------------------------------------------------------------

--- a/backend/config.py
+++ b/backend/config.py
@@ -8,7 +8,7 @@ Currently covers MQTT configuration. Expand as needed for other subsystems.
 from __future__ import annotations
 
 import os
-from typing import Optional
+
 from pydantic import BaseModel, Field, model_validator
 
 
@@ -86,7 +86,7 @@ class EventLockSettings(BaseModel):
     )
 
     @classmethod
-    def from_env(cls) -> "EventLockSettings":
+    def from_env(cls) -> EventLockSettings:
         """Load Event lock observability settings from environment variables."""
         sample_window_size = _env_int_bounded(
             "EVENT_LOCK_SAMPLE_WINDOW_SIZE",
@@ -128,7 +128,7 @@ class EventLockSettings(BaseModel):
         )
 
 
-_event_lock_settings: Optional[EventLockSettings] = None
+_event_lock_settings: EventLockSettings | None = None
 
 
 def get_event_lock_settings() -> EventLockSettings:
@@ -152,7 +152,7 @@ class EventBatchSettings(BaseModel):
     batch_timeout_s: int = 30
 
     @classmethod
-    def from_env(cls) -> "EventBatchSettings":
+    def from_env(cls) -> EventBatchSettings:
         """Load event batch settings from environment variables."""
         return cls(
             batch_size=int(os.getenv("EVENT_BATCH_SIZE", "500")),
@@ -161,7 +161,7 @@ class EventBatchSettings(BaseModel):
         )
 
 
-_event_batch_settings: Optional[EventBatchSettings] = None
+_event_batch_settings: EventBatchSettings | None = None
 
 
 def get_event_batch_settings() -> EventBatchSettings:
@@ -181,14 +181,14 @@ class MQTTSettings(BaseModel):
     """MQTT broker connection settings."""
 
     broker_url: str = "mqtt://localhost:1883"
-    username: Optional[str] = None
-    password: Optional[str] = None
+    username: str | None = None
+    password: str | None = None
     client_id: str = "rtu-telemetry-subscriber"
     wildcard_topic: str = "rtu/+/+/telemetry"
     qos: int = 1
 
     @classmethod
-    def from_env(cls) -> "MQTTSettings":
+    def from_env(cls) -> MQTTSettings:
         """Load MQTT settings from environment variables."""
         return cls(
             broker_url=os.getenv("MQTT_BROKER_URL", "mqtt://localhost:1883"),
@@ -201,7 +201,7 @@ class MQTTSettings(BaseModel):
 
 
 # Singleton instance (lazy-loaded)
-_mqtt_settings: Optional[MQTTSettings] = None
+_mqtt_settings: MQTTSettings | None = None
 
 
 def get_mqtt_settings() -> MQTTSettings:
@@ -220,12 +220,12 @@ def get_mqtt_settings() -> MQTTSettings:
 class CLICredentialsSettings(BaseModel):
     """CLI credential settings for network device access."""
 
-    default_user: Optional[str] = None
-    default_pass: Optional[str] = None
-    enable_pass: Optional[str] = None
+    default_user: str | None = None
+    default_pass: str | None = None
+    enable_pass: str | None = None
 
     @classmethod
-    def from_env(cls) -> "CLICredentialsSettings":
+    def from_env(cls) -> CLICredentialsSettings:
         """Load CLI credentials from environment variables."""
         return cls(
             default_user=os.getenv("CLI_DEFAULT_USER"),
@@ -234,7 +234,7 @@ class CLICredentialsSettings(BaseModel):
         )
 
 
-_cli_credentials_settings: Optional[CLICredentialsSettings] = None
+_cli_credentials_settings: CLICredentialsSettings | None = None
 
 
 def get_cli_credentials_settings() -> CLICredentialsSettings:
@@ -290,7 +290,7 @@ class PollingPipelineSettings(BaseModel):
     benchmark_sink: str = "synthetic"
 
     @classmethod
-    def from_env(cls) -> "PollingPipelineSettings":
+    def from_env(cls) -> PollingPipelineSettings:
         """Load polling pipeline settings from environment variables."""
         return cls(
             pipeline_observe_only=_env_bool("POLLING_PIPELINE_OBSERVE_ONLY"),
@@ -320,7 +320,7 @@ class PollingPipelineSettings(BaseModel):
         )
 
 
-_polling_pipeline_settings: Optional[PollingPipelineSettings] = None
+_polling_pipeline_settings: PollingPipelineSettings | None = None
 
 
 def get_polling_pipeline_settings() -> PollingPipelineSettings:
@@ -346,13 +346,13 @@ class ICMPSettings(BaseModel):
     latency_critical_ms: float = Field(default=500.0, gt=0)
 
     @model_validator(mode="after")
-    def validate_latency_thresholds(self) -> "ICMPSettings":
+    def validate_latency_thresholds(self) -> ICMPSettings:
         if self.latency_warning_ms >= self.latency_critical_ms:
             raise ValueError("ICMP_LATENCY_WARNING_MS must be less than ICMP_LATENCY_CRITICAL_MS")
         return self
 
     @classmethod
-    def from_env(cls) -> "ICMPSettings":
+    def from_env(cls) -> ICMPSettings:
         """Load ICMP settings from environment variables."""
         return cls(
             timeout_ms=int(os.getenv("ICMP_TIMEOUT_MS", "3000")),
@@ -363,7 +363,7 @@ class ICMPSettings(BaseModel):
         )
 
 
-_icmp_settings: Optional[ICMPSettings] = None
+_icmp_settings: ICMPSettings | None = None
 
 
 def get_icmp_settings() -> ICMPSettings:
@@ -389,7 +389,7 @@ class LMStudioSettings(BaseModel):
     max_tokens: int = Field(default=800, gt=0, le=4096)
 
     @classmethod
-    def from_env(cls) -> "LMStudioSettings":
+    def from_env(cls) -> LMStudioSettings:
         """Load LM Studio settings from environment variables."""
         return cls(
             enabled=_env_bool("LM_STUDIO_ENABLED", default=False),
@@ -434,7 +434,7 @@ class AIPromptsSettings(BaseModel):
     prompts_dir: str = ""
 
     @classmethod
-    def from_env(cls) -> "AIPromptsSettings":
+    def from_env(cls) -> AIPromptsSettings:
         """Load the AI prompts folder from the environment."""
         return cls(prompts_dir=os.getenv("AI_PROMPTS_DIR", "").strip())
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -305,9 +305,15 @@ class PollingPipelineSettings(BaseModel):
             db_writer_count=int(os.getenv("POLLING_DB_WRITERS", "1")),
             task_batch_size=int(os.getenv("POLLING_TASK_BATCH_SIZE", "100")),
             result_batch_size=int(os.getenv("POLLING_RESULT_BATCH_SIZE", "500")),
-            backpressure_max_task_queue_depth=int(os.getenv("POLLING_BACKPRESSURE_MAX_TASK_QUEUE_DEPTH", "100000")),
-            backpressure_max_writer_lag_seconds=int(os.getenv("POLLING_BACKPRESSURE_MAX_WRITER_LAG_SECONDS", "120")),
-            backpressure_retry_max_attempts=int(os.getenv("POLLING_BACKPRESSURE_RETRY_MAX_ATTEMPTS", "5")),
+            backpressure_max_task_queue_depth=int(
+                os.getenv("POLLING_BACKPRESSURE_MAX_TASK_QUEUE_DEPTH", "100000")
+            ),
+            backpressure_max_writer_lag_seconds=int(
+                os.getenv("POLLING_BACKPRESSURE_MAX_WRITER_LAG_SECONDS", "120")
+            ),
+            backpressure_retry_max_attempts=int(
+                os.getenv("POLLING_BACKPRESSURE_RETRY_MAX_ATTEMPTS", "5")
+            ),
             metadata_cache_ttl_seconds=int(os.getenv("POLLING_METADATA_CACHE_TTL_SECONDS", "300")),
             benchmark_ci_count=int(os.getenv("POLLING_BENCHMARK_CI_COUNT", "8000")),
             benchmark_metrics_per_ci=int(os.getenv("POLLING_BENCHMARK_METRICS_PER_CI", "35")),

--- a/backend/services/event_lock.py
+++ b/backend/services/event_lock.py
@@ -23,19 +23,17 @@ no session management, no Neo4j concerns, just one well-named primitive.
 
 from __future__ import annotations
 
-import os
-import socket
 import logging
 import math
+import os
+import socket
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
 
-from sqlalchemy import text
-
 from config import EventLockSettings, get_event_lock_settings
-
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/event_lock.py
+++ b/backend/services/event_lock.py
@@ -25,11 +25,175 @@ from __future__ import annotations
 
 import os
 import socket
+import logging
+import math
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
 
 from sqlalchemy import text
 
+from config import EventLockSettings, get_event_lock_settings
 
-def acquire_event_triplet_lock(pg_db, ci_id: str, metric_id: str, event_type: str) -> None:
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _WriterLockMetrics:
+    """Bounded wait samples and acquisition count for one writer context."""
+
+    window_size: int
+    acquisitions_total: int = 0
+    waits_ms: deque[float] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.waits_ms = deque(maxlen=self.window_size)
+
+    def record(self, wait_ms: float) -> None:
+        self.acquisitions_total += 1
+        self.waits_ms.append(wait_ms)
+
+    def snapshot(self) -> dict:
+        values = list(self.waits_ms)
+        return {
+            "acquisitions_total": self.acquisitions_total,
+            "wait_ms": _wait_distribution(values),
+        }
+
+
+@dataclass
+class _EventLockMetrics:
+    """Thread-safe in-process metrics for Event advisory-lock acquisition."""
+
+    settings: EventLockSettings
+    acquisitions_total: int = 0
+    waits_ms: deque[float] = field(init=False)
+    by_writer: dict[str, _WriterLockMetrics] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def __post_init__(self) -> None:
+        self.waits_ms = deque(maxlen=self.settings.sample_window_size)
+
+    def record(self, wait_ms: float, writer_context: str) -> None:
+        writer = _bounded_writer_context(writer_context)
+        with self._lock:
+            self.acquisitions_total += 1
+            self.waits_ms.append(wait_ms)
+            writer_metrics = self.by_writer.get(writer)
+            if writer_metrics is None:
+                named_context_budget = max(0, self.settings.max_writer_contexts - 1)
+                if writer != "other" and len(self.by_writer) >= named_context_budget:
+                    writer = "other"
+                    writer_metrics = self.by_writer.get(writer)
+                if writer_metrics is None:
+                    writer_metrics = _WriterLockMetrics(self.settings.sample_window_size)
+                    self.by_writer[writer] = writer_metrics
+            writer_metrics.record(wait_ms)
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            waits = list(self.waits_ms)
+            by_writer = {
+                writer: metrics.snapshot()
+                for writer, metrics in sorted(self.by_writer.items())
+            }
+            distribution = _wait_distribution(waits)
+            return {
+                "acquisitions_total": self.acquisitions_total,
+                "wait_ms": distribution,
+                "alert_state": _derive_alert_state(distribution, self.settings),
+                "thresholds_ms": {
+                    "info": self.settings.slow_log_info_ms,
+                    "warning_p95": self.settings.warning_p95_ms,
+                    "critical_p99": self.settings.critical_p99_ms,
+                },
+                "by_writer": by_writer,
+            }
+
+
+_EVENT_LOCK_METRICS: _EventLockMetrics | None = None
+_EVENT_LOCK_METRICS_INIT_LOCK = threading.Lock()
+
+
+def _get_metrics() -> _EventLockMetrics:
+    global _EVENT_LOCK_METRICS
+    if _EVENT_LOCK_METRICS is None:
+        with _EVENT_LOCK_METRICS_INIT_LOCK:
+            if _EVENT_LOCK_METRICS is None:
+                _EVENT_LOCK_METRICS = _EventLockMetrics(get_event_lock_settings())
+    return _EVENT_LOCK_METRICS
+
+
+def _bounded_writer_context(writer_context: str | None) -> str:
+    value = (writer_context or "unknown").strip() or "unknown"
+    safe = "".join(ch if ch.isalnum() or ch in {"_", "-", "."} else "_" for ch in value)
+    return safe[:80] or "unknown"
+
+
+def _percentile(values: list[float], percentile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, math.ceil((percentile / 100.0) * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _wait_distribution(values: list[float]) -> dict:
+    return {
+        "count": len(values),
+        "p95": _percentile(values, 95),
+        "p99": _percentile(values, 99),
+        "max": max(values) if values else None,
+    }
+
+
+def _derive_alert_state(distribution: dict, settings: EventLockSettings) -> str:
+    p99 = distribution["p99"]
+    p95 = distribution["p95"]
+    max_wait = distribution["max"]
+    if p99 is not None and p99 >= settings.critical_p99_ms:
+        return "CRITICAL"
+    if p95 is not None and p95 >= settings.warning_p95_ms:
+        return "WARNING"
+    if (
+        settings.slow_log_info_ms > 0
+        and max_wait is not None
+        and max_wait >= settings.slow_log_info_ms
+    ):
+        return "INFO"
+    return "OK"
+
+
+def record_event_lock_acquisition(wait_ms: float, writer_context: str = "unknown") -> None:
+    """Record a successful Event advisory-lock acquisition wait duration."""
+    _get_metrics().record(wait_ms, writer_context)
+
+
+def get_event_lock_observability_snapshot() -> dict:
+    """Return a bounded in-process snapshot for Event lock observability."""
+    return _get_metrics().snapshot()
+
+
+def reset_event_lock_observability_for_tests(sample_window_size: int | None = None) -> None:
+    """Reset in-process Event lock metrics for deterministic unit tests."""
+    global _EVENT_LOCK_METRICS
+    with _EVENT_LOCK_METRICS_INIT_LOCK:
+        settings = get_event_lock_settings()
+        if sample_window_size is not None:
+            settings = settings.model_copy(update={"sample_window_size": sample_window_size})
+        _EVENT_LOCK_METRICS = _EventLockMetrics(settings)
+
+
+def acquire_event_triplet_lock(
+    pg_db,
+    ci_id: str,
+    metric_id: str,
+    event_type: str,
+    *,
+    writer_context: str = "unknown",
+) -> None:
     """Acquire a transaction-scoped PostgreSQL advisory lock for one triplet.
 
     The lock key is ``"{ci_id}|{metric_id}|{event_type}"``; ``hashtext`` collapses
@@ -50,10 +214,25 @@ def acquire_event_triplet_lock(pg_db, ci_id: str, metric_id: str, event_type: st
         The triplet identifying the Event being created/updated.
     """
     key = f"{ci_id}|{metric_id}|{event_type}"
+    start = time.monotonic()
     pg_db.execute(
         text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
         {"key": key},
     )
+    wait_ms = round((time.monotonic() - start) * 1000, 3)
+    bounded_context = _bounded_writer_context(writer_context)
+    record_event_lock_acquisition(wait_ms, writer_context=bounded_context)
+
+    settings = get_event_lock_settings()
+    if settings.slow_log_info_ms > 0 and wait_ms >= settings.slow_log_info_ms:
+        logger.info(
+            "event_lock_slow_acquisition",
+            extra={
+                "event_lock_writer_context": bounded_context,
+                "event_lock_wait_ms": round(wait_ms),
+                "event_lock_threshold_ms": round(settings.slow_log_info_ms),
+            },
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/event_lock.py
+++ b/backend/services/event_lock.py
@@ -94,8 +94,7 @@ class _EventLockMetrics:
         with self._lock:
             waits = list(self.waits_ms)
             by_writer = {
-                writer: metrics.snapshot()
-                for writer, metrics in sorted(self.by_writer.items())
+                writer: metrics.snapshot() for writer, metrics in sorted(self.by_writer.items())
             }
             distribution = _wait_distribution(waits)
             return {

--- a/backend/tests/test_writer_advisory_lock.py
+++ b/backend/tests/test_writer_advisory_lock.py
@@ -102,21 +102,19 @@ def test_acquire_event_triplet_lock_helper():
     # SQL is the first positional arg.
     sql_obj = args[0] if args else kwargs.get("text")
     sql_text = _normalize_sql_for_lookup(sql_obj)
-    assert "pg_advisory_xact_lock" in sql_text, (
-        f"expected pg_advisory_xact_lock in SQL, got: {sql_text!r}"
-    )
-    assert "hashtext" in sql_text, (
-        f"expected hashtext in SQL, got: {sql_text!r}"
-    )
+    assert (
+        "pg_advisory_xact_lock" in sql_text
+    ), f"expected pg_advisory_xact_lock in SQL, got: {sql_text!r}"
+    assert "hashtext" in sql_text, f"expected hashtext in SQL, got: {sql_text!r}"
 
     # The key parameter must match the "ci|metric|type" format exactly.
     params = args[1] if len(args) > 1 else kwargs.get("params") or kwargs
     # ``text("… :key")`` plus a dict binding ``{"key": …}`` is the canonical
     # pattern; we accept both binding styles for forward-compat.
     flat_values = params.values() if isinstance(params, dict) else (params,)
-    assert expected_key in flat_values, (
-        f"expected key {expected_key!r} in bind params, got {params!r}"
-    )
+    assert (
+        expected_key in flat_values
+    ), f"expected key {expected_key!r} in bind params, got {params!r}"
 
 
 def test_services_event_lock_imports_from_backend_import_root():
@@ -191,7 +189,6 @@ def test_event_lock_metrics_initialize_once_under_concurrent_cold_start(monkeypa
 
     created_instances = []
     original_metrics_cls = event_lock_module._EventLockMetrics
-
 
     class SlowConstructingMetrics(original_metrics_cls):
         def __post_init__(self) -> None:
@@ -459,11 +456,15 @@ def test_event_lock_slow_log_threshold_zero_disables_info_logs_and_info_alerts(m
             writer_context="snmp_worker",
         )
 
-    assert [record for record in caplog.records if record.message == "event_lock_slow_acquisition"] == []
+    assert [
+        record for record in caplog.records if record.message == "event_lock_slow_acquisition"
+    ] == []
     assert event_lock_module.get_event_lock_observability_snapshot()["alert_state"] == "OK"
 
 
-def test_acquire_event_triplet_lock_emits_structured_slow_log_at_info_threshold(caplog, monkeypatch):
+def test_acquire_event_triplet_lock_emits_structured_slow_log_at_info_threshold(
+    caplog, monkeypatch
+):
     """Acquisitions at or above 250ms emit one structured INFO slow-lock log."""
     from services import event_lock as event_lock_module
 
@@ -481,7 +482,9 @@ def test_acquire_event_triplet_lock_emits_structured_slow_log_at_info_threshold(
             writer_context="snmp_worker",
         )
 
-    slow_records = [record for record in caplog.records if record.message == "event_lock_slow_acquisition"]
+    slow_records = [
+        record for record in caplog.records if record.message == "event_lock_slow_acquisition"
+    ]
     assert len(slow_records) == 1
     assert slow_records[0].event_lock_writer_context == "snmp_worker"
     assert slow_records[0].event_lock_wait_ms == 250
@@ -506,7 +509,9 @@ def test_acquire_event_triplet_lock_avoids_info_log_below_threshold(caplog, monk
             writer_context="snmp_worker",
         )
 
-    assert [record for record in caplog.records if record.message == "event_lock_slow_acquisition"] == []
+    assert [
+        record for record in caplog.records if record.message == "event_lock_slow_acquisition"
+    ] == []
     snapshot = event_lock_module.get_event_lock_observability_snapshot()
     assert snapshot["acquisitions_total"] == 1
     assert snapshot["wait_ms"]["max"] == 249
@@ -622,6 +627,7 @@ def _swap_in_real_psycopg2():
     saved = sys.modules.pop("psycopg2", None)
     saved_ext = sys.modules.pop("psycopg2.extensions", None)
     import psycopg2 as real_psycopg2  # fresh import — now genuinely real
+
     sys.modules["psycopg2"] = real_psycopg2
     sys.modules["psycopg2.extensions"] = real_psycopg2.extensions
 
@@ -669,9 +675,7 @@ def test_concurrent_writers_block_on_lock():
         from testcontainers.postgres import PostgresContainer
 
         with PostgresContainer("postgres:15-alpine") as pg:
-            conn_url = pg.get_connection_url().replace(
-                "postgresql+psycopg2://", "postgresql://"
-            )
+            conn_url = pg.get_connection_url().replace("postgresql+psycopg2://", "postgresql://")
             triplet_key = "ci-001|icmp_latency_ms|THRESHOLD_BREACH"
             check_window = 0.5  # how long main waits before declaring "waiter is blocked"
 
@@ -733,9 +737,7 @@ def test_concurrent_writers_block_on_lock():
             release.set()
             holder_thread.join(timeout=15)
 
-            assert waiter_finished.wait(timeout=10), (
-                "waiter never acquired the lock after release"
-            )
+            assert waiter_finished.wait(timeout=10), "waiter never acquired the lock after release"
             waiter_thread.join(timeout=10)
 
             # The waiter MUST have been blocked for at least the check window.
@@ -933,9 +935,7 @@ def test_sorted_lock_acquisition_prevents_deadlock():
                 fut_a.result(timeout=30)
                 fut_b.result(timeout=30)
 
-            assert results["a"] == "ok", (
-                f"thread A failed: {results['a']!r}"
-            )
+            assert results["a"] == "ok", f"thread A failed: {results['a']!r}"
             assert results["b"] == "ok", (
                 f"thread B failed: {results['b']!r} — sorted acquisition "
                 f"did NOT prevent the deadlock; the deterministic-ordering "
@@ -1056,11 +1056,16 @@ def test_full_poll_cycle_no_duplicates():
                 try:
                     # event_writer batch path: a single-row batch
                     # containing the same triplet.
-                    _acquire_sorted_locks(session, [{
-                        "ci_id": ci_id,
-                        "metric_id": metric_id,
-                        "event_type": event_type,
-                    }])
+                    _acquire_sorted_locks(
+                        session,
+                        [
+                            {
+                                "ci_id": ci_id,
+                                "metric_id": metric_id,
+                                "event_type": event_type,
+                            }
+                        ],
+                    )
                     with sink_lock:
                         if triplet not in neo4j_sink:
                             neo4j_sink[triplet] = "created"
@@ -1085,20 +1090,16 @@ def test_full_poll_cycle_no_duplicates():
                 f"{neo4j_sink!r} — lock did NOT serialize writers; duplicate "
                 f"Events would have been created in real Neo4j"
             )
-            assert triplet in neo4j_sink, (
-                f"triplet {triplet!r} missing from sink: {neo4j_sink!r}"
-            )
+            assert triplet in neo4j_sink, f"triplet {triplet!r} missing from sink: {neo4j_sink!r}"
 
             # Exactly 1 writer "created"; the other 2 "found_existing".
             created = [k for k, v in results.items() if v == "created"]
             found = [k for k, v in results.items() if v == "found_existing"]
             assert len(created) == 1, (
-                f"expected exactly 1 writer to CREATE, got {len(created)}: "
-                f"{results!r}"
+                f"expected exactly 1 writer to CREATE, got {len(created)}: " f"{results!r}"
             )
             assert len(found) == 2, (
-                f"expected 2 writers to FIND_EXISTING, got {len(found)}: "
-                f"{results!r}"
+                f"expected 2 writers to FIND_EXISTING, got {len(found)}: " f"{results!r}"
             )
     finally:
         restore_psycopg2()

--- a/backend/tests/test_writer_advisory_lock.py
+++ b/backend/tests/test_writer_advisory_lock.py
@@ -34,12 +34,41 @@ Per-writer integration tests against ``snmp_worker.py`` /
 from __future__ import annotations
 
 import concurrent.futures
+import logging
+import os
+import subprocess
 import sys
 import threading
 import time
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+
+EVENT_LOCK_ENV_VARS = (
+    "EVENT_LOCK_SLOW_LOG_INFO_MS",
+    "EVENT_LOCK_WARNING_P95_MS",
+    "EVENT_LOCK_CRITICAL_P99_MS",
+    "EVENT_LOCK_SAMPLE_WINDOW_SIZE",
+    "EVENT_LOCK_MAX_WRITER_CONTEXTS",
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_event_lock_settings(monkeypatch):
+    """Keep Event lock settings/metrics deterministic across tests."""
+    for name in EVENT_LOCK_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    import config as config_module
+    from services import event_lock as event_lock_module
+
+    monkeypatch.setattr(config_module, "_event_lock_settings", None)
+    monkeypatch.setattr(event_lock_module, "_EVENT_LOCK_METRICS", None)
+    yield
+    monkeypatch.setattr(config_module, "_event_lock_settings", None)
+    monkeypatch.setattr(event_lock_module, "_EVENT_LOCK_METRICS", None)
 
 
 def _normalize_sql_for_lookup(sql_obj):
@@ -60,7 +89,7 @@ def test_acquire_event_triplet_lock_helper():
     NOT prove that two real Postgres transactions block each other; that
     concurrency proof lands in a later PR's dedicated testcontainers test.
     """
-    from backend.services.event_lock import acquire_event_triplet_lock
+    from services.event_lock import acquire_event_triplet_lock
 
     pg_db = MagicMock()
     acquire_event_triplet_lock(pg_db, "ci-001", "icmp_latency_ms", "THRESHOLD_BREACH")
@@ -91,6 +120,419 @@ def test_acquire_event_triplet_lock_helper():
     )
 
 
+def test_services_event_lock_imports_from_backend_import_root():
+    """Production-style backend import root can import the shared lock helper."""
+    backend_dir = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(backend_dir)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import services.event_lock as event_lock; print(event_lock.__name__)",
+        ],
+        cwd=backend_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "services.event_lock"
+
+
+def test_event_lock_metrics_record_count_distribution_alerts_and_bounded_labels():
+    """Lock observability records waits by bounded writer labels only."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=10)
+
+    for wait_ms in [10, 20, 30, 40, 50, 60, 70, 80, 90, 1200]:
+        event_lock_module.record_event_lock_acquisition(wait_ms, writer_context="snmp_worker")
+    event_lock_module.record_event_lock_acquisition(6000, writer_context="polling_event_writer")
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+
+    assert snapshot["acquisitions_total"] == 11
+    assert snapshot["wait_ms"]["count"] == 10
+    assert snapshot["wait_ms"]["max"] == 6000
+    assert snapshot["wait_ms"]["p95"] == 6000
+    assert snapshot["wait_ms"]["p99"] == 6000
+    assert snapshot["alert_state"] == "CRITICAL"
+    assert set(snapshot["by_writer"]) == {"snmp_worker", "polling_event_writer"}
+
+    serialized = repr(snapshot)
+    assert "ci-001" not in serialized
+    assert "icmp_latency_ms" not in serialized
+    assert "THRESHOLD_BREACH" not in serialized
+
+
+def test_event_lock_alert_state_warns_when_p95_exceeds_threshold_without_critical():
+    """p95 wait above the warning threshold derives WARNING alert state."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=20)
+
+    for wait_ms in [25] * 18 + [1100, 1200]:
+        event_lock_module.record_event_lock_acquisition(wait_ms, writer_context="snmp_service")
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+
+    assert snapshot["wait_ms"]["p95"] == 1100
+    assert snapshot["wait_ms"]["p99"] == 1200
+    assert snapshot["alert_state"] == "WARNING"
+
+
+def test_event_lock_metrics_initialize_once_under_concurrent_cold_start(monkeypatch):
+    """Concurrent first records MUST all land in the same metrics instance."""
+    from services import event_lock as event_lock_module
+
+    created_instances = []
+    original_metrics_cls = event_lock_module._EventLockMetrics
+
+
+    class SlowConstructingMetrics(original_metrics_cls):
+        def __post_init__(self) -> None:
+            created_instances.append(self)
+            time.sleep(0.01)
+            super().__post_init__()
+
+    monkeypatch.setattr(event_lock_module, "_EventLockMetrics", SlowConstructingMetrics)
+    monkeypatch.setattr(event_lock_module, "_EVENT_LOCK_METRICS", None)
+
+    worker_count = 24
+    barrier = threading.Barrier(worker_count)
+
+    def record_once(index: int) -> None:
+        barrier.wait(timeout=5)
+        event_lock_module.record_event_lock_acquisition(index + 1, writer_context="cold_start")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as pool:
+        futures = [pool.submit(record_once, index) for index in range(worker_count)]
+        for future in futures:
+            future.result(timeout=5)
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert snapshot["acquisitions_total"] == worker_count
+    assert snapshot["by_writer"]["cold_start"]["acquisitions_total"] == worker_count
+    assert len(created_instances) == 1
+
+
+def test_event_lock_settings_use_safe_defaults():
+    """Default Event lock env settings match the documented PR1 thresholds."""
+    from config import (
+        EVENT_LOCK_DEFAULT_CRITICAL_P99_MS,
+        EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS,
+        EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE,
+        EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS,
+        EVENT_LOCK_DEFAULT_WARNING_P95_MS,
+        EventLockSettings,
+    )
+
+    settings = EventLockSettings.from_env()
+
+    assert settings.slow_log_info_ms == EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS
+    assert settings.warning_p95_ms == EVENT_LOCK_DEFAULT_WARNING_P95_MS
+    assert settings.critical_p99_ms == EVENT_LOCK_DEFAULT_CRITICAL_P99_MS
+    assert settings.sample_window_size == EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE
+    assert settings.max_writer_contexts == EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS
+
+
+def test_event_lock_settings_apply_env_overrides(monkeypatch):
+    """EVENT_LOCK_* overrides are parsed when they stay inside safe bounds."""
+    from config import EventLockSettings
+
+    monkeypatch.setenv("EVENT_LOCK_SLOW_LOG_INFO_MS", "125.5")
+    monkeypatch.setenv("EVENT_LOCK_WARNING_P95_MS", "750")
+    monkeypatch.setenv("EVENT_LOCK_CRITICAL_P99_MS", "2500")
+    monkeypatch.setenv("EVENT_LOCK_SAMPLE_WINDOW_SIZE", "42")
+    monkeypatch.setenv("EVENT_LOCK_MAX_WRITER_CONTEXTS", "3")
+
+    settings = EventLockSettings.from_env()
+
+    assert settings.slow_log_info_ms == 125.5
+    assert settings.warning_p95_ms == 750.0
+    assert settings.critical_p99_ms == 2500.0
+    assert settings.sample_window_size == 42
+    assert settings.max_writer_contexts == 3
+
+
+def test_event_lock_settings_fall_back_for_invalid_or_out_of_range_env(monkeypatch):
+    """Invalid/out-of-range EVENT_LOCK_* values fall back to safe defaults."""
+    from config import (
+        EVENT_LOCK_DEFAULT_CRITICAL_P99_MS,
+        EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS,
+        EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE,
+        EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS,
+        EVENT_LOCK_DEFAULT_WARNING_P95_MS,
+        EventLockSettings,
+    )
+
+    monkeypatch.setenv("EVENT_LOCK_SLOW_LOG_INFO_MS", "-1")
+    monkeypatch.setenv("EVENT_LOCK_WARNING_P95_MS", "not-a-number")
+    monkeypatch.setenv("EVENT_LOCK_CRITICAL_P99_MS", "600000.5")
+    monkeypatch.setenv("EVENT_LOCK_SAMPLE_WINDOW_SIZE", "0")
+    monkeypatch.setenv("EVENT_LOCK_MAX_WRITER_CONTEXTS", "0")
+
+    settings = EventLockSettings.from_env()
+
+    assert settings.slow_log_info_ms == EVENT_LOCK_DEFAULT_SLOW_LOG_INFO_MS
+    assert settings.warning_p95_ms == EVENT_LOCK_DEFAULT_WARNING_P95_MS
+    assert settings.critical_p99_ms == EVENT_LOCK_DEFAULT_CRITICAL_P99_MS
+    assert settings.sample_window_size == EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE
+    assert settings.max_writer_contexts == EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS
+
+
+def test_event_lock_settings_reject_unsafe_sample_and_writer_context_clamps(monkeypatch):
+    """Oversized window/context overrides fall back before they can create unbounded samples."""
+    from config import (
+        EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS,
+        EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE,
+        EventLockSettings,
+    )
+
+    monkeypatch.setenv("EVENT_LOCK_SAMPLE_WINDOW_SIZE", "100000")
+    monkeypatch.setenv("EVENT_LOCK_MAX_WRITER_CONTEXTS", "1000")
+
+    settings = EventLockSettings.from_env()
+
+    assert settings.sample_window_size == EVENT_LOCK_DEFAULT_SAMPLE_WINDOW_SIZE
+    assert settings.max_writer_contexts == EVENT_LOCK_DEFAULT_MAX_WRITER_CONTEXTS
+
+
+def test_event_lock_settings_cap_total_writer_sample_budget(monkeypatch):
+    """Valid individual overrides are capped by the total per-writer sample budget."""
+    from config import EventLockSettings
+
+    monkeypatch.setenv("EVENT_LOCK_SAMPLE_WINDOW_SIZE", "1000")
+    monkeypatch.setenv("EVENT_LOCK_MAX_WRITER_CONTEXTS", "20")
+
+    settings = EventLockSettings.from_env()
+
+    assert settings.sample_window_size == 1000
+    assert settings.max_writer_contexts == 10
+
+
+def test_event_lock_empty_snapshot_is_ok():
+    """An initialized snapshot with no samples reports OK and empty distribution values."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=3)
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+
+    assert snapshot["acquisitions_total"] == 0
+    assert snapshot["wait_ms"] == {"count": 0, "p95": None, "p99": None, "max": None}
+    assert snapshot["alert_state"] == "OK"
+    assert snapshot["by_writer"] == {}
+
+
+def test_event_lock_info_only_alert_state_below_warning_threshold():
+    """Slow samples below p95/p99 thresholds produce INFO, not WARNING/CRITICAL."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=5)
+    for wait_ms in [10, 20, 250, 300, 400]:
+        event_lock_module.record_event_lock_acquisition(wait_ms, writer_context="snmp_worker")
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert snapshot["wait_ms"]["max"] == 400
+    assert snapshot["alert_state"] == "INFO"
+
+
+def test_event_lock_threshold_equality_escalates_alert_state(monkeypatch):
+    """Wait percentiles equal to configured thresholds are considered crossing them."""
+    import config as config_module
+    from config import EventLockSettings
+    from services import event_lock as event_lock_module
+
+    monkeypatch.setattr(
+        config_module,
+        "_event_lock_settings",
+        EventLockSettings(
+            slow_log_info_ms=250.0,
+            warning_p95_ms=1000.0,
+            critical_p99_ms=5000.0,
+            sample_window_size=10,
+        ),
+    )
+    event_lock_module.reset_event_lock_observability_for_tests()
+
+    for wait_ms in [10, 20, 30, 40, 50, 60, 70, 80, 1000, 5000]:
+        event_lock_module.record_event_lock_acquisition(wait_ms, writer_context="snmp_worker")
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert snapshot["wait_ms"]["p95"] == 5000
+    assert snapshot["wait_ms"]["p99"] == 5000
+    assert snapshot["alert_state"] == "CRITICAL"
+
+
+def test_event_lock_sample_window_evicts_oldest_samples():
+    """The bounded sample window evicts oldest waits while preserving total count."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=3)
+
+    for wait_ms in [1, 2, 3, 4, 5]:
+        event_lock_module.record_event_lock_acquisition(wait_ms, writer_context="snmp_worker")
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert snapshot["acquisitions_total"] == 5
+    assert snapshot["wait_ms"] == {"count": 3, "p95": 5, "p99": 5, "max": 5}
+    assert snapshot["by_writer"]["snmp_worker"]["acquisitions_total"] == 5
+    assert snapshot["by_writer"]["snmp_worker"]["wait_ms"] == {
+        "count": 3,
+        "p95": 5,
+        "p99": 5,
+        "max": 5,
+    }
+
+
+def test_event_lock_routes_writer_context_overflow_to_other(monkeypatch):
+    """Distinct writer contexts are bounded; overflow is aggregated as other."""
+    import config as config_module
+    from config import EventLockSettings
+    from services import event_lock as event_lock_module
+
+    monkeypatch.setattr(
+        config_module,
+        "_event_lock_settings",
+        EventLockSettings(sample_window_size=10, max_writer_contexts=2),
+    )
+    event_lock_module.reset_event_lock_observability_for_tests()
+
+    for writer in ["writer_a", "writer_b", "writer_c", "writer_d"]:
+        event_lock_module.record_event_lock_acquisition(10, writer_context=writer)
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert len(snapshot["by_writer"]) == 2
+    assert set(snapshot["by_writer"]) == {"writer_a", "other"}
+    assert snapshot["by_writer"]["writer_a"]["acquisitions_total"] == 1
+    assert snapshot["by_writer"]["other"]["acquisitions_total"] == 3
+
+
+def test_event_lock_writer_context_overflow_stays_within_exact_budget(monkeypatch):
+    """The overflow bucket is reserved inside max_writer_contexts, not added on top."""
+    import config as config_module
+    from config import EventLockSettings
+    from services import event_lock as event_lock_module
+
+    monkeypatch.setattr(
+        config_module,
+        "_event_lock_settings",
+        EventLockSettings(sample_window_size=10, max_writer_contexts=3),
+    )
+    event_lock_module.reset_event_lock_observability_for_tests()
+
+    for writer in ["writer_a", "writer_b", "writer_c", "writer_d", "writer_e"]:
+        event_lock_module.record_event_lock_acquisition(10, writer_context=writer)
+
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert len(snapshot["by_writer"]) == 3
+    assert set(snapshot["by_writer"]) == {"writer_a", "writer_b", "other"}
+    assert snapshot["by_writer"]["other"]["acquisitions_total"] == 3
+
+
+def test_event_lock_slow_log_threshold_zero_disables_info_logs_and_info_alerts(monkeypatch, caplog):
+    """A zero INFO threshold is disabled so operators cannot create log storms."""
+    import config as config_module
+    from config import EventLockSettings
+    from services import event_lock as event_lock_module
+
+    monkeypatch.setattr(
+        config_module,
+        "_event_lock_settings",
+        EventLockSettings(slow_log_info_ms=0.0, sample_window_size=5),
+    )
+    event_lock_module.reset_event_lock_observability_for_tests()
+    monotonic_values = iter([100.0, 100.001])
+    monkeypatch.setattr(event_lock_module.time, "monotonic", lambda: next(monotonic_values))
+
+    with caplog.at_level(logging.INFO, logger="services.event_lock"):
+        event_lock_module.acquire_event_triplet_lock(
+            MagicMock(),
+            "ci-001",
+            "icmp_latency_ms",
+            "THRESHOLD_BREACH",
+            writer_context="snmp_worker",
+        )
+
+    assert [record for record in caplog.records if record.message == "event_lock_slow_acquisition"] == []
+    assert event_lock_module.get_event_lock_observability_snapshot()["alert_state"] == "OK"
+
+
+def test_acquire_event_triplet_lock_emits_structured_slow_log_at_info_threshold(caplog, monkeypatch):
+    """Acquisitions at or above 250ms emit one structured INFO slow-lock log."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=10)
+    monotonic_values = iter([100.0, 100.250])
+    monkeypatch.setattr(event_lock_module.time, "monotonic", lambda: next(monotonic_values))
+
+    pg_db = MagicMock()
+    with caplog.at_level(logging.INFO, logger="services.event_lock"):
+        event_lock_module.acquire_event_triplet_lock(
+            pg_db,
+            "ci-001",
+            "icmp_latency_ms",
+            "THRESHOLD_BREACH",
+            writer_context="snmp_worker",
+        )
+
+    slow_records = [record for record in caplog.records if record.message == "event_lock_slow_acquisition"]
+    assert len(slow_records) == 1
+    assert slow_records[0].event_lock_writer_context == "snmp_worker"
+    assert slow_records[0].event_lock_wait_ms == 250
+    assert slow_records[0].event_lock_threshold_ms == 250
+
+
+def test_acquire_event_triplet_lock_avoids_info_log_below_threshold(caplog, monkeypatch):
+    """Acquisitions below 250ms still record metrics but avoid noisy INFO logs."""
+    from services import event_lock as event_lock_module
+
+    event_lock_module.reset_event_lock_observability_for_tests(sample_window_size=10)
+    monotonic_values = iter([100.0, 100.249])
+    monkeypatch.setattr(event_lock_module.time, "monotonic", lambda: next(monotonic_values))
+
+    pg_db = MagicMock()
+    with caplog.at_level(logging.INFO, logger="services.event_lock"):
+        event_lock_module.acquire_event_triplet_lock(
+            pg_db,
+            "ci-001",
+            "icmp_latency_ms",
+            "THRESHOLD_BREACH",
+            writer_context="snmp_worker",
+        )
+
+    assert [record for record in caplog.records if record.message == "event_lock_slow_acquisition"] == []
+    snapshot = event_lock_module.get_event_lock_observability_snapshot()
+    assert snapshot["acquisitions_total"] == 1
+    assert snapshot["wait_ms"]["max"] == 249
+
+
+def test_event_lock_sql_remains_blocking_only_without_timeout_policy():
+    """Observability MUST NOT add timeout, try-lock, or fail-open/fail-closed SQL/settings."""
+    from config import EventLockSettings
+    from services.event_lock import acquire_event_triplet_lock
+
+    pg_db = MagicMock()
+    acquire_event_triplet_lock(pg_db, "ci-001", "icmp_latency_ms", "THRESHOLD_BREACH")
+
+    sql_obj = pg_db.execute.call_args.args[0]
+    sql_text = _normalize_sql_for_lookup(sql_obj).lower()
+    settings_fields = set(EventLockSettings.model_fields)
+
+    assert "pg_advisory_xact_lock(hashtext(:key))" in sql_text
+    assert "pg_try_advisory" not in sql_text
+    assert "lock_timeout" not in sql_text
+    assert "statement_timeout" not in sql_text
+    assert not any("timeout" in field for field in settings_fields)
+    assert not any("fail_open" in field or "fail_closed" in field for field in settings_fields)
+
+
 def test_get_poll_collector_id_returns_non_empty_string():
     """#322 / spec §Poll collector identity persistence — helper returns a
     non-empty hostname string sourced from ``HOSTNAME`` env var with
@@ -100,7 +542,7 @@ def test_get_poll_collector_id_returns_non_empty_string():
     import os
     import socket
 
-    from backend.services.event_lock import get_poll_collector_id
+    from services.event_lock import get_poll_collector_id
 
     value = get_poll_collector_id()
     assert isinstance(value, str)
@@ -122,7 +564,7 @@ def test_get_poll_collector_id_is_cached_at_module_load(monkeypatch):
     """
     import socket
 
-    from backend.services import event_lock as event_lock_module
+    from services import event_lock as event_lock_module
 
     # Reset the cache to force re-evaluation against the patched hostname.
     monkeypatch.setattr(event_lock_module, "_CACHED_HOSTNAME", None)
@@ -148,7 +590,7 @@ def test_get_poll_collector_id_raises_when_hostname_unavailable(monkeypatch):
     """
     import socket
 
-    from backend.services import event_lock as event_lock_module
+    from services import event_lock as event_lock_module
 
     monkeypatch.setattr(event_lock_module, "_CACHED_HOSTNAME", None)
     monkeypatch.setenv("HOSTNAME", "")
@@ -362,7 +804,7 @@ def test_unsorted_lock_acquisition_deadlocks():
         from sqlalchemy.exc import OperationalError
         from testcontainers.postgres import PostgresContainer
 
-        from backend.polling.event_writer import _acquire_unsorted_locks
+        from polling.event_writer import _acquire_unsorted_locks
 
         with PostgresContainer("postgres:15-alpine") as pg:
             # SQLAlchemy with psycopg2 — psycopg2 is now genuinely real
@@ -458,7 +900,7 @@ def test_sorted_lock_acquisition_prevents_deadlock():
         from sqlalchemy.orm import sessionmaker
         from testcontainers.postgres import PostgresContainer
 
-        from backend.polling.event_writer import _acquire_sorted_locks
+        from polling.event_writer import _acquire_sorted_locks
 
         with PostgresContainer("postgres:15-alpine") as pg:
             conn_url = pg.get_connection_url()
@@ -562,8 +1004,8 @@ def test_full_poll_cycle_no_duplicates():
         from sqlalchemy.orm import sessionmaker
         from testcontainers.postgres import PostgresContainer
 
-        from backend.polling.event_writer import _acquire_sorted_locks
-        from backend.services.event_lock import acquire_event_triplet_lock
+        from polling.event_writer import _acquire_sorted_locks
+        from services.event_lock import acquire_event_triplet_lock
 
         with PostgresContainer("postgres:15-alpine") as pg:
             conn_url = pg.get_connection_url()

--- a/backend/tests/test_writer_advisory_lock.py
+++ b/backend/tests/test_writer_advisory_lock.py
@@ -45,7 +45,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 EVENT_LOCK_ENV_VARS = (
     "EVENT_LOCK_SLOW_LOG_INFO_MS",
     "EVENT_LOCK_WARNING_P95_MS",
@@ -674,7 +673,6 @@ def test_concurrent_writers_block_on_lock():
                 "postgresql+psycopg2://", "postgresql://"
             )
             triplet_key = "ci-001|icmp_latency_ms|THRESHOLD_BREACH"
-            hold_seconds = 3.0  # >> check timeout; proves waiter is provably blocked during the check
             check_window = 0.5  # how long main waits before declaring "waiter is blocked"
 
             got_lock = threading.Event()
@@ -724,8 +722,8 @@ def test_concurrent_writers_block_on_lock():
             waiter_thread.start()
 
             # If the lock is honored, the waiter must still be blocked here.
-            # Check window (0.5s) is much smaller than hold_seconds (3.0s) so a
-            # passing assertion here is genuine proof of blocking.
+            # Passing this check proves the waiter remained blocked while the
+            # holder still owned the transaction-scoped lock.
             assert not waiter_finished.wait(timeout=0.5), (
                 "waiter acquired the lock while holder still held it — "
                 "pg_advisory_xact_lock is NOT serializing writers!"
@@ -799,19 +797,18 @@ def test_unsorted_lock_acquisition_deadlocks():
     """
     psycopg2, restore_psycopg2 = _swap_in_real_psycopg2()
     try:
-        from sqlalchemy import create_engine
-        from sqlalchemy.orm import sessionmaker
-        from sqlalchemy.exc import OperationalError
-        from testcontainers.postgres import PostgresContainer
-
         from polling.event_writer import _acquire_unsorted_locks
+        from sqlalchemy import create_engine
+        from sqlalchemy.exc import OperationalError
+        from sqlalchemy.orm import sessionmaker
+        from testcontainers.postgres import PostgresContainer
 
         with PostgresContainer("postgres:15-alpine") as pg:
             # SQLAlchemy with psycopg2 — psycopg2 is now genuinely real
             # because of _swap_in_real_psycopg2().
             conn_url = pg.get_connection_url()
             engine = create_engine(conn_url)
-            SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+            session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
 
             # Triplet sets in REVERSE order — perfect deadlock setup.
             triplets_forward = [
@@ -824,7 +821,7 @@ def test_unsorted_lock_acquisition_deadlocks():
             results: dict[str, object] = {"a": None, "b": None}
 
             def worker(triplets: list[tuple[str, str, str]], key: str) -> None:
-                session = SessionLocal()
+                session = session_factory()
                 try:
                     _acquire_unsorted_locks(session, triplets)
                     results[key] = "ok"
@@ -896,16 +893,15 @@ def test_sorted_lock_acquisition_prevents_deadlock():
     """
     psycopg2, restore_psycopg2 = _swap_in_real_psycopg2()
     try:
+        from polling.event_writer import _acquire_sorted_locks
         from sqlalchemy import create_engine
         from sqlalchemy.orm import sessionmaker
         from testcontainers.postgres import PostgresContainer
 
-        from polling.event_writer import _acquire_sorted_locks
-
         with PostgresContainer("postgres:15-alpine") as pg:
             conn_url = pg.get_connection_url()
             engine = create_engine(conn_url)
-            SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+            session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
 
             # Two batches of ROW DICTS (not pre-extracted triplets) with
             # the SAME triplets in REVERSE orders. _acquire_sorted_locks
@@ -920,7 +916,7 @@ def test_sorted_lock_acquisition_prevents_deadlock():
             results: dict[str, object] = {"a": None, "b": None}
 
             def worker(rows: list[dict], key: str) -> None:
-                session = SessionLocal()
+                session = session_factory()
                 try:
                     _acquire_sorted_locks(session, rows)
                     results[key] = "ok"
@@ -1000,17 +996,16 @@ def test_full_poll_cycle_no_duplicates():
     """
     psycopg2, restore_psycopg2 = _swap_in_real_psycopg2()
     try:
+        from polling.event_writer import _acquire_sorted_locks
+        from services.event_lock import acquire_event_triplet_lock
         from sqlalchemy import create_engine
         from sqlalchemy.orm import sessionmaker
         from testcontainers.postgres import PostgresContainer
 
-        from polling.event_writer import _acquire_sorted_locks
-        from services.event_lock import acquire_event_triplet_lock
-
         with PostgresContainer("postgres:15-alpine") as pg:
             conn_url = pg.get_connection_url()
             engine = create_engine(conn_url)
-            SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+            session_factory = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
 
             triplet = ("ci-001", "cpu", "COLLECTION_FAILURE")
             ci_id, metric_id, event_type = triplet
@@ -1028,7 +1023,7 @@ def test_full_poll_cycle_no_duplicates():
             results: dict[str, str] = {}
 
             def snmp_worker_writer() -> None:
-                session = SessionLocal()
+                session = session_factory()
                 try:
                     acquire_event_triplet_lock(session, ci_id, metric_id, event_type)
                     with sink_lock:
@@ -1043,7 +1038,7 @@ def test_full_poll_cycle_no_duplicates():
                     session.close()
 
             def snmp_service_writer() -> None:
-                session = SessionLocal()
+                session = session_factory()
                 try:
                     acquire_event_triplet_lock(session, ci_id, metric_id, event_type)
                     with sink_lock:
@@ -1057,7 +1052,7 @@ def test_full_poll_cycle_no_duplicates():
                     session.close()
 
             def event_writer_batch() -> None:
-                session = SessionLocal()
+                session = session_factory()
                 try:
                     # event_writer batch path: a single-row batch
                     # containing the same triplet.

--- a/openspec/changes/event-writer-coordination-observability/design.md
+++ b/openspec/changes/event-writer-coordination-observability/design.md
@@ -1,0 +1,70 @@
+# Design: Event Writer Coordination Observability
+
+## Technical Approach
+
+Instrument the existing shared Event advisory-lock helper and preserve the current writer topology. `backend/services/event_lock.py` remains the only primitive that executes `SELECT pg_advisory_xact_lock(hashtext(:key))`; it will measure elapsed blocking time, record bounded in-process metrics, emit slow-lock logs, and expose a snapshot/alert helper for status reporting. Call sites only add stable writer context labels. No timeout, exporter, fail-open/fail-closed policy, or readiness/liveness behavior is introduced.
+
+## Architecture Decisions
+
+| Option | Tradeoff | Decision |
+|---|---|---|
+| Instrument `event_lock.py` centrally | Lowest semantic risk; all protected writers already converge there | Use this; avoid touching Neo4j Event write/dedup Cypher beyond context arguments |
+| Add Prometheus/OpenTelemetry/exporter | Better external integration but adds dependency and endpoint scope | Defer; first slice uses in-process Python state with exporter-ready snapshot shape |
+| Use lock wait as healthcheck failure | Visible to orchestration but can restart healthy blocked writers | Do not degrade `/` or `/api/system/status`; report `event_lock.alert_state` only |
+| Add lock timeout policy | Reduces blocking but requires fail-open/fail-closed product decision | Out of scope; keep PostgreSQL blocking semantics unchanged |
+
+## Data Flow
+
+```text
+Event writer -> acquire_event_triplet_lock(writer=...)
+             -> pg_advisory_xact_lock blocks until acquired
+             -> EventLockMetrics records count/wait
+             -> slow log if wait >= INFO threshold
+             -> existing Neo4j Event create/update path
+
+/api/system/status -> get_event_lock_observability_snapshot()
+                   -> derived INFO/WARNING/CRITICAL alert_state
+                   -> payload only; no status-code or health degradation
+```
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `backend/config.py` | Modify | Add `EventLockSettings` and cached env-backed lock observability settings: INFO `250ms`, p95 WARNING `1000ms`, p99 CRITICAL `5000ms`, bounded window/sample size. PR1 scope. |
+| `backend/services/event_lock.py` | Modify | Add bounded in-memory metrics, percentile/alert snapshot, slow-lock structured logging, optional `writer_context` argument. Preserve SQL and blocking semantics. PR1 scope. |
+| `backend/engines/snmp_worker.py` | Modify | Pass bounded writer contexts for collection failure, ICMP availability, and threshold breach lock acquisitions. Keep sorted acquisition order. Later slice: PR2. |
+| `backend/services/snmp_service.py` | Modify | Pass legacy writer context while keeping the existing PostgreSQL session open across the Neo4j write. Later slice: PR2. |
+| `backend/polling/event_writer.py` | Modify | Thread `writer_context="polling_event_writer"` through sorted batch lock acquisition without changing distinct-triplet sorting. Later slice: PR2. |
+| `backend/main.py` | Modify | Add `event_lock` snapshot to `/api/system/status`; do not alter root healthcheck, service status strings, or HTTP status behavior. Later slice: PR2. |
+| `backend/tests/test_writer_advisory_lock.py` | Modify | Unit-test SQL preservation, metrics recording, alert thresholds, no timeout SQL/settings, and slow-lock logging. |
+| `backend/tests/test_snmp_worker.py`, `backend/tests/test_snmp_service_collection_failures.py`, `backend/tests/test_polling_event_writer.py` | Modify | Assert call sites pass expected writer context while keeping current lock counts/order. Later slice: PR2. |
+| `backend/tests/test_system_status.py` | Modify | Assert status payload includes lock observability without changing health semantics. Later slice: PR2. |
+| `docs/polling-pipeline-runbook.md` | Modify | Document shared PostgreSQL identity, session lifetime, sorted locks, thresholds, and #334 as complementary CI coverage. Later slice: PR3. |
+
+## Interfaces / Contracts
+
+```python
+def acquire_event_triplet_lock(pg_db, ci_id: str, metric_id: str, event_type: str, *, writer_context: str = "unknown") -> None: ...
+def get_event_lock_observability_snapshot() -> dict: ...
+def reset_event_lock_observability_for_tests() -> None: ...
+```
+
+Snapshot contract: `{"acquisitions_total": int, "wait_ms": {"count": int, "p95": float|None, "p99": float|None, "max": float|None}, "alert_state": "OK|INFO|WARNING|CRITICAL", "thresholds_ms": {...}, "by_writer": {...}}`. Labels are bounded writer contexts only; raw triplet IDs are not default labels.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit | Metrics, percentiles, alert state, slow-log threshold, SQL unchanged | pytest with fake clock/MagicMock/caplog in `test_writer_advisory_lock.py` |
+| Integration-ish | Writer context propagation and sorted lock order | Existing patched writer tests; update expected calls without real DB |
+| API | Status payload exposes lock state without health degradation | `test_system_status.py`; root endpoint unchanged |
+| E2E | None in first slice | Existing real-Postgres advisory-lock blocking tests remain the semantic proof |
+
+## Migration / Rollout
+
+No migration required. Rollout is code-only, dependency-free, and reversible. Operators may tune thresholds by environment variables after deploy.
+
+## Open Questions
+
+None blocking. Future exporter integration and lock timeout policy remain separate decisions.

--- a/openspec/changes/event-writer-coordination-observability/exploration.md
+++ b/openspec/changes/event-writer-coordination-observability/exploration.md
@@ -1,0 +1,50 @@
+## Exploration: Event writer coordination observability
+
+### Current State
+Issue #322 is implemented: `backend/services/event_lock.py` exposes `acquire_event_triplet_lock(pg_db, ci_id, metric_id, event_type)`, which runs `SELECT pg_advisory_xact_lock(hashtext(:key))` using the triplet key. The three protected polling Event writers already acquire this lock before Neo4j Event create/update paths: `backend/engines/snmp_worker.py`, `backend/services/snmp_service.py`, and `backend/polling/event_writer.py` via `writer_pool.run_writer_once`. Batched writers sort distinct triplets before acquisition to avoid PostgreSQL advisory-lock deadlocks.
+
+Issue #334 has also landed a CI guard in `backend/tests/test_event_writer_lock_guard.py` plus `backend/tests/README.md`; it discovers production Event emitters and requires protected/exempt classification with evidence metadata, but it intentionally does not add runtime observability. There is no Prometheus/OpenTelemetry dependency in backend requirements, no existing lock metrics, no lock wait logging, and the only current health surfaces are `/` and `/api/system/status`.
+
+### Affected Areas
+- `backend/services/event_lock.py` — central point for measuring lock acquisition count, wait duration, timeout failures, and structured logging without changing each writer's Event semantics.
+- `backend/engines/snmp_worker.py` — protected writer; likely needs a `writer` label/context when calling the shared helper.
+- `backend/services/snmp_service.py` — protected legacy writer; session lifetime must remain open across the Neo4j write after any observability wrapper.
+- `backend/polling/event_writer.py` — protected batch writer; `_acquire_sorted_locks` should preserve deterministic ordering while passing writer context into the helper.
+- `backend/polling/writer_pool.py` — confirms the queue writer passes the open Timescale session as `lock_db`; timeout behavior must preserve result retry semantics.
+- `backend/tests/test_writer_advisory_lock.py`, `backend/tests/test_snmp_worker.py`, `backend/tests/test_snmp_service_collection_failures.py`, `backend/tests/test_polling_event_writer.py` — current lock behavior tests; best place for regression coverage around metrics/logging/timeout semantics.
+- `backend/tests/test_event_writer_lock_guard.py` and `backend/tests/README.md` — existing future-writer guard; issue #326 should not duplicate #334, only document how the guard complements runtime observability.
+- `backend/main.py` — current `/` and `/api/system/status` health surfaces; any lock healthcheck/status exposure would integrate here unless a dedicated observability endpoint is introduced.
+- `backend/postgres_db.py` and `docker-compose.yml` — deployment invariant location: all Event writers must point at the same PostgreSQL/Timescale instance via the same `POSTGRES_HOST`, `POSTGRES_PORT`, and database identity.
+- `docs/itsm/event-flow.md`, `docs/polling-pipeline-runbook.md`, or a new focused backend event-writer document — appropriate homes for operational invariants without overloading test documentation.
+
+### Approaches
+1. **Minimal helper-level instrumentation and documentation** — Keep `pg_advisory_xact_lock`, measure elapsed time around `pg_db.execute`, increment in-process counters/histograms, emit structured logs at DEBUG/INFO thresholds, and document shared-Postgres/session-lifetime invariants.
+   - Pros: low semantic risk; one central helper; avoids touching Neo4j Event logic; fast to test with existing mocks; keeps issue #334 scoped to CI guardrails.
+   - Cons: in-process metrics may not be scrape-compatible without a metrics exporter; helper needs writer context added to call sites for useful labels.
+   - Effort: Medium.
+
+2. **Timeout-capable lock helper using PostgreSQL local settings** — Add a configurable lock timeout around acquisition, e.g. `SET LOCAL lock_timeout` before `pg_advisory_xact_lock`, then fail fast with structured logging/metrics when lock acquisition cannot complete.
+   - Pros: directly addresses blocking/unavailability; keeps timeout scoped to the current transaction; preserves PostgreSQL as the coordination backend.
+   - Cons: product/operations must decide whether timeout is fail-closed (skip/retry Event write) or fail-open (write without lock and risk duplicates); tests need real-Postgres coverage for timeout behavior.
+   - Effort: Medium/High.
+
+3. **Full observability surface and runtime invariant checks** — Add scrapeable metrics endpoint/dependency, lock health in `/api/system/status` or a dedicated health endpoint, startup/runtime checks that all writers target the same PostgreSQL instance, and alert-ready documentation.
+   - Pros: most operationally complete; aligns with issue's metrics/alerts/healthcheck ambitions; makes drift visible to operators.
+   - Cons: larger PR; may exceed review budget; introduces product decisions around metrics stack, alert ownership, healthcheck failure semantics, and deployment topology; could blur into framework-level single-writer enforcement.
+   - Effort: High.
+
+### Recommendation
+Proceed with a scoped proposal that splits issue #326 into two reviewable slices if needed: first add helper-level runtime observability plus invariant documentation, then add timeout/healthcheck behavior once fail-open vs fail-closed policy is decided. Instrumenting `backend/services/event_lock.py` is the safest anchor because all protected writers already converge there and existing tests can prove semantics remain unchanged.
+
+Do not reimplement issue #334. Treat the existing `test_event_writer_lock_guard.py` as the future-writer enforcement baseline and limit this change to documenting the guard's role plus adding runtime observability for actual lock usage.
+
+### Risks
+- Timeout behavior is a real product/operations decision: fail-open preserves Event writes but can reintroduce duplicate OPEN Events; fail-closed preserves dedup semantics but can drop/defer Event visibility during PostgreSQL issues.
+- A scrapeable Prometheus-style implementation may require adding a new dependency and endpoint; the repo currently has no general metrics exporter pattern.
+- Logging every acquisition with triplet labels can become noisy and may expose high-cardinality identifiers; default DEBUG plus INFO only above a wait threshold is safer.
+- Hash collisions from `hashtext()` only cause false contention, not data loss, but metrics may make collision-like contention visible without proving root cause.
+- Healthcheck semantics can cause operational harm if lock contention marks the backend unhealthy and triggers restarts while writers are merely waiting.
+- PostgreSQL pool exhaustion remains possible because lock waits hold connections for the Neo4j write duration; documentation should include pool-sizing guidance.
+
+### Ready for Proposal
+Yes — proposal can start, but it should ask these open questions before design/tasks: Which metrics backend should be used (in-process/status payload only vs Prometheus-compatible exporter)? Should alert definitions be documentation-only or implemented in repo? Should lock acquisition timeout fail-open, fail-closed/retry, or only log for the first slice? Should lock health affect `/api/system/status`, `/`, a new endpoint, or only metrics/logs? What wait thresholds should drive INFO logs and alerts (`50ms` log and `100ms p99` alert are issue defaults but need confirmation)?

--- a/openspec/changes/event-writer-coordination-observability/proposal.md
+++ b/openspec/changes/event-writer-coordination-observability/proposal.md
@@ -1,0 +1,68 @@
+# Proposal: Event Writer Coordination Observability
+
+## Intent
+
+Make PostgreSQL advisory-lock coordination for cross-writer Event deduplication observable without changing Event write semantics. Operators need runtime evidence of lock acquisition volume, wait latency, slow-lock conditions, and derived alert state while #334 remains the CI guard for future writer coverage.
+
+## Scope
+
+### PR1 Boundary Note
+
+PR1 is limited to the metrics/settings/logging core in `backend/config.py`, `backend/services/event_lock.py`, and focused lock-helper tests. Writer/status wiring and operator documentation remain later chained slices (PR2 and PR3 respectively) even where listed as affected areas for the full change.
+
+### In Scope
+- Add lightweight in-process lock metrics and structured logs around shared Event triplet lock acquisition.
+- Surface real application alert state from lock metrics: INFO above 250ms, WARNING when p95 exceeds 1s, CRITICAL when p99 exceeds 5s over the configured window.
+- Document shared PostgreSQL/session-lifetime invariants and how #334 complements runtime observability.
+
+### Out of Scope
+- Prometheus/OpenTelemetry/exporter dependencies or scrape endpoint.
+- Fail-open/fail-closed lock timeout behavior; this slice only measures and logs waits.
+- Liveness/readiness degradation from lock contention.
+- Reimplementing or expanding the #334 CI guard, except as an integration reference.
+
+## Capabilities
+
+### New Capabilities
+- `event-writer-coordination-observability`: Runtime metrics, structured logs, alert state, and operational invariants for Event writer advisory-lock coordination.
+
+### Modified Capabilities
+- None; existing Event deduplication behavior remains unchanged.
+
+## Approach
+
+Instrument `backend/services/event_lock.py` as the central lock helper. Add writer/context labels at protected call sites, keep metric state in-process with a stable internal model for a future exporter adapter, and derive alert state from configurable conservative thresholds. Preserve `pg_advisory_xact_lock` blocking semantics and deterministic sorted lock acquisition.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `backend/services/event_lock.py` | Modified | Measure acquisition count/wait duration, emit slow-lock logs, maintain alert state. |
+| `backend/engines/snmp_worker.py` | Modified | Pass writer context to shared lock helper. |
+| `backend/services/snmp_service.py` | Modified | Pass legacy writer context while preserving session lifetime. |
+| `backend/polling/event_writer.py` | Modified | Pass batch writer context without changing sorted acquisition. |
+| `backend/tests/*event*lock*` | Modified | Cover metrics/logging semantics without changing lock behavior. |
+| `docs/itsm/event-flow.md` or runbook | Modified | Document invariants, thresholds, and #334 relationship. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Metric/log cardinality from triplet labels | Med | Use writer/status labels; avoid raw high-cardinality IDs in default logs. |
+| Alert thresholds too noisy | Med | Use conservative configurable defaults and document rationale. |
+| Observability changes lock semantics | Low | Centralize timing around existing acquisition and test no timeout behavior. |
+
+## Rollback Plan
+
+Revert the proposal implementation commit(s). Event writers fall back to existing advisory-lock behavior because no schema, dependency, exporter, or timeout policy changes are introduced.
+
+## Dependencies
+
+- Existing #322 advisory-lock helper and protected writers.
+- #334 CI guard remains an external coverage guard only.
+
+## Success Criteria
+
+- [ ] Lock acquisition count, wait latency, slow-lock logs, and alert state are available in-process.
+- [ ] Thresholds default to 250ms INFO, 1s p95 WARNING, 5s p99 CRITICAL and are configurable where appropriate.
+- [ ] Tests prove Event deduplication semantics and healthcheck behavior remain unchanged.

--- a/openspec/changes/event-writer-coordination-observability/tasks.md
+++ b/openspec/changes/event-writer-coordination-observability/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Event Writer Coordination Observability
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 550-750 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 metrics/settings → PR 2 writer/status wiring → PR 3 docs/polish |
+| Delivery strategy | auto-forecast |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Add lock metrics/settings/logging in `backend/services/event_lock.py` and `backend/config.py` | PR 1 | Include unit tests for metrics, thresholds, SQL preservation, and no timeout behavior. |
+| 2 | Wire writer contexts and status payload in backend call sites | PR 2 | Depends on PR 1; include propagation and status tests. |
+| 3 | Document operational invariants and verify full suite scope | PR 3 | Depends on PR 2; include runbook update and final verification. |
+
+PR1 boundary: this slice is complete when metrics/settings/logging core and focused lock-helper tests are review-ready. Phase 3 writer/status rows and Phase 4 documentation/final-verification rows intentionally remain unchecked for later chained slices.
+
+## Phase 1: RED Foundation Tests
+
+- [x] 1.1 Add failing tests in `backend/tests/test_writer_advisory_lock.py` for acquisition count, wait distribution, p95/p99 alert thresholds, and raw triplet IDs excluded from labels.
+- [x] 1.2 Add failing tests in `backend/tests/test_writer_advisory_lock.py` for structured slow-lock logging at 250ms and no INFO log below threshold.
+- [x] 1.3 Add failing tests proving `pg_advisory_xact_lock(hashtext(:key))` remains blocking-only with no timeout or fail-open/fail-closed SQL/settings.
+
+## Phase 2: GREEN Lock Observability Core
+
+- [x] 2.1 Add env-backed `EventLockSettings` defaults in `backend/config.py`: INFO 250ms, p95 WARNING 1000ms, p99 CRITICAL 5000ms, bounded sample window.
+- [x] 2.2 Implement bounded in-process metrics, percentiles, alert derivation, and test reset helper in `backend/services/event_lock.py`.
+- [x] 2.3 Update `acquire_event_triplet_lock(..., writer_context="unknown")` to time acquisition, record metrics after success, and emit bounded structured slow-lock logs.
+
+## Phase 3: RED/GREEN Writer and Status Wiring
+
+- [ ] 3.1 Add failing assertions in `backend/tests/test_snmp_worker.py`, `backend/tests/test_snmp_service_collection_failures.py`, and `backend/tests/test_polling_event_writer.py` for expected writer contexts and unchanged lock counts/order.
+- [ ] 3.2 Thread writer contexts through `backend/engines/snmp_worker.py`, `backend/services/snmp_service.py`, and `backend/polling/event_writer.py` without changing sorted acquisition or session lifetime.
+- [ ] 3.3 Add failing status tests in `backend/tests/test_system_status.py` for `event_lock` snapshot presence and unchanged health/status behavior.
+- [ ] 3.4 Expose `get_event_lock_observability_snapshot()` from `backend/services/event_lock.py` through `/api/system/status` in `backend/main.py` only.
+
+## Phase 4: Documentation, Verification
+
+- [ ] 4.1 Review and document the stable snapshot contract after PR2 status wiring; PR1 already implements exporter-ready keys: `acquisitions_total`, `wait_ms`, `alert_state`, `thresholds_ms`, and `by_writer`.
+- [ ] 4.2 Update `docs/polling-pipeline-runbook.md` with PostgreSQL identity, session lifetime, sorted locks, thresholds, and #334 CI-guard relationship.
+- [ ] 4.3 Run `cd backend && python -m pytest` or document targeted/manual evidence if a relevant automated test cannot reasonably run.

--- a/openspec/changes/event-writer-coordination-observability/verify-report-pr1.md
+++ b/openspec/changes/event-writer-coordination-observability/verify-report-pr1.md
@@ -1,0 +1,130 @@
+# Verification Report: Event Writer Coordination Observability — PR Slice 1
+
+## Status
+
+**Final verdict**: PASS WITH WARNINGS  
+**Mode**: Strict TDD verification  
+**Scope**: Partial verification for PR slice 1 only — tasks 1.1, 1.2, 1.3, 2.1, 2.2, 2.3.  
+**Change root**: `openspec/changes/event-writer-coordination-observability`  
+**Branch verified**: `fix/issue-326-lock-observability-core`
+
+## Executive Summary
+
+PR1 satisfies the metrics/settings/logging core scope. The completed tasks are checked in `tasks.md`, runtime evidence passed under the issue #326 project-local `.venv`, and source inspection confirms PR1 stayed inside `backend/config.py`, `backend/services/event_lock.py`, and `backend/tests/test_writer_advisory_lock.py`.
+
+No PR2 writer/status wiring or PR3 documentation/final-verification implementation was introduced in this slice. Those unchecked tasks are pending later slices and are not blockers for PR1.
+
+Warnings remain for known environmental and review-scope constraints: Docker/testcontainers integration tests were not part of the targeted local run, `backend/config.py` whole-file coverage is 79% because the command measures unrelated config sections, and PR1 remains oversized but must not grow further.
+
+## Completeness
+
+| Area | Result | Evidence |
+|------|--------|----------|
+| PR1 task status | PASS | Tasks 1.1, 1.2, 1.3, 2.1, 2.2, 2.3 are checked in `tasks.md`. |
+| PR2/PR3 task boundary | PASS | Tasks 3.1-3.4 and 4.1-4.3 remain unchecked; changed files do not include writer call sites, `backend/main.py`, or docs. |
+| Apply-progress read | PASS | Engram topic `sdd/event-writer-coordination-observability/apply-progress` read; TDD evidence table present. |
+| Runtime evidence | PASS | Targeted non-integration pytest run passed: 23 passed, 4 deselected. |
+| Static/import smoke | PASS | `py_compile` passed; import smoke is covered by `test_services_event_lock_imports_from_backend_import_root`. |
+
+## Command Evidence
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `../.venv/bin/python -m pytest tests/test_writer_advisory_lock.py -m 'not integration'` | PASS | 23 passed, 4 deselected in 1.12s. |
+| `../.venv/bin/python -m py_compile config.py services/event_lock.py tests/test_writer_advisory_lock.py` | PASS | No output; exit code 0. |
+| `../.venv/bin/python -m pytest tests/test_writer_advisory_lock.py -m 'not integration' --cov=config --cov=services.event_lock --cov-report=term-missing` | PASS WITH WARNING | 23 passed, 4 deselected. `services/event_lock.py` 100%; `config.py` 79%; total 88%. |
+| `git status --short && git diff --stat && git diff --name-only` | PASS | Only PR1 code files modified: `backend/config.py`, `backend/services/event_lock.py`, `backend/tests/test_writer_advisory_lock.py`; OpenSpec artifacts untracked. |
+
+## Strict TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD evidence reported | PASS | Apply-progress contains a TDD Cycle Evidence table. |
+| All PR1 tasks have tests | PASS | Tasks 1.1-1.3 and 2.1-2.3 all map to `backend/tests/test_writer_advisory_lock.py`. |
+| RED confirmed | PASS | Test file exists and apply-progress reports RED evidence for PR1 behavior plus remediation. |
+| GREEN confirmed | PASS | Current execution passed 23/23 selected non-integration tests. |
+| Triangulation adequate | PASS | Metrics, alert thresholds, label exclusion, slow-log threshold/below-threshold, zero-threshold, SQL/no-timeout, env defaults/overrides, bounded windows, and writer-context overflow are covered. |
+| Safety net for modified files | PASS | Apply-progress reports pre-remediation safety net runs; current targeted run confirms no regression in PR1 tests. |
+
+**Strict TDD evidence verdict**: PASS.
+
+## Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit/smoke | 23 selected tests | 1 | pytest |
+| Integration | 4 deselected tests | 1 | pytest + testcontainers/Docker |
+| E2E | 0 | 0 | Not applicable |
+| Total collected | 27 | 1 | pytest |
+
+## Changed File Coverage
+
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `backend/services/event_lock.py` | 100% | Not reported | — | Excellent |
+| `backend/config.py` | 79% | Not reported | unrelated config sections plus some env fallback branches | Warning |
+
+**Average reported coverage for selected modules**: 88% total. The warning is not blocking for PR1 because the uncovered `config.py` lines include unrelated configuration classes outside the event-lock settings slice.
+
+## Assertion Quality
+
+**Assertion quality**: PASS — no tautological assertions, ghost loops, production-code-free assertions, or smoke-only tests were found in the PR1-relevant tests. Assertions exercise production helpers/settings and verify concrete values or log fields.
+
+## Spec Compliance Matrix
+
+| Requirement / Scenario | PR1 Status | Runtime Evidence | Notes |
+|------------------------|------------|------------------|-------|
+| Lock Acquisition Metrics — successful acquisition is measured | PASS | `test_event_lock_metrics_record_count_distribution_alerts_and_bounded_labels`, `test_acquire_event_triplet_lock_avoids_info_log_below_threshold` passed. | Acquisition count and wait distribution are recorded after successful lock acquisition. |
+| Lock Acquisition Metrics — high-cardinality identifiers excluded | PASS | `test_event_lock_metrics_record_count_distribution_alerts_and_bounded_labels` passed. | Snapshot labels are bounded writer contexts; raw triplet IDs are not required as default labels. |
+| Structured Slow-Lock Logging — slow lock is logged | PASS | `test_acquire_event_triplet_lock_emits_structured_slow_log_at_info_threshold` passed. | Structured INFO log includes writer context, wait, and threshold. |
+| Structured Slow-Lock Logging — normal wait avoids noisy logs | PASS | `test_acquire_event_triplet_lock_avoids_info_log_below_threshold` passed. | Below-threshold acquisition records metrics without slow log. |
+| Derived Lock Alert State — WARNING threshold exceeded | PASS | `test_event_lock_alert_state_warns_when_p95_exceeds_threshold_without_critical` passed. | p95 warning behavior covered. |
+| Derived Lock Alert State — CRITICAL threshold exceeded | PASS | `test_event_lock_metrics_record_count_distribution_alerts_and_bounded_labels`, `test_event_lock_threshold_equality_escalates_alert_state` passed. | p99 critical behavior and equality behavior covered. |
+| Alert state does not fail healthchecks | PENDING — PR2 | Not run for PR1. | Requires `backend/main.py` status/health wiring, explicitly out of PR1 scope. |
+| Coordination invariants documentation — operator reviews invariants | PENDING — PR3 | Not run for PR1. | Documentation task 4.2 remains unchecked by design. |
+| Timeout policy remains unchanged | PASS | `test_event_lock_sql_remains_blocking_only_without_timeout_policy` passed. | SQL remains `pg_advisory_xact_lock(hashtext(:key))`; no timeout/fail-open/fail-closed settings. |
+
+## Design Coherence
+
+| Design Decision | Result | Evidence |
+|-----------------|--------|----------|
+| Instrument `event_lock.py` centrally | PASS | Core metrics/logging/snapshot helpers are implemented in `backend/services/event_lock.py`. |
+| Add env-backed settings without new dependencies | PASS | `EventLockSettings` exists in `backend/config.py`; no exporter dependency added. |
+| Preserve blocking lock semantics | PASS | Runtime SQL invariant test passed; source keeps `SELECT pg_advisory_xact_lock(hashtext(:key))`. |
+| Avoid health/readiness degradation in PR1 | PASS | No `backend/main.py` or health/status endpoint changes in this slice. |
+| Defer writer contexts/status/docs | PASS | Writer call sites, status payload, and docs were not modified. |
+
+## Issues
+
+### Critical
+
+None for PR1.
+
+### Warnings
+
+- Full modified-file integration coverage was not executed in this environment because Docker/testcontainers tests are known to fail locally; targeted non-integration tests passed.
+- `backend/config.py` reported 79% coverage under whole-file coverage, but uncovered lines are mostly unrelated settings outside the PR1 event-lock slice.
+- PR1 is oversized at approximately 711 insertions and should not grow further.
+- Production visibility remains pending until PR2 wires writer contexts and `/api/system/status` exposure.
+
+### Suggestions
+
+- Keep PR2 strictly limited to writer/status wiring and associated tests.
+- Keep PR3 limited to documentation and final broader verification.
+
+## Pending Items for Later Slices
+
+| Slice | Pending Tasks |
+|-------|---------------|
+| PR2 | 3.1, 3.2, 3.3, 3.4 — writer context propagation and `/api/system/status` exposure. |
+| PR3 | 4.1, 4.2, 4.3 — snapshot contract review/documentation and final verification. |
+
+## Next Recommended
+
+Proceed with PR1 review as PASS WITH WARNINGS. Do not add more PR1 scope. Start PR2 from the writer/status wiring tasks only after PR1 is accepted.
+
+## Skill Resolution
+
+- Loaded/read `sdd-verify/SKILL.md` directly as executor instructions.
+- Loaded/read `sdd-verify/strict-tdd-verify.md` because Strict TDD mode is active.
+- Verification used OpenSpec artifacts plus Engram apply-progress.

--- a/openspec/specs/event-writer-coordination-observability/spec.md
+++ b/openspec/specs/event-writer-coordination-observability/spec.md
@@ -1,0 +1,80 @@
+# Event Writer Coordination Observability Specification
+
+## Purpose
+
+Define runtime observability for Event writer PostgreSQL advisory-lock coordination without changing Event write, deduplication, blocking, retry, or healthcheck semantics.
+
+## Requirements
+
+### Requirement: Lock Acquisition Metrics
+
+The system MUST maintain lightweight in-process metrics for shared Event triplet lock acquisition, including acquisition count and wait-duration distribution by bounded writer/context labels.
+
+#### Scenario: Successful acquisition is measured
+
+- GIVEN an Event writer acquires the shared triplet lock
+- WHEN the acquisition completes
+- THEN the metrics include one additional acquisition
+- AND the observed wait duration is recorded for that writer context
+
+#### Scenario: High-cardinality identifiers are excluded
+
+- GIVEN lock metrics are recorded for a CI, metric, and event type triplet
+- WHEN metric labels are produced
+- THEN raw triplet identifiers MUST NOT be required as default metric labels
+
+### Requirement: Structured Slow-Lock Logging
+
+The system MUST emit structured slow-lock logs when acquisition wait time crosses the configured INFO threshold, defaulting to 250ms.
+
+#### Scenario: Slow lock is logged
+
+- GIVEN lock acquisition takes longer than the configured INFO threshold
+- WHEN the lock is acquired
+- THEN a structured log entry records writer context and wait duration
+- AND Event write semantics remain unchanged
+
+#### Scenario: Normal wait avoids noisy logs
+
+- GIVEN lock acquisition completes below the configured INFO threshold
+- WHEN the lock is acquired
+- THEN the system SHOULD avoid emitting an INFO slow-lock log
+
+### Requirement: Derived Lock Alert State
+
+The system MUST derive alert state from in-process lock wait metrics without degrading liveness or readiness checks.
+
+#### Scenario: Warning threshold is exceeded
+
+- GIVEN the configured observation window has lock wait p95 above 1s
+- WHEN alert state is evaluated
+- THEN the system reports WARNING for lock coordination
+
+#### Scenario: Critical threshold is exceeded
+
+- GIVEN the configured observation window has lock wait p99 above 5s
+- WHEN alert state is evaluated
+- THEN the system reports CRITICAL for lock coordination
+
+#### Scenario: Alert state does not fail healthchecks
+
+- GIVEN lock alert state is WARNING or CRITICAL
+- WHEN application health or readiness is evaluated
+- THEN the result MUST NOT change solely because of lock contention observability
+
+### Requirement: Coordination Invariants Documentation
+
+The system MUST document operational invariants for advisory-lock coordination: all Event writers share the same PostgreSQL database identity, lock acquisition remains session/transaction scoped, deterministic sorted acquisition is preserved for batched writers, and issue #334 remains the complementary CI guard for future writer coverage.
+
+#### Scenario: Operator reviews invariants
+
+- GIVEN an operator reads Event writer coordination documentation
+- WHEN they verify deployment requirements
+- THEN the documentation identifies shared PostgreSQL identity and session-lifetime requirements
+- AND it explains that #334 guards writer coverage in CI, not runtime contention
+
+#### Scenario: Timeout policy remains unchanged
+
+- GIVEN an Event writer waits for the shared advisory lock
+- WHEN observability is enabled
+- THEN the system MUST NOT introduce fail-open, fail-closed, or timeout behavior in this capability


### PR DESCRIPTION
## Descripción del Cambio
Closes #326

PR 1 de la cadena de #326. Este slice agrega el núcleo de observabilidad del lock de eventos:
- métricas internas acotadas para adquisición y espera de `pg_advisory_xact_lock`;
- thresholds configurables y logs estructurados de lock lento;
- pruebas Strict TDD para settings, percentiles, límites de memoria, import root y semántica blocking-only.

### Chain Context
Estrategia: feature-branch-chain.

```text
main
└── fix/issue-326-event-coordination-observability   [tracker]
    └── fix/issue-326-lock-observability-core        📍 PR 1: metrics/settings/logging core
        └── PR 2: writer/status wiring               [pendiente]
            └── PR 3: docs/final verification        [pendiente]
```

Base de este PR: `fix/issue-326-event-coordination-observability`.
Fuera de scope: wiring de writers, `/api/system/status`, docs/runbook finales y cierre completo de #326.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] `cd backend && ../.venv/bin/python -m pytest tests/test_writer_advisory_lock.py -m 'not integration'` → 23 passed, 4 deselected
- [x] `cd backend && ../.venv/bin/python -m py_compile config.py services/event_lock.py tests/test_writer_advisory_lock.py` → passed
- [x] SDD verify PR1 → PASS WITH WARNINGS (`openspec/changes/event-writer-coordination-observability/verify-report-pr1.md`)
- [x] Full 4R review before PR → no blockers/critical findings

Advertencias conocidas:
- Docker/testcontainers integration tests quedan para CI o entorno con Docker disponible.
- PR1 no expone visibilidad productiva todavía; eso queda para PR2.
- PR1 supera 400 líneas por tests + artefactos SDD; no se debe agregar más scope a este PR.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
