### PR TITLE
feat(tunnels): add backend tunnel health normalization

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -157,6 +157,7 @@ from routers import (  # noqa: E402
     permissions,
     roles,
     rtus,
+    tunnels,
     users,
 )
 
@@ -274,6 +275,7 @@ app.include_router(nodes.router, prefix="/api")
 app.include_router(metrics.router, prefix="/api")
 app.include_router(catalog.router, prefix="/api")
 app.include_router(links.router, prefix="/api")
+app.include_router(tunnels.router, prefix="/api")
 app.include_router(events.router, prefix="/api")
 app.include_router(backup.router, prefix="/api")
 app.include_router(dictionaries.router, prefix="/api")

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -10,6 +10,16 @@ from config import get_icmp_settings
 from database import get_db
 from models.core import Node
 from polling.icmp_measurements import ICMP_JITTER_METRIC_ID, ICMP_LATENCY_METRIC_ID
+from services.tunnel_health import (
+    TUNNEL_MEDIA,
+    IcmpReason,
+    LinkIdentity,
+    TunnelAuthoritySample,
+    TunnelHealthResponse,
+    TunnelIcmpSample,
+    encode_link_id,
+    normalize_tunnel_health,
+)
 
 _relationship_types = importlib.import_module("services.relationship_types")
 LISTABLE_RELATIONSHIP_TYPES = _relationship_types.LISTABLE_RELATIONSHIP_TYPES
@@ -182,6 +192,148 @@ def _validate_node_label(label: str) -> str:
     if label not in _VALID_NODE_LABELS:
         raise ValueError(f"Invalid node label: {label}")
     return label
+
+
+def _row_value(row, key: str, default=None):
+    if row is None:
+        return default
+    if hasattr(row, "get"):
+        return row.get(key, default)
+    try:
+        return row[key]
+    except (KeyError, IndexError, TypeError):
+        return default
+
+
+def _authority_from_tunnel_row(row) -> TunnelAuthoritySample | None:
+    state = _row_value(row, "tunnel_authority_state")
+    if state not in {"UP", "DOWN"}:
+        return None
+    return TunnelAuthoritySample(
+        state=state,
+        source=_row_value(row, "tunnel_authority_source"),
+        observed_at=_row_value(row, "tunnel_authority_observed_at"),
+    )
+
+
+def _icmp_from_tunnel_row(row) -> TunnelIcmpSample | None:
+    available = _row_value(row, "tunnel_icmp_available")
+    latency_ms = _row_value(row, "tunnel_icmp_latency_ms")
+    error = _row_value(row, "tunnel_icmp_error")
+    reason = _row_value(row, "tunnel_icmp_reason")
+    if available is None and latency_ms is None and error is None and reason is None:
+        return None
+    return TunnelIcmpSample(
+        available=bool(available),
+        latency_ms=latency_ms,
+        error=error,
+        reason=reason if reason in IcmpReason.__args__ else None,
+    )
+
+
+def get_tunnel_health_link(
+    identity: LinkIdentity,
+    allowed_locations: list[str] | None = None,
+    is_admin: bool = False,
+) -> TunnelHealthResponse | None:
+    """Read latest tunnel health for one eligible, scoped CI-to-CI tunnel link."""
+    rel = _validate_relationship(identity.relationship)
+    if identity.medium not in TUNNEL_MEDIA:
+        raise ValueError(f"Invalid tunnel medium: {identity.medium}")
+    if not is_admin and not allowed_locations:
+        return None
+
+    driver = get_db()
+    query = f"""
+        MATCH (a:CI {{id: $source}})-[r:{rel}]->(b:CI {{id: $target}})
+        WHERE r.medium = $medium
+          AND r.medium IN $eligible_media
+    """
+    params: dict[str, Any] = {
+        "source": identity.source,
+        "target": identity.target,
+        "medium": identity.medium,
+        "eligible_media": sorted(TUNNEL_MEDIA),
+    }
+    if not is_admin:
+        query += (
+            " AND (a.location_name IN $allowed_locations OR b.location_name IN $allowed_locations)"
+        )
+        params["allowed_locations"] = allowed_locations
+    query += """
+        RETURN a.id AS source_id,
+               a.public_ip AS source_public_ip,
+               b.id AS target_id,
+               b.public_ip AS target_public_ip,
+               type(r) AS relationship,
+               r.medium AS medium,
+               r.tunnel_health_status AS tunnel_health_status,
+               r.tunnel_authority_state AS tunnel_authority_state,
+               r.tunnel_authority_source AS tunnel_authority_source,
+               r.tunnel_authority_observed_at AS tunnel_authority_observed_at,
+               r.tunnel_icmp_available AS tunnel_icmp_available,
+               r.tunnel_icmp_latency_ms AS tunnel_icmp_latency_ms,
+               r.tunnel_icmp_error AS tunnel_icmp_error,
+               r.tunnel_icmp_reason AS tunnel_icmp_reason,
+               r.tunnel_observed_at AS tunnel_observed_at
+    """
+    with driver.session() as session:
+        row = session.run(query, **params).single()
+    if not row:
+        return None
+
+    link_id = encode_link_id(identity)
+    missing_public_ip = not _row_value(row, "source_public_ip") or not _row_value(
+        row, "target_public_ip"
+    )
+    return normalize_tunnel_health(
+        link_id=link_id,
+        source=_row_value(row, "source_id"),
+        target=_row_value(row, "target_id"),
+        relationship=_row_value(row, "relationship"),
+        medium=_row_value(row, "medium"),
+        authority=_authority_from_tunnel_row(row),
+        icmp=_icmp_from_tunnel_row(row),
+        missing_public_ip=missing_public_ip,
+        observed_at=_row_value(row, "tunnel_observed_at"),
+    )
+
+
+def save_latest_tunnel_health(identity: LinkIdentity, health: TunnelHealthResponse) -> None:
+    """Persist latest-only tunnel health as scalar properties on the relationship."""
+    rel = _validate_relationship(identity.relationship)
+    if identity.medium not in TUNNEL_MEDIA:
+        raise ValueError(f"Invalid tunnel medium: {identity.medium}")
+    driver = get_db()
+    query = f"""
+        MATCH (a:CI {{id: $source}})-[r:{rel}]->(b:CI {{id: $target}})
+        WHERE r.medium = $medium
+        SET r.tunnel_health_status = $status,
+            r.tunnel_authority_state = $authority_state,
+            r.tunnel_authority_source = $authority_source,
+            r.tunnel_authority_observed_at = $authority_observed_at,
+            r.tunnel_icmp_available = $icmp_available,
+            r.tunnel_icmp_latency_ms = $icmp_latency_ms,
+            r.tunnel_icmp_error = $icmp_error,
+            r.tunnel_icmp_reason = $icmp_reason,
+            r.tunnel_observed_at = $observed_at
+    """
+    with driver.session() as session:
+        session.run(
+            query,
+            source=identity.source,
+            target=identity.target,
+            medium=identity.medium,
+            status=health.status,
+            authority_state=health.authority.state,
+            authority_source=health.authority.source,
+            authority_observed_at=health.authority.observed_at,
+            icmp_available=health.icmp.available,
+            icmp_latency_ms=health.icmp.latency_ms,
+            icmp_error=health.icmp.error,
+            icmp_reason=health.icmp.reason,
+            observed_at=health.observed_at,
+        )
 
 
 def get_template_data():

--- a/backend/routers/tunnels.py
+++ b/backend/routers/tunnels.py
@@ -1,0 +1,35 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from models.user import User
+from repositories import topology_repo
+from services.auth_service import get_current_active_user
+from services.tunnel_health import TunnelHealthResponse, decode_link_id
+
+router = APIRouter(
+    prefix="/tunnels",
+    tags=["Tunnels"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get("/{link_id}/health", response_model=TunnelHealthResponse)
+async def get_tunnel_health(
+    link_id: str,
+    current_user: Annotated[User, Depends(get_current_active_user)],
+):
+    try:
+        identity = decode_link_id(link_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid tunnel link id") from exc
+
+    is_admin = current_user.role == "ADMIN"
+    allowed_locations = current_user.allowed_locations
+    health = topology_repo.get_tunnel_health_link(
+        identity,
+        allowed_locations=allowed_locations,
+        is_admin=is_admin,
+    )
+    if health is None:
+        raise HTTPException(status_code=404, detail="Tunnel link not found")
+    return health

--- a/backend/services/tunnel_health.py
+++ b/backend/services/tunnel_health.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel
+from services.relationship_types import validate_ci_relationship_type
+
+TunnelStatus = Literal["UP", "DOWN", "UNKNOWN"]
+TunnelMedium = Literal["vpn", "sd_wan", "satellite"]
+AuthorityState = Literal["UP", "DOWN"]
+AuthorityReason = Literal["sample", "no_sample"]
+IcmpReason = Literal["sample", "missing_public_ip", "no_sample", "failed"]
+
+TUNNEL_MEDIA = frozenset({"vpn", "sd_wan", "satellite"})
+LINK_ID_FIELDS = ("source", "relationship", "target", "medium")
+MAX_LINK_ID_DECODED_BYTES = 512
+
+
+@dataclass(frozen=True)
+class LinkIdentity:
+    source: str
+    relationship: str
+    target: str
+    medium: TunnelMedium
+
+
+class TunnelAuthoritySample(BaseModel):
+    state: AuthorityState
+    source: str | None = None
+    observed_at: str | None = None
+
+
+class TunnelIcmpSample(BaseModel):
+    available: bool
+    latency_ms: float | None = None
+    error: str | None = None
+    reason: IcmpReason | None = None
+
+
+class AuthorityContext(BaseModel):
+    state: AuthorityState | None
+    source: str | None
+    observed_at: str | None
+    reason: AuthorityReason
+
+
+class IcmpContext(BaseModel):
+    available: bool
+    latency_ms: float | None
+    error: str | None
+    reason: IcmpReason
+
+
+class TunnelHealthResponse(BaseModel):
+    link_id: str
+    source: str
+    target: str
+    relationship: str
+    medium: TunnelMedium
+    status: TunnelStatus
+    authority: AuthorityContext
+    icmp: IcmpContext
+    observed_at: str | None
+
+
+def _canonical_payload(identity: LinkIdentity) -> dict[str, str]:
+    relationship = validate_ci_relationship_type(identity.relationship)
+    medium = identity.medium
+    if medium not in TUNNEL_MEDIA:
+        raise ValueError(f"Invalid tunnel medium: {medium}")
+    return {
+        "source": identity.source,
+        "relationship": relationship,
+        "target": identity.target,
+        "medium": medium,
+    }
+
+
+def encode_link_id(identity: LinkIdentity) -> str:
+    payload = _canonical_payload(identity)
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(raw) > MAX_LINK_ID_DECODED_BYTES:
+        raise ValueError("Decoded link_id payload is too large")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_link_id(link_id: str) -> LinkIdentity:
+    if not link_id or "=" in link_id:
+        raise ValueError("Invalid unpadded base64url link_id")
+
+    padded = link_id + ("=" * (-len(link_id) % 4))
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode("ascii"))
+    except (UnicodeEncodeError, binascii.Error) as exc:
+        raise ValueError("Invalid base64url link_id") from exc
+
+    if len(raw) > MAX_LINK_ID_DECODED_BYTES:
+        raise ValueError("Decoded link_id payload is too large")
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Invalid JSON link_id payload") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid link_id payload")
+    if tuple(payload.keys()) != LINK_ID_FIELDS:
+        raise ValueError("link_id payload must use canonical fields")
+
+    values = {field: payload[field] for field in LINK_ID_FIELDS}
+    if not all(isinstance(value, str) and value for value in values.values()):
+        raise ValueError("link_id payload fields must be non-empty strings")
+
+    relationship = validate_ci_relationship_type(values["relationship"])
+    medium = values["medium"]
+    if medium not in TUNNEL_MEDIA:
+        raise ValueError(f"Invalid tunnel medium: {medium}")
+
+    identity = LinkIdentity(
+        source=values["source"],
+        relationship=relationship,
+        target=values["target"],
+        medium=medium,  # type: ignore[arg-type]
+    )
+    if encode_link_id(identity) != link_id:
+        raise ValueError("link_id payload is not canonical")
+    return identity
+
+
+def normalize_tunnel_health(
+    *,
+    link_id: str,
+    source: str,
+    target: str,
+    relationship: str,
+    medium: TunnelMedium,
+    authority: TunnelAuthoritySample | None,
+    icmp: TunnelIcmpSample | None,
+    missing_public_ip: bool = False,
+    observed_at: str | None = None,
+) -> TunnelHealthResponse:
+    relationship = validate_ci_relationship_type(relationship)
+    if medium not in TUNNEL_MEDIA:
+        raise ValueError(f"Invalid tunnel medium: {medium}")
+
+    if authority is None:
+        status: TunnelStatus = "UNKNOWN"
+        authority_context = AuthorityContext(
+            state=None,
+            source=None,
+            observed_at=None,
+            reason="no_sample",
+        )
+    else:
+        status = authority.state
+        authority_context = AuthorityContext(
+            state=authority.state,
+            source=authority.source,
+            observed_at=authority.observed_at,
+            reason="sample",
+        )
+
+    if missing_public_ip:
+        icmp_context = IcmpContext(
+            available=False,
+            latency_ms=None,
+            error=None,
+            reason="missing_public_ip",
+        )
+    elif icmp is None or icmp.reason == "no_sample":
+        icmp_context = IcmpContext(
+            available=False,
+            latency_ms=None,
+            error=None,
+            reason="no_sample",
+        )
+    elif icmp.reason == "missing_public_ip":
+        icmp_context = IcmpContext(
+            available=False,
+            latency_ms=None,
+            error=None,
+            reason="missing_public_ip",
+        )
+    elif icmp.reason == "failed":
+        icmp_context = IcmpContext(
+            available=False,
+            latency_ms=icmp.latency_ms,
+            error=icmp.error,
+            reason="failed",
+        )
+    elif icmp.available:
+        icmp_context = IcmpContext(
+            available=True,
+            latency_ms=icmp.latency_ms,
+            error=icmp.error,
+            reason="sample",
+        )
+    else:
+        icmp_context = IcmpContext(
+            available=False,
+            latency_ms=icmp.latency_ms,
+            error=icmp.error,
+            reason="failed",
+        )
+
+    return TunnelHealthResponse(
+        link_id=link_id,
+        source=source,
+        target=target,
+        relationship=relationship,
+        medium=medium,
+        status=status,
+        authority=authority_context,
+        icmp=icmp_context,
+        observed_at=observed_at,
+    )

--- a/backend/tests/test_routers_tunnels.py
+++ b/backend/tests/test_routers_tunnels.py
@@ -1,0 +1,212 @@
+import base64
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+from models.user import User
+from services.auth_service import get_current_active_user
+from services.tunnel_health import LinkIdentity, encode_link_id
+
+client = TestClient(app)
+
+
+def _tunnel_user(role="OPERATOR", allowed_locations=None):
+    return User(
+        username="operator",
+        role=role,
+        permissions=["CI_VIEW"],
+        allowed_locations=allowed_locations or ["HQ-Madrid"],
+    )
+
+
+@pytest.fixture(autouse=True)
+def authenticated_tunnel_user():
+    app.dependency_overrides[get_current_active_user] = _tunnel_user
+    yield
+    app.dependency_overrides.pop(get_current_active_user, None)
+
+
+def _link_id(medium="vpn"):
+    return encode_link_id(
+        LinkIdentity(source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium=medium)
+    )
+
+
+def test_get_tunnel_health_returns_latest_health_for_accessible_link():
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link") as mock_get:
+        mock_get.return_value = {
+            "link_id": _link_id(),
+            "source": "hub-a",
+            "target": "edge-b",
+            "relationship": "CONNECTS_TO",
+            "medium": "vpn",
+            "status": "UP",
+            "authority": {
+                "state": "UP",
+                "source": "SNMP",
+                "observed_at": "2026-07-04T10:00:00Z",
+                "reason": "sample",
+            },
+            "icmp": {"available": True, "latency_ms": 10.0, "error": None, "reason": "sample"},
+            "observed_at": "2026-07-04T10:00:01Z",
+        }
+
+        response = client.get(f"/api/tunnels/{_link_id()}/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UP"
+    assert data["authority"]["state"] == "UP"
+    assert data["icmp"]["available"] is True
+    mock_get.assert_called_once_with(
+        LinkIdentity(
+            source="hub-a",
+            relationship="CONNECTS_TO",
+            target="edge-b",
+            medium="vpn",
+        ),
+        allowed_locations=["HQ-Madrid"],
+        is_admin=False,
+    )
+
+
+def test_get_tunnel_health_rejects_unauthenticated_request_before_repository_lookup():
+    app.dependency_overrides.pop(get_current_active_user, None)
+
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link") as mock_get:
+        response = client.get(f"/api/tunnels/{_link_id()}/health")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Not authenticated"
+    mock_get.assert_not_called()
+
+
+def test_get_tunnel_health_forwards_admin_scope_to_repository():
+    app.dependency_overrides[get_current_active_user] = lambda: _tunnel_user(
+        role="ADMIN",
+        allowed_locations=["HQ-Madrid", "Remote-Site"],
+    )
+
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link") as mock_get:
+        mock_get.return_value = {
+            "link_id": _link_id(),
+            "source": "hub-a",
+            "target": "edge-b",
+            "relationship": "CONNECTS_TO",
+            "medium": "vpn",
+            "status": "UP",
+            "authority": {"state": "UP", "source": "SNMP", "observed_at": None, "reason": "sample"},
+            "icmp": {"available": True, "latency_ms": 10.0, "error": None, "reason": "sample"},
+            "observed_at": "2026-07-04T10:00:01Z",
+        }
+
+        response = client.get(f"/api/tunnels/{_link_id()}/health")
+
+    assert response.status_code == 200
+    mock_get.assert_called_once_with(
+        LinkIdentity(
+            source="hub-a",
+            relationship="CONNECTS_TO",
+            target="edge-b",
+            medium="vpn",
+        ),
+        allowed_locations=["HQ-Madrid", "Remote-Site"],
+        is_admin=True,
+    )
+
+
+@pytest.mark.parametrize("bad_link_id", ["not-base64", "eyJ1bmtub3duIjoiZmllbGQifQ"])
+def test_get_tunnel_health_rejects_malformed_link_id(bad_link_id):
+    response = client.get(f"/api/tunnels/{bad_link_id}/health")
+
+    assert response.status_code == 400
+
+
+def test_get_tunnel_health_rejects_oversized_link_id_before_repository_lookup():
+    payload = {
+        "source": "hub-a" + ("x" * 600),
+        "relationship": "CONNECTS_TO",
+        "target": "edge-b",
+        "medium": "vpn",
+    }
+    oversized_link_id = (
+        base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link") as mock_get:
+        response = client.get(f"/api/tunnels/{oversized_link_id}/health")
+
+    assert response.status_code == 400
+    mock_get.assert_not_called()
+
+
+def test_get_tunnel_health_returns_404_for_missing_or_inaccessible_link():
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link", return_value=None):
+        response = client.get(f"/api/tunnels/{_link_id()}/health")
+
+    assert response.status_code == 404
+
+
+def test_get_tunnel_health_preserves_no_sample_response_body():
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link") as mock_get:
+        mock_get.return_value = {
+            "link_id": _link_id("satellite"),
+            "source": "hub-a",
+            "target": "edge-b",
+            "relationship": "CONNECTS_TO",
+            "medium": "satellite",
+            "status": "UNKNOWN",
+            "authority": {
+                "state": None,
+                "source": None,
+                "observed_at": None,
+                "reason": "no_sample",
+            },
+            "icmp": {"available": False, "latency_ms": None, "error": None, "reason": "no_sample"},
+            "observed_at": None,
+        }
+
+        response = client.get(f"/api/tunnels/{_link_id('satellite')}/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UNKNOWN"
+    assert data["authority"]["reason"] == "no_sample"
+    assert data["icmp"]["reason"] == "no_sample"
+    assert data["observed_at"] is None
+
+
+def test_get_tunnel_health_preserves_missing_public_ip_and_icmp_failure_contexts():
+    with patch("routers.tunnels.topology_repo.get_tunnel_health_link") as mock_get:
+        mock_get.return_value = {
+            "link_id": _link_id(),
+            "source": "hub-a",
+            "target": "edge-b",
+            "relationship": "CONNECTS_TO",
+            "medium": "vpn",
+            "status": "UP",
+            "authority": {"state": "UP", "source": "SNMP", "observed_at": None, "reason": "sample"},
+            "icmp": {
+                "available": False,
+                "latency_ms": None,
+                "error": None,
+                "reason": "missing_public_ip",
+            },
+            "observed_at": "2026-07-04T10:00:01Z",
+        }
+
+        response = client.get(f"/api/tunnels/{_link_id()}/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "UP"
+    assert data["icmp"] == {
+        "available": False,
+        "latency_ms": None,
+        "error": None,
+        "reason": "missing_public_ip",
+    }

--- a/backend/tests/test_topology_tunnel_health.py
+++ b/backend/tests/test_topology_tunnel_health.py
@@ -1,0 +1,204 @@
+import pytest
+from repositories import topology_repo
+from services.tunnel_health import LinkIdentity, TunnelHealthResponse
+
+
+def test_get_tunnel_health_link_reads_only_eligible_tunnel_media(mock_neo4j_driver):
+    identity = LinkIdentity(
+        source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium="vpn"
+    )
+    mock_neo4j_driver.mock_session.set_default_response(
+        [
+            {
+                "source_id": "hub-a",
+                "source_public_ip": "198.51.100.10",
+                "target_id": "edge-b",
+                "target_public_ip": "203.0.113.20",
+                "relationship": "CONNECTS_TO",
+                "medium": "vpn",
+                "tunnel_health_status": "UP",
+                "tunnel_authority_state": "UP",
+                "tunnel_authority_source": "SNMP",
+                "tunnel_authority_observed_at": "2026-07-04T10:00:00Z",
+                "tunnel_icmp_available": True,
+                "tunnel_icmp_latency_ms": 11.5,
+                "tunnel_icmp_error": None,
+                "tunnel_icmp_reason": "sample",
+                "tunnel_observed_at": "2026-07-04T10:00:01Z",
+            }
+        ]
+    )
+
+    health = topology_repo.get_tunnel_health_link(identity, allowed_locations=[], is_admin=True)
+
+    query = mock_neo4j_driver.mock_session.queries[-1]["query"]
+    params = mock_neo4j_driver.mock_session.queries[-1]["params"]
+    assert "MATCH (a:CI {id: $source})-[r:CONNECTS_TO]->(b:CI {id: $target})" in query
+    assert "r.medium = $medium" in query
+    assert "vpn" in params["eligible_media"]
+    assert "microwave" not in params["eligible_media"]
+    assert health.status == "UP"
+    assert health.icmp.latency_ms == 11.5
+
+
+@pytest.mark.parametrize(
+    ("persisted_reason", "persisted_available", "persisted_latency", "persisted_error"),
+    [
+        ("no_sample", False, None, None),
+        ("failed", False, None, "timeout"),
+    ],
+)
+def test_get_tunnel_health_link_preserves_persisted_icmp_reason_from_read_path(
+    mock_neo4j_driver,
+    persisted_reason,
+    persisted_available,
+    persisted_latency,
+    persisted_error,
+):
+    identity = LinkIdentity(
+        source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium="vpn"
+    )
+    mock_neo4j_driver.mock_session.set_default_response(
+        [
+            {
+                "source_id": "hub-a",
+                "source_public_ip": "198.51.100.10",
+                "target_id": "edge-b",
+                "target_public_ip": "203.0.113.20",
+                "relationship": "CONNECTS_TO",
+                "medium": "vpn",
+                "tunnel_health_status": "UNKNOWN",
+                "tunnel_authority_state": None,
+                "tunnel_authority_source": None,
+                "tunnel_authority_observed_at": None,
+                "tunnel_icmp_available": persisted_available,
+                "tunnel_icmp_latency_ms": persisted_latency,
+                "tunnel_icmp_error": persisted_error,
+                "tunnel_icmp_reason": persisted_reason,
+                "tunnel_observed_at": "2026-07-04T10:00:01Z",
+            }
+        ]
+    )
+
+    health = topology_repo.get_tunnel_health_link(identity, allowed_locations=[], is_admin=True)
+
+    assert health.status == "UNKNOWN"
+    assert health.icmp.available is persisted_available
+    assert health.icmp.latency_ms == persisted_latency
+    assert health.icmp.error == persisted_error
+    assert health.icmp.reason == persisted_reason
+
+
+def test_get_tunnel_health_link_returns_no_sample_for_eligible_row_without_health_properties(
+    mock_neo4j_driver,
+):
+    identity = LinkIdentity(
+        source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium="vpn"
+    )
+    mock_neo4j_driver.mock_session.set_default_response(
+        [
+            {
+                "source_id": "hub-a",
+                "source_public_ip": "198.51.100.10",
+                "target_id": "edge-b",
+                "target_public_ip": "203.0.113.20",
+                "relationship": "CONNECTS_TO",
+                "medium": "vpn",
+            }
+        ]
+    )
+
+    health = topology_repo.get_tunnel_health_link(identity, allowed_locations=[], is_admin=True)
+
+    assert health.status == "UNKNOWN"
+    assert health.authority.state is None
+    assert health.authority.reason == "no_sample"
+    assert health.icmp.available is False
+    assert health.icmp.latency_ms is None
+    assert health.icmp.reason == "no_sample"
+    assert health.observed_at is None
+
+
+def test_get_tunnel_health_link_returns_none_for_non_admin_without_scope(mock_neo4j_driver):
+    identity = LinkIdentity(
+        source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium="vpn"
+    )
+
+    result = topology_repo.get_tunnel_health_link(identity, allowed_locations=[], is_admin=False)
+
+    assert result is None
+    assert mock_neo4j_driver.mock_session.queries == []
+
+
+def test_get_tunnel_health_link_applies_non_admin_location_scope(mock_neo4j_driver):
+    identity = LinkIdentity(
+        source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium="vpn"
+    )
+    mock_neo4j_driver.mock_session.set_default_response([])
+
+    result = topology_repo.get_tunnel_health_link(
+        identity,
+        allowed_locations=["HQ-Madrid"],
+        is_admin=False,
+    )
+
+    query_call = mock_neo4j_driver.mock_session.queries[-1]
+    assert result is None
+    assert (
+        "(a.location_name IN $allowed_locations OR b.location_name IN $allowed_locations)"
+        in query_call["query"]
+    )
+    assert query_call["params"]["allowed_locations"] == ["HQ-Madrid"]
+
+
+def test_get_tunnel_health_link_validates_relationship_before_cypher(mock_neo4j_driver):
+    identity = LinkIdentity(
+        source="hub-a", relationship="HAS_METRIC", target="edge-b", medium="vpn"
+    )
+
+    with pytest.raises(ValueError):
+        topology_repo.get_tunnel_health_link(identity, allowed_locations=[], is_admin=True)
+
+    assert mock_neo4j_driver.mock_session.queries == []
+
+
+def test_save_latest_tunnel_health_writes_scalar_relationship_properties_only(mock_neo4j_driver):
+    identity = LinkIdentity(
+        source="hub-a", relationship="CONNECTS_TO", target="edge-b", medium="vpn"
+    )
+    health = TunnelHealthResponse.model_validate(
+        {
+            "link_id": "encoded",
+            "source": "hub-a",
+            "target": "edge-b",
+            "relationship": "CONNECTS_TO",
+            "medium": "vpn",
+            "status": "UP",
+            "authority": {
+                "state": "UP",
+                "source": "SNMP",
+                "observed_at": "2026-07-04T10:00:00Z",
+                "reason": "sample",
+            },
+            "icmp": {
+                "available": False,
+                "latency_ms": None,
+                "error": "timeout",
+                "reason": "failed",
+            },
+            "observed_at": "2026-07-04T10:00:01Z",
+        }
+    )
+
+    topology_repo.save_latest_tunnel_health(identity, health)
+
+    query = mock_neo4j_driver.mock_session.queries[-1]["query"]
+    params = mock_neo4j_driver.mock_session.queries[-1]["params"]
+    assert "SET r.tunnel_health_status = $status" in query
+    assert "r.status" not in query
+    assert "n.status" not in query
+    assert "HAS_METRIC" not in query
+    assert "Event" not in query
+    assert params["status"] == "UP"
+    assert params["authority_state"] == "UP"
+    assert params["icmp_error"] == "timeout"

--- a/backend/tests/test_tunnel_health.py
+++ b/backend/tests/test_tunnel_health.py
@@ -1,0 +1,199 @@
+import base64
+import json
+
+import pytest
+from services.tunnel_health import (
+    LinkIdentity,
+    TunnelAuthoritySample,
+    TunnelIcmpSample,
+    decode_link_id,
+    encode_link_id,
+    normalize_tunnel_health,
+)
+
+
+def test_authority_up_keeps_status_up_when_icmp_failed():
+    health = normalize_tunnel_health(
+        link_id="link-1",
+        source="hub-a",
+        target="edge-b",
+        relationship="CONNECTS_TO",
+        medium="vpn",
+        authority=TunnelAuthoritySample(
+            state="UP", source="SNMP", observed_at="2026-07-04T10:00:00Z"
+        ),
+        icmp=TunnelIcmpSample(available=False, latency_ms=900.0, error="timeout"),
+        missing_public_ip=False,
+        observed_at="2026-07-04T10:00:01Z",
+    )
+
+    assert health.status == "UP"
+    assert health.authority.state == "UP"
+    assert health.authority.reason == "sample"
+    assert health.icmp.available is False
+    assert health.icmp.reason == "failed"
+    assert health.icmp.error == "timeout"
+
+
+def test_authority_down_keeps_status_down_even_when_icmp_available():
+    health = normalize_tunnel_health(
+        link_id="link-2",
+        source="hub-a",
+        target="edge-b",
+        relationship="CONNECTS_TO",
+        medium="sd_wan",
+        authority=TunnelAuthoritySample(
+            state="DOWN", source="CLI", observed_at="2026-07-04T10:00:00Z"
+        ),
+        icmp=TunnelIcmpSample(available=True, latency_ms=12.5),
+        observed_at="2026-07-04T10:00:01Z",
+    )
+
+    assert health.status == "DOWN"
+    assert health.authority.state == "DOWN"
+    assert health.icmp.available is True
+    assert health.icmp.latency_ms == 12.5
+    assert health.icmp.reason == "sample"
+
+
+def test_missing_authority_returns_unknown_with_no_sample_context():
+    health = normalize_tunnel_health(
+        link_id="link-3",
+        source="hub-a",
+        target="edge-b",
+        relationship="CONNECTS_TO",
+        medium="satellite",
+        authority=None,
+        icmp=None,
+        observed_at=None,
+    )
+
+    assert health.status == "UNKNOWN"
+    assert health.authority.state is None
+    assert health.authority.source is None
+    assert health.authority.reason == "no_sample"
+    assert health.icmp.available is False
+    assert health.icmp.latency_ms is None
+    assert health.icmp.reason == "no_sample"
+    assert health.observed_at is None
+
+
+def test_missing_public_ip_returns_deterministic_unavailable_icmp_context():
+    health = normalize_tunnel_health(
+        link_id="link-4",
+        source="hub-a",
+        target="edge-b",
+        relationship="CONNECTS_TO",
+        medium="vpn",
+        authority=TunnelAuthoritySample(state="UP", source="SNMP"),
+        icmp=TunnelIcmpSample(available=True, latency_ms=8.0),
+        missing_public_ip=True,
+        observed_at="2026-07-04T10:00:01Z",
+    )
+
+    assert health.status == "UP"
+    assert health.icmp.available is False
+    assert health.icmp.latency_ms is None
+    assert health.icmp.error is None
+    assert health.icmp.reason == "missing_public_ip"
+
+
+def test_status_domain_never_contains_degraded_from_icmp_context():
+    health = normalize_tunnel_health(
+        link_id="link-5",
+        source="hub-a",
+        target="edge-b",
+        relationship="CONNECTS_TO",
+        medium="vpn",
+        authority=None,
+        icmp=TunnelIcmpSample(available=False, latency_ms=5000.0, error="high latency"),
+        observed_at="2026-07-04T10:00:01Z",
+    )
+
+    assert health.status == "UNKNOWN"
+    assert health.status in {"UP", "DOWN", "UNKNOWN"}
+
+
+def test_link_id_encodes_canonical_unpadded_base64url_json():
+    identity = LinkIdentity(
+        source="hub-a",
+        relationship="CONNECTS_TO",
+        target="edge-b",
+        medium="vpn",
+    )
+
+    link_id = encode_link_id(identity)
+    decoded_json = base64.urlsafe_b64decode(link_id + "==").decode("utf-8")
+
+    assert "=" not in link_id
+    assert (
+        decoded_json
+        == '{"source":"hub-a","relationship":"CONNECTS_TO","target":"edge-b","medium":"vpn"}'
+    )
+    assert decode_link_id(link_id) == identity
+
+
+def test_decode_link_id_rejects_padded_payload():
+    identity = LinkIdentity(
+        source="hub-a",
+        relationship="CONNECTS_TO",
+        target="edge-b",
+        medium="vpn",
+    )
+
+    with pytest.raises(ValueError, match="unpadded"):
+        decode_link_id(encode_link_id(identity) + "=")
+
+
+def test_decode_link_id_rejects_non_canonical_field_order():
+    payload = {
+        "relationship": "CONNECTS_TO",
+        "source": "hub-a",
+        "target": "edge-b",
+        "medium": "vpn",
+    }
+    link_id = (
+        base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        .decode("ascii")
+        .rstrip("=")
+    )
+
+    with pytest.raises(ValueError, match="canonical fields"):
+        decode_link_id(link_id)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "source": "hub-a",
+            "relationship": "CONNECTS_TO",
+            "target": "edge-b",
+            "medium": "microwave",
+        },
+        {"source": "hub-a", "relationship": "CONNECTS_TO", "target": "edge-b"},
+        {
+            "source": "hub-a",
+            "relationship": "CONNECTS_TO",
+            "target": "edge-b",
+            "medium": "vpn",
+            "extra": "x",
+        },
+        {"source": "hub-a", "relationship": "HAS_METRIC", "target": "edge-b", "medium": "vpn"},
+    ],
+)
+def test_decode_link_id_rejects_invalid_payloads(payload):
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    link_id = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    with pytest.raises(ValueError):
+        decode_link_id(link_id)
+
+
+def test_decode_link_id_rejects_oversized_payload_before_validation():
+    oversized = (
+        base64.urlsafe_b64encode(b'{"source":"' + (b"a" * 513) + b'"}').decode("ascii").rstrip("=")
+    )
+
+    with pytest.raises(ValueError, match="too large"):
+        decode_link_id(oversized)

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/apply-progress.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/apply-progress.md
@@ -1,0 +1,139 @@
+# Apply Progress: Tunnel Health Normalization
+
+## Change
+
+feat-324-tunnel-health-normalization
+
+## Mode
+
+Strict TDD — focused Slice 2 pytest now runs in the authorized local backend virtual environment created with `/Users/macbook/.local/bin/python3.11`. Tests were written before production code, and the focused command is GREEN.
+
+## Completed Tasks
+
+- [x] 1.1 Service normalization RED tests written.
+- [x] 1.2 Canonical link id RED tests written.
+- [x] 2.1 Tunnel health service/models/link id implementation created.
+- [x] 2.2 ICMP context kept separate from normalized status domain.
+- [x] 3.1 Repository eligible-link tests written.
+- [x] 3.2 Repository whitelist/scoping tests written.
+- [x] 3.3 Repository scalar persistence/isolation tests written.
+- [x] 4.1 Scoped tunnel lookup implemented.
+- [x] 4.2 Latest-health scalar read/write helpers implemented.
+- [x] 5.1 Router/API tests written.
+- [x] 5.2 Deterministic API response body tests written.
+- [x] 6.1 Authenticated tunnel health endpoint implemented.
+- [x] 6.2 Router registered under `/api`.
+- [x] 7.1 Refactor pass kept response shape deterministic.
+- [x] Fix: repository read path now preserves persisted `tunnel_icmp_reason` for deterministic ICMP contexts, including `no_sample` and `failed`.
+- [x] Fix: router endpoint now has oversized `link_id` 400 coverage before repository lookup.
+- [x] 7.2 Focused pytest command executed with the authorized backend venv: 25 passed, 7 warnings.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 1.1 | `backend/tests/test_tunnel_health.py` | Unit | N/A (new) | ✅ Written before service existed | ✅ `backend/.venv/bin/python -m pytest ...` passed | ✅ Multiple authority/ICMP cases | ✅ Response semantics remain deterministic |
+| 1.2 | `backend/tests/test_tunnel_health.py` | Unit | N/A (new) | ✅ Written before service existed | ✅ `backend/.venv/bin/python -m pytest ...` passed | ✅ Valid, invalid, unsafe, oversized cases | ✅ Canonical link identity stays bounded |
+| 2.1 | `backend/tests/test_tunnel_health.py` | Unit | N/A (new) | ✅ Service tests existed before production code | ✅ Focused pytest passed | ✅ Canonical and invalid link id cases | ✅ Pure functions/models extracted |
+| 2.2 | `backend/tests/test_tunnel_health.py` | Unit | N/A (new) | ✅ ICMP/status domain tests existed first | ✅ Focused pytest passed | ✅ UP/DOWN/UNKNOWN plus ICMP failure/missing public IP | ✅ Status literals constrain domain |
+| 3.1 | `backend/tests/test_topology_tunnel_health.py` | Integration (mock Neo4j) | N/A (new helper tests) | ✅ Written before repository helpers existed | ✅ Focused pytest passed | ✅ Eligible medium and non-match/no-row cases | ✅ Query isolated to CI-to-CI tunnel relationship |
+| 3.2 | `backend/tests/test_topology_tunnel_health.py` | Integration (mock Neo4j) | N/A (new helper tests) | ✅ Written before repository helpers existed | ✅ Focused pytest passed | ✅ Admin, scoped operator, invalid relationship cases | ✅ Whitelist validation occurs before DB access |
+| 3.3 | `backend/tests/test_topology_tunnel_health.py` | Integration (mock Neo4j) | N/A (new helper tests) | ✅ Written before repository helpers existed | ✅ Focused pytest passed | ✅ Read/write and forbidden Cypher assertions | ✅ Scalar property mapping centralized |
+| 4.1 | `backend/tests/test_topology_tunnel_health.py` | Integration (mock Neo4j) | N/A (new helper) | ✅ Repository tests existed first | ✅ Focused pytest passed | ✅ Scoped exact link lookup covered | ✅ Reused existing relationship validator |
+| 4.2 | `backend/tests/test_topology_tunnel_health.py` | Integration (mock Neo4j) | N/A (new helper) | ✅ Persistence tests existed first | ✅ Focused pytest passed | ✅ Scalar property assertions covered | ✅ No metric/event/status mutation in helper |
+| 5.1 | `backend/tests/test_routers_tunnels.py` | API | N/A (new route) | ✅ Written before router existed | ✅ Focused pytest passed | ✅ 200/400/404 cases | ✅ Router returns response model |
+| 5.2 | `backend/tests/test_routers_tunnels.py` | API | N/A (new route) | ✅ Written before router existed | ✅ Focused pytest passed | ✅ sample/no-sample/missing-public-IP bodies | ✅ Deterministic model response |
+| 6.1 | `backend/tests/test_routers_tunnels.py` | API | N/A (new route) | ✅ Router tests existed first | ✅ Focused pytest passed | ✅ scoped repository call and error mapping | ✅ Small route boundary |
+| 6.2 | `backend/tests/test_routers_tunnels.py` | API | Existing router registration expectation | ✅ Router registration expected by API tests | ✅ Focused pytest passed | ➖ Registration is structural | ✅ No frontend/poller/vendor changes |
+| 7.1 | All focused tests | Unit/Integration/API | N/A | ✅ Refactor constrained by prior tests | ✅ Focused pytest passed | ✅ Focused Slice 2 suite executed | ✅ No production changes needed during verification |
+| 7.2 | Focused pytest command | Unit/Integration/API | N/A | ✅ Previously blocked, now unblocked by authorized venv | ✅ 25 passed, 7 warnings | N/A | ✅ GREEN evidence recorded |
+| Fix: persisted ICMP reason readback | `backend/tests/test_topology_tunnel_health.py` | Repository (mock Neo4j) | Focused pytest validates regression | ✅ Added repository read-path regression before production fix | ✅ Focused pytest passed | ✅ Covers `no_sample` and `failed` persisted reasons with public IPs present | ✅ Readback preserves deterministic ICMP context |
+| Fix: oversized endpoint mapping | `backend/tests/test_routers_tunnels.py` | API | Focused pytest validates regression | ✅ Added endpoint 400 regression before no production change was needed | ✅ Focused pytest passed | ✅ Asserts repository is not called for oversized decoded payload | ✅ Endpoint rejects oversized id before repository lookup |
+
+## Test Commands and Evidence
+
+- RED command attempted: `uv run pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` from repo root → blocked: `zsh:1: command not found: uv`.
+- Fallback attempted: `python -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` from `backend/` → blocked: `zsh:1: command not found: python`.
+- Fallback attempted: `python3 -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` from `backend/` → blocked: `/Library/Developer/CommandLineTools/usr/bin/python3: No module named pytest`.
+- Syntax validation: `python3 -m py_compile backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/main.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` → passed.
+- Fix rerun attempted: `uv run pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` from repo root → blocked: `zsh:1: command not found: uv`.
+- Fix rerun fallback attempted: `python -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` from `backend/` → blocked: `zsh:1: command not found: python`.
+- Fix rerun fallback attempted: `python3 -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` from `backend/` → blocked: `/Library/Developer/CommandLineTools/usr/bin/python3: No module named pytest`.
+- Fix syntax validation: `python3 -m py_compile backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/main.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` → passed.
+- Environment setup: `/Users/macbook/.local/bin/python3.11 -m venv backend/.venv` followed by `backend/.venv/bin/python -m pip install --upgrade pip` and `backend/.venv/bin/python -m pip install -r backend/requirements.txt -r backend/requirements-dev.txt` → passed.
+- Focused GREEN command from repo root: `backend/.venv/bin/python -m pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` → 25 passed, 7 warnings in 65.53s.
+
+## Files Changed
+
+- `backend/services/tunnel_health.py` — pure models, canonical link id encode/decode, and authority-only normalization.
+- `backend/repositories/topology_repo.py` — scoped eligible tunnel lookup and latest-health scalar relationship read/write helpers.
+- `backend/routers/tunnels.py` — authenticated `GET /api/tunnels/{link_id}/health` endpoint.
+- `backend/main.py` — registered tunnels router under `/api`.
+- `backend/tests/test_tunnel_health.py` — service/link id tests.
+- `backend/tests/test_topology_tunnel_health.py` — repository helper tests.
+- `backend/tests/test_routers_tunnels.py` — API endpoint tests.
+- `backend/services/tunnel_health.py` — `TunnelIcmpSample` now carries an optional persisted ICMP reason and normalization preserves deterministic persisted ICMP contexts.
+- `backend/repositories/topology_repo.py` — repository read mapping now passes `tunnel_icmp_reason` back into normalization.
+- `backend/tests/test_topology_tunnel_health.py` — added regression coverage for persisted `no_sample` and `failed` ICMP reasons through the real repository read helper.
+- `backend/tests/test_routers_tunnels.py` — added endpoint-level oversized `link_id` 400 coverage and repository bypass assertion.
+- `openspec/changes/feat-324-tunnel-health-normalization/tasks.md` — marked focused pytest verification complete after GREEN venv execution.
+- `openspec/changes/feat-324-tunnel-health-normalization/apply-progress.md` — this progress artifact, updated with GREEN pytest evidence.
+
+## Deviations from Design
+
+None — implementation matches design. Automated GREEN evidence is now available from the authorized backend venv.
+
+## Remaining Work
+
+- [x] Focused Slice 2 pytest is GREEN. No remaining Slice 2 apply-verification work in this batch.
+
+## Pre-PR Blocker Remediation Addendum
+
+### Date
+
+2026-07-04
+
+### Completed Fixes
+
+- [x] Installed CI-pinned `ruff==0.15.18` and `black==26.5.1` into the worktree-local `backend/.venv` only.
+- [x] Applied Ruff/Black-compatible formatting and lint fixes to changed backend Python files.
+- [x] Added API coverage proving unauthenticated requests are rejected before repository lookup.
+- [x] Added API coverage proving operator/admin `allowed_locations` and `is_admin` values are forwarded to `topology_repo.get_tunnel_health_link()`.
+- [x] Added canonical link-id hardening coverage for padded and non-canonical field-order payloads.
+- [x] Added repository read-model coverage for an eligible tunnel row with no tunnel health properties, returning deterministic `UNKNOWN` / `no_sample` context.
+
+### TDD Cycle Evidence Addendum
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| Pre-PR auth/scope blocker | `backend/tests/test_routers_tunnels.py` | API | ✅ Existing focused suite was known GREEN before blocker fix | ✅ Added failing assertions for unauthenticated rejection and scope forwarding | ✅ Focused suite passed: 30 passed, 7 warnings | ✅ Operator and admin forwarding plus unauthenticated rejection | ✅ Router uses `Annotated[User, Depends(...)]` to satisfy Ruff B008 without behavior change |
+| Pre-PR canonical/no-sample warnings | `backend/tests/test_tunnel_health.py`, `backend/tests/test_topology_tunnel_health.py` | Unit / repository | ✅ Existing focused suite was known GREEN before blocker fix | ✅ Added failing coverage for padded/non-canonical ids and no-health eligible row behavior | ✅ Focused suite passed: 30 passed, 7 warnings | ✅ Padded id, non-canonical order, and eligible no-sample row cases | ✅ `_row_value()` fallback avoids SIM401 while preserving missing-key defaults |
+| Pre-PR lint blocker | Changed backend Python files | Static | ✅ Ruff/Black initially reported blockers | ✅ Local CI-pinned Ruff/Black checks reproduced lint/format failures | ✅ Ruff and Black checks passed | N/A | ✅ Applied import ordering, Black formatting, SIM401/SIM114 fixes, and FastAPI dependency annotation |
+
+### Test and Lint Evidence
+
+- Focused suite: `backend/.venv/bin/python -m pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` → 30 passed, 7 warnings in 3.67s.
+- Compatibility suite: `backend/.venv/bin/python -m pytest backend/tests/test_topology_relationships.py backend/tests/test_routers_links.py backend/tests/test_topology_repo_nodes.py` → 52 passed, 7 warnings in 3.11s.
+- Ruff: `backend/.venv/bin/python -m ruff check --config backend/ruff.toml backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py backend/main.py` → passed.
+- Black: `backend/.venv/bin/python -m black --check backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py backend/main.py` → 7 files would be left unchanged.
+
+## Pre-PR CI-Equivalent Lint Addendum
+
+### Date
+
+2026-07-04
+
+### Completed Fix
+
+- [x] Reproduced the remaining CI-equivalent Ruff blocker from `backend/` with `--config ruff.toml`; Ruff 0.15.18 reported I001 import-ordering failures in the seven changed backend Python files.
+- [x] Ran Ruff's fixer from the same `backend/` working directory to organize imports without behavior changes.
+- [x] Re-ran Ruff, Black, focused Slice 2 pytest, and Slice 1 compatibility pytest from `backend/`; all passed.
+
+### CI-Equivalent Evidence
+
+- Reproduced blocker: from `backend/`, `.venv/bin/python -m ruff check --config ruff.toml main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → 7 I001 errors.
+- Fix command: from `backend/`, `.venv/bin/python -m ruff check --config ruff.toml --fix main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → `Found 7 errors (7 fixed, 0 remaining).`
+- Ruff verification: from `backend/`, `.venv/bin/python -m ruff check --config ruff.toml main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → `All checks passed!`
+- Black verification: from `backend/`, `.venv/bin/python -m black --check main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → `7 files would be left unchanged.`
+- Focused suite: from `backend/`, `.venv/bin/python -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → 30 passed, 7 warnings.
+- Compatibility suite: from `backend/`, `.venv/bin/python -m pytest tests/test_topology_relationships.py tests/test_routers_links.py tests/test_topology_repo_nodes.py` → 52 passed, 7 warnings.

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/archive-report.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/archive-report.md
@@ -1,0 +1,66 @@
+# Archive Report — feat-324-tunnel-health-normalization (Slice 2 — partial)
+
+## Status
+
+**PASS — PARTIAL ARCHIVE (Slice 2 only)**
+
+Slice 2 backend tunnel-health normalization was implemented, verified, and archived into the canonical specs tree. Slice 3 frontend visualization/filter/tooltips work remains future work and is intentionally NOT synced.
+
+## Scope statement
+
+**Partial archive.** Only Slice 2 work is being archived as completed.
+
+- `tunnel-monitoring` capability: FULLY implemented in Slice 2, synced to canonical spec.
+- `vpn-tunnel-relations` capability: UPDATED with additive eligible-link identity/read semantics for tunnel-health consumers.
+- Slice 3 frontend visualization/filter/tooltips: NOT implemented, NOT synced, issue remains open.
+
+## Archive date
+
+2026-07-04
+
+## Issue
+
+`alexandervazquez98/next-gen#324` — `feat(network): VPN, SD-WAN, and satellite link simulation`
+
+## Change ID
+
+`feat-324-tunnel-health-normalization`
+
+## Verify result
+
+**PASS WITH WARNINGS**
+
+### Verification notes
+
+- Tasks complete: 15/15
+- Focused backend pytest passed: 25 passed, 7 warnings
+- Compatibility addendum passed: 52 passed, 7 warnings
+- No CRITICAL issues were reported
+
+## Specs synced
+
+| Domain | Action | Details |
+|--------|--------|---------|
+| `tunnel-monitoring` | Created | Canonical source of truth created from the completed Slice 2 spec.
+| `vpn-tunnel-relations` | Updated | Added eligible-link read/identity requirements for tunnel-health consumers while preserving Slice 1 contracts.
+
+## Archived contents
+
+- `proposal.md`
+- `design.md`
+- `tasks.md`
+- `apply-progress.md`
+- `verify-report.md`
+- `archive-report.md`
+- `exploration.md`
+- `specs/tunnel-monitoring/spec.md`
+- `specs/vpn-tunnel-relations/spec.md`
+
+## Source of truth updated
+
+- `openspec/specs/tunnel-monitoring/spec.md`
+- `openspec/specs/vpn-tunnel-relations/spec.md`
+
+## Result
+
+Slice 2 is archived. The change remains intentionally open for Slice 3 frontend work.

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/design.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/design.md
@@ -1,0 +1,86 @@
+# Design: Tunnel Health Normalization
+
+## Technical Approach
+
+Add a backend-only tunnel health slice that reads existing CI-to-CI relationships with `medium in ['vpn','sd_wan','satellite']`, normalizes authority samples in a pure service, persists latest scalar health fields on the existing relationship, and exposes a scoped read endpoint. Slice 1 contracts stay intact. ICMP/public-IP data is context only and never drives normalized status.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives considered | Rationale |
+|---|---|---|---|
+| Link identity | Use deterministic unpadded base64url JSON for `{source, relationship, target, medium}`. JSON MUST use canonical key order and compact separators. Decode MUST reject padding requirement ambiguity, decoded payloads over 512 bytes, unknown fields, missing fields, invalid medium, and invalid relationship. | Neo4j internal id; required `Link.id`; hash-only id. | Composite identity is stable and reversible, but only safe if canonical and strictly bounded. |
+| Relationship whitelist | Before any dynamic Cypher, pass decoded `relationship` through existing `validate_ci_relationship_type()` / `_validate_relationship()` and use only the returned whitelisted value. | Trust decoded JSON; regex-only validation. | Existing `topology_repo.py` and `services.relationship_types` already centralize injection prevention; reusing them avoids a parallel allowlist. |
+| Persistence shape | Store latest health as scalar relationship properties: `tunnel_health_status`, `tunnel_authority_state`, `tunnel_authority_source`, `tunnel_icmp_available`, `tunnel_icmp_latency_ms`, `tunnel_icmp_error`, `tunnel_observed_at`. | Nested map on relationship; separate `TunnelHealth` node; Timescale history. | Neo4j relationship properties must remain scalar/array; latest-only state is enough for Slice 2 and avoids new history/migration scope. |
+| Service boundary | Create `backend/services/tunnel_health.py` with Pydantic/dataclass models and pure `normalize_tunnel_health()`. | Embed logic in router or SNMP worker. | Keeps authority rules unit-testable and prevents coupling to metric/event/CI status writers. |
+| API behavior | Create authenticated `GET /api/tunnels/{link_id}/health`; invalid id => 400, missing/non-tunnel/inaccessible link => 404. Repository lookup MUST apply `current_user.role` and `allowed_locations` with the existing link scoping rule: non-admin users can read only links where at least one endpoint is in scope. | Query params; reuse `/links`. | Dedicated endpoint keeps link payloads unchanged and prevents client-side-only scoping. |
+
+## Data Flow
+
+    Authenticated client ─GET /api/tunnels/{link_id}/health→ routers/tunnels.py
+       └─ tunnel_health.decode_link_id() ── validate relationship whitelist
+          └─ topology_repo scoped exact CI-[rel {medium}]->CI read/latest fields
+
+Sample persistence uses the same service/repository helper, but Slice 2 does not add a background poller.
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/services/tunnel_health.py` | Create | Pure models, link id encode/decode, authority normalization, ICMP context shaping. |
+| `backend/repositories/topology_repo.py` | Modify | Add eligible tunnel lookup, latest-health read/write helpers, exact relationship matching, whitelist validation, and location-scoped reads. |
+| `backend/routers/tunnels.py` | Create | Authenticated read endpoint with 400/404 behavior and response model. |
+| `backend/main.py` | Modify | Import/register `tunnels.router` with `/api` prefix. |
+| `backend/tests/test_tunnel_health.py` | Create | Unit tests for authority and ICMP semantics. |
+| `backend/tests/test_topology_tunnel_health.py` | Create | Repository query/property/isolation tests using mock Neo4j driver. |
+| `backend/tests/test_routers_tunnels.py` | Create | FastAPI endpoint tests. |
+
+## Interfaces / Contracts
+
+```python
+TunnelStatus = Literal["UP", "DOWN", "UNKNOWN"]
+AuthorityState = Literal["UP", "DOWN"] | None
+
+class TunnelHealthResponse(BaseModel):
+    link_id: str
+    source: str
+    target: str
+    relationship: str
+    medium: Literal["vpn", "sd_wan", "satellite"]
+    status: TunnelStatus
+    authority: AuthorityContext
+    icmp: IcmpContext
+    observed_at: str | None
+
+class AuthorityContext(BaseModel):
+    state: Literal["UP", "DOWN"] | None
+    source: str | None
+    observed_at: str | None
+    reason: Literal["sample", "no_sample"]
+
+class IcmpContext(BaseModel):
+    available: bool
+    latency_ms: float | None
+    error: str | None
+    reason: Literal["sample", "missing_public_ip", "no_sample", "failed"]
+```
+
+Normalization: `authority.state == 'UP' -> UP`; `DOWN -> DOWN`; `None -> UNKNOWN`. Missing `public_ip` MUST return `icmp.available=false`, `latency_ms=null`, `reason='missing_public_ip'`; no sample MUST return deterministic `UNKNOWN`/`no_sample` fields.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | Authority rules, deterministic response fields, missing authority, failed ICMP, missing `public_ip`, canonical link id, size/field/relationship validation. | Write failing tests first in `test_tunnel_health.py`; no DB. |
+| Repository | Eligible medium filtering, scoped exact match, relationship whitelist before Cypher, scalar field writes, no `HAS_METRIC`, `Event`, `n.status`, or `r.status` mutation. | Mock Neo4j driver and assert Cypher/params. |
+| API | 200 eligible link, 400 malformed/oversized/unknown-field `link_id`, 404 non-tunnel/not found/inaccessible, missing `public_ip` and no-sample bodies preserved. | TestClient with auth dependency overrides and mocked service/repo. |
+| E2E | Not required for backend-only Slice 2. | Automated backend tests are sufficient. |
+
+Strict TDD: add tests before implementation, then implement minimal service/repo/router changes. Expected review size is medium and should stay under the 800-line budget if kept to one backend slice.
+
+## Migration / Rollout
+
+No required data migration. Latest health properties are written lazily when samples are saved. Existing relationships without samples read as `UNKNOWN` with no-sample context.
+
+## Open Questions
+
+- [ ] None.

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/exploration.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/exploration.md
@@ -1,0 +1,40 @@
+## Exploration: feat-324-tunnel-health-normalization
+
+### Current State
+Slice 1 is present in this worktree. Canonical OpenSpec specs include `vpn-tunnel-relations` and `category-technology-icons`; the Slice 1 archive is also present. The backend model already supports `Node.public_ip`, `Link.medium` values `vpn|sd_wan|satellite`, `vpn_hub` endpoint validation, and link/graph read exposure without changing node status or event fields.
+
+Tunnel health does not exist yet as a first-class backend capability. There is no `backend/services/tunnel_health.py`, no `backend/routers/tunnels.py`, and no tunnel-specific tests. Existing collection paths are node-metric oriented: `backend/engines/snmp_worker.py` polls `(CI)-[:HAS_METRIC]->(MetricDef)` and writes metrics/events/status, while `backend/polling/snmp_executor.py` normalizes leased SNMP/ICMP task results. ICMP helpers already expose structured `PingMeasurement`, latency parsing, sidecar telemetry, and threshold evaluation that can be reused for tunnel liveness context.
+
+### Affected Areas
+- `openspec/specs/vpn-tunnel-relations/spec.md` — Source-of-truth Slice 1 model contract that Slice 2 should consume, not modify destructively.
+- `openspec/changes/archive/2026-06-27-feat-324-vpn-sdwan-satellite-link-simulation-slice-1/` — Archived prior plan contains deferred Slice 2 design/tasks that are useful input but must be adapted to the confirmed product decisions.
+- `backend/models/core.py` — `Node.public_ip` and `Link.medium` primitives already exist and define valid tunnel inputs.
+- `backend/services/link_service.py` — Central tunnel medium constants and hub-required validation already exist; likely source for shared medium validation.
+- `backend/repositories/topology_repo.py` — Current repository reads/writes `medium`; Slice 2 needs read/query helpers for tunnel links and a relationship health sample writer/reader.
+- `backend/engines/snmp_worker.py` — Existing engine has SNMP and ICMP fetch helpers, but its main loop is metric/event/status oriented; tunnel polling must remain isolated from `HAS_METRIC`, `Event`, and CI status writes.
+- `backend/polling/icmp_measurements.py` — Reusable structured ping and threshold utilities for liveness/RTT context.
+- `backend/main.py` — Router registry location for a future `/api/tunnels/{link_id}/health` endpoint.
+- `backend/tests/test_topology_relationships.py` and `backend/tests/test_routers_links.py` — Existing Slice 1 tests prove tunnel primitives; Slice 2 should add focused backend tests for rollup, isolation, repository samples, and endpoint behavior.
+
+### Approaches
+1. **Isolated tunnel health service + relationship sample endpoint** — Add pure rollup and sampling helpers in a new service, add repository functions for `medium` relationships, store latest normalized health fields on the relationship, and expose a read-only tunnel health endpoint.
+   - Pros: Preserves existing metric/event pipelines; aligns with confirmed rule that SNMP/CLI authority controls UP/DOWN; small backend-only Slice 2 surface; testable with pure unit tests and mocked repository/router tests.
+   - Cons: Relationship latest-state storage is not historical; requires careful link identity/query design because existing links are source/target/type oriented and do not expose a stable separate link id.
+   - Effort: Medium
+
+2. **Extend existing metric/ICMP pipeline with tunnel MetricDefs** — Model tunnel authority and ICMP context as additional metric definitions tied to CIs or relationships and reuse the existing event writer pipeline.
+   - Pros: Reuses existing polling/storage/event infrastructure.
+   - Cons: Violates Slice 2 isolation intent; risks false CI/node events and CI status changes; makes ICMP authority creep more likely; expands scope into event semantics rather than normalization first.
+   - Effort: High
+
+### Recommendation
+Use the isolated tunnel health service + relationship sample endpoint. The proposal should scope Slice 2 to backend normalization only: query existing `medium` links, resolve endpoint `public_ip`, normalize authority samples from existing/simulable SNMP/CLI signals, add ICMP RTT/liveness context only when available, store latest health on the relationship, and expose a read endpoint. The rollup contract should be explicit and authority-driven: SNMP/CLI `DOWN` returns `DOWN`, SNMP/CLI `UP` remains `UP` even when ICMP context is poor, ICMP failure never returns `DEGRADED` or `DOWN`, and missing `public_ip` returns `UNKNOWN`/unavailable ICMP context rather than degraded.
+
+### Risks
+- Existing links do not expose a dedicated stable `link_id`; endpoint design must choose and document a deterministic identifier or use source/target/relationship lookup semantics.
+- `snmp_worker.py` is large and event-sensitive; adding tunnel polling inline risks accidental metric/event/status side effects unless helpers are isolated and tests prove no `HAS_METRIC`/`Event`/CI status writes.
+- Archived Slice 2 notes mention vendor registry/OID placeholders; confirmed scope says no Cisco-specific or multi-vendor adapters, so proposal/spec must keep adapter work out of scope and rely on existing or simulable signals.
+- Missing `public_ip` behavior must stay `UNKNOWN`/unavailable context, not `DEGRADED`; this needs direct tests because it differs from common liveness assumptions.
+
+### Ready for Proposal
+Yes — proceed to `sdd-propose` for Slice 2 only. Tell the user the worktree already contains Slice 1 primitives and archived guidance; the next artifact should define a backend-only change for tunnel health normalization, latest-health persistence/read endpoint, and rollup tests, explicitly excluding frontend visualization and vendor-specific adapters.

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/proposal.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: Tunnel Health Normalization
+
+## Intent
+
+Normalize backend tunnel health for VPN, SD-WAN, and satellite links so operators can read latest tunnel state through an API without changing existing node status, metric, event, or frontend behavior. SNMP/CLI authority exclusively drives normalized status in Slice 2: authority `UP` yields `UP`, authority `DOWN` yields `DOWN`, and missing authority yields `UNKNOWN`. ICMP/public-IP checks only add liveness and RTT context and MUST NOT change normalized status to `DEGRADED` or `DOWN`.
+
+## Scope
+
+### In Scope
+- Backend-only tunnel health normalization and rollup for Slice 2: authority `UP` => `UP`, authority `DOWN` => `DOWN`, missing authority => `UNKNOWN`; ICMP/public-IP context MUST NOT produce `DEGRADED` or `DOWN`.
+- Latest-health persistence/read behavior for existing tunnel relations using `medium: vpn|sd_wan|satellite`.
+- Read endpoint such as `GET /api/tunnels/{link_id}/health` backed by existing or simulable SNMP/CLI/ICMP signals.
+- Tests for authority rules, missing `public_ip`, latest read behavior, and pipeline isolation.
+
+### Out of Scope
+- Frontend visual states, Monitoring Console filter, tooltips, or rendering changes.
+- Cisco-specific, vendor-complete, or multi-vendor OID/CLI adapters.
+- Changes to Slice 1 contracts: `vpn_hub`, `public_ip`, `Link.medium`, and hub-required tunnel validation.
+- Mutating node metric, event, or CI status pipelines for tunnel health.
+
+## Capabilities
+
+### New Capabilities
+- `tunnel-monitoring`: Backend tunnel health normalization, latest-health storage/read API, and SNMP/CLI-authoritative rollup with ICMP context.
+
+### Modified Capabilities
+- `vpn-tunnel-relations`: Preserve Slice 1 tunnel relation contracts while allowing tunnel-health consumers to identify eligible tunnel links safely.
+
+## Approach
+
+Add an isolated tunnel health service and repository helpers. Query existing tunnel-medium relationships, resolve endpoint `public_ip`, normalize SNMP/CLI authority samples, enrich with ICMP RTT/liveness only when available, and persist the latest health on the relationship or adjacent health record. Missing authority yields normalized `UNKNOWN`; missing `public_ip` yields unavailable ICMP context without changing the authority-driven normalized status. Avoid coupling to `HAS_METRIC`, `Event`, or CI status writes.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `backend/services/tunnel_health.py` | New | Rollup and normalization rules. |
+| `backend/repositories/topology_repo.py` | Modified | Tunnel link lookup and latest-health read/write. |
+| `backend/routers/tunnels.py`, `backend/main.py` | New/Modified | Register tunnel health read endpoint. |
+| `backend/polling/icmp_measurements.py` | Modified | Reuse ICMP measurement context only. |
+| `backend/tests/` | Modified | Backend tests for rollup, endpoint, persistence, isolation. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Links may lack stable dedicated `link_id` | High | Specify deterministic relationship identity or source/target/type/medium lookup before endpoint specs. |
+| Accidental metric/event/status mutation | Med | Keep service isolated and test no pipeline side effects. |
+| ICMP semantics drift into authority | Med | Test ICMP never returns `DEGRADED` or `DOWN`; missing `public_ip` only affects ICMP context. |
+
+## Rollback Plan
+
+Remove the tunnel router/service/repository health helpers and latest-health fields. Existing Slice 1 tunnel relations remain valid because no `public_ip`, `medium`, or hub-validation contract is changed.
+
+## Dependencies
+
+- Slice 1 tunnel primitives already merged via PR #339.
+- Existing ICMP measurement utilities and simulable SNMP/CLI authority samples.
+
+## Success Criteria
+
+- [ ] Backend returns latest normalized tunnel health for eligible tunnel links.
+- [ ] SNMP/CLI authority controls normalized status: `UP`, `DOWN`, or `UNKNOWN` when missing.
+- [ ] ICMP/public-IP liveness and RTT are context only and never produce `DEGRADED` or `DOWN`.
+- [ ] Missing `public_ip` reports unavailable ICMP context, not degradation.
+- [ ] Tests prove existing metric/event/CI status pipelines remain isolated.

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/specs/tunnel-monitoring/spec.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/specs/tunnel-monitoring/spec.md
@@ -1,0 +1,100 @@
+# Tunnel Monitoring Specification
+
+## Purpose
+
+Define backend-only normalized health for eligible VPN, SD-WAN, and satellite tunnel links without changing node metrics, events, CI status, or frontend behavior.
+
+## Requirements
+
+### Requirement: Authoritative Tunnel State Rollup
+
+The system MUST normalize Slice 2 tunnel health from SNMP/CLI authority only: authority `UP` SHALL produce `UP`, authority `DOWN` SHALL produce `DOWN`, and missing authority SHALL produce `UNKNOWN`. ICMP/public-IP liveness or RTT MUST remain context only and MUST NOT produce normalized `DEGRADED` or `DOWN`.
+
+#### Scenario: Authority reports down
+
+- GIVEN an eligible tunnel link has SNMP/CLI state `DOWN`
+- WHEN tunnel health is normalized
+- THEN normalized status MUST be `DOWN`
+- AND ICMP liveness or RTT MUST NOT override it
+
+#### Scenario: Authority up with poor ICMP context
+
+- GIVEN an eligible tunnel link has SNMP/CLI state `UP`
+- AND ICMP context is failed, unavailable, or exceeds accepted RTT thresholds
+- WHEN tunnel health is normalized
+- THEN normalized status MUST be `UP`
+- AND ICMP liveness or RTT MUST remain separate context
+
+#### Scenario: Authority unavailable
+
+- GIVEN no SNMP/CLI authority sample is available for an eligible tunnel link
+- WHEN tunnel health is normalized
+- THEN normalized status MUST be `UNKNOWN`
+
+### Requirement: ICMP Context Semantics
+
+The system SHALL expose deterministic ICMP/public-IP liveness and RTT context only when available. Missing endpoint `public_ip`, ICMP failure, poor RTT, or missing ICMP sample MUST set `icmp.available`, `icmp.latency_ms`, `icmp.error`, and `icmp.reason` predictably and MUST NOT change the authority-driven normalized status.
+
+#### Scenario: Missing public IP
+
+- GIVEN an eligible tunnel link has an endpoint without `public_ip`
+- WHEN tunnel health is read
+- THEN ICMP context MUST report `available=false`, `latency_ms=null`, and `reason=missing_public_ip`
+- AND normalized status MUST remain based only on SNMP/CLI authority
+
+#### Scenario: No ICMP sample
+
+- GIVEN an eligible tunnel link has no ICMP sample
+- WHEN tunnel health is read
+- THEN ICMP context MUST report `available=false`, `latency_ms=null`, and `reason=no_sample`
+
+#### Scenario: ICMP failure while authority is up
+
+- GIVEN SNMP/CLI state is `UP`
+- AND ICMP liveness is failed for a public endpoint
+- WHEN tunnel health is normalized
+- THEN normalized status MUST remain `UP`
+- AND liveness failure MUST be visible as context
+
+### Requirement: Latest Tunnel Health Read Model
+
+The system MUST persist and read the latest normalized tunnel health for an eligible tunnel link. Reads SHALL return deterministic fields: `status`, `authority.state`, `authority.source`, `authority.observed_at`, `authority.reason`, `icmp.available`, `icmp.latency_ms`, `icmp.error`, `icmp.reason`, and `observed_at`.
+
+#### Scenario: Latest sample returned
+
+- GIVEN an eligible tunnel link has a latest normalized health sample
+- WHEN a client reads tunnel health
+- THEN the response MUST include status, authority context, ICMP context, and observed timestamp
+
+#### Scenario: No sample exists
+
+- GIVEN an eligible tunnel link exists but has no health sample
+- WHEN a client reads tunnel health
+- THEN the response MUST report `status=UNKNOWN`, `authority.reason=no_sample`, `authority.state=null`, and `observed_at=null`
+
+### Requirement: Tunnel Health Endpoint
+
+The backend SHALL expose an authenticated read endpoint for a single eligible tunnel link's latest health. The endpoint MUST reject malformed identifiers, return not found for non-tunnel, missing, or inaccessible links, enforce backend user/location scoping, and MUST NOT require vendor-specific adapters.
+
+#### Scenario: Read eligible tunnel health
+
+- GIVEN a link is eligible for tunnel monitoring
+- WHEN a client requests its tunnel health endpoint
+- THEN the backend MUST return its latest normalized health
+
+#### Scenario: Inaccessible link is rejected server-side
+
+- GIVEN a non-admin user lacks location scope for a tunnel link
+- WHEN the user requests that link's health endpoint
+- THEN the backend MUST return not found without leaking link health
+
+
+### Requirement: Pipeline Isolation
+
+Tunnel health normalization SHALL NOT mutate existing node metric, event, or CI status pipelines.
+
+#### Scenario: Health update is isolated
+
+- GIVEN tunnel health is normalized and saved
+- WHEN existing metric, event, and CI status records are inspected
+- THEN no node metric, event lifecycle, or CI status mutation is caused by tunnel health

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/specs/vpn-tunnel-relations/spec.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/specs/vpn-tunnel-relations/spec.md
@@ -1,0 +1,43 @@
+# Delta for VPN Tunnel Relations
+
+## ADDED Requirements
+
+### Requirement: Eligible Tunnel Health Link Reads
+
+The system MUST let backend tunnel-health consumers identify eligible tunnel links without changing Slice 1 relation contracts. A link SHALL be eligible when it connects two CIs, has `medium` of `vpn`, `sd_wan`, or `satellite`, and satisfies existing tunnel endpoint validation. Link reads used for tunnel health MUST preserve existing node status, event fields, relationship type compatibility, and tunnel metadata.
+
+#### Scenario: Eligible tunnel link can be read
+
+- GIVEN a valid tunnel relation has `medium: vpn` and one endpoint is `vpn_hub`
+- WHEN backend tunnel-health logic reads eligible links
+- THEN the relation MUST be included with enough identity to request latest tunnel health
+- AND existing link metadata remains unchanged
+
+#### Scenario: Non-tunnel link is excluded
+
+- GIVEN a CI-to-CI relationship has no tunnel `medium`
+- WHEN backend tunnel-health logic reads eligible links
+- THEN the relationship MUST NOT be treated as tunnel-health eligible
+
+#### Scenario: Slice 1 contract remains stable
+
+- GIVEN clients read links or graph data after tunnel-health support is added
+- WHEN the payload includes tunnel relations
+- THEN `public_ip`, `vpn_hub`, and `medium` behavior MUST remain compatible with Slice 1
+- AND node status and event fields MUST remain unchanged
+
+### Requirement: Tunnel Health Link Identity Validation
+
+Tunnel health link identifiers MUST be deterministic unpadded base64url JSON with only `source`, `relationship`, `target`, and `medium` fields in canonical order. Decoding MUST reject payloads larger than 512 bytes, unknown fields, missing fields, invalid tunnel media, and any relationship not accepted by the existing CI relationship whitelist before repository Cypher is constructed.
+
+#### Scenario: Valid canonical identifier
+
+- GIVEN an eligible tunnel relation has source, whitelisted relationship, target, and tunnel medium
+- WHEN a tunnel health link id is encoded and decoded
+- THEN the decoded identity MUST match the original fields exactly
+
+#### Scenario: Unsafe identifier rejected
+
+- GIVEN a link id decodes to an unknown field, oversized payload, or non-whitelisted relationship
+- WHEN the tunnel health endpoint validates it
+- THEN the request MUST be rejected before dynamic Cypher is constructed

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/tasks.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/tasks.md
@@ -1,0 +1,64 @@
+# Tasks: Tunnel Health Normalization
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 520-680 |
+| 800-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single backend Slice 2 PR |
+| Delivery strategy | ask-always |
+| Chain strategy | N/A unless user chooses to split further |
+
+Decision needed before apply: Yes — estimate exceeds the 400-line downstream guard; user must choose single PR with size exception or split further before apply.
+Chained PRs recommended: No
+Chain strategy: N/A unless split further
+800-line budget risk: Low
+400-line budget risk: Medium
+
+### Suggested Work Units / Commit Guidance
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Pure tunnel-health service and ID validation | Single PR | Commit tests with service code. |
+| 2 | Repository latest-health read/write and scoping | Single PR | Commit repository tests with Cypher helpers. |
+| 3 | Authenticated API endpoint and registration | Single PR | Commit API tests with router code. |
+
+Keep commits behavior-based, not file-type based. Each commit must include its RED test, GREEN implementation, and related refactor.
+
+## Phase 1: RED Service Tests
+
+- [x] 1.1 Create `backend/tests/test_tunnel_health.py` cases for authority `UP`, `DOWN`, missing authority, ICMP failure, missing `public_ip`, and no ICMP sample.
+- [x] 1.2 Add canonical `link_id` tests for unpadded base64url JSON key order, compact separators, unknown fields, missing fields, invalid medium, oversize >512 bytes, and unsafe relationship rejection.
+
+## Phase 2: GREEN Service Implementation
+
+- [x] 2.1 Create `backend/services/tunnel_health.py` models, `encode_link_id()`, `decode_link_id()`, and `normalize_tunnel_health()`.
+- [x] 2.2 Ensure ICMP never returns normalized `DEGRADED` or `DOWN`; status domain is only `UP`, `DOWN`, `UNKNOWN`.
+
+## Phase 3: RED Repository Tests
+
+- [x] 3.1 Create `backend/tests/test_topology_tunnel_health.py` for eligible `vpn|sd_wan|satellite` exact-link lookup and non-tunnel exclusion.
+- [x] 3.2 Test relationship whitelist validation occurs before dynamic Cypher and inaccessible non-admin links return no row.
+- [x] 3.3 Test latest scalar relationship properties are read/written and no `HAS_METRIC`, `Event`, `n.status`, or `r.status` mutation appears in Cypher.
+
+## Phase 4: GREEN Repository Implementation
+
+- [x] 4.1 Update `backend/repositories/topology_repo.py` with scoped tunnel lookup using decoded identity and existing relationship validators.
+- [x] 4.2 Add latest-health read/write helpers with scalar properties from the design contract.
+
+## Phase 5: RED API Tests
+
+- [x] 5.1 Create `backend/tests/test_routers_tunnels.py` for authenticated 200, malformed/oversized/unknown-field 400, and missing/non-tunnel/inaccessible 404.
+- [x] 5.2 Test deterministic response bodies for authority sample, no sample, missing `public_ip`, and ICMP failure states.
+
+## Phase 6: GREEN API Wiring
+
+- [x] 6.1 Create `backend/routers/tunnels.py` with `GET /api/tunnels/{link_id}/health`, auth dependency, scoped repository call, and 400/404 mapping.
+- [x] 6.2 Register `tunnels.router` in `backend/main.py` under `/api` without frontend, vendor-adapter, poller, metric, event, or CI-status changes.
+
+## Phase 7: REFACTOR / Verify
+
+- [x] 7.1 Refactor duplicated fixtures/helpers only after tests pass; keep public response shape deterministic.
+- [x] 7.2 Run `backend/.venv/bin/python -m pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py` from repo root.

--- a/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/verify-report.md
+++ b/openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/verify-report.md
@@ -1,0 +1,273 @@
+## Verification Report
+
+**Change**: feat-324-tunnel-health-normalization
+**Version**: N/A
+**Mode**: Strict TDD
+**Artifact store mode**: openspec
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 15 |
+| Tasks complete | 15 |
+| Tasks incomplete | 0 |
+| Required artifacts read | proposal, design, tunnel-monitoring spec, vpn-tunnel-relations spec, tasks, apply-progress |
+| Implementation dimensions verified | specs, design, tasks, Strict TDD evidence, source isolation, runtime tests |
+
+### Build & Tests Execution
+
+**Build / static check**: ✅ Passed
+
+```text
+git diff --check
+Result: passed with no whitespace errors.
+```
+
+**Focused Strict TDD test suite**: ✅ 25 passed, 0 failed, 7 warnings
+
+```text
+backend/.venv/bin/python -m pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py
+
+Result: 25 passed, 7 warnings in 5.49s.
+Warnings are pre-existing dependency/framework deprecations from SQLAlchemy declarative_base, passlib crypt, pandas pyarrow, and FastAPI on_event usage.
+```
+
+**Coverage command**: ✅ Executed, informational warnings only
+
+```text
+backend/.venv/bin/python -m pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py --cov=services.tunnel_health --cov=repositories.topology_repo --cov=routers.tunnels --cov-report=term-missing
+
+Result: 25 passed, 7 warnings in 4.98s.
+Coverage summary:
+- backend/services/tunnel_health.py: 91%
+- backend/routers/tunnels.py: 100%
+- backend/repositories/topology_repo.py: 21% whole-file coverage because the file is a large existing repository module; the new tunnel-health helper paths are exercised by the focused tests.
+```
+
+**Quality metrics**:
+
+```text
+backend/.venv/bin/python -m ruff check backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py
+
+Result: not available — No module named ruff.
+```
+
+### TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | `apply-progress.md` contains a full TDD Cycle Evidence table. |
+| All tasks have tests | ✅ | 15/15 completed tasks map to focused service, repository, or API tests. |
+| RED confirmed | ✅ | Reported test files exist: `test_tunnel_health.py`, `test_topology_tunnel_health.py`, `test_routers_tunnels.py`. |
+| GREEN confirmed | ✅ | Authorized focused suite passed: 25/25 tests. |
+| Triangulation adequate | ✅ | Authority, ICMP, link-id validation, repository scoping, persistence isolation, and API error mapping each have multiple cases. |
+| Safety Net for modified files | ✅ | New slice files are covered by new tests; modified repository/main paths are covered structurally by repository/API tests. |
+
+**TDD Compliance**: 6/6 checks passed.
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit | 11 | 1 | pytest |
+| Integration / repository with mock Neo4j | 7 | 1 | pytest + repository mock fixture |
+| API | 7 | 1 | pytest + FastAPI TestClient |
+| E2E | 0 | 0 | Not required by design |
+| **Total** | **25** | **3** | |
+
+### Changed File Coverage
+
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `backend/services/tunnel_health.py` | 91% | N/A | 75, 88, 94, 99-100, 111, 117, 131, 149, 190 | ⚠️ Acceptable |
+| `backend/routers/tunnels.py` | 100% | N/A | — | ✅ Excellent |
+| `backend/repositories/topology_repo.py` | 21% whole-file | N/A | Existing unrelated repository paths dominate uncovered lines; focused tunnel helper paths are tested. | ⚠️ Low whole-file signal |
+
+**Average reported module coverage**: 38% across the three measured modules. This is not a blocking failure because `topology_repo.py` is a large pre-existing module and the focused tests exercise the new tunnel-health helper paths. No changed-line coverage tool was available.
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All assertions verify real behavior. No tautologies, ghost loops, smoke-only tests, or type-only assertions were found in the three focused test files.
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Authoritative Tunnel State Rollup | Authority reports down | `backend/tests/test_tunnel_health.py::test_authority_down_keeps_status_down_even_when_icmp_available` | ✅ COMPLIANT |
+| Authoritative Tunnel State Rollup | Authority up with poor ICMP context | `backend/tests/test_tunnel_health.py::test_authority_up_keeps_status_up_when_icmp_failed`; `test_status_domain_never_contains_degraded_from_icmp_context` | ✅ COMPLIANT |
+| Authoritative Tunnel State Rollup | Authority unavailable | `backend/tests/test_tunnel_health.py::test_missing_authority_returns_unknown_with_no_sample_context` | ✅ COMPLIANT |
+| ICMP Context Semantics | Missing public IP | `backend/tests/test_tunnel_health.py::test_missing_public_ip_returns_deterministic_unavailable_icmp_context`; `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_preserves_missing_public_ip_and_icmp_failure_contexts` | ✅ COMPLIANT |
+| ICMP Context Semantics | No ICMP sample | `backend/tests/test_tunnel_health.py::test_missing_authority_returns_unknown_with_no_sample_context`; `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_preserves_no_sample_response_body` | ✅ COMPLIANT |
+| ICMP Context Semantics | ICMP failure while authority is up | `backend/tests/test_tunnel_health.py::test_authority_up_keeps_status_up_when_icmp_failed`; `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_preserves_missing_public_ip_and_icmp_failure_contexts` | ✅ COMPLIANT |
+| Latest Tunnel Health Read Model | Latest sample returned | `backend/tests/test_topology_tunnel_health.py::test_get_tunnel_health_link_reads_only_eligible_tunnel_media`; `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_returns_latest_health_for_accessible_link` | ✅ COMPLIANT |
+| Latest Tunnel Health Read Model | No sample exists | `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_preserves_no_sample_response_body`; `backend/tests/test_topology_tunnel_health.py::test_get_tunnel_health_link_preserves_persisted_icmp_reason_from_read_path[...]` | ✅ COMPLIANT |
+| Tunnel Health Endpoint | Read eligible tunnel health | `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_returns_latest_health_for_accessible_link` | ✅ COMPLIANT |
+| Tunnel Health Endpoint | Inaccessible link is rejected server-side | `backend/tests/test_topology_tunnel_health.py::test_get_tunnel_health_link_returns_none_for_non_admin_without_scope`; `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_returns_404_for_missing_or_inaccessible_link` | ✅ COMPLIANT |
+| Pipeline Isolation | Health update is isolated | `backend/tests/test_topology_tunnel_health.py::test_save_latest_tunnel_health_writes_scalar_relationship_properties_only` | ✅ COMPLIANT |
+| Eligible Tunnel Health Link Reads | Eligible tunnel link can be read | `backend/tests/test_topology_tunnel_health.py::test_get_tunnel_health_link_reads_only_eligible_tunnel_media` | ✅ COMPLIANT |
+| Eligible Tunnel Health Link Reads | Non-tunnel link is excluded | `backend/tests/test_topology_tunnel_health.py::test_get_tunnel_health_link_reads_only_eligible_tunnel_media` validates `r.medium = $medium`, eligible media whitelist, and exclusion of `microwave`. | ✅ COMPLIANT |
+| Eligible Tunnel Health Link Reads | Slice 1 contract remains stable | `backend/tests/test_topology_tunnel_health.py::test_save_latest_tunnel_health_writes_scalar_relationship_properties_only` plus source inspection confirms no frontend/vendor/poller/link-service changes and no node status/event mutation in tunnel helpers. | ⚠️ PARTIAL |
+| Tunnel Health Link Identity Validation | Valid canonical identifier | `backend/tests/test_tunnel_health.py::test_link_id_encodes_canonical_unpadded_base64url_json` | ✅ COMPLIANT |
+| Tunnel Health Link Identity Validation | Unsafe identifier rejected | `backend/tests/test_tunnel_health.py::test_decode_link_id_rejects_invalid_payloads`; `test_decode_link_id_rejects_oversized_payload_before_validation`; `backend/tests/test_routers_tunnels.py::test_get_tunnel_health_rejects_malformed_link_id[...]`; `test_get_tunnel_health_rejects_oversized_link_id_before_repository_lookup` | ✅ COMPLIANT |
+
+**Compliance summary**: 15/16 scenarios compliant, 1/16 partial, 0 failing, 0 untested.
+
+### Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Authority-only status `UP`/`DOWN`/`UNKNOWN` | ✅ Implemented | `normalize_tunnel_health()` maps only authority state to status and exposes `TunnelStatus = Literal["UP", "DOWN", "UNKNOWN"]`. |
+| ICMP context-only semantics | ✅ Implemented | ICMP failure, no sample, and missing public IP only shape `icmp`, never normalized status. |
+| Missing public IP deterministic response | ✅ Implemented | `missing_public_ip=True` forces `available=false`, `latency_ms=null`, `error=null`, `reason=missing_public_ip`. |
+| No-sample deterministic response | ✅ Implemented | Missing authority returns `UNKNOWN`, `authority.reason=no_sample`, and null observed fields. |
+| Canonical link-id validation | ✅ Implemented | Decode rejects padding, oversize payloads, non-dict JSON, unknown/missing fields, non-empty violations, invalid media, unsafe relationships, and non-canonical re-encoding. |
+| Relationship whitelist before dynamic Cypher | ✅ Implemented | `decode_link_id()` and repository helpers call `validate_ci_relationship_type()` before interpolating the relationship type into Cypher. |
+| Authenticated/scoped endpoint | ✅ Implemented | Router depends on `get_current_active_user`; repository applies admin/location scoping and maps no row to 404. |
+| No frontend/vendor/poller work | ✅ Implemented | Changed files are backend service/repository/router/main/tests and OpenSpec artifacts only. |
+| No metric/event/CI status mutation | ✅ Implemented | Tunnel persistence writes only `r.tunnel_*` scalar fields; tests assert no `HAS_METRIC`, `Event`, `n.status`, or `r.status` in the tunnel save Cypher. |
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Deterministic unpadded base64url JSON link identity | ✅ Yes | `encode_link_id()` uses compact JSON and strips padding; decode enforces canonical field order and re-encoding equality. |
+| Relationship whitelist before dynamic Cypher | ✅ Yes | Validation is performed before query construction in repository helpers. |
+| Latest scalar relationship properties | ✅ Yes | `save_latest_tunnel_health()` persists scalar `tunnel_*` fields on the relationship. |
+| Pure service boundary | ✅ Yes | `backend/services/tunnel_health.py` contains pure models, link-id helpers, and normalization. |
+| Authenticated scoped API behavior | ✅ Yes | `GET /api/tunnels/{link_id}/health` is registered and maps invalid id to 400 and missing/inaccessible to 404. |
+| No background poller for Slice 2 | ✅ Yes | No poller/vendor/frontend files changed. |
+
+### Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**:
+- Whole-file coverage for `backend/repositories/topology_repo.py` is low at 21% because the file is a broad pre-existing repository module. The new tunnel-health helper paths are exercised, but changed-line coverage was not available.
+- The Slice 1 compatibility scenario is partially verified by focused tests and source inspection. The authorized focused suite does not re-run the older Slice 1 link-service/full-graph compatibility tests.
+
+**SUGGESTION**:
+- If this change is reviewed with broader regression time available, run the existing Slice 1 link relation tests as a non-blocking confidence pass after the formal focused suite.
+
+### Verdict
+
+PASS WITH WARNINGS
+
+The required Strict TDD focused suite passed, all tasks are complete, and the implementation matches the authority-only tunnel health design. Warnings are limited to whole-file coverage signal quality and the fact that the focused verification suite only partially exercises older Slice 1 compatibility behavior.
+
+### Addendum: Slice 1 Compatibility Verification
+
+**Date**: 2026-07-04
+**Purpose**: Non-blocking compatibility check for Slice 1 tunnel/link primitives before archive, after Slice 2 repository/router changes.
+
+**Command**: ✅ Passed
+
+```text
+backend/.venv/bin/python -m pytest backend/tests/test_topology_relationships.py backend/tests/test_routers_links.py backend/tests/test_topology_repo_nodes.py
+
+Result: 52 passed, 7 warnings in 3.19s.
+Warnings are the same dependency/framework deprecations observed in formal verify: SQLAlchemy declarative_base, passlib crypt, pandas pyarrow, and FastAPI on_event usage.
+```
+
+**Scope confirmed**: All suggested compatibility targets existed and were run unchanged.
+
+**Compatibility impact**: No Slice 1 regressions were detected in link creation/listing/deletion, full-graph link payload behavior, medium/tunnel validation, VPN hub node modeling, scoped node repository behavior, or public IP node persistence/validation.
+
+### Addendum: Pre-PR Blocker Verification
+
+**Date**: 2026-07-04
+**Purpose**: Resolve confirmed pre-PR blockers from the 4R review before opening issue #324 Slice 2.
+
+**Fixes verified**:
+
+- Ruff/Black CI compatibility is now local-green with CI-pinned `ruff==0.15.18` and `black==26.5.1` installed only in `backend/.venv`.
+- `backend/tests/test_routers_tunnels.py` now proves unauthenticated tunnel-health requests return `401` before repository lookup.
+- Router tests now prove `allowed_locations` and `is_admin` are forwarded to `topology_repo.get_tunnel_health_link()` for operator and admin users.
+- Reliability warning coverage was added for padded/non-canonical `link_id` rejection and eligible repository rows with no tunnel health properties.
+
+**Focused command**: ✅ Passed
+
+```text
+backend/.venv/bin/python -m pytest backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py
+
+Result: 30 passed, 7 warnings in 3.67s.
+```
+
+**Compatibility command**: ✅ Passed
+
+```text
+backend/.venv/bin/python -m pytest backend/tests/test_topology_relationships.py backend/tests/test_routers_links.py backend/tests/test_topology_repo_nodes.py
+
+Result: 52 passed, 7 warnings in 3.11s.
+```
+
+**Ruff command**: ✅ Passed
+
+```text
+backend/.venv/bin/python -m ruff check --config backend/ruff.toml backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py backend/main.py
+
+Result: All checks passed.
+```
+
+**Black command**: ✅ Passed
+
+```text
+backend/.venv/bin/python -m black --check backend/services/tunnel_health.py backend/repositories/topology_repo.py backend/routers/tunnels.py backend/tests/test_tunnel_health.py backend/tests/test_topology_tunnel_health.py backend/tests/test_routers_tunnels.py backend/main.py
+
+Result: 7 files would be left unchanged.
+```
+
+### Addendum: CI-Equivalent Import Ordering Verification
+
+**Date**: 2026-07-04
+**Purpose**: Resolve the remaining pre-PR CI lint blocker by using the same working directory/config shape as the backend lint job.
+
+**Initial CI-equivalent Ruff command**: ❌ Reproduced blocker
+
+```text
+cd backend && .venv/bin/python -m ruff check --config ruff.toml main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py
+
+Result: 7 I001 import-ordering errors.
+```
+
+**Fix command**: ✅ Applied
+
+```text
+cd backend && .venv/bin/python -m ruff check --config ruff.toml --fix main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py
+
+Result: Found 7 errors (7 fixed, 0 remaining).
+```
+
+**Ruff verification**: ✅ Passed
+
+```text
+cd backend && .venv/bin/python -m ruff check --config ruff.toml main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py
+
+Result: All checks passed.
+```
+
+**Black verification**: ✅ Passed
+
+```text
+cd backend && .venv/bin/python -m black --check main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py
+
+Result: 7 files would be left unchanged.
+```
+
+**Focused pytest**: ✅ Passed
+
+```text
+cd backend && .venv/bin/python -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py
+
+Result: 30 passed, 7 warnings.
+```
+
+**Compatibility pytest**: ✅ Passed
+
+```text
+cd backend && .venv/bin/python -m pytest tests/test_topology_relationships.py tests/test_routers_links.py tests/test_topology_repo_nodes.py
+
+Result: 52 passed, 7 warnings.
+```
+
+**Verdict**: PASS. The remaining Slice 2 pre-PR lint blocker was import ordering only; it is now fixed and verified with the CI-equivalent backend working directory/config path.

--- a/openspec/specs/tunnel-monitoring/spec.md
+++ b/openspec/specs/tunnel-monitoring/spec.md
@@ -1,0 +1,100 @@
+# Tunnel Monitoring Specification
+
+## Purpose
+
+Define backend-only normalized health for eligible VPN, SD-WAN, and satellite tunnel links without changing node metrics, events, CI status, or frontend behavior.
+
+## Requirements
+
+### Requirement: Authoritative Tunnel State Rollup
+
+The system MUST normalize Slice 2 tunnel health from SNMP/CLI authority only: authority `UP` SHALL produce `UP`, authority `DOWN` SHALL produce `DOWN`, and missing authority SHALL produce `UNKNOWN`. ICMP/public-IP liveness or RTT MUST remain context only and MUST NOT produce normalized `DEGRADED` or `DOWN`.
+
+#### Scenario: Authority reports down
+
+- GIVEN an eligible tunnel link has SNMP/CLI state `DOWN`
+- WHEN tunnel health is normalized
+- THEN normalized status MUST be `DOWN`
+- AND ICMP liveness or RTT MUST NOT override it
+
+#### Scenario: Authority up with poor ICMP context
+
+- GIVEN an eligible tunnel link has SNMP/CLI state `UP`
+- AND ICMP context is failed, unavailable, or exceeds accepted RTT thresholds
+- WHEN tunnel health is normalized
+- THEN normalized status MUST be `UP`
+- AND ICMP liveness or RTT MUST remain separate context
+
+#### Scenario: Authority unavailable
+
+- GIVEN no SNMP/CLI authority sample is available for an eligible tunnel link
+- WHEN tunnel health is normalized
+- THEN normalized status MUST be `UNKNOWN`
+
+### Requirement: ICMP Context Semantics
+
+The system SHALL expose deterministic ICMP/public-IP liveness and RTT context only when available. Missing endpoint `public_ip`, ICMP failure, poor RTT, or missing ICMP sample MUST set `icmp.available`, `icmp.latency_ms`, `icmp.error`, and `icmp.reason` predictably and MUST NOT change the authority-driven normalized status.
+
+#### Scenario: Missing public IP
+
+- GIVEN an eligible tunnel link has an endpoint without `public_ip`
+- WHEN tunnel health is read
+- THEN ICMP context MUST report `available=false`, `latency_ms=null`, and `reason=missing_public_ip`
+- AND normalized status MUST remain based only on SNMP/CLI authority
+
+#### Scenario: No ICMP sample
+
+- GIVEN an eligible tunnel link has no ICMP sample
+- WHEN tunnel health is read
+- THEN ICMP context MUST report `available=false`, `latency_ms=null`, and `reason=no_sample`
+
+#### Scenario: ICMP failure while authority is up
+
+- GIVEN SNMP/CLI state is `UP`
+- AND ICMP liveness is failed for a public endpoint
+- WHEN tunnel health is normalized
+- THEN normalized status MUST remain `UP`
+- AND liveness failure MUST be visible as context
+
+### Requirement: Latest Tunnel Health Read Model
+
+The system MUST persist and read the latest normalized tunnel health for an eligible tunnel link. Reads SHALL return deterministic fields: `status`, `authority.state`, `authority.source`, `authority.observed_at`, `authority.reason`, `icmp.available`, `icmp.latency_ms`, `icmp.error`, `icmp.reason`, and `observed_at`.
+
+#### Scenario: Latest sample returned
+
+- GIVEN an eligible tunnel link has a latest normalized health sample
+- WHEN a client reads tunnel health
+- THEN the response MUST include status, authority context, ICMP context, and observed timestamp
+
+#### Scenario: No sample exists
+
+- GIVEN an eligible tunnel link exists but has no health sample
+- WHEN a client reads tunnel health
+- THEN the response MUST report `status=UNKNOWN`, `authority.reason=no_sample`, `authority.state=null`, and `observed_at=null`
+
+### Requirement: Tunnel Health Endpoint
+
+The backend SHALL expose an authenticated read endpoint for a single eligible tunnel link's latest health. The endpoint MUST reject malformed identifiers, return not found for non-tunnel, missing, or inaccessible links, enforce backend user/location scoping, and MUST NOT require vendor-specific adapters.
+
+#### Scenario: Read eligible tunnel health
+
+- GIVEN a link is eligible for tunnel monitoring
+- WHEN a client requests its tunnel health endpoint
+- THEN the backend MUST return its latest normalized health
+
+#### Scenario: Inaccessible link is rejected server-side
+
+- GIVEN a non-admin user lacks location scope for a tunnel link
+- WHEN the user requests that link's health endpoint
+- THEN the backend MUST return not found without leaking link health
+
+
+### Requirement: Pipeline Isolation
+
+Tunnel health normalization SHALL NOT mutate existing node metric, event, or CI status pipelines.
+
+#### Scenario: Health update is isolated
+
+- GIVEN tunnel health is normalized and saved
+- WHEN existing metric, event, and CI status records are inspected
+- THEN no node metric, event lifecycle, or CI status mutation is caused by tunnel health

--- a/openspec/specs/vpn-tunnel-relations/spec.md
+++ b/openspec/specs/vpn-tunnel-relations/spec.md
@@ -73,3 +73,43 @@ The system MUST accept and return `public_ip`, `vpn_hub`, and tunnel `medium` me
 - WHEN a client fetches links or the full graph
 - THEN the payload includes the tunnel medium
 - AND node status/event fields are unchanged
+
+### Requirement: Eligible Tunnel Health Link Reads
+
+The system MUST let backend tunnel-health consumers identify eligible tunnel links without changing Slice 1 relation contracts. A link SHALL be eligible when it connects two CIs, has `medium` of `vpn`, `sd_wan`, or `satellite`, and satisfies existing tunnel endpoint validation. Link reads used for tunnel health MUST preserve existing node status, event fields, relationship type compatibility, and tunnel metadata.
+
+#### Scenario: Eligible tunnel link can be read
+
+- GIVEN a valid tunnel relation has `medium: vpn` and one endpoint is `vpn_hub`
+- WHEN backend tunnel-health logic reads eligible links
+- THEN the relation MUST be included with enough identity to request latest tunnel health
+- AND existing link metadata remains unchanged
+
+#### Scenario: Non-tunnel link is excluded
+
+- GIVEN a CI-to-CI relationship has no tunnel `medium`
+- WHEN backend tunnel-health logic reads eligible links
+- THEN the relationship MUST NOT be treated as tunnel-health eligible
+
+#### Scenario: Slice 1 contract remains stable
+
+- GIVEN clients read links or graph data after tunnel-health support is added
+- WHEN the payload includes tunnel relations
+- THEN `public_ip`, `vpn_hub`, and `medium` behavior MUST remain compatible with Slice 1
+- AND node status and event fields MUST remain unchanged
+
+### Requirement: Tunnel Health Link Identity Validation
+
+Tunnel health link identifiers MUST be deterministic unpadded base64url JSON with only `source`, `relationship`, `target`, and `medium` fields in canonical order. Decoding MUST reject payloads larger than 512 bytes, unknown fields, missing fields, invalid tunnel media, and any relationship not accepted by the existing CI relationship whitelist before repository Cypher is constructed.
+
+#### Scenario: Valid canonical identifier
+
+- GIVEN an eligible tunnel relation has source, whitelisted relationship, target, and tunnel medium
+- WHEN a tunnel health link id is encoded and decoded
+- THEN the decoded identity MUST match the original fields exactly
+
+#### Scenario: Unsafe identifier rejected
+
+- GIVEN a link id decodes to an unknown field, oversized payload, or non-whitelisted relationship
+- WHEN the tunnel health endpoint validates it
+- THEN the request MUST be rejected before dynamic Cypher is constructed


### PR DESCRIPTION
## Description

Slice 2 of issue #324: backend-only VPN/SD-WAN/satellite tunnel health normalization.

This PR intentionally does **not** close #324. Slice 3 frontend visualization/filter/tooltips remains future work.

Refs #324

## Type of Change
- [x] Feat (New functionality)

## Summary
- Adds authority-driven tunnel health normalization for VPN/SD-WAN/satellite links.
- Adds authenticated `GET /api/tunnels/{link_id}/health` with deterministic link ID validation and location scoping.
- Persists latest tunnel-health scalar fields on eligible relationships without mutating metrics, events, CI status, frontend, pollers, or vendor adapters.

## Changes

| File | Change |
|------|--------|
| `backend/services/tunnel_health.py` | Pure tunnel health models, canonical link ID encode/decode, and authority-only normalization. |
| `backend/repositories/topology_repo.py` | Scoped eligible tunnel lookup plus latest-health scalar relationship read/write helpers. |
| `backend/routers/tunnels.py` | Authenticated tunnel health read endpoint with 400/404 behavior. |
| `backend/main.py` | Registers the tunnels router under `/api`. |
| `backend/tests/test_tunnel_health.py` | Unit coverage for authority rules, ICMP context, and link ID validation. |
| `backend/tests/test_topology_tunnel_health.py` | Repository tests for scoping, whitelist-before-Cypher, scalar persistence, and no pipeline mutation. |
| `backend/tests/test_routers_tunnels.py` | API tests for auth, scoping forwarding, malformed IDs, inaccessible links, and deterministic response bodies. |
| `openspec/specs/tunnel-monitoring/spec.md` | Canonical Slice 2 tunnel monitoring spec. |
| `openspec/specs/vpn-tunnel-relations/spec.md` | Additive eligible-link identity/read semantics for tunnel health consumers. |
| `openspec/changes/archive/2026-07-04-feat-324-tunnel-health-normalization/` | Archived SDD audit trail for Slice 2. |

## Verification

- [x] Focused Slice 2 pytest: `cd backend && .venv/bin/python -m pytest tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → `30 passed, 7 warnings`.
- [x] Slice 1 compatibility pytest: `cd backend && .venv/bin/python -m pytest tests/test_topology_relationships.py tests/test_routers_links.py tests/test_topology_repo_nodes.py` → `52 passed, 7 warnings`.
- [x] CI-equivalent Ruff: `cd backend && .venv/bin/python -m ruff check --config ruff.toml main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → passed.
- [x] CI-equivalent Black: `cd backend && .venv/bin/python -m black --check main.py repositories/topology_repo.py routers/tunnels.py services/tunnel_health.py tests/test_tunnel_health.py tests/test_topology_tunnel_health.py tests/test_routers_tunnels.py` → passed.
- [x] `git diff --check` → passed.

Warnings are existing dependency/framework deprecations from the backend test environment.

## SDD / Review Notes

- SDD verify result: **PASS WITH WARNINGS**.
- Extra Slice 1 compatibility pass added after verify.
- Full 4R pre-PR review ran; confirmed blockers were fixed before this PR.
- `size:exception` is maintainer-approved for this Slice 2 PR. Production code is focused; archived SDD artifacts and strict-TDD tests account for most added lines.

## Out of Scope

- Frontend visual states, Monitoring Console filter, and tooltips.
- Vendor-specific OID/CLI adapters.
- Background poller changes.
- Closing issue #324.

## Checklist

- [x] Linked approved issue: #324 has `status:approved`.
- [x] Add exactly one `type:*` label: `type:feature`.
- [x] Conventional commit format used.
- [x] No secrets or API keys added.
- [x] No `Co-Authored-By` trailers.
