### PR TITLE
feat(events): wire lock observability status

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -1,46 +1,41 @@
+import logging
 import os
 import platform
-import time
-import schedule
-import random
-import sys
 import subprocess
+import sys
+import time
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
-# Add root and backend to python path to verify imports work
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.append(os.path.join(os.path.dirname(__file__), '../backend'))
-
-import logging
-
+import schedule
 from neo4j import GraphDatabase
 
-logger = logging.getLogger(__name__)
-from sqlalchemy import text
+# Add root and backend to python path to verify imports work
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(os.path.join(os.path.dirname(__file__), "../backend"))
 
-from repositories.metric_repo import insert_metric_value, bulk_insert_metrics
-from repositories.topology_repo import build_open_parent_index
-from postgres_db import SessionLocal
-from config import get_icmp_settings, get_polling_pipeline_settings
-from polling.icmp_measurements import (
+from config import get_icmp_settings, get_polling_pipeline_settings  # noqa: E402
+from polling.icmp_measurements import (  # noqa: E402
     ICMP_AVAILABILITY_METRIC_ID,
     ICMP_LATENCY_METRIC_ID,
+    PingMeasurement,
     build_icmp_sidecar_samples,
     coerce_ping_measurement,
     evaluate_latency_status,
     is_icmp_availability_metric,
     is_icmp_telemetry_metric,
     latency_threshold_metadata,
-    PingMeasurement,
     parse_ping_latency_ms,
 )
-from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
-from services.neo4j_write_guard import (
+from postgres_db import SessionLocal  # noqa: E402
+from repositories.metric_repo import bulk_insert_metrics  # noqa: E402
+from repositories.topology_repo import build_open_parent_index  # noqa: E402
+from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock  # noqa: E402
+from services.neo4j_write_guard import (  # noqa: E402
     is_poll_collector_id_undefined_error,
     run_with_cypher_param_fallback,
 )
-from services.polling_event_lifecycle import (
+from services.polling_event_lifecycle import (  # noqa: E402
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
     EVENT_TYPE_THRESHOLD_BREACH,
@@ -50,6 +45,9 @@ from services.polling_event_lifecycle import (
     is_snmp_no_response_failure,
     normalized_protocol,
 )
+from sqlalchemy import text  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 # poll_collector_id is sourced from services.event_lock.get_poll_collector_id
 # (cached at module load from HOSTNAME env var with socket.gethostname()
@@ -66,6 +64,7 @@ try:
         UdpTransportTarget,
         getCmd,
     )
+
     SNMP_AVAILABLE = True
 except ImportError:
     SNMP_AVAILABLE = False
@@ -77,6 +76,7 @@ NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "password")
 
 driver = GraphDatabase.driver(URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
 
+
 def verify_connection():
     max_retries = 60
     for i in range(max_retries):
@@ -84,18 +84,21 @@ def verify_connection():
             driver.verify_connectivity()
             print("Connected to Neo4j!")
             return
-        except Exception as e:
+        except Exception:
             print(f"Waiting for Neo4j... ({i+1}/{max_retries})")
             time.sleep(2)
     raise Exception("Could not connect to Neo4j after multiple retries")
 
+
 # Module-level consecutive failure counter for ICMP debounce (keyed by node_id)
 # NOTE: This dict grows unbounded. If a node is deleted from Neo4j, its entry remains.
 # For production, consider persisting this to Neo4j or using a bounded cache (e.g. LRU).
-_consecutive_failures: Dict[str, int] = {}
+_consecutive_failures: dict[str, int] = {}
 
 
-def fetch_icmp_ping_measurement(ip: str, timeout_ms: int = 3000, retries: int = 2) -> PingMeasurement:
+def fetch_icmp_ping_measurement(
+    ip: str, timeout_ms: int = 3000, retries: int = 2
+) -> PingMeasurement:
     """Perform ICMP ping with configurable timeout and retry.
 
     Args:
@@ -111,17 +114,12 @@ def fetch_icmp_ping_measurement(ip: str, timeout_ms: int = 3000, retries: int = 
 
     for attempt in range(attempts):
         try:
-            if system == 'windows':
-                cmd = ['ping', '-n', '1', '-w', str(timeout_ms), ip]
+            if system == "windows":
+                cmd = ["ping", "-n", "1", "-w", str(timeout_ms), ip]
             else:
                 timeout_sec = max(1, timeout_ms // 1000)
-                cmd = ['ping', '-c', '1', '-W', str(timeout_sec), ip]
-            result = subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True
-            )
+                cmd = ["ping", "-c", "1", "-W", str(timeout_sec), ip]
+            result = subprocess.run(cmd, capture_output=True, text=True)
             output = f"{result.stdout or ''}\n{result.stderr or ''}"
             if result.returncode == 0:
                 return PingMeasurement(True, parse_ping_latency_ms(output), raw=output)
@@ -134,10 +132,13 @@ def fetch_icmp_ping_measurement(ip: str, timeout_ms: int = 3000, retries: int = 
     return PingMeasurement(False, None, raw=None, error="ICMP ping failed")
 
 
-def fetch_icmp_ping(ip: str, timeout_ms: int = 3000, retries: int = 2, include_measurement: bool = False):
+def fetch_icmp_ping(
+    ip: str, timeout_ms: int = 3000, retries: int = 2, include_measurement: bool = False
+):
     """Perform ICMP ping and preserve the legacy binary availability contract by default."""
     measurement = fetch_icmp_ping_measurement(ip, timeout_ms=timeout_ms, retries=retries)
     return measurement if include_measurement else measurement.availability_value
+
 
 def fetch_snmp_value(ip, community, oid, port=161, include_status=False):
     """Perform a real SNMP GET.
@@ -146,6 +147,7 @@ def fetch_snmp_value(ip, community, oid, port=161, include_status=False):
     requests structured status so only real timeout/no-data failures become
     SNMP_NO_RESPONSE collection-failure events.
     """
+
     def result(value, status, error):
         return (value, status, error) if include_status else value
 
@@ -167,7 +169,9 @@ def fetch_snmp_value(ip, community, oid, port=161, include_status=False):
             error_message = str(error_indication)
             status = (
                 "TIMEOUT"
-                if is_snmp_no_response_failure(SOURCE_PROTOCOL_SNMP, "ERROR", {"message": error_message})
+                if is_snmp_no_response_failure(
+                    SOURCE_PROTOCOL_SNMP, "ERROR", {"message": error_message}
+                )
                 else "ERROR"
             )
             return result(None, status, error_message)
@@ -193,7 +197,9 @@ def _coerce_snmp_fetch_result(raw: Any) -> tuple[float | None, str, str | None]:
     return raw, "OK", None
 
 
-def _log_observe_only_cycle(settings, metrics_count, collected_count, failed_count, duration, jobs_per_min):
+def _log_observe_only_cycle(
+    settings, metrics_count, collected_count, failed_count, duration, jobs_per_min
+):
     """Emit PR1 baseline telemetry without changing polling behavior."""
     if not settings.pipeline_observe_only:
         return
@@ -304,13 +310,21 @@ def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=Non
     # (issue #322). Locks are sorted lexicographically so two batches do not
     # trigger Postgres deadlock detection when they overlap on different keys.
     if lock_db is not None:
-        distinct_triplets = sorted({
-            (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
-            for row in failures
-            if row.get("node_id") and row.get("metric_id") and row.get("event_type")
-        })
+        distinct_triplets = sorted(
+            {
+                (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
+                for row in failures
+                if row.get("node_id") and row.get("metric_id") and row.get("event_type")
+            }
+        )
         for ci_id, metric_id, event_type in distinct_triplets:
-            acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+            acquire_event_triplet_lock(
+                lock_db,
+                ci_id,
+                metric_id,
+                event_type,
+                writer_context="snmp_worker_collection_failure",
+            )
     primary_query = """
         UNWIND $failures AS row
         MATCH (n:CI {id: row.node_id})
@@ -431,13 +445,21 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
     # Sorted lexicographic acquisition prevents Postgres deadlock detection
     # from aborting one of two overlapping batches.
     if lock_db is not None:
-        distinct_triplets = sorted({
-            (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
-            for row in availability_events
-            if row.get("node_id") and row.get("metric_id") and row.get("event_type")
-        })
+        distinct_triplets = sorted(
+            {
+                (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
+                for row in availability_events
+                if row.get("node_id") and row.get("metric_id") and row.get("event_type")
+            }
+        )
         for ci_id, metric_id, event_type in distinct_triplets:
-            acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+            acquire_event_triplet_lock(
+                lock_db,
+                ci_id,
+                metric_id,
+                event_type,
+                writer_context="snmp_worker_icmp_availability",
+            )
     primary_query = """
         UNWIND $availability_events AS row
         WITH row WHERE row.event_type = 'AVAILABILITY'
@@ -546,7 +568,8 @@ def _recover_icmp_availability_events(session, updates):
     ]
     if not recoveries:
         return
-    session.run("""
+    session.run(
+        """
         UNWIND $recoveries AS row
         MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
         WHERE e.status IN ['OPEN', 'ACK']
@@ -570,7 +593,9 @@ def _recover_icmp_availability_events(session, updates):
             RETURN count(pe) AS propagated_recovered
         }
         RETURN e
-    """, recoveries=recoveries)
+    """,
+        recoveries=recoveries,
+    )
 
 
 def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
@@ -594,13 +619,21 @@ def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
     # Sorted lexicographic acquisition prevents Postgres deadlock detection
     # from aborting one of two overlapping batches.
     if lock_db is not None:
-        distinct_triplets = sorted({
-            (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
-            for row in breaches
-            if row.get("node_id") and row.get("metric_id") and row.get("event_type")
-        })
+        distinct_triplets = sorted(
+            {
+                (row.get("node_id"), row.get("metric_id"), row.get("event_type"))
+                for row in breaches
+                if row.get("node_id") and row.get("metric_id") and row.get("event_type")
+            }
+        )
         for ci_id, metric_id, event_type in distinct_triplets:
-            acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+            acquire_event_triplet_lock(
+                lock_db,
+                ci_id,
+                metric_id,
+                event_type,
+                writer_context="snmp_worker_icmp_latency",
+            )
     primary_query = """
         UNWIND $breaches AS row
         MATCH (n:CI {id: row.node_id})
@@ -699,7 +732,8 @@ def _recover_icmp_latency_events(session, updates):
     ]
     if not recoveries:
         return
-    session.run("""
+    session.run(
+        """
         UNWIND $recoveries AS row
         MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
         WHERE e.status IN ['OPEN', 'ACK']
@@ -722,14 +756,19 @@ def _recover_icmp_latency_events(session, updates):
             RETURN count(pe) AS propagated_recovered
         }
         RETURN e
-    """, recoveries=recoveries)
+    """,
+        recoveries=recoveries,
+    )
 
 
 def _recover_snmp_collection_failures(session, updates):
-    recoveries = [u for u in updates if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_SNMP]
+    recoveries = [
+        u for u in updates if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_SNMP
+    ]
     if not recoveries:
         return
-    session.run("""
+    session.run(
+        """
         UNWIND $recoveries AS row
         MATCH (:CI {id: row.node_id})-[:HAS_EVENT]->(e:Event {metric_id: row.metric_id})
         WHERE e.status IN ['OPEN', 'ACK']
@@ -761,7 +800,9 @@ def _recover_snmp_collection_failures(session, updates):
             RETURN count(pe) AS propagated_recovered
         }
         RETURN e
-    """, recoveries=recoveries)
+    """,
+        recoveries=recoveries,
+    )
 
 
 def poll_snmp():
@@ -779,11 +820,11 @@ def poll_snmp():
             # Enhanced query: Get CI credentials and Metric metadata
             result = session.run("""
                 MATCH (n:CI)-[r:HAS_METRIC]->(m:MetricDef)
-                WITH n, r, m, 
+                WITH n, r, m,
                      coalesce(m.polling_interval, 60) as interval,
                      coalesce(r.last_polled, datetime({year:1970})) as last_p
                 WHERE duration.between(last_p, datetime()).seconds >= interval
-                RETURN n.id as node_id, n.ip as ip, 
+                RETURN n.id as node_id, n.ip as ip,
                        coalesce(n.snmp_community, 'public') as community,
                        coalesce(n.snmp_port, 161) as port,
                        m.id as metric_id, m.name as metric_name, m.protocol as protocol,
@@ -792,13 +833,22 @@ def poll_snmp():
                        m.availability_source as availability_source,
                        interval
             """)
-            
+
             records = list(result)
-            records.sort(key=lambda record: (
-                1 if normalized_protocol(record["protocol"]) == "ICMP" and is_icmp_telemetry_metric(record["metric_id"], {"metric_kind": record.get("metric_kind")}) else 0,
-                record["node_id"],
-                record["metric_id"],
-            ))
+            records.sort(
+                key=lambda record: (
+                    (
+                        1
+                        if normalized_protocol(record["protocol"]) == "ICMP"
+                        and is_icmp_telemetry_metric(
+                            record["metric_id"], {"metric_kind": record.get("metric_kind")}
+                        )
+                        else 0
+                    ),
+                    record["node_id"],
+                    record["metric_id"],
+                )
+            )
             polled_icmp_nodes = set()
 
             # Use iterator to process one by one
@@ -808,7 +858,7 @@ def poll_snmp():
                 mid = record["metric_id"]
                 protocol = normalized_protocol(record["protocol"])
                 ip = record["ip"]
-                
+
                 if not ip:
                     print(f"Skipping {node_id}: No IP address.")
                     continue
@@ -828,19 +878,25 @@ def poll_snmp():
                     polled_icmp_nodes.add(node_id)
                     mid = ICMP_AVAILABILITY_METRIC_ID
                     internal_icmp_poll = True
-                elif protocol == "ICMP" and availability_source and is_icmp_availability_metric(mid, metric_metadata):
+                elif (
+                    protocol == "ICMP"
+                    and availability_source
+                    and is_icmp_availability_metric(mid, metric_metadata)
+                ):
                     if node_id in polled_icmp_nodes:
                         continue
                     polled_icmp_nodes.add(node_id)
                 elif protocol == "ICMP":
                     continue
                 if protocol == "ICMP":
-                    measurement = coerce_ping_measurement(fetch_icmp_ping(
-                        ip,
-                        timeout_ms=icmp_settings.timeout_ms,
-                        retries=icmp_settings.retries,
-                        include_measurement=True,
-                    ))
+                    measurement = coerce_ping_measurement(
+                        fetch_icmp_ping(
+                            ip,
+                            timeout_ms=icmp_settings.timeout_ms,
+                            retries=icmp_settings.retries,
+                            include_measurement=True,
+                        )
+                    )
                     val = measurement.availability_value
                     sample_time = datetime.utcnow()
                     # Debounce logic: track consecutive failures per node
@@ -883,47 +939,75 @@ def poll_snmp():
                             include_status=True,
                         )
                     )
-                
+
                 if val is not None:
                     primary_time = datetime.utcnow()
                     if not internal_icmp_poll:
-                        metrics_to_save.append({
-                            "node_id": node_id,
-                            "metric_id": mid,
-                            "value": val,
-                            "time": primary_time
-                        })
+                        metrics_to_save.append(
+                            {
+                                "node_id": node_id,
+                                "metric_id": mid,
+                                "value": val,
+                                "time": primary_time,
+                            }
+                        )
                     metrics_to_save.extend(sidecar_samples)
 
                     metric_name = record["metric_name"] or mid
                     severity = _base_severity_from_criticality(record["criticality"])
                     if not internal_icmp_poll:
-                        latest_updates.append({
-                            "node_id": node_id,
-                            "metric_id": mid,
-                            "value": val,
-                            "protocol": protocol,
-                            "metric_name": metric_name,
-                            "criticality": record["criticality"],
-                            "status": severity if protocol == SOURCE_PROTOCOL_ICMP and availability_source and val == 0.0 else "OK",
-                            "message": (
-                                f"Service/Host Down: {metric_name}"
-                                if protocol == SOURCE_PROTOCOL_ICMP and availability_source and val == 0.0
-                                else "Latest sample collected by legacy SNMP worker"
-                            ),
-                            "event_type": EVENT_TYPE_AVAILABILITY if protocol == SOURCE_PROTOCOL_ICMP and availability_source and val == 0.0 else None,
-                            "source_protocol": SOURCE_PROTOCOL_ICMP if protocol == SOURCE_PROTOCOL_ICMP else protocol,
-                            "availability_source": availability_source,
-                            "severity": severity,
-                            "metric_kind": "availability" if protocol == SOURCE_PROTOCOL_ICMP and availability_source else "telemetry",
-                        })
+                        latest_updates.append(
+                            {
+                                "node_id": node_id,
+                                "metric_id": mid,
+                                "value": val,
+                                "protocol": protocol,
+                                "metric_name": metric_name,
+                                "criticality": record["criticality"],
+                                "status": (
+                                    severity
+                                    if protocol == SOURCE_PROTOCOL_ICMP
+                                    and availability_source
+                                    and val == 0.0
+                                    else "OK"
+                                ),
+                                "message": (
+                                    f"Service/Host Down: {metric_name}"
+                                    if protocol == SOURCE_PROTOCOL_ICMP
+                                    and availability_source
+                                    and val == 0.0
+                                    else "Latest sample collected by legacy SNMP worker"
+                                ),
+                                "event_type": (
+                                    EVENT_TYPE_AVAILABILITY
+                                    if protocol == SOURCE_PROTOCOL_ICMP
+                                    and availability_source
+                                    and val == 0.0
+                                    else None
+                                ),
+                                "source_protocol": (
+                                    SOURCE_PROTOCOL_ICMP
+                                    if protocol == SOURCE_PROTOCOL_ICMP
+                                    else protocol
+                                ),
+                                "availability_source": availability_source,
+                                "severity": severity,
+                                "metric_kind": (
+                                    "availability"
+                                    if protocol == SOURCE_PROTOCOL_ICMP and availability_source
+                                    else "telemetry"
+                                ),
+                            }
+                        )
                     for sample in sidecar_samples:
                         latency_thresholds = latency_threshold_metadata(
                             warning_ms=icmp_settings.latency_warning_ms,
                             critical_ms=icmp_settings.latency_critical_ms,
                         )
                         sample_status = "OK"
-                        sample_message = "Latest ICMP telemetry sample collected by legacy SNMP worker"
+                        sample_message = (
+                            "Latest ICMP telemetry sample collected by legacy SNMP worker"
+                        )
                         sample_event_type = None
                         sample_severity = "INFO"
                         if sample["metric_id"] == ICMP_LATENCY_METRIC_ID:
@@ -932,7 +1016,11 @@ def poll_snmp():
                                 warning_ms=icmp_settings.latency_warning_ms,
                                 critical_ms=icmp_settings.latency_critical_ms,
                             )
-                            sample_severity = sample_status if sample_status in {"WARNING", "CRITICAL"} else "INFO"
+                            sample_severity = (
+                                sample_status
+                                if sample_status in {"WARNING", "CRITICAL"}
+                                else "INFO"
+                            )
                             if sample_status == "CRITICAL":
                                 sample_message = f"Critical Threshold Breached: {sample['value']} >= {icmp_settings.latency_critical_ms}"
                                 sample_event_type = EVENT_TYPE_THRESHOLD_BREACH
@@ -940,21 +1028,29 @@ def poll_snmp():
                                 sample_message = f"Warning Threshold Breached: {sample['value']} >= {icmp_settings.latency_warning_ms}"
                                 sample_event_type = EVENT_TYPE_THRESHOLD_BREACH
                             else:
-                                sample_message = f"Metric ICMP Latency is OK. Value: {sample['value']}"
-                        latest_updates.append({
-                            "node_id": node_id,
-                            "metric_id": sample["metric_id"],
-                            "value": sample["value"],
-                            "protocol": protocol,
-                            "metric_name": sample["metric_id"],
-                            "criticality": latency_thresholds["criticality"] if sample["metric_id"] == ICMP_LATENCY_METRIC_ID else record["criticality"],
-                            "status": sample_status,
-                            "message": sample_message,
-                            "event_type": sample_event_type,
-                            "source_protocol": SOURCE_PROTOCOL_ICMP,
-                            "severity": sample_severity,
-                            "metric_kind": "telemetry",
-                        })
+                                sample_message = (
+                                    f"Metric ICMP Latency is OK. Value: {sample['value']}"
+                                )
+                        latest_updates.append(
+                            {
+                                "node_id": node_id,
+                                "metric_id": sample["metric_id"],
+                                "value": sample["value"],
+                                "protocol": protocol,
+                                "metric_name": sample["metric_id"],
+                                "criticality": (
+                                    latency_thresholds["criticality"]
+                                    if sample["metric_id"] == ICMP_LATENCY_METRIC_ID
+                                    else record["criticality"]
+                                ),
+                                "status": sample_status,
+                                "message": sample_message,
+                                "event_type": sample_event_type,
+                                "source_protocol": SOURCE_PROTOCOL_ICMP,
+                                "severity": sample_severity,
+                                "metric_kind": "telemetry",
+                            }
+                        )
                 else:
                     failed_count += 1
                     if is_snmp_no_response_failure(
@@ -962,21 +1058,28 @@ def poll_snmp():
                         snmp_status,
                         {"message": snmp_error},
                     ):
-                        failure_updates.append({
-                            "node_id": node_id,
-                            "metric_id": mid,
-                            "severity": "WARNING",
-                            "message": f"Metric Collection Failed: {snmp_error or 'No SNMP response received before timeout'}",
-                            "event_type": EVENT_TYPE_COLLECTION_FAILURE,
-                            "failure_family": FAILURE_FAMILY_SNMP_NO_RESPONSE,
-                            "source_protocol": SOURCE_PROTOCOL_SNMP,
-                        })
+                        failure_updates.append(
+                            {
+                                "node_id": node_id,
+                                "metric_id": mid,
+                                "severity": "WARNING",
+                                "message": f"Metric Collection Failed: {snmp_error or 'No SNMP response received before timeout'}",
+                                "event_type": EVENT_TYPE_COLLECTION_FAILURE,
+                                "failure_family": FAILURE_FAMILY_SNMP_NO_RESPONSE,
+                                "source_protocol": SOURCE_PROTOCOL_SNMP,
+                            }
+                        )
 
             # Update collector status in Neo4j
             duration_current = time.time() - start_time
-            jobs_per_min = round((len(metrics_to_save) / duration_current) * 60, 1) if duration_current > 0 else 0.0
+            jobs_per_min = (
+                round((len(metrics_to_save) / duration_current) * 60, 1)
+                if duration_current > 0
+                else 0.0
+            )
             monitored_ci_count = _count_monitored_cis(session)
-            session.run("""
+            session.run(
+                """
                 MERGE (c:CollectorStatus {id: 'main'})
                 SET c.last_run = datetime(),
                     c.status = 'RUNNING',
@@ -986,7 +1089,14 @@ def poll_snmp():
                     c.metrics_failed = $failed,
                     c.cycle_duration = $duration,
                     c.jobs_per_min = $jobs_per_min
-            """, cis_monitored=monitored_ci_count, last_cycle_metrics_processed=metrics_count, collected=len(metrics_to_save), failed=failed_count, duration=round(duration_current, 2), jobs_per_min=jobs_per_min)
+            """,
+                cis_monitored=monitored_ci_count,
+                last_cycle_metrics_processed=metrics_count,
+                collected=len(metrics_to_save),
+                failed=failed_count,
+                duration=round(duration_current, 2),
+                jobs_per_min=jobs_per_min,
+            )
             _log_observe_only_cycle(
                 polling_settings,
                 metrics_count,
@@ -1009,13 +1119,15 @@ def poll_snmp():
             # rebuilds the cache automatically, and (b) ENABLE_TOPOLOGY_RCA=false
             # is the deterministic operator kill-switch.
             availability_pairs_updates = [
-                u for u in latest_updates
+                u
+                for u in latest_updates
                 if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
                 and _availability_source(u.get("availability_source")) is not None
                 and float(u.get("value") or 0) == 0.0
             ]
             latency_pairs_updates = [
-                u for u in latest_updates
+                u
+                for u in latest_updates
                 if str(u.get("protocol") or "").upper() == SOURCE_PROTOCOL_ICMP
                 and u.get("metric_id") == ICMP_LATENCY_METRIC_ID
                 and u.get("event_type") == EVENT_TYPE_THRESHOLD_BREACH
@@ -1054,38 +1166,60 @@ def poll_snmp():
             if metrics_to_save:
                 bulk_insert_metrics(db, metrics_to_save)
                 for update in latest_updates:
-                    if update["protocol"].upper() == "ICMP" and update.get("metric_kind") == "availability" and update["value"] in (0.0, 1.0):
+                    if (
+                        update["protocol"].upper() == "ICMP"
+                        and update.get("metric_kind") == "availability"
+                        and update["value"] in (0.0, 1.0)
+                    ):
                         session.run(
                             "MATCH (n:CI {id: $id}) SET n.status = $status, n.last_seen = datetime()",
                             id=update["node_id"],
                             status="CRITICAL" if update["value"] == 0.0 else "OK",
                         )
                         _consecutive_failures[update["node_id"]] = 0
-                    session.run("""
+                    session.run(
+                        """
                         MATCH (n:CI {id: $nid})-[r:HAS_METRIC]->(m:MetricDef {id: $mid})
                         SET r.last_polled = datetime(),
                             r.last_value = $val,
                             r.last_updated = datetime(),
                             r.status = $status,
                             r.last_message = $msg
-                    """, nid=update["node_id"], mid=update["metric_id"], val=update["value"], status=update["status"], msg=update["message"])
-                availability_updates = [u for u in latest_updates if u.get("metric_kind") == "availability"]
-                _refresh_icmp_availability_events(session, availability_updates, cache=cache, lock_db=db)
+                    """,
+                        nid=update["node_id"],
+                        mid=update["metric_id"],
+                        val=update["value"],
+                        status=update["status"],
+                        msg=update["message"],
+                    )
+                availability_updates = [
+                    u for u in latest_updates if u.get("metric_kind") == "availability"
+                ]
+                _refresh_icmp_availability_events(
+                    session, availability_updates, cache=cache, lock_db=db
+                )
                 _recover_icmp_availability_events(session, availability_updates)
-                latency_updates = [u for u in latest_updates if u.get("metric_id") == ICMP_LATENCY_METRIC_ID]
+                latency_updates = [
+                    u for u in latest_updates if u.get("metric_id") == ICMP_LATENCY_METRIC_ID
+                ]
                 _refresh_icmp_latency_events(session, latency_updates, cache=cache, lock_db=db)
                 _recover_icmp_latency_events(session, latency_updates)
                 _recover_snmp_collection_failures(session, latest_updates)
-                print(f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB.")
+                print(
+                    f"[{datetime.now().isoformat()}] Bulk saved {len(metrics_to_save)} metrics to TimescaleDB."
+                )
 
         duration = time.time() - start_time
         if metrics_count > 0:
-            print(f"[{datetime.now().isoformat()}] Cycle Complete: {metrics_count} metrics processed ({failed_count} failed) in {duration:.2f}s.")
+            print(
+                f"[{datetime.now().isoformat()}] Cycle Complete: {metrics_count} metrics processed ({failed_count} failed) in {duration:.2f}s."
+            )
 
     except Exception as e:
         print(f"Error during dynamic polling cycle: {e}")
     finally:
         db.close()
+
 
 def job():
     try:
@@ -1102,6 +1236,7 @@ def job():
         poll_snmp()
     except Exception as e:
         print(f"Error in polling job: {e}")
+
 
 # Run once every 10 seconds
 schedule.every(10).seconds.do(job)

--- a/backend/main.py
+++ b/backend/main.py
@@ -679,6 +679,13 @@ def _build_system_status_payload() -> dict:
         postgres_status = "DISCONNECTED"
 
     collector = get_collector_status()
+    from services.event_lock import get_event_lock_observability_snapshot
+
+    try:
+        event_lock_snapshot = get_event_lock_observability_snapshot()
+    except Exception as exc:
+        logger.warning("Failed to build event lock observability snapshot: %s", exc)
+        event_lock_snapshot = {"alert_state": "UNKNOWN", "snapshot_error": True}
 
     return {
         "cpu": round(cpu_percent, 1),
@@ -688,6 +695,7 @@ def _build_system_status_payload() -> dict:
         "neo4j": neo4j_status,
         "postgres": postgres_status,
         "collector": collector,
+        "event_lock": event_lock_snapshot,
         "startup_time": STARTUP_TIME,
     }
 

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, Iterable, Mapping
+from typing import Any
 from uuid import UUID
 
 from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
 from services.polling_event_lifecycle import (
-    COLLECTION_FAILURE_PREFIX,
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
     EVENT_TYPE_THRESHOLD_BREACH,
@@ -68,7 +68,12 @@ def _collection_failure_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[
     for row in rows:
         if not (row.get("is_breach") and row.get("event_type") == EVENT_TYPE_COLLECTION_FAILURE):
             continue
-        key = (row.get("ci_id"), row.get("metric_id"), row.get("event_type"), row.get("failure_family"))
+        key = (
+            row.get("ci_id"),
+            row.get("metric_id"),
+            row.get("event_type"),
+            row.get("failure_family"),
+        )
         deduped[key] = row
     return list(deduped.values())
 
@@ -84,7 +89,7 @@ def _observed_at_order(value: Any) -> float | None:
     else:
         return None
     if observed.tzinfo is None:
-        observed = observed.replace(tzinfo=timezone.utc)
+        observed = observed.replace(tzinfo=UTC)
     return observed.timestamp()
 
 
@@ -126,11 +131,18 @@ def _non_collection_event_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str,
     return [
         row
         for row in _dedupe_non_collection_latest_state(rows)
-        if row.get("is_breach") and row.get("event_type") and row.get("event_type") != EVENT_TYPE_COLLECTION_FAILURE
+        if row.get("is_breach")
+        and row.get("event_type")
+        and row.get("event_type") != EVENT_TYPE_COLLECTION_FAILURE
     ]
 
 
-def _acquire_unsorted_locks(lock_db, triplets: list[tuple[str, str, str]]) -> None:
+def _acquire_unsorted_locks(
+    lock_db,
+    triplets: list[tuple[str, str, str]],
+    *,
+    writer_context: str = "polling_event_writer",
+) -> None:
     """Acquire ``pg_advisory_xact_lock`` for each triplet in the order given.
 
     This is the inner acquisition loop extracted from
@@ -149,7 +161,13 @@ def _acquire_unsorted_locks(lock_db, triplets: list[tuple[str, str, str]]) -> No
         caller wants the locks acquired. No sorting is performed here.
     """
     for ci_id, metric_id, event_type in triplets:
-        acquire_event_triplet_lock(lock_db, ci_id, metric_id, event_type)
+        acquire_event_triplet_lock(
+            lock_db,
+            ci_id,
+            metric_id,
+            event_type,
+            writer_context=writer_context,
+        )
 
 
 def _acquire_sorted_locks(lock_db, rows: Iterable[Mapping[str, Any]]) -> None:
@@ -164,12 +182,18 @@ def _acquire_sorted_locks(lock_db, rows: Iterable[Mapping[str, Any]]) -> None:
     to :func:`_acquire_unsorted_locks` so the acquisition loop is shared
     with the deadlock-prevention tests.
     """
-    distinct_triplets = sorted({
-        (row.get("ci_id"), row.get("metric_id"), row.get("event_type"))
-        for row in rows
-        if row.get("ci_id") and row.get("metric_id") and row.get("event_type")
-    })
-    _acquire_unsorted_locks(lock_db, distinct_triplets)
+    distinct_triplets = sorted(
+        {
+            (row.get("ci_id"), row.get("metric_id"), row.get("event_type"))
+            for row in rows
+            if row.get("ci_id") and row.get("metric_id") and row.get("event_type")
+        }
+    )
+    _acquire_unsorted_locks(
+        lock_db,
+        distinct_triplets,
+        writer_context="polling_event_writer",
+    )
 
 
 def _latest_metric_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -225,54 +249,64 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
                 message = f"Service/Host Down: {metric_name}"
             elif not availability:
                 op = str(metadata.get("operator") or ">=")
-                if metadata.get("critical") is not None and _check(numeric, float(metadata["critical"]), op):
+                if metadata.get("critical") is not None and _check(
+                    numeric, float(metadata["critical"]), op
+                ):
                     severity = "CRITICAL"
                     is_breach = True
                     event_type = EVENT_TYPE_THRESHOLD_BREACH
-                    message = f"Critical Threshold Breached: {display_value} {op} {metadata['critical']}"
-                elif metadata.get("warning") is not None and _check(numeric, float(metadata["warning"]), op):
+                    message = (
+                        f"Critical Threshold Breached: {display_value} {op} {metadata['critical']}"
+                    )
+                elif metadata.get("warning") is not None and _check(
+                    numeric, float(metadata["warning"]), op
+                ):
                     severity = "WARNING"
                     is_breach = True
                     event_type = EVENT_TYPE_THRESHOLD_BREACH
-                    message = f"Warning Threshold Breached: {display_value} {op} {metadata['warning']}"
+                    message = (
+                        f"Warning Threshold Breached: {display_value} {op} {metadata['warning']}"
+                    )
 
         recover_non_collection_event = numeric is not None and not is_breach
 
-        rows.append({
-            "idempotency_key": envelope.get("idempotency_key"),
-            "ci_id": envelope.get("ci_id"),
-            "metric_id": metric_id,
-            "value": display_value,
-            "status": severity if is_breach else "OK",
-            "severity": severity,
-            "message": message,
-            "is_breach": is_breach,
-            "event_type": event_type,
-            "failure_family": failure_family,
-            "source_protocol": source_protocol,
-            "availability_source": _availability_source(metadata),
-            "recover_collection_failure": recover_collection_failure,
-            "recover_non_collection_event": recover_non_collection_event,
-            "collection_recovery_message": collection_recovery_message,
-            "observed_at": _value(envelope.get("observed_at")),
-            "correlation_type": metadata.get("correlation_type") or "ROOT",
-            "propagated_from": metadata.get("propagated_from"),
-            "root_cause_event_id": metadata.get("root_cause_event_id"),
-            "root_cause_ci_id": metadata.get("root_cause_ci_id") or envelope.get("ci_id"),
-            "business_service_id": metadata.get("business_service_id"),
-            "business_service_name": metadata.get("business_service_name"),
-            "business_service_tier": metadata.get("business_service_tier"),
-            "owner_t1": metadata.get("owner_t1"),
-            "owner_t2": metadata.get("owner_t2"),
-            "owner_t3": metadata.get("owner_t3"),
-            "impacted_users": metadata.get("impacted_users"),
-            "site": metadata.get("site") or metadata.get("site_id"),
-            "service_catalog_id": metadata.get("service_catalog_id"),
-            "service_category": metadata.get("service_category"),
-            "service_tier": metadata.get("service_tier"),
-            "sla_minutes": metadata.get("sla_minutes"),
-            "poll_collector_id": POLL_COLLECTOR_ID,
-        })
+        rows.append(
+            {
+                "idempotency_key": envelope.get("idempotency_key"),
+                "ci_id": envelope.get("ci_id"),
+                "metric_id": metric_id,
+                "value": display_value,
+                "status": severity if is_breach else "OK",
+                "severity": severity,
+                "message": message,
+                "is_breach": is_breach,
+                "event_type": event_type,
+                "failure_family": failure_family,
+                "source_protocol": source_protocol,
+                "availability_source": _availability_source(metadata),
+                "recover_collection_failure": recover_collection_failure,
+                "recover_non_collection_event": recover_non_collection_event,
+                "collection_recovery_message": collection_recovery_message,
+                "observed_at": _value(envelope.get("observed_at")),
+                "correlation_type": metadata.get("correlation_type") or "ROOT",
+                "propagated_from": metadata.get("propagated_from"),
+                "root_cause_event_id": metadata.get("root_cause_event_id"),
+                "root_cause_ci_id": metadata.get("root_cause_ci_id") or envelope.get("ci_id"),
+                "business_service_id": metadata.get("business_service_id"),
+                "business_service_name": metadata.get("business_service_name"),
+                "business_service_tier": metadata.get("business_service_tier"),
+                "owner_t1": metadata.get("owner_t1"),
+                "owner_t2": metadata.get("owner_t2"),
+                "owner_t3": metadata.get("owner_t3"),
+                "impacted_users": metadata.get("impacted_users"),
+                "site": metadata.get("site") or metadata.get("site_id"),
+                "service_catalog_id": metadata.get("service_catalog_id"),
+                "service_category": metadata.get("service_category"),
+                "service_tier": metadata.get("service_tier"),
+                "sla_minutes": metadata.get("sla_minutes"),
+                "poll_collector_id": POLL_COLLECTOR_ID,
+            }
+        )
     return rows
 
 

--- a/backend/services/snmp_service.py
+++ b/backend/services/snmp_service.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-import asyncio
 import ast
+import asyncio
 import json
 import logging
 import subprocess
 import time
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any
 
 from database import get_db
 from postgres_db import SessionLocal
 from repositories.metric_repo import insert_metric_value
 from services.event_lock import POLL_COLLECTOR_ID, acquire_event_triplet_lock
+from services.metric_service import metric_matches_ci
 from services.neo4j_write_guard import (
     is_poll_collector_id_undefined_error,
     run_with_cypher_param_fallback,
 )
-from services.metric_service import metric_matches_ci
 from services.polling_event_lifecycle import (
     EVENT_TYPE_AVAILABILITY,
     EVENT_TYPE_COLLECTION_FAILURE,
@@ -90,18 +90,23 @@ def get_collector_status():
             """).single()
             if record:
                 last_run_val = record.get("last_run")
-                last_run_str = last_run_val.isoformat() if hasattr(last_run_val, "isoformat") else str(last_run_val) if last_run_val else None
+                last_run_str = (
+                    last_run_val.isoformat()
+                    if hasattr(last_run_val, "isoformat")
+                    else str(last_run_val) if last_run_val else None
+                )
                 return {
                     "last_run": last_run_str,
                     "status": record.get("status") or "UNKNOWN",
                     "stats": {
                         "cis_monitored": record.get("cis_monitored") or 0,
-                        "last_cycle_metrics_processed": record.get("last_cycle_metrics_processed") or 0,
+                        "last_cycle_metrics_processed": record.get("last_cycle_metrics_processed")
+                        or 0,
                         "metrics_collected": record.get("metrics_collected") or 0,
                         "metrics_failed": record.get("metrics_failed") or 0,
                         "cycle_duration": record.get("cycle_duration") or 0.0,
                         "jobs_per_min": record.get("jobs_per_min") or 0.0,
-                    }
+                    },
                 }
     except Exception as e:
         logger.error("Failed to read collector status from Neo4j: %s", e)
@@ -113,7 +118,7 @@ def get_collector_status():
     }
 
 
-def _parse_snmp_config(snmp_raw: Any) -> Dict[str, Any]:
+def _parse_snmp_config(snmp_raw: Any) -> dict[str, Any]:
     if not snmp_raw:
         return {}
     if isinstance(snmp_raw, dict):
@@ -127,7 +132,7 @@ def _parse_snmp_config(snmp_raw: Any) -> Dict[str, Any]:
             return {}
 
 
-def resolve_event_snapshot(session, ci_id: str) -> Dict[str, Any]:
+def resolve_event_snapshot(session, ci_id: str) -> dict[str, Any]:
     record = session.run(
         """
         MATCH (ci:CI {id: $ci_id})
@@ -192,13 +197,9 @@ async def snmp_collector_loop():
             GLOBAL_STATS["metrics_collected"] = stats.get("total", 0)
             GLOBAL_STATS["metrics_failed"] = stats.get("errors", 0)
             if elapsed > 0:
-                GLOBAL_STATS["jobs_per_min"] = round(
-                    (stats.get("total", 0) / elapsed) * 60, 1
-                )
+                GLOBAL_STATS["jobs_per_min"] = round((stats.get("total", 0) / elapsed) * 60, 1)
 
-            logger.info(
-                "[Collector] Cycle finished in %.2fs. Stats: %s", elapsed, GLOBAL_STATS
-            )
+            logger.info("[Collector] Cycle finished in %.2fs. Stats: %s", elapsed, GLOBAL_STATS)
             await asyncio.sleep(60)
         except Exception as exc:
             logger.error("[Collector] Critical Loop Error: %s", exc, exc_info=True)
@@ -208,13 +209,11 @@ async def snmp_collector_loop():
 
 def run_snmp_cycle_sync(driver):
     with driver.session() as session:
-        cis_result = session.run(
-            """
+        cis_result = session.run("""
             MATCH (n:CI)
             WHERE n.ip IS NOT NULL AND n.status <> 'EXCEPTION'
             RETURN n
-        """
-        )
+        """)
         cis = [dict(record["n"]) for record in cis_result]
         logger.info("[Collector] Found %s candidate CIs for monitoring.", len(cis))
 
@@ -302,9 +301,7 @@ def poll_metric(ci, metric_def, snmp_conf):
         param = "-n" if platform.system().lower() == "windows" else "-c"
         command = ["ping", param, "1", ci.get("ip")]
         try:
-            result = subprocess.call(
-                command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-            )
+            result = subprocess.call(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             return (1, "OK", None) if result == 0 else (0, "OK", None)
         except Exception as exc:
             logger.error("PING Exception for %s: %s", ci.get("ip"), exc)
@@ -331,7 +328,9 @@ def poll_metric(ci, metric_def, snmp_conf):
                 error_message = str(error_indication)
                 status = (
                     "TIMEOUT"
-                    if is_snmp_no_response_failure(SOURCE_PROTOCOL_SNMP, "ERROR", {"message": error_message})
+                    if is_snmp_no_response_failure(
+                        SOURCE_PROTOCOL_SNMP, "ERROR", {"message": error_message}
+                    )
                     else "ERROR"
                 )
                 return None, status, error_message
@@ -406,7 +405,9 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     severity = "CRITICAL"
                     is_breach = True
                     event_type = EVENT_TYPE_THRESHOLD_BREACH
-                    message = f"Critical Threshold Breached: {val} {operator} {metric_def['critical']}"
+                    message = (
+                        f"Critical Threshold Breached: {val} {operator} {metric_def['critical']}"
+                    )
                 elif metric_def.get("warning") is not None and check_op(
                     num_val, float(metric_def["warning"]), operator
                 ):
@@ -414,7 +415,9 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     severity = "WARNING"
                     is_breach = True
                     event_type = EVENT_TYPE_THRESHOLD_BREACH
-                    message = f"Warning Threshold Breached: {val} {operator} {metric_def['warning']}"
+                    message = (
+                        f"Warning Threshold Breached: {val} {operator} {metric_def['warning']}"
+                    )
 
             if is_availability_metric and float(val) == 0:
                 status = "CRITICAL"
@@ -505,6 +508,7 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         ci.get("id"),
                         metric_def["id"],
                         event_type,
+                        writer_context="snmp_service",
                     )
                 existing = session.run(
                     """
@@ -574,13 +578,16 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         "poll_collector_id": POLL_COLLECTOR_ID,
                     }
                     fallback_params = {
-                        k: v for k, v in primary_params.items()
-                        if k != "poll_collector_id"
+                        k: v for k, v in primary_params.items() if k != "poll_collector_id"
                     }
                     run_with_cypher_param_fallback(
-                        session, primary_query, primary_params,
-                        fallback_query, fallback_params,
-                        is_poll_collector_id_undefined_error, logger,
+                        session,
+                        primary_query,
+                        primary_params,
+                        fallback_query,
+                        fallback_params,
+                        is_poll_collector_id_undefined_error,
+                        logger,
                     )
                 else:
                     snapshot = resolve_event_snapshot(session, ci.get("id"))
@@ -593,14 +600,22 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                     if metric_def.get("can_propagate", True):
                         try:
                             from repositories.topology_repo import find_open_parent_event
+
                             parent_info = find_open_parent_event(ci.get("id"), max_depth=3)
                             if parent_info:
                                 correlation_type = "PROPAGATED"
                                 propagated_from = parent_info["parent_event_id"]
-                                root_cause_ci_id = parent_info.get("root_cause_ci_id") or parent_info["parent_event_id"]
+                                root_cause_ci_id = (
+                                    parent_info.get("root_cause_ci_id")
+                                    or parent_info["parent_event_id"]
+                                )
                         except Exception as exc:
-                            logger.warning("Topology correlation check failed for CI %s metric %s: %s",
-                                           ci.get("id"), metric_def.get("id"), exc)
+                            logger.warning(
+                                "Topology correlation check failed for CI %s metric %s: %s",
+                                ci.get("id"),
+                                metric_def.get("id"),
+                                exc,
+                            )
                     # --- End correlation check ---
 
                     primary_query = """
@@ -696,13 +711,16 @@ def store_metric_result(ci, metric_def, val, poll_status, err_msg, driver):
                         **snapshot,
                     }
                     fallback_params = {
-                        k: v for k, v in primary_params.items()
-                        if k != "poll_collector_id"
+                        k: v for k, v in primary_params.items() if k != "poll_collector_id"
                     }
                     run_with_cypher_param_fallback(
-                        session, primary_query, primary_params,
-                        fallback_query, fallback_params,
-                        is_poll_collector_id_undefined_error, logger,
+                        session,
+                        primary_query,
+                        primary_params,
+                        fallback_query,
+                        fallback_params,
+                        is_poll_collector_id_undefined_error,
+                        logger,
                     )
             else:
                 # Recovery path for threshold/availability events; SNMP collection failures

--- a/backend/tests/test_neo4j_write_guard.py
+++ b/backend/tests/test_neo4j_write_guard.py
@@ -3,9 +3,11 @@
 
 Strict TDD (tasks.md §Phase 1): this file lands BEFORE the helper.
 """
+
 from __future__ import annotations
 
 import logging
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -42,6 +44,7 @@ def _install_fake_client_error(monkeypatch):
     monkeypatch.setattr(guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
     try:
         from services import neo4j_write_guard as services_guard_module
+
         monkeypatch.setattr(services_guard_module, "_CLIENT_ERROR_CLASS", _FakeClientError)
     except ImportError:
         pass
@@ -55,17 +58,26 @@ def test_predicate_unit_cases(_install_fake_client_error):
     """True / false positives / wrong exception type — design §8 contract."""
     guard_module = _install_fake_client_error
     # True: matching ClientError
-    assert guard_module.is_poll_collector_id_undefined_error(
-        _FakeClientError("Variable poll_collector_id not defined")
-    ) is True
+    assert (
+        guard_module.is_poll_collector_id_undefined_error(
+            _FakeClientError("Variable poll_collector_id not defined")
+        )
+        is True
+    )
     # False: ClientError with unrelated message
-    assert guard_module.is_poll_collector_id_undefined_error(
-        _FakeClientError("Syntax error: unexpected token")
-    ) is False
+    assert (
+        guard_module.is_poll_collector_id_undefined_error(
+            _FakeClientError("Syntax error: unexpected token")
+        )
+        is False
+    )
     # False: wrong exception type even with matching message
-    assert guard_module.is_poll_collector_id_undefined_error(
-        RuntimeError("Variable poll_collector_id not defined")
-    ) is False
+    assert (
+        guard_module.is_poll_collector_id_undefined_error(
+            RuntimeError("Variable poll_collector_id not defined")
+        )
+        is False
+    )
 
 
 # Tests for ``run_with_cypher_param_fallback`` (cases a–d) -------------------
@@ -86,9 +98,13 @@ def test_primary_success_skips_fallback(_install_fake_client_error):
 
     fake_session = _FakeSession()
     result = guard_module.run_with_cypher_param_fallback(
-        fake_session, "primary query", {"poll_collector_id": "host-1"},
-        "fallback query", {},
-        guard_module.is_poll_collector_id_undefined_error, logger,
+        fake_session,
+        "primary query",
+        {"poll_collector_id": "host-1"},
+        "fallback query",
+        {},
+        guard_module.is_poll_collector_id_undefined_error,
+        logger,
     )
     assert result == "primary-result"
     assert fake_session.calls == [("primary query", {"poll_collector_id": "host-1"})]
@@ -112,9 +128,13 @@ def test_matching_client_error_triggers_fallback_and_logs(_install_fake_client_e
     fake_session = _FakeSession()
     with caplog.at_level(logging.ERROR, logger=logger.name):
         result = guard_module.run_with_cypher_param_fallback(
-            fake_session, "primary query", {"poll_collector_id": "host-1"},
-            "fallback query", {},
-            guard_module.is_poll_collector_id_undefined_error, logger,
+            fake_session,
+            "primary query",
+            {"poll_collector_id": "host-1"},
+            "fallback query",
+            {},
+            guard_module.is_poll_collector_id_undefined_error,
+            logger,
         )
     assert result == "fallback-result"
     assert fake_session.calls[0][0] == "primary query"
@@ -145,9 +165,13 @@ def test_non_matching_client_error_reraises_without_fallback(_install_fake_clien
     fake_session = _FakeSession()
     with pytest.raises(_FakeClientError, match="unrelated"):
         guard_module.run_with_cypher_param_fallback(
-            fake_session, "primary query", {},
-            "fallback query", {},
-            guard_module.is_poll_collector_id_undefined_error, logger,
+            fake_session,
+            "primary query",
+            {},
+            "fallback query",
+            {},
+            guard_module.is_poll_collector_id_undefined_error,
+            logger,
         )
     assert len(fake_session.calls) == 1
 
@@ -168,9 +192,13 @@ def test_non_client_error_reraises_unchanged(_install_fake_client_error):
     fake_session = _FakeSession()
     with pytest.raises(RuntimeError, match="boom"):
         guard_module.run_with_cypher_param_fallback(
-            fake_session, "primary query", {},
-            "fallback query", {},
-            guard_module.is_poll_collector_id_undefined_error, logger,
+            fake_session,
+            "primary query",
+            {},
+            "fallback query",
+            {},
+            guard_module.is_poll_collector_id_undefined_error,
+            logger,
         )
     assert len(fake_session.calls) == 1
 
@@ -178,7 +206,7 @@ def test_non_client_error_reraises_unchanged(_install_fake_client_error):
 # CRITICAL #2 — Predicate must read ``error.message``, not ``str(error) -------
 
 
-class _FakeClientErrorWithMessage(_FakeClientError):
+class _FakeClientErrorWithMessageError(_FakeClientError):
     """Real-exception-class stand-in for ``neo4j.exceptions.ClientError``
     with a ``message`` attribute that DIFFERS from ``str(error)``.
 
@@ -211,7 +239,7 @@ def test_predicate_uses_error_message_attribute(_install_fake_client_error):
     guard_module = _install_fake_client_error
 
     # Case 1 — production-shaped message, str() deliberately unrelated.
-    err_match = _FakeClientErrorWithMessage(
+    err_match = _FakeClientErrorWithMessageError(
         message="Variable poll_collector_id not defined",
     )
     assert guard_module.is_poll_collector_id_undefined_error(err_match) is True, (
@@ -220,7 +248,7 @@ def test_predicate_uses_error_message_attribute(_install_fake_client_error):
     )
 
     # Case 2 — message missing 'not defined'.
-    err_no_not_defined = _FakeClientErrorWithMessage(
+    err_no_not_defined = _FakeClientErrorWithMessageError(
         message="Variable poll_collector_id something_else_completely",
     )
     assert (
@@ -228,7 +256,7 @@ def test_predicate_uses_error_message_attribute(_install_fake_client_error):
     ), "predicate MUST reject ClientError whose .message lacks 'not defined'"
 
     # Case 3 — message missing 'poll_collector_id'.
-    err_no_param = _FakeClientErrorWithMessage(
+    err_no_param = _FakeClientErrorWithMessageError(
         message="Variable other_param not defined",
     )
     assert (
@@ -252,34 +280,52 @@ def test_fallback_query_has_no_dangling_commas(_install_fake_client_error):
     """
     from unittest.mock import MagicMock
 
-    guard_module = _install_fake_client_error
-
     # Sample rows — minimal inputs the writers accept.
     failure_row = {
-        "node_id": "CI-1", "metric_id": "m", "event_type": "COLLECTION_FAILURE",
-        "severity": "CRITICAL", "message": "x", "failure_family": "SNMP_NO_RESPONSE",
-        "source_protocol": "SNMP", "correlation_type": "ROOT",
-        "propagated_from": None, "root_cause_ci_id": "CI-1",
+        "node_id": "CI-1",
+        "metric_id": "m",
+        "event_type": "COLLECTION_FAILURE",
+        "severity": "CRITICAL",
+        "message": "x",
+        "failure_family": "SNMP_NO_RESPONSE",
+        "source_protocol": "SNMP",
+        "correlation_type": "ROOT",
+        "propagated_from": None,
+        "root_cause_ci_id": "CI-1",
     }
     availability_row = {
-        "node_id": "CI-1", "metric_id": "icmp_avail", "event_type": "AVAILABILITY",
-        "protocol": "ICMP", "availability_source": "PING", "value": 0.0,
-        "severity": "CRITICAL", "message": "down",
-        "source_protocol": "ICMP", "correlation_type": "ROOT",
-        "propagated_from": None, "root_cause_ci_id": "CI-1",
+        "node_id": "CI-1",
+        "metric_id": "icmp_avail",
+        "event_type": "AVAILABILITY",
+        "protocol": "ICMP",
+        "availability_source": "PING",
+        "value": 0.0,
+        "severity": "CRITICAL",
+        "message": "down",
+        "source_protocol": "ICMP",
+        "correlation_type": "ROOT",
+        "propagated_from": None,
+        "root_cause_ci_id": "CI-1",
     }
     latency_row = {
-        "node_id": "CI-1", "metric_id": "icmp_latency_ms", "event_type": "THRESHOLD_BREACH",
-        "protocol": "ICMP", "status": "CRITICAL", "message": "breach",
-        "source_protocol": "ICMP", "correlation_type": "ROOT",
-        "propagated_from": None, "root_cause_ci_id": "CI-1",
+        "node_id": "CI-1",
+        "metric_id": "icmp_latency_ms",
+        "event_type": "THRESHOLD_BREACH",
+        "protocol": "ICMP",
+        "status": "CRITICAL",
+        "message": "breach",
+        "source_protocol": "ICMP",
+        "correlation_type": "ROOT",
+        "propagated_from": None,
+        "root_cause_ci_id": "CI-1",
     }
 
     import re
+
     bad_patterns = [
-        (re.compile(r",\s*}"),  "trailing comma before }"),
+        (re.compile(r",\s*}"), "trailing comma before }"),
         (re.compile(r",\s*MERGE\b"), "trailing comma before MERGE"),
-        (re.compile(r",\s*WITH\b"),  "trailing comma before WITH"),
+        (re.compile(r",\s*WITH\b"), "trailing comma before WITH"),
         # Trailing comma right before the closing """ of the query string.
         # The query is indented, so the literal "\n                    \"\"\"" appears.
         (re.compile(r",\s*\n\s*\"\"\""), "trailing comma before query end"),
@@ -287,26 +333,31 @@ def test_fallback_query_has_no_dangling_commas(_install_fake_client_error):
 
     def _make_session():
         raised = {"done": False}
+
         def run(query, **params):
             if not raised["done"]:
                 raised["done"] = True
                 raise _FakeClientError("Variable poll_collector_id not defined")
             return "fallback-ok"
+
         fake = MagicMock()
         fake.run.side_effect = run
         return fake
 
     def _check(query):
         for pattern, desc in bad_patterns:
-            assert not pattern.search(query), (
-                f"Fallback Cypher has {desc}: matched {pattern.pattern!r}\n--- query ---\n{query}"
-            )
+            assert not pattern.search(
+                query
+            ), f"Fallback Cypher has {desc}: matched {pattern.pattern!r}\n--- query ---\n{query}"
 
     # 1) _refresh_snmp_collection_failures -----------------------------------
     from backend.engines import snmp_worker
+
     session = _make_session()
     snmp_worker._refresh_snmp_collection_failures(
-        session, [failure_row], lock_db=MagicMock(),
+        session,
+        [failure_row],
+        lock_db=MagicMock(),
     )
     fallback_query = session.run.call_args_list[1].args[0]
     _check(fallback_query)
@@ -314,7 +365,9 @@ def test_fallback_query_has_no_dangling_commas(_install_fake_client_error):
     # 2) _refresh_icmp_availability_events ------------------------------------
     session = _make_session()
     snmp_worker._refresh_icmp_availability_events(
-        session, [availability_row], lock_db=MagicMock(),
+        session,
+        [availability_row],
+        lock_db=MagicMock(),
     )
     fallback_query = session.run.call_args_list[1].args[0]
     _check(fallback_query)
@@ -322,7 +375,9 @@ def test_fallback_query_has_no_dangling_commas(_install_fake_client_error):
     # 3) _refresh_icmp_latency_events -----------------------------------------
     session = _make_session()
     snmp_worker._refresh_icmp_latency_events(
-        session, [latency_row], lock_db=MagicMock(),
+        session,
+        [latency_row],
+        lock_db=MagicMock(),
     )
     fallback_query = session.run.call_args_list[1].args[0]
     _check(fallback_query)
@@ -344,18 +399,22 @@ def test_lock_acquired_before_session_run_in_fallback_path(_install_fake_client_
     """
     from unittest.mock import MagicMock, patch
 
-    guard_module = _install_fake_client_error
-
     failure_row = {
-        "node_id": "CI-1", "metric_id": "m", "event_type": "COLLECTION_FAILURE",
-        "severity": "CRITICAL", "message": "x", "failure_family": "SNMP_NO_RESPONSE",
-        "source_protocol": "SNMP", "correlation_type": "ROOT",
-        "propagated_from": None, "root_cause_ci_id": "CI-1",
+        "node_id": "CI-1",
+        "metric_id": "m",
+        "event_type": "COLLECTION_FAILURE",
+        "severity": "CRITICAL",
+        "message": "x",
+        "failure_family": "SNMP_NO_RESPONSE",
+        "source_protocol": "SNMP",
+        "correlation_type": "ROOT",
+        "propagated_from": None,
+        "root_cause_ci_id": "CI-1",
     }
 
     events = []  # ordered log: ("lock", triplet) or ("run", query_marker)
 
-    def spy_acquire(pg_db, ci_id, metric_id, event_type):
+    def spy_acquire(pg_db, ci_id, metric_id, event_type, **_kwargs):
         events.append(("lock", (ci_id, metric_id, event_type)))
 
     raised = {"done": False}
@@ -375,36 +434,26 @@ def test_lock_acquired_before_session_run_in_fallback_path(_install_fake_client_
         side_effect=spy_acquire,
     ):
         from backend.engines import snmp_worker
+
         snmp_worker._refresh_snmp_collection_failures(
-            session, [failure_row], lock_db=MagicMock(),
+            session,
+            [failure_row],
+            lock_db=MagicMock(),
         )
 
-    # Filter to lock + run events for the (CI-1, m, COLLECTION_FAILURE) triplet.
-    relevant = [
-        e for e in events
-        if e[0] == "lock"
-        and e[1] == ("CI-1", "m", "COLLECTION_FAILURE")
-        or e[0] == "run"
-    ]
     lock_count = sum(1 for e in events if e[0] == "lock")
     run_count = sum(1 for e in events if e[0] == "run")
 
     # Exactly ONE lock acquisition for this triplet (not 2 — the fallback
     # must NOT re-acquire).
-    assert lock_count == 1, (
-        f"expected exactly 1 lock acquisition, got {lock_count}: {events}"
-    )
+    assert lock_count == 1, f"expected exactly 1 lock acquisition, got {lock_count}: {events}"
     # Two session.run calls (primary + fallback).
-    assert run_count == 2, (
-        f"expected 2 session.run calls (primary + fallback), got {run_count}"
-    )
+    assert run_count == 2, f"expected 2 session.run calls (primary + fallback), got {run_count}"
 
     # The lock event MUST appear before the first run event.
     first_lock = next(i for i, e in enumerate(events) if e[0] == "lock")
     first_run = next(i for i, e in enumerate(events) if e[0] == "run")
-    assert first_lock < first_run, (
-        f"lock must precede first session.run: {events}"
-    )
+    assert first_lock < first_run, f"lock must precede first session.run: {events}"
 
 
 def _make_context_mock():

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from tests.conftest import MockNeo4jDriver
 
@@ -10,7 +10,7 @@ def _event_row(value: float | None = 97.0, status="OK", metadata=None):
         "metric_id": "cpu",
         "protocol": "SNMP",
         "source": "10.0.0.1:161/1.2.3",
-        "observed_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "observed_at": datetime(2026, 1, 1, tzinfo=UTC),
         "status": status,
         "value": {"numeric": value, "raw": value},
         "error": {"message": None},
@@ -21,14 +21,58 @@ def _event_row(value: float | None = 97.0, status="OK", metadata=None):
 def test_event_writer_ignores_icmp_latency_and_jitter_as_availability_events():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3, "availability_source": "PING"}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-router", "metadata": {"name": "PING-router", "criticality": 3, "availability_source": "ICMP"}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_latency_ms", "metadata": {"name": "ICMP Latency", "criticality": 3}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_jitter_ms", "metadata": {"name": "ICMP Jitter", "criticality": 3}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_latency_ms", "metadata": {"name": "ICMP Latency", "criticality": 3, "metric_kind": "availability"}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "icmp_jitter_ms", "metadata": {"name": "ICMP Jitter", "criticality": 3, "metric_kind": "availability"}},
-    ])
+    rows = build_event_rows(
+        [
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "PING-CHECK",
+                "metadata": {"name": "PING-CHECK", "criticality": 3, "availability_source": "PING"},
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "PING-router",
+                "metadata": {
+                    "name": "PING-router",
+                    "criticality": 3,
+                    "availability_source": "ICMP",
+                },
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {"name": "ICMP Latency", "criticality": 3},
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_jitter_ms",
+                "metadata": {"name": "ICMP Jitter", "criticality": 3},
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "criticality": 3,
+                    "metric_kind": "availability",
+                },
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_jitter_ms",
+                "metadata": {
+                    "name": "ICMP Jitter",
+                    "criticality": 3,
+                    "metric_kind": "availability",
+                },
+            },
+        ]
+    )
 
     assert rows[0]["event_type"] == "AVAILABILITY"
     assert rows[1]["event_type"] == "AVAILABILITY"
@@ -40,11 +84,28 @@ def test_event_writer_ignores_icmp_latency_and_jitter_as_availability_events():
 def test_event_writer_requires_explicit_availability_source_tag():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3}},
-        {**_event_row(0.0), "protocol": "SNMP", "metric_id": "mariadb-GS", "metadata": {"name": "mariadb-GS", "criticality": 3}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"name": "PING-CHECK", "criticality": 3, "availability_source": "PING"}},
-    ])
+    rows = build_event_rows(
+        [
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "PING-CHECK",
+                "metadata": {"name": "PING-CHECK", "criticality": 3},
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "SNMP",
+                "metric_id": "mariadb-GS",
+                "metadata": {"name": "mariadb-GS", "criticality": 3},
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "PING-CHECK",
+                "metadata": {"name": "PING-CHECK", "criticality": 3, "availability_source": "PING"},
+            },
+        ]
+    )
 
     assert rows[0]["event_type"] is None
     assert rows[0]["is_breach"] is False
@@ -57,11 +118,23 @@ def test_event_writer_requires_explicit_availability_source_tag():
 def test_event_writer_derives_threshold_breach_and_availability_recovery_rows():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        _event_row(97.0),
-        {**_event_row(1.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"availability_source": "PING", "criticality": 3}},
-        {**_event_row(0.0), "protocol": "ICMP", "metric_id": "PING-CHECK", "metadata": {"availability_source": "PING", "criticality": 3}},
-    ])
+    rows = build_event_rows(
+        [
+            _event_row(97.0),
+            {
+                **_event_row(1.0),
+                "protocol": "ICMP",
+                "metric_id": "PING-CHECK",
+                "metadata": {"availability_source": "PING", "criticality": 3},
+            },
+            {
+                **_event_row(0.0),
+                "protocol": "ICMP",
+                "metric_id": "PING-CHECK",
+                "metadata": {"availability_source": "PING", "criticality": 3},
+            },
+        ]
+    )
 
     assert rows[0]["is_breach"] is True
     assert rows[0]["severity"] == "CRITICAL"
@@ -85,16 +158,25 @@ def test_event_writer_derives_icmp_latency_warning_and_critical_threshold_rows()
         **_event_row(99.9),
         "protocol": "ICMP",
         "metric_id": "icmp_latency_ms",
-        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
+        "metadata": {
+            "name": "ICMP Latency",
+            "warning": 100,
+            "critical": 500,
+            "operator": ">=",
+            "metric_kind": "telemetry",
+            "criticality": 3,
+        },
     }
 
-    rows = build_event_rows([
-        base,
-        {**base, "value": {"numeric": 100.0, "raw": 100.0}},
-        {**base, "value": {"numeric": 499.9, "raw": 499.9}},
-        {**base, "value": {"numeric": 500.0, "raw": 500.0}},
-        {**base, "value": {"numeric": None, "raw": None}},
-    ])
+    rows = build_event_rows(
+        [
+            base,
+            {**base, "value": {"numeric": 100.0, "raw": 100.0}},
+            {**base, "value": {"numeric": 499.9, "raw": 499.9}},
+            {**base, "value": {"numeric": 500.0, "raw": 500.0}},
+            {**base, "value": {"numeric": None, "raw": None}},
+        ]
+    )
 
     assert rows[0]["is_breach"] is False
     assert rows[0]["recover_non_collection_event"] is True
@@ -110,7 +192,9 @@ def test_event_writer_uses_unwind_for_latest_breach_and_recovery_updates():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [_event_row(95.0), {**_event_row(1.0), "idempotency_key": "idem-2"}])
+    batch_update_events(
+        driver, [_event_row(95.0), {**_event_row(1.0), "idempotency_key": "idem-2"}]
+    )
 
     queries = "\n".join(q["query"] for q in driver.mock_session.queries)
     assert queries.count("UNWIND $rows AS row") >= 3
@@ -129,7 +213,9 @@ def test_event_writer_icmp_success_recovers_only_icmp_availability_events():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [{**_event_row(1.0), "protocol": "ICMP", "metric_id": "PING-CHECK"}])
+    batch_update_events(
+        driver, [{**_event_row(1.0), "protocol": "ICMP", "metric_id": "PING-CHECK"}]
+    )
 
     recovery_queries = [
         q["query"]
@@ -148,14 +234,28 @@ def test_event_writer_icmp_latency_ok_recovers_threshold_breach_events():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [{
-        **_event_row(42.0),
-        "protocol": "ICMP",
-        "metric_id": "icmp_latency_ms",
-        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-    }])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(42.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            }
+        ],
+    )
 
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"]
+    )
     assert "e.event_type = 'THRESHOLD_BREACH'" in recovery_query["query"]
     assert "row.metric_id = e.metric_id" in recovery_query["query"]
 
@@ -164,14 +264,28 @@ def test_event_writer_direct_latency_recovery_excludes_propagated_events():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [{
-        **_event_row(42.0),
-        "protocol": "ICMP",
-        "metric_id": "icmp_latency_ms",
-        "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-    }])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(42.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            }
+        ],
+    )
 
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])["query"]
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"]
+    )["query"]
     assert "coalesce(e.correlation_type, 'ROOT') = 'ROOT'" in recovery_query
     assert "pe.root_cause_ci_id = e.ci_id" in recovery_query
     assert "pe.correlation_type = 'PROPAGATED'" in recovery_query
@@ -200,76 +314,124 @@ def test_event_writer_threshold_breach_refresh_updates_open_or_ack_events_withou
 
         driver.mock_session.run = tracking_run
 
-        batch_update_events(driver, [{
-            **_event_row(500.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        }], lock_db=lock_db)
+        batch_update_events(
+            driver,
+            [
+                {
+                    **_event_row(500.0),
+                    "protocol": "ICMP",
+                    "metric_id": "icmp_latency_ms",
+                    "metadata": {
+                        "name": "ICMP Latency",
+                        "warning": 100,
+                        "critical": 500,
+                        "operator": ">=",
+                        "metric_kind": "telemetry",
+                        "criticality": 3,
+                    },
+                }
+            ],
+            lock_db=lock_db,
+        )
 
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
     assert "existing.status IN ['OPEN', 'ACK']" in breach_query["query"]
-    assert "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')" in breach_query["query"]
+    assert (
+        "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')"
+        in breach_query["query"]
+    )
     assert "coalesce(row.correlation_type, 'ROOT') <> 'PROPAGATED'" in breach_query["query"]
     # #322 / design §6/§11 — POSITIVE flipped assertion: lock helper IS called
     # with the open PG session and the breach triplet. Replaces the old
     # negative MERGE-absent check.
-    assert mock_lock.call_count == 1, (
-        f"acquire_event_triplet_lock MUST be called once; got {mock_lock.call_count}"
-    )
+    assert (
+        mock_lock.call_count == 1
+    ), f"acquire_event_triplet_lock MUST be called once; got {mock_lock.call_count}"
     lock_args = mock_lock.call_args_list[0].args
+    lock_kwargs = mock_lock.call_args_list[0].kwargs
     assert lock_args[0] is lock_db, "lock helper must receive the open PG session"
     assert lock_args[1] == "ci-1"
     assert lock_args[2] == "icmp_latency_ms"
     assert lock_args[3] == "THRESHOLD_BREACH"
+    assert lock_kwargs["writer_context"] == "polling_event_writer"
     # Lock MUST be acquired BEFORE the breach query's session.run.
-    lock_idx = next(
-        i for i, (kind, _) in enumerate(call_order) if kind == "lock"
-    )
+    lock_idx = next(i for i, (kind, _) in enumerate(call_order) if kind == "lock")
     breach_idx = next(
-        i for i, (kind, q) in enumerate(call_order)
-        if kind == "neo4j" and "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in (q or "")
+        i
+        for i, (kind, q) in enumerate(call_order)
+        if kind == "neo4j"
+        and "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in (q or "")
     )
     assert lock_idx < breach_idx, (
         f"lock (idx {lock_idx}) must precede breach query (idx {breach_idx}); "
         f"order={call_order!r}"
     )
     # Defensive regression: no MERGE pattern in the breach query.
-    assert "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN'})" not in breach_query["query"]
+    assert (
+        "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, event_type: row.event_type, status: 'OPEN'})"
+        not in breach_query["query"]
+    )
     assert "created_at: datetime(), last_seen: datetime()" in breach_query["query"]
     assert "SET existing.severity = row.severity" in breach_query["query"]
-    assert "existing.created_at = coalesce(existing.created_at, existing.last_seen, datetime())" in breach_query["query"]
-    assert "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END" in breach_query["query"]
+    assert (
+        "existing.created_at = coalesce(existing.created_at, existing.last_seen, datetime())"
+        in breach_query["query"]
+    )
+    assert (
+        "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END"
+        in breach_query["query"]
+    )
 
 
 def test_event_writer_propagated_breach_refresh_matches_correlation_and_root_identifiers():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [{
-        **_event_row(500.0),
-        "protocol": "ICMP",
-        "metric_id": "icmp_latency_ms",
-        "metadata": {
-            "name": "ICMP Latency",
-            "warning": 100,
-            "critical": 500,
-            "operator": ">=",
-            "metric_kind": "telemetry",
-            "criticality": 3,
-            "correlation_type": "PROPAGATED",
-            "propagated_from": "event-parent",
-            "root_cause_event_id": "event-root",
-            "root_cause_ci_id": "ci-root",
-        },
-    }])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(500.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                    "correlation_type": "PROPAGATED",
+                    "propagated_from": "event-parent",
+                    "root_cause_event_id": "event-root",
+                    "root_cause_ci_id": "ci-root",
+                },
+            }
+        ],
+    )
 
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
     query = breach_query["query"]
-    assert "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')" in query
+    assert (
+        "coalesce(existing.correlation_type, 'ROOT') = coalesce(row.correlation_type, 'ROOT')"
+        in query
+    )
     assert "row.propagated_from IS NULL OR existing.propagated_from = row.propagated_from" in query
-    assert "row.root_cause_event_id IS NULL OR existing.root_cause_event_id = row.root_cause_event_id" in query
-    assert "row.root_cause_ci_id IS NULL OR existing.root_cause_ci_id = row.root_cause_ci_id" in query
+    assert (
+        "row.root_cause_event_id IS NULL OR existing.root_cause_event_id = row.root_cause_event_id"
+        in query
+    )
+    assert (
+        "row.root_cause_ci_id IS NULL OR existing.root_cause_ci_id = row.root_cause_ci_id" in query
+    )
     assert breach_query["params"]["rows"][0]["correlation_type"] == "PROPAGATED"
     assert breach_query["params"]["rows"][0]["root_cause_event_id"] == "event-root"
 
@@ -278,22 +440,43 @@ def test_event_writer_deduplicates_non_collection_breaches_before_create_query()
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        {
-            **_event_row(100.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-        {
-            **_event_row(500.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-    ])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(100.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+            {
+                **_event_row(500.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+        ],
+    )
 
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
     assert len(breach_query["params"]["rows"]) == 1
     assert breach_query["params"]["rows"][0]["severity"] == "CRITICAL"
     assert breach_query["params"]["rows"][0]["value"] == "500.0"
@@ -303,42 +486,49 @@ def test_event_writer_keeps_distinct_propagated_roots_in_non_collection_batch():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        {
-            **_event_row(500.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "metadata": {
-                "name": "ICMP Latency",
-                "critical": 500,
-                "operator": ">=",
-                "metric_kind": "telemetry",
-                "criticality": 3,
-                "correlation_type": "PROPAGATED",
-                "propagated_from": "event-parent-a",
-                "root_cause_event_id": "event-root-a",
-                "root_cause_ci_id": "ci-root-a",
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(500.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                    "correlation_type": "PROPAGATED",
+                    "propagated_from": "event-parent-a",
+                    "root_cause_event_id": "event-root-a",
+                    "root_cause_ci_id": "ci-root-a",
+                },
             },
-        },
-        {
-            **_event_row(500.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "metadata": {
-                "name": "ICMP Latency",
-                "critical": 500,
-                "operator": ">=",
-                "metric_kind": "telemetry",
-                "criticality": 3,
-                "correlation_type": "PROPAGATED",
-                "propagated_from": "event-parent-b",
-                "root_cause_event_id": "event-root-b",
-                "root_cause_ci_id": "ci-root-b",
+            {
+                **_event_row(500.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                    "correlation_type": "PROPAGATED",
+                    "propagated_from": "event-parent-b",
+                    "root_cause_event_id": "event-root-b",
+                    "root_cause_ci_id": "ci-root-b",
+                },
             },
-        },
-    ])
+        ],
+    )
 
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
     assert len(breach_query["params"]["rows"]) == 2
 
 
@@ -346,26 +536,49 @@ def test_event_writer_uses_latest_non_collection_state_for_ok_then_warning_batch
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        {
-            **_event_row(42.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "observed_at": datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-        {
-            **_event_row(100.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-    ])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(42.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "observed_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+            {
+                **_event_row(100.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=UTC),
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+        ],
+    )
 
     latest_query = driver.mock_session.queries[0]
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"]
+    )
     assert len(latest_query["params"]["rows"]) == 1
     assert latest_query["params"]["rows"][0]["status"] == "WARNING"
     assert len(breach_query["params"]["rows"]) == 1
@@ -377,26 +590,49 @@ def test_event_writer_uses_latest_non_collection_state_for_warning_then_ok_batch
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        {
-            **_event_row(100.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "observed_at": datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-        {
-            **_event_row(42.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-    ])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(100.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "observed_at": datetime(2026, 1, 1, 12, 0, tzinfo=UTC),
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+            {
+                **_event_row(42.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=UTC),
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+        ],
+    )
 
     latest_query = driver.mock_session.queries[0]
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"]
+    )
     assert len(latest_query["params"]["rows"]) == 1
     assert latest_query["params"]["rows"][0]["status"] == "OK"
     assert breach_query["params"]["rows"] == []
@@ -408,26 +644,49 @@ def test_event_writer_prefers_latest_observed_timestamp_over_last_duplicate_orde
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        {
-            **_event_row(42.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "observed_at": datetime(2026, 1, 1, 12, 2, tzinfo=timezone.utc),
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-        {
-            **_event_row(500.0),
-            "protocol": "ICMP",
-            "metric_id": "icmp_latency_ms",
-            "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc),
-            "metadata": {"name": "ICMP Latency", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3},
-        },
-    ])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(42.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "observed_at": datetime(2026, 1, 1, 12, 2, tzinfo=UTC),
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+            {
+                **_event_row(500.0),
+                "protocol": "ICMP",
+                "metric_id": "icmp_latency_ms",
+                "observed_at": datetime(2026, 1, 1, 12, 1, tzinfo=UTC),
+                "metadata": {
+                    "name": "ICMP Latency",
+                    "warning": 100,
+                    "critical": 500,
+                    "operator": ">=",
+                    "metric_kind": "telemetry",
+                    "criticality": 3,
+                },
+            },
+        ],
+    )
 
     latest_query = driver.mock_session.queries[0]
-    breach_query = next(q for q in driver.mock_session.queries if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"])
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"])
+    breach_query = next(
+        q
+        for q in driver.mock_session.queries
+        if "row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in q["query"]
+    )
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_non_collection_event" in q["query"]
+    )
     assert latest_query["params"]["rows"][0]["status"] == "OK"
     assert breach_query["params"]["rows"] == []
     assert recovery_query["params"]["rows"][0]["value"] == "42.0"
@@ -436,20 +695,22 @@ def test_event_writer_prefers_latest_observed_timestamp_over_last_duplicate_orde
 def test_event_writer_preserves_propagated_correlation_metadata():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        _event_row(
-            95.0,
-            metadata={
-                "critical": 90,
-                "criticality": 3,
-                "operator": ">=",
-                "correlation_type": "PROPAGATED",
-                "propagated_from": "event-root",
-                "root_cause_ci_id": "ci-root",
-                "business_service_id": "bs-1",
-            },
-        )
-    ])
+    rows = build_event_rows(
+        [
+            _event_row(
+                95.0,
+                metadata={
+                    "critical": 90,
+                    "criticality": 3,
+                    "operator": ">=",
+                    "correlation_type": "PROPAGATED",
+                    "propagated_from": "event-root",
+                    "root_cause_ci_id": "ci-root",
+                    "business_service_id": "bs-1",
+                },
+            )
+        ]
+    )
 
     assert rows[0]["correlation_type"] == "PROPAGATED"
     assert rows[0]["propagated_from"] == "event-root"
@@ -461,13 +722,15 @@ def test_event_writer_preserves_propagated_correlation_metadata():
 def test_event_writer_derives_snmp_no_data_as_warning_collection_failure():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        _event_row(
-            None,
-            status="NO_DATA",
-            metadata={"name": "ifInOctets", "criticality": 1},
-        )
-    ])
+    rows = build_event_rows(
+        [
+            _event_row(
+                None,
+                status="NO_DATA",
+                metadata={"name": "ifInOctets", "criticality": 1},
+            )
+        ]
+    )
 
     assert rows[0]["is_breach"] is True
     assert rows[0]["severity"] == "WARNING"
@@ -480,16 +743,18 @@ def test_event_writer_derives_snmp_no_data_as_warning_collection_failure():
 def test_event_writer_does_not_label_generic_snmp_error_as_no_response():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        {
-            **_event_row(
-                None,
-                status="ERROR",
-                metadata={"name": "ifInOctets", "criticality": 3},
-            ),
-            "error": {"code": "value_error", "message": "could not convert string to float"},
-        }
-    ])
+    rows = build_event_rows(
+        [
+            {
+                **_event_row(
+                    None,
+                    status="ERROR",
+                    metadata={"name": "ifInOctets", "criticality": 3},
+                ),
+                "error": {"code": "value_error", "message": "could not convert string to float"},
+            }
+        ]
+    )
 
     assert rows[0]["is_breach"] is True
     assert rows[0]["severity"] == "CRITICAL"
@@ -501,12 +766,16 @@ def test_event_writer_does_not_label_generic_snmp_error_as_no_response():
 def test_event_writer_labels_explicit_snmp_timeout_error_as_no_response_warning():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        {
-            **_event_row(None, status="ERROR", metadata={"name": "ifInOctets", "criticality": 3}),
-            "error": {"code": "timeout", "message": "No SNMP response received before timeout"},
-        }
-    ])
+    rows = build_event_rows(
+        [
+            {
+                **_event_row(
+                    None, status="ERROR", metadata={"name": "ifInOctets", "criticality": 3}
+                ),
+                "error": {"code": "timeout", "message": "No SNMP response received before timeout"},
+            }
+        ]
+    )
 
     assert rows[0]["severity"] == "WARNING"
     assert rows[0]["event_type"] == "COLLECTION_FAILURE"
@@ -516,15 +785,27 @@ def test_event_writer_labels_explicit_snmp_timeout_error_as_no_response_warning(
 def test_event_writer_marks_valid_rows_for_collection_failure_recovery_even_on_breach():
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        _event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90}),
-        _event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90, "operator": ">="}),
-        {
-            **_event_row(97.0, metadata={"name": "cli-health", "criticality": 3, "critical": 90, "operator": ">="}),
-            "protocol": "CLI",
-            "metric_id": "cli-health",
-        },
-    ])
+    rows = build_event_rows(
+        [
+            _event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90}),
+            _event_row(
+                97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90, "operator": ">="}
+            ),
+            {
+                **_event_row(
+                    97.0,
+                    metadata={
+                        "name": "cli-health",
+                        "criticality": 3,
+                        "critical": 90,
+                        "operator": ">=",
+                    },
+                ),
+                "protocol": "CLI",
+                "metric_id": "cli-health",
+            },
+        ]
+    )
 
     assert rows[0]["is_breach"] is False
     assert rows[0]["recover_collection_failure"] is True
@@ -553,8 +834,18 @@ def test_event_writer_uses_discriminator_aware_event_queries():
             driver,
             [
                 _event_row(None, status="NO_DATA"),  # COLLECTION_FAILURE
-                {**_event_row(500.0), "protocol": "SNMP", "metric_id": "cpu",
-                 "metadata": {"name": "cpu", "criticality": 3, "critical": 100, "warning": 80, "operator": ">="}},
+                {
+                    **_event_row(500.0),
+                    "protocol": "SNMP",
+                    "metric_id": "cpu",
+                    "metadata": {
+                        "name": "cpu",
+                        "criticality": 3,
+                        "critical": 100,
+                        "warning": 80,
+                        "operator": ">=",
+                    },
+                },
             ],
             lock_db=lock_db,
         )
@@ -572,20 +863,29 @@ def test_event_writer_uses_discriminator_aware_event_queries():
         f"got {mock_lock.call_count} calls"
     )
     triplets = [
-        (call.args[1], call.args[2], call.args[3])
+        (call.args[1], call.args[2], call.args[3], call.kwargs.get("writer_context"))
         for call in mock_lock.call_args_list
         if len(call.args) >= 4
     ]
     # The collection-failure envelope and the threshold-breach envelope
     # produce different triplets — both MUST be locked.
-    assert ("ci-1", "cpu", "COLLECTION_FAILURE") in triplets, (
-        f"collection-failure triplet MUST be locked; got {triplets!r}"
-    )
-    assert ("ci-1", "cpu", "THRESHOLD_BREACH") in triplets, (
-        f"threshold-breach triplet MUST be locked; got {triplets!r}"
-    )
+    assert (
+        "ci-1",
+        "cpu",
+        "COLLECTION_FAILURE",
+        "polling_event_writer",
+    ) in triplets, f"collection-failure triplet MUST be locked; got {triplets!r}"
+    assert (
+        "ci-1",
+        "cpu",
+        "THRESHOLD_BREACH",
+        "polling_event_writer",
+    ) in triplets, f"threshold-breach triplet MUST be locked; got {triplets!r}"
     # Defensive regression: no MERGE pattern in any of the queries.
-    assert "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN'})" not in queries
+    assert (
+        "MERGE (e:Event {ci_id: row.ci_id, metric_id: row.metric_id, status: 'OPEN'})"
+        not in queries
+    )
     assert "COLLECTION_FAILURE" in queries
     assert "SNMP_NO_RESPONSE" in queries
 
@@ -610,20 +910,53 @@ def test_event_writer_acquires_locks_in_lexicographic_order_across_batch():
     lock_db = MagicMock()
     lock_call_order: list[tuple[str, str, str]] = []
 
-    def _capture(lock_db_arg, ci_id, metric_id, event_type):
-        lock_call_order.append((ci_id, metric_id, event_type))
+    def _capture(lock_db_arg, ci_id, metric_id, event_type, *, writer_context):
+        lock_call_order.append((ci_id, metric_id, event_type, writer_context))
 
     # Input ORDER is Z, Y, X — writer MUST sort to X, Y, Z internally.
     envelopes_in_reverse = [
-        {**_event_row(500.0), "ci_id": "ci-Z", "metric_id": "metric-Z",
-         "protocol": "ICMP",
-         "metadata": {"name": "metric-Z", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3}},
-        {**_event_row(500.0), "ci_id": "ci-Y", "metric_id": "metric-Y",
-         "protocol": "ICMP",
-         "metadata": {"name": "metric-Y", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3}},
-        {**_event_row(500.0), "ci_id": "ci-X", "metric_id": "metric-X",
-         "protocol": "ICMP",
-         "metadata": {"name": "metric-X", "warning": 100, "critical": 500, "operator": ">=", "metric_kind": "telemetry", "criticality": 3}},
+        {
+            **_event_row(500.0),
+            "ci_id": "ci-Z",
+            "metric_id": "metric-Z",
+            "protocol": "ICMP",
+            "metadata": {
+                "name": "metric-Z",
+                "warning": 100,
+                "critical": 500,
+                "operator": ">=",
+                "metric_kind": "telemetry",
+                "criticality": 3,
+            },
+        },
+        {
+            **_event_row(500.0),
+            "ci_id": "ci-Y",
+            "metric_id": "metric-Y",
+            "protocol": "ICMP",
+            "metadata": {
+                "name": "metric-Y",
+                "warning": 100,
+                "critical": 500,
+                "operator": ">=",
+                "metric_kind": "telemetry",
+                "criticality": 3,
+            },
+        },
+        {
+            **_event_row(500.0),
+            "ci_id": "ci-X",
+            "metric_id": "metric-X",
+            "protocol": "ICMP",
+            "metadata": {
+                "name": "metric-X",
+                "warning": 100,
+                "critical": 500,
+                "operator": ">=",
+                "metric_kind": "telemetry",
+                "criticality": 3,
+            },
+        },
     ]
 
     with patch("polling.event_writer.acquire_event_triplet_lock", side_effect=_capture):
@@ -631,12 +964,10 @@ def test_event_writer_acquires_locks_in_lexicographic_order_across_batch():
 
     # Acquisitions MUST be in lexicographic order regardless of input order.
     assert lock_call_order == [
-        ("ci-X", "metric-X", "THRESHOLD_BREACH"),
-        ("ci-Y", "metric-Y", "THRESHOLD_BREACH"),
-        ("ci-Z", "metric-Z", "THRESHOLD_BREACH"),
-    ], (
-        f"locks MUST be acquired in lexicographic order; got {lock_call_order!r}"
-    )
+        ("ci-X", "metric-X", "THRESHOLD_BREACH", "polling_event_writer"),
+        ("ci-Y", "metric-Y", "THRESHOLD_BREACH", "polling_event_writer"),
+        ("ci-Z", "metric-Z", "THRESHOLD_BREACH", "polling_event_writer"),
+    ], f"locks MUST be acquired in lexicographic order; got {lock_call_order!r}"
 
 
 def test_event_writer_persists_poll_collector_id_on_event_create():
@@ -646,40 +977,49 @@ def test_event_writer_persists_poll_collector_id_on_event_create():
     """
     from polling.event_writer import build_event_rows
 
-    rows = build_event_rows([
-        _event_row(500.0, metadata={"name": "cpu", "criticality": 3, "critical": 90}),
-    ])
+    rows = build_event_rows(
+        [
+            _event_row(500.0, metadata={"name": "cpu", "criticality": 3, "critical": 90}),
+        ]
+    )
 
     assert rows, "expected at least one row"
     for row in rows:
-        assert "poll_collector_id" in row, (
-            f"row MUST carry poll_collector_id; got keys={list(row.keys())!r}"
-        )
-        assert row["poll_collector_id"], (
-            f"poll_collector_id MUST be non-empty; got {row['poll_collector_id']!r}"
-        )
+        assert (
+            "poll_collector_id" in row
+        ), f"row MUST carry poll_collector_id; got keys={list(row.keys())!r}"
+        assert row[
+            "poll_collector_id"
+        ], f"poll_collector_id MUST be non-empty; got {row['poll_collector_id']!r}"
 
 
 def test_event_writer_collection_failure_matching_does_not_treat_null_family_as_wildcard():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        {
-            **_event_row(
-                None,
-                status="ERROR",
-                metadata={"name": "ifInOctets", "criticality": 3},
-            ),
-            "error": {"code": "value_error", "message": "could not convert string to float"},
-        }
-    ])
+    batch_update_events(
+        driver,
+        [
+            {
+                **_event_row(
+                    None,
+                    status="ERROR",
+                    metadata={"name": "ifInOctets", "criticality": 3},
+                ),
+                "error": {"code": "value_error", "message": "could not convert string to float"},
+            }
+        ],
+    )
 
     collection_query = next(
-        q for q in driver.mock_session.queries
+        q
+        for q in driver.mock_session.queries
         if "row.event_type = 'COLLECTION_FAILURE'" in q["query"]
     )["query"]
-    assert "row.failure_family IS NULL OR existing.failure_family = row.failure_family" not in collection_query
+    assert (
+        "row.failure_family IS NULL OR existing.failure_family = row.failure_family"
+        not in collection_query
+    )
     assert "row.failure_family IS NULL AND existing.failure_family IS NULL" in collection_query
     assert "row.failure_family IS NOT NULL" in collection_query
 
@@ -687,25 +1027,35 @@ def test_event_writer_collection_failure_matching_does_not_treat_null_family_as_
 def test_event_writer_recovers_non_collection_events_on_normal_rows():
     from polling.event_writer import batch_update_events, build_event_rows
 
-    rows = build_event_rows([_event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+    rows = build_event_rows(
+        [_event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})]
+    )
     assert rows[0]["recover_collection_failure"] is True
     assert rows[0]["recover_non_collection_event"] is True
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [_event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+    batch_update_events(
+        driver, [_event_row(42.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})]
+    )
 
     queries = "\n".join(q["query"] for q in driver.mock_session.queries)
     assert "row.recover_non_collection_event" in queries
     assert "e.created_at = coalesce(e.created_at, e.last_seen, datetime())" in queries
     assert "e.event_type <> 'COLLECTION_FAILURE'" in queries
-    assert "NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')" in queries
+    assert (
+        "NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')"
+        in queries
+    )
 
 
 def test_event_writer_recovers_non_snmp_collection_failures_on_valid_rows_even_when_breaching():
     from polling.event_writer import batch_update_events, build_event_rows
 
     envelope = {
-        **_event_row(97.0, metadata={"name": "cli-health", "criticality": 3, "critical": 90, "operator": ">="}),
+        **_event_row(
+            97.0,
+            metadata={"name": "cli-health", "criticality": 3, "critical": 90, "operator": ">="},
+        ),
         "protocol": "CLI",
         "metric_id": "cli-health",
     }
@@ -716,9 +1066,14 @@ def test_event_writer_recovers_non_snmp_collection_failures_on_valid_rows_even_w
     driver = MockNeo4jDriver()
     batch_update_events(driver, [envelope])
 
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_collection_failure" in q["query"])
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_collection_failure" in q["query"]
+    )
     assert "e.event_type = 'COLLECTION_FAILURE'" in recovery_query["query"]
-    assert "e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:'" in recovery_query["query"]
+    assert (
+        "e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:'"
+        in recovery_query["query"]
+    )
     assert "toUpper(e.source_protocol) = row.source_protocol" in recovery_query["query"]
 
 
@@ -726,13 +1081,17 @@ def test_event_writer_deduplicates_collection_failure_rows_before_event_write():
     from polling.event_writer import batch_update_events
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [
-        _event_row(None, status="NO_DATA"),
-        {**_event_row(None, status="NO_DATA"), "idempotency_key": "idem-2"},
-    ])
+    batch_update_events(
+        driver,
+        [
+            _event_row(None, status="NO_DATA"),
+            {**_event_row(None, status="NO_DATA"), "idempotency_key": "idem-2"},
+        ],
+    )
 
     collection_query = next(
-        q for q in driver.mock_session.queries
+        q
+        for q in driver.mock_session.queries
         if "row.event_type = 'COLLECTION_FAILURE'" in q["query"]
     )
     assert len(collection_query["params"]["rows"]) == 1
@@ -741,14 +1100,22 @@ def test_event_writer_deduplicates_collection_failure_rows_before_event_write():
 def test_event_writer_uses_collection_recovery_message_for_threshold_breach_recovery():
     from polling.event_writer import batch_update_events, build_event_rows
 
-    rows = build_event_rows([_event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+    rows = build_event_rows(
+        [_event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})]
+    )
     assert rows[0]["is_breach"] is True
     assert rows[0]["message"].startswith("Critical Threshold Breached")
     assert rows[0]["collection_recovery_message"].startswith("Metric collection recovered")
 
     driver = MockNeo4jDriver()
-    batch_update_events(driver, [_event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})])
+    batch_update_events(
+        driver, [_event_row(97.0, metadata={"name": "cpu", "criticality": 3, "critical": 90})]
+    )
 
-    recovery_query = next(q for q in driver.mock_session.queries if "row.recover_collection_failure" in q["query"])
-    assert "e.created_at = coalesce(e.created_at, e.last_seen, datetime())" in recovery_query["query"]
+    recovery_query = next(
+        q for q in driver.mock_session.queries if "row.recover_collection_failure" in q["query"]
+    )
+    assert (
+        "e.created_at = coalesce(e.created_at, e.last_seen, datetime())" in recovery_query["query"]
+    )
     assert "row.collection_recovery_message" in recovery_query["query"]

--- a/backend/tests/test_snmp_service_collection_failures.py
+++ b/backend/tests/test_snmp_service_collection_failures.py
@@ -22,7 +22,9 @@ def _make_context_mock():
     return fake
 
 
-def test_snmp_collection_failure_on_critical_metric_is_warning_with_discriminators(mock_neo4j_driver):
+def test_snmp_collection_failure_on_critical_metric_is_warning_with_discriminators(
+    mock_neo4j_driver,
+):
     snmp_service = _load_snmp_service_module()
     session = mock_neo4j_driver.mock_session
     session.set_response("MATCH (existing:Event)", [])
@@ -107,7 +109,14 @@ def test_snmp_threshold_breach_uses_threshold_event_type_not_collection_failure(
     ):
         snmp_service.store_metric_result(
             {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            {
+                "id": "cpu",
+                "name": "cpu",
+                "protocol": "SNMP",
+                "criticality": 3,
+                "critical": 90,
+                "operator": ">=",
+            },
             "97",
             "OK",
             None,
@@ -133,7 +142,14 @@ def test_snmp_threshold_breach_still_recovers_existing_collection_failure(mock_n
     ):
         snmp_service.store_metric_result(
             {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-            {"id": "cpu", "name": "cpu", "protocol": "snmp", "criticality": 3, "critical": 90, "operator": ">="},
+            {
+                "id": "cpu",
+                "name": "cpu",
+                "protocol": "snmp",
+                "criticality": 3,
+                "critical": 90,
+                "operator": ">=",
+            },
             "97",
             "OK",
             None,
@@ -141,10 +157,13 @@ def test_snmp_threshold_breach_still_recovers_existing_collection_failure(mock_n
         )
 
     recovery_queries = [
-        q for q in session.queries
+        q
+        for q in session.queries
         if "SET e.status = 'RECOVERED'" in q["query"] and "COLLECTION_FAILURE" in q["query"]
     ]
-    assert recovery_queries, "valid SNMP values must recover collection failures before threshold handling"
+    assert (
+        recovery_queries
+    ), "valid SNMP values must recover collection failures before threshold handling"
     assert "coalesce(m.can_propagate, true) = true" in recovery_queries[0]["query"]
     create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
     assert create_event["params"]["event_type"] == "THRESHOLD_BREACH"
@@ -153,7 +172,10 @@ def test_snmp_threshold_breach_still_recovers_existing_collection_failure(mock_n
 def test_repeated_collection_failure_updates_exact_matched_event(mock_neo4j_driver):
     snmp_service = _load_snmp_service_module()
     session = mock_neo4j_driver.mock_session
-    session.set_response("MATCH (existing:Event)", [{"existing_status": "OPEN", "existing_element_id": "element-collection"}])
+    session.set_response(
+        "MATCH (existing:Event)",
+        [{"existing_status": "OPEN", "existing_element_id": "element-collection"}],
+    )
 
     fake_pg = _make_context_mock()
 
@@ -168,10 +190,15 @@ def test_repeated_collection_failure_updates_exact_matched_event(mock_neo4j_driv
         )
 
     lookup_event = next(q for q in session.queries if "MATCH (existing:Event)" in q["query"])
-    assert "$failure_family IS NULL OR existing.failure_family = $failure_family" not in lookup_event["query"]
+    assert (
+        "$failure_family IS NULL OR existing.failure_family = $failure_family"
+        not in lookup_event["query"]
+    )
     assert "$failure_family IS NULL AND existing.failure_family IS NULL" in lookup_event["query"]
     assert "$failure_family IS NOT NULL" in lookup_event["query"]
-    update_event = next(q for q in session.queries if "elementId(existing) = $existing_element_id" in q["query"])
+    update_event = next(
+        q for q in session.queries if "elementId(existing) = $existing_element_id" in q["query"]
+    )
     assert update_event["params"]["existing_element_id"] == "element-collection"
     assert "existing.status = $old_status" not in update_event["query"]
 
@@ -195,7 +222,10 @@ def test_non_breach_value_recovers_non_collection_events(mock_neo4j_driver):
 
     queries = "\n".join(q["query"] for q in mock_neo4j_driver.mock_session.queries)
     assert "e.event_type <> 'COLLECTION_FAILURE'" in queries
-    assert "NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')" in queries
+    assert (
+        "NOT (e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:')"
+        in queries
+    )
 
 
 def test_valid_non_snmp_threshold_breach_recovers_collection_failures(mock_neo4j_driver):
@@ -211,7 +241,13 @@ def test_valid_non_snmp_threshold_breach_recovers_collection_failures(mock_neo4j
     ):
         snmp_service.store_metric_result(
             {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-            {"id": "cli-health", "name": "cli-health", "protocol": "CLI", "criticality": 3, "critical": 90},
+            {
+                "id": "cli-health",
+                "name": "cli-health",
+                "protocol": "CLI",
+                "criticality": 3,
+                "critical": 90,
+            },
             "97",
             "OK",
             None,
@@ -219,18 +255,27 @@ def test_valid_non_snmp_threshold_breach_recovers_collection_failures(mock_neo4j
         )
 
     recovery_queries = [
-        q for q in session.queries
+        q
+        for q in session.queries
         if "SET e.status = 'RECOVERED'" in q["query"] and "Metric Collection Failed:" in q["query"]
     ]
-    assert recovery_queries, "valid non-SNMP samples must recover collection failures even when breaching"
+    assert (
+        recovery_queries
+    ), "valid non-SNMP samples must recover collection failures even when breaching"
     assert "toUpper(e.source_protocol) = $source_protocol" in recovery_queries[0]["query"]
-    assert "e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:'" in recovery_queries[0]["query"]
+    assert (
+        "e.event_type IS NULL AND e.message STARTS WITH 'Metric Collection Failed:'"
+        in recovery_queries[0]["query"]
+    )
 
 
 def test_poll_metric_non_timeout_error_indication_returns_error_not_timeout():
     snmp_service = _load_snmp_service_module()
 
-    with patch("services.snmp_service.getCmd", return_value=iter([("authorization failure", None, None, [])])):
+    with patch(
+        "services.snmp_service.getCmd",
+        return_value=iter([("authorization failure", None, None, [])]),
+    ):
         value, status, error = snmp_service.poll_metric(
             {"id": "ci-1", "ip": "10.0.0.1"},
             {"id": "ifInOctets", "protocol": "SNMP", "oid": "1.2.3"},
@@ -245,7 +290,10 @@ def test_poll_metric_non_timeout_error_indication_returns_error_not_timeout():
 def test_poll_metric_timeout_error_indication_returns_timeout():
     snmp_service = _load_snmp_service_module()
 
-    with patch("services.snmp_service.getCmd", return_value=iter([("No SNMP response received before timeout", None, None, [])])):
+    with patch(
+        "services.snmp_service.getCmd",
+        return_value=iter([("No SNMP response received before timeout", None, None, [])]),
+    ):
         value, status, error = snmp_service.poll_metric(
             {"id": "ci-1", "ip": "10.0.0.1"},
             {"id": "ifInOctets", "protocol": "SNMP", "oid": "1.2.3"},
@@ -310,7 +358,14 @@ def test_store_metric_result_keeps_pg_session_open_during_neo4j_write(mock_neo4j
     ):
         snmp_service.store_metric_result(
             {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            {
+                "id": "cpu",
+                "name": "cpu",
+                "protocol": "SNMP",
+                "criticality": 3,
+                "critical": 90,
+                "operator": ">=",
+            },
             "97",
             "OK",
             None,
@@ -320,16 +375,15 @@ def test_store_metric_result_keeps_pg_session_open_during_neo4j_write(mock_neo4j
     # The PG context MUST be entered BEFORE the Neo4j write.
     assert "pg_enter" in call_order, "pg context was never entered"
     assert "neo4j_run" in call_order, "neo4j session.run never executed"
-    assert call_order.index("pg_enter") < call_order.index("neo4j_run"), (
-        f"pg context enter must precede neo4j run; order={call_order}"
-    )
+    assert call_order.index("pg_enter") < call_order.index(
+        "neo4j_run"
+    ), f"pg context enter must precede neo4j run; order={call_order}"
 
     # The PG context MUST NOT exit BEFORE the Neo4j write completes —
     # otherwise the advisory lock would be released mid-transaction.
     assert "pg_exit" in call_order, "pg context was never exited"
     assert call_order.index("pg_exit") > call_order.index("neo4j_run"), (
-        f"pg context exited BEFORE neo4j run (lock released too early); "
-        f"order={call_order}"
+        f"pg context exited BEFORE neo4j run (lock released too early); " f"order={call_order}"
     )
 
 
@@ -356,7 +410,14 @@ def test_store_metric_result_acquires_pg_advisory_lock_before_neo4j_read(mock_ne
     ):
         snmp_service.store_metric_result(
             {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            {
+                "id": "cpu",
+                "name": "cpu",
+                "protocol": "SNMP",
+                "criticality": 3,
+                "critical": 90,
+                "operator": ">=",
+            },
             "97",
             "OK",
             None,
@@ -367,7 +428,8 @@ def test_store_metric_result_acquires_pg_advisory_lock_before_neo4j_read(mock_ne
 
     # Locate the call that matches the breach triplet (ci-1, cpu, THRESHOLD_BREACH).
     matching = [
-        call for call in mock_lock.call_args_list
+        call
+        for call in mock_lock.call_args_list
         if len(call.args) >= 4
         and call.args[1] == "ci-1"
         and call.args[2] == "cpu"
@@ -378,9 +440,10 @@ def test_store_metric_result_acquires_pg_advisory_lock_before_neo4j_read(mock_ne
         f"got calls={mock_lock.call_args_list!r}"
     )
     # The first matching call MUST use the open PG session as the lock target.
-    assert matching[0].args[0] is fake_pg, (
-        f"lock helper must receive the writer's open PG session; got {matching[0].args[0]!r}"
-    )
+    assert (
+        matching[0].args[0] is fake_pg
+    ), f"lock helper must receive the writer's open PG session; got {matching[0].args[0]!r}"
+    assert matching[0].kwargs["writer_context"] == "snmp_service"
 
 
 def test_store_metric_result_persists_poll_collector_id_on_event_create(mock_neo4j_driver):
@@ -402,7 +465,14 @@ def test_store_metric_result_persists_poll_collector_id_on_event_create(mock_neo
     ):
         snmp_service.store_metric_result(
             {"id": "ci-1", "ip": "10.0.0.1", "name": "Router"},
-            {"id": "cpu", "name": "cpu", "protocol": "SNMP", "criticality": 3, "critical": 90, "operator": ">="},
+            {
+                "id": "cpu",
+                "name": "cpu",
+                "protocol": "SNMP",
+                "criticality": 3,
+                "critical": 90,
+                "operator": ">=",
+            },
             "97",
             "OK",
             None,
@@ -410,14 +480,15 @@ def test_store_metric_result_persists_poll_collector_id_on_event_create(mock_neo
         )
 
     create_event = next(q for q in session.queries if "CREATE (e:Event" in q["query"])
-    assert "poll_collector_id" in create_event["query"], (
-        f"poll_collector_id MUST be set in CREATE clause; query={create_event['query']!r}"
-    )
+    assert (
+        "poll_collector_id" in create_event["query"]
+    ), f"poll_collector_id MUST be set in CREATE clause; query={create_event['query']!r}"
     assert create_event["params"].get("poll_collector_id"), (
         f"poll_collector_id MUST be passed as a non-empty parameter; "
         f"params={create_event['params']!r}"
     )
     from services.snmp_service import POLL_COLLECTOR_ID
+
     assert create_event["params"]["poll_collector_id"] == POLL_COLLECTOR_ID, (
         f"poll_collector_id MUST match the cached POLL_COLLECTOR_ID; "
         f"got={create_event['params']['poll_collector_id']!r}, expected={POLL_COLLECTOR_ID!r}"

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -4,16 +4,17 @@ Unit tests for backend/engines/snmp_worker.py
 Tests ICMP polling: fetch_icmp_ping retry logic and debounce counter behavior.
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
-import sys
 import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # Ensure backend root is on path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Import the conftest MockNeo4jSession for proper mocking
-from tests.conftest import MockNeo4jSession, MockNeo4jDriver
+from tests.conftest import MockNeo4jDriver, MockNeo4jSession
 
 
 class TestICMPSettings:
@@ -22,6 +23,7 @@ class TestICMPSettings:
     def test_icmp_settings_defaults(self):
         """ICMPSettings has correct defaults."""
         from config import ICMPSettings
+
         settings = ICMPSettings()
         assert settings.timeout_ms == 3000
         assert settings.retries == 2
@@ -32,13 +34,18 @@ class TestICMPSettings:
     def test_icmp_settings_from_env_override(self):
         """ICMPSettings.from_env reads env vars correctly."""
         from config import ICMPSettings
-        with patch.dict(os.environ, {
-            "ICMP_TIMEOUT_MS": "5000",
-            "ICMP_RETRIES": "5",
-            "ICMP_DEBOUNCE_COUNT": "7",
-            "ICMP_LATENCY_WARNING_MS": "150",
-            "ICMP_LATENCY_CRITICAL_MS": "600",
-        }, clear=True):
+
+        with patch.dict(
+            os.environ,
+            {
+                "ICMP_TIMEOUT_MS": "5000",
+                "ICMP_RETRIES": "5",
+                "ICMP_DEBOUNCE_COUNT": "7",
+                "ICMP_LATENCY_WARNING_MS": "150",
+                "ICMP_LATENCY_CRITICAL_MS": "600",
+            },
+            clear=True,
+        ):
             settings = ICMPSettings.from_env()
             assert settings.timeout_ms == 5000
             assert settings.retries == 5
@@ -48,17 +55,18 @@ class TestICMPSettings:
 
     def test_icmp_latency_thresholds_must_be_ordered(self):
         """ICMP latency warning threshold must remain below critical."""
-        from pydantic import ValidationError
         from config import ICMPSettings
+        from pydantic import ValidationError
 
         with pytest.raises(ValidationError, match="ICMP_LATENCY_WARNING_MS"):
             ICMPSettings(latency_warning_ms=500, latency_critical_ms=500)
 
     def test_get_icmp_settings_singleton(self):
         """get_icmp_settings returns cached singleton."""
-        from config import get_icmp_settings, ICMPSettings
         # Clear any cached value first
         import config as config_module
+        from config import get_icmp_settings
+
         config_module._icmp_settings = None
 
         settings1 = get_icmp_settings()
@@ -74,14 +82,19 @@ class TestFetchICMPPing:
         """Returns 1.0 when first ping succeeds."""
         mock_run.return_value = MagicMock(returncode=0)
         from engines.snmp_worker import fetch_icmp_ping
+
         result = fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=2)
         assert result == 1.0
         assert mock_run.call_count == 1
 
     @patch("engines.snmp_worker.subprocess.run")
-    def test_fetch_icmp_ping_measurement_extracts_latency_while_binary_wrapper_stays_compatible(self, mock_run):
+    def test_fetch_icmp_ping_measurement_extracts_latency_while_binary_wrapper_stays_compatible(
+        self, mock_run
+    ):
         """Structured ICMP returns latency but legacy wrapper still returns 1.0."""
-        mock_run.return_value = MagicMock(returncode=0, stdout="64 bytes from 192.168.1.1: time=9.75 ms", stderr="")
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="64 bytes from 192.168.1.1: time=9.75 ms", stderr=""
+        )
         from engines.snmp_worker import fetch_icmp_ping, fetch_icmp_ping_measurement
 
         measurement = fetch_icmp_ping_measurement("192.168.1.1", timeout_ms=3000, retries=0)
@@ -97,6 +110,7 @@ class TestFetchICMPPing:
             MagicMock(returncode=0),  # retry succeeds
         ]
         from engines.snmp_worker import fetch_icmp_ping
+
         result = fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=2)
         assert result == 1.0
         assert mock_run.call_count == 2
@@ -106,6 +120,7 @@ class TestFetchICMPPing:
         """Returns 0.0 when all attempts fail."""
         mock_run.return_value = MagicMock(returncode=1)
         from engines.snmp_worker import fetch_icmp_ping
+
         result = fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=2)
         assert result == 0.0
         assert mock_run.call_count == 3  # 1 initial + 2 retries
@@ -115,6 +130,7 @@ class TestFetchICMPPing:
         """With retries=0, stops after single attempt."""
         mock_run.return_value = MagicMock(returncode=1)
         from engines.snmp_worker import fetch_icmp_ping
+
         result = fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=0)
         assert result == 0.0
         assert mock_run.call_count == 1
@@ -124,9 +140,10 @@ class TestFetchICMPPing:
         """Expected OS/subprocess failures fail that attempt, retry continues."""
         mock_run.side_effect = [
             OSError("network error"),  # first attempt throws
-            MagicMock(returncode=0),    # retry succeeds
+            MagicMock(returncode=0),  # retry succeeds
         ]
         from engines.snmp_worker import fetch_icmp_ping
+
         result = fetch_icmp_ping("192.168.1.1", timeout_ms=3000, retries=2)
         assert result == 1.0
         assert mock_run.call_count == 2
@@ -157,11 +174,13 @@ class TestSNMPWorkerObservability:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         mock_bulk_insert.assert_not_called()
         observe_calls = [
-            call for call in mock_logger.info.call_args_list
+            call
+            for call in mock_logger.info.call_args_list
             if call.args and call.args[0] == "polling_observe_cycle"
         ]
         assert observe_calls
@@ -186,15 +205,20 @@ class TestSNMPWorkerObservability:
         mock_session_local.return_value = MagicMock()
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "CPU",
-            "protocol": "SNMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": "1.3.6.1.2.1.25.3.3.1.2",
-            "port": 161,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "CPU",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                    "port": 161,
+                }
+            ],
+        )
         mock_session.set_default_response([])
 
         mock_driver = MagicMock()
@@ -203,6 +227,7 @@ class TestSNMPWorkerObservability:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         mock_bulk_insert.assert_called_once()
@@ -212,7 +237,8 @@ class TestSNMPWorkerObservability:
         assert saved_metrics[0]["value"] == 42.0
 
         latest_update_calls = [
-            call for call in mock_session.queries
+            call
+            for call in mock_session.queries
             if "r.last_value" in call["query"] and call["params"].get("nid") == "ci-001"
         ]
         assert latest_update_calls
@@ -221,7 +247,8 @@ class TestSNMPWorkerObservability:
         assert latest_update_calls[0]["params"]["status"] == "OK"
 
         observe_calls = [
-            call for call in mock_logger.info.call_args_list
+            call
+            for call in mock_logger.info.call_args_list
             if call.args and call.args[0] == "polling_observe_cycle"
         ]
         assert observe_calls
@@ -253,6 +280,7 @@ class TestSNMPWorkerObservability:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         mock_bulk_insert.assert_not_called()
@@ -319,35 +347,38 @@ class TestMonitoredCIStatus:
 
         mock_session = MockNeo4jSession()
         mock_session.set_response("count(distinct n) as cis_monitored", [{"cis_monitored": 2}])
-        mock_session.set_response("match (n:ci)-[r:has_metric]->(m:metricdef)", [
-            {
-                "node_id": "ci-001",
-                "metric_id": "cpu",
-                "protocol": "SNMP",
-                "ip": "192.168.1.1",
-                "community": "public",
-                "oid": "1.3.6.1.2.1.25.3.3.1.2",
-                "port": 161,
-            },
-            {
-                "node_id": "ci-001",
-                "metric_id": "memory",
-                "protocol": "SNMP",
-                "ip": "192.168.1.1",
-                "community": "public",
-                "oid": "1.3.6.1.2.1.25.2.3.1.6",
-                "port": 161,
-            },
-            {
-                "node_id": "ci-002",
-                "metric_id": "cpu",
-                "protocol": "SNMP",
-                "ip": "192.168.1.2",
-                "community": "public",
-                "oid": "1.3.6.1.2.1.25.3.3.1.2",
-                "port": 161,
-            },
-        ])
+        mock_session.set_response(
+            "match (n:ci)-[r:has_metric]->(m:metricdef)",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "cpu",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                    "port": 161,
+                },
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "memory",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.25.2.3.1.6",
+                    "port": 161,
+                },
+                {
+                    "node_id": "ci-002",
+                    "metric_id": "cpu",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.2",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.25.3.3.1.2",
+                    "port": 161,
+                },
+            ],
+        )
         mock_session.set_default_response([])
 
         mock_driver = MagicMock()
@@ -356,11 +387,11 @@ class TestMonitoredCIStatus:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         status_update = next(
-            q for q in mock_session.queries
-            if "MERGE (c:CollectorStatus" in q["query"]
+            q for q in mock_session.queries if "MERGE (c:CollectorStatus" in q["query"]
         )
         assert status_update["params"]["cis_monitored"] == 2
         assert status_update["params"]["last_cycle_metrics_processed"] == 3
@@ -381,15 +412,20 @@ class TestSNMPCollectionFailures:
         mock_session_local.return_value = MagicMock()
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "ifInOctets",
-            "protocol": "SNMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": "1.3.6.1.2.1.2.2.1.10.1",
-            "port": 161,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "ifInOctets",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                    "port": 161,
+                }
+            ],
+        )
         mock_session.set_default_response([])
 
         mock_driver = MagicMock()
@@ -398,6 +434,7 @@ class TestSNMPCollectionFailures:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         mock_bulk_insert.assert_not_called()
@@ -417,15 +454,20 @@ class TestSNMPCollectionFailures:
         mock_session_local.return_value = MagicMock()
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "ifInOctets",
-            "protocol": "SNMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": "1.3.6.1.2.1.2.2.1.10.1",
-            "port": 161,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "ifInOctets",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                    "port": 161,
+                }
+            ],
+        )
         mock_session.set_default_response([])
 
         mock_driver = MagicMock()
@@ -434,6 +476,7 @@ class TestSNMPCollectionFailures:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         queries = "\n".join(q["query"] for q in mock_session.queries)
@@ -453,26 +496,29 @@ class TestSNMPCollectionFailures:
         mock_session_local.return_value = MagicMock()
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [
-            {
-                "node_id": "ci-001",
-                "metric_id": "ifInOctets",
-                "protocol": "SNMP",
-                "ip": "192.168.1.1",
-                "community": "public",
-                "oid": "1.3.6.1.2.1.2.2.1.10.1",
-                "port": 161,
-            },
-            {
-                "node_id": "ci-001",
-                "metric_id": "ifInOctets",
-                "protocol": "SNMP",
-                "ip": "192.168.1.1",
-                "community": "public",
-                "oid": "1.3.6.1.2.1.2.2.1.10.1",
-                "port": 161,
-            },
-        ])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "ifInOctets",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                    "port": 161,
+                },
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "ifInOctets",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                    "port": 161,
+                },
+            ],
+        )
         mock_session.set_default_response([])
 
         mock_driver = MagicMock()
@@ -481,6 +527,7 @@ class TestSNMPCollectionFailures:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         failure_batches = [q["params"].get("failures", []) for q in mock_session.queries]
@@ -496,15 +543,20 @@ class TestSNMPCollectionFailures:
         mock_session_local.return_value = MagicMock()
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "ifInOctets",
-            "protocol": "SNMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": "1.3.6.1.2.1.2.2.1.10.1",
-            "port": 161,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "ifInOctets",
+                    "protocol": "SNMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": "1.3.6.1.2.1.2.2.1.10.1",
+                    "port": 161,
+                }
+            ],
+        )
         mock_session.set_default_response([])
 
         mock_driver = MagicMock()
@@ -513,6 +565,7 @@ class TestSNMPCollectionFailures:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         failure_batches = [q["params"].get("failures", []) for q in mock_session.queries]
@@ -539,23 +592,29 @@ class TestICMPDebounce:
     ):
         """Counter below debounce threshold does not create event."""
         from engines.snmp_worker import _consecutive_failures
+
         _consecutive_failures.clear()
 
         mock_fetch_icmp.return_value = 0.0  # ping fails
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "Ping availability",
-            "criticality": 3,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "PING-CHECK",
+                    "availability_source": "ICMP",
+                    "protocol": "ICMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": None,
+                    "port": 161,
+                    "metric_name": "Ping availability",
+                    "criticality": 3,
+                }
+            ],
+        )
 
         mock_session_local.return_value.__enter__ = MagicMock(return_value=mock_session)
         mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
@@ -566,16 +625,19 @@ class TestICMPDebounce:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         # No CRITICAL status set because debounce_count=3 and we only have 1 failure
         critical_calls = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "set n.status" in q["query"].lower() and q["params"].get("status") == "CRITICAL"
         ]
         assert len(critical_calls) == 0, f"Unexpected CRITICAL calls: {critical_calls}"
         availability_queries = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "AVAILABILITY" in q["query"] or q["params"].get("availability_events")
         ]
         assert availability_queries == []
@@ -590,23 +652,29 @@ class TestICMPDebounce:
     ):
         """Counter reaches debounce threshold and creates CRITICAL event."""
         from engines.snmp_worker import _consecutive_failures
+
         _consecutive_failures.clear()
 
         mock_fetch_icmp.return_value = 0.0  # ping fails
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "Ping availability",
-            "criticality": 3,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "PING-CHECK",
+                    "availability_source": "ICMP",
+                    "protocol": "ICMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": None,
+                    "port": 161,
+                    "metric_name": "Ping availability",
+                    "criticality": 3,
+                }
+            ],
+        )
 
         mock_session_local.return_value.__enter__ = MagicMock(return_value=mock_session)
         mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
@@ -624,23 +692,39 @@ class TestICMPDebounce:
 
         # After 3rd failure, CRITICAL status should be set and a 0.0 sample/event is persisted.
         critical_calls = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "set n.status" in q["query"].lower() and q["params"].get("status") == "CRITICAL"
         ]
-        assert len(critical_calls) >= 1, f"Expected at least 1 CRITICAL call, got {len(critical_calls)}: {mock_session.queries}"
+        assert (
+            len(critical_calls) >= 1
+        ), f"Expected at least 1 CRITICAL call, got {len(critical_calls)}: {mock_session.queries}"
         mock_bulk_insert.assert_called()
         saved_rows = mock_bulk_insert.call_args.args[1]
-        assert any(row["node_id"] == "ci-001" and row["metric_id"] == "PING-CHECK" and row["value"] == 0.0 for row in saved_rows)
+        assert any(
+            row["node_id"] == "ci-001" and row["metric_id"] == "PING-CHECK" and row["value"] == 0.0
+            for row in saved_rows
+        )
         availability_queries = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "event_type: row.event_type" in q["query"] and "AVAILABILITY" in q["query"]
         ]
         assert availability_queries, mock_session.queries
         availability_query = "\n".join(q["query"] for q in availability_queries)
         assert "source_protocol" in availability_query
-        assert "MERGE (created)-[:TRIGGERED_BY]->(m)" in availability_query or "MERGE (existing)-[:TRIGGERED_BY]->(m)" in availability_query
-        availability_batches = [q["params"].get("availability_events", []) for q in availability_queries]
-        assert any(row["event_type"] == "AVAILABILITY" and row["source_protocol"] == "ICMP" for batch in availability_batches for row in batch)
+        assert (
+            "MERGE (created)-[:TRIGGERED_BY]->(m)" in availability_query
+            or "MERGE (existing)-[:TRIGGERED_BY]->(m)" in availability_query
+        )
+        availability_batches = [
+            q["params"].get("availability_events", []) for q in availability_queries
+        ]
+        assert any(
+            row["event_type"] == "AVAILABILITY" and row["source_protocol"] == "ICMP"
+            for batch in availability_batches
+            for row in batch
+        )
         # Counter resets after event
         assert _consecutive_failures.get("ci-001", 0) == 0
 
@@ -652,22 +736,28 @@ class TestICMPDebounce:
     ):
         """Successful ping resets debounce counter to 0."""
         from engines.snmp_worker import _consecutive_failures
+
         _consecutive_failures.clear()
         _consecutive_failures["ci-001"] = 2  # simulate 2 prior failures
 
         mock_fetch_icmp.return_value = 1.0  # ping succeeds
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "PING-CHECK",
+                    "availability_source": "ICMP",
+                    "protocol": "ICMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": None,
+                    "port": 161,
+                }
+            ],
+        )
 
         mock_session_local.return_value.__enter__ = MagicMock(return_value=mock_session)
         mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
@@ -678,6 +768,7 @@ class TestICMPDebounce:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         # Counter should be reset to 0
@@ -691,24 +782,30 @@ class TestICMPDebounce:
     ):
         """After CRITICAL, successful ping creates OK status update."""
         from engines.snmp_worker import _consecutive_failures
+
         _consecutive_failures.clear()
         _consecutive_failures["ci-001"] = 3  # already at threshold (pre-simulated)
 
         mock_fetch_icmp.return_value = 1.0  # ping succeeds
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "Ping availability",
-            "criticality": 3,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "PING-CHECK",
+                    "availability_source": "ICMP",
+                    "protocol": "ICMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": None,
+                    "port": 161,
+                    "metric_name": "Ping availability",
+                    "criticality": 3,
+                }
+            ],
+        )
 
         mock_session_local.return_value.__enter__ = MagicMock(return_value=mock_session)
         mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
@@ -719,16 +816,21 @@ class TestICMPDebounce:
 
         with patch("engines.snmp_worker.driver", mock_driver):
             from engines.snmp_worker import poll_snmp
+
             poll_snmp()
 
         # Should set OK status (recovery)
         ok_calls = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "set n.status" in q["query"].lower() and q["params"].get("status") == "OK"
         ]
-        assert len(ok_calls) == 1, f"Expected 1 OK call, got {len(ok_calls)}: {mock_session.queries}"
+        assert (
+            len(ok_calls) == 1
+        ), f"Expected 1 OK call, got {len(ok_calls)}: {mock_session.queries}"
         recovery_queries = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "SET e.status = 'RECOVERED'" in q["query"] and "AVAILABILITY" in q["query"]
         ]
         assert recovery_queries, mock_session.queries
@@ -747,24 +849,30 @@ class TestICMPDebounce:
     ):
         """ICMP availability events are not written unless durable insert succeeds."""
         from engines.snmp_worker import _consecutive_failures
+
         _consecutive_failures.clear()
 
         mock_fetch_icmp.return_value = 0.0
         mock_bulk_insert.side_effect = RuntimeError("timescale unavailable")
 
         mock_session = MockNeo4jSession()
-        mock_session.set_response("match", [{
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "Ping availability",
-            "criticality": 3,
-        }])
+        mock_session.set_response(
+            "match",
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "PING-CHECK",
+                    "availability_source": "ICMP",
+                    "protocol": "ICMP",
+                    "ip": "192.168.1.1",
+                    "community": "public",
+                    "oid": None,
+                    "port": 161,
+                    "metric_name": "Ping availability",
+                    "criticality": 3,
+                }
+            ],
+        )
 
         mock_session_local.return_value.__enter__ = MagicMock(return_value=mock_session)
         mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
@@ -781,12 +889,14 @@ class TestICMPDebounce:
 
         mock_bulk_insert.assert_called_once()
         critical_calls = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "set n.status" in q["query"].lower() and q["params"].get("status") == "CRITICAL"
         ]
         assert critical_calls == []
         availability_queries = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "event_type: row.event_type" in q["query"] and "AVAILABILITY" in q["query"]
         ]
         assert availability_queries == []
@@ -801,44 +911,52 @@ def test_poll_snmp_prefers_legacy_availability_when_sidecars_return_first():
     mock_db = MagicMock()
     mock_db.execute.return_value.first.return_value = None
     mock_session = MockNeo4jSession()
-    mock_session.set_response("match", [
-        {
-            "node_id": "ci-001",
-            "metric_id": "icmp_latency_ms",
-            "protocol": "ICMP",
-            "metric_kind": "telemetry",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "ICMP Latency",
-            "criticality": 1,
-        },
-        {
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "metric_kind": "availability",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "Ping availability",
-            "criticality": 3,
-        },
-    ])
+    mock_session.set_response(
+        "match",
+        [
+            {
+                "node_id": "ci-001",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "metric_kind": "telemetry",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": None,
+                "port": 161,
+                "metric_name": "ICMP Latency",
+                "criticality": 1,
+            },
+            {
+                "node_id": "ci-001",
+                "metric_id": "PING-CHECK",
+                "availability_source": "ICMP",
+                "protocol": "ICMP",
+                "metric_kind": "availability",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": None,
+                "port": 161,
+                "metric_name": "Ping availability",
+                "criticality": 3,
+            },
+        ],
+    )
     mock_session.set_default_response([])
 
     mock_driver = MagicMock()
     mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
     mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=mock_db), \
-         patch("engines.snmp_worker.bulk_insert_metrics") as mock_bulk_insert, \
-         patch("engines.snmp_worker.fetch_icmp_ping", return_value=PingMeasurement(True, 12.0)) as mock_fetch_icmp:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=mock_db),
+        patch("engines.snmp_worker.bulk_insert_metrics") as mock_bulk_insert,
+        patch(
+            "engines.snmp_worker.fetch_icmp_ping", return_value=PingMeasurement(True, 12.0)
+        ) as mock_fetch_icmp,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()
 
     mock_fetch_icmp.assert_called_once()
@@ -850,22 +968,32 @@ def test_refresh_icmp_latency_events_updates_open_or_ack_events_without_merge_du
     from engines.snmp_worker import _refresh_icmp_latency_events
 
     session = MockNeo4jSession()
-    _refresh_icmp_latency_events(session, [{
-        "node_id": "ci-001",
-        "metric_id": "icmp_latency_ms",
-        "protocol": "ICMP",
-        "source_protocol": "ICMP",
-        "event_type": "THRESHOLD_BREACH",
-        "status": "WARNING",
-        "message": "Latency warning",
-    }])
+    _refresh_icmp_latency_events(
+        session,
+        [
+            {
+                "node_id": "ci-001",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "event_type": "THRESHOLD_BREACH",
+                "status": "WARNING",
+                "message": "Latency warning",
+            }
+        ],
+    )
 
     query = session.queries[0]["query"]
     assert "existing.status IN ['OPEN', 'ACK']" in query
     assert "coalesce(existing.correlation_type, 'ROOT') = 'ROOT'" in query
-    assert "MERGE (e:Event {ci_id: row.node_id, metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH', status: 'OPEN'})" not in query
+    assert (
+        "MERGE (e:Event {ci_id: row.node_id, metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH', status: 'OPEN'})"
+        not in query
+    )
     assert "SET existing.severity = row.status" in query
-    assert "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END" in query
+    assert (
+        "existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END" in query
+    )
 
 
 def test_refresh_icmp_latency_events_acquires_pg_advisory_lock_before_neo4j_write():
@@ -902,51 +1030,131 @@ def test_refresh_icmp_latency_events_acquires_pg_advisory_lock_before_neo4j_writ
 
         _refresh_icmp_latency_events(
             session,
-            [{
-                "node_id": "ci-001",
-                "metric_id": "icmp_latency_ms",
-                "protocol": "ICMP",
-                "source_protocol": "ICMP",
-                "event_type": "THRESHOLD_BREACH",
-                "status": "WARNING",
-                "message": "Latency warning",
-            }],
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "icmp_latency_ms",
+                    "protocol": "ICMP",
+                    "source_protocol": "ICMP",
+                    "event_type": "THRESHOLD_BREACH",
+                    "status": "WARNING",
+                    "message": "Latency warning",
+                }
+            ],
             lock_db=lock_db,
         )
 
     # Lock helper MUST be called with the writer's open PG session and the triplet.
-    assert mock_lock.call_count == 1, (
-        f"expected acquire_event_triplet_lock called once, got {mock_lock.call_count}"
-    )
+    assert (
+        mock_lock.call_count == 1
+    ), f"expected acquire_event_triplet_lock called once, got {mock_lock.call_count}"
     lock_args = mock_lock.call_args_list[0].args
+    lock_kwargs = mock_lock.call_args_list[0].kwargs
     assert lock_args[0] is lock_db, "lock helper must receive the writer's open PG session"
     assert lock_args[1] == "ci-001"
     assert lock_args[2] == "icmp_latency_ms"
     assert lock_args[3] == "THRESHOLD_BREACH"
+    assert lock_kwargs["writer_context"] == "snmp_worker_icmp_latency"
 
     # Lock MUST be acquired BEFORE the Neo4j write — design §5 race-safety analysis.
     assert call_order, "no calls recorded"
-    assert call_order[0] == "lock", (
-        f"expected lock acquisition first, got order={call_order}"
-    )
+    assert call_order[0] == "lock", f"expected lock acquisition first, got order={call_order}"
     assert "neo4j" in call_order
-    assert call_order.index("lock") < call_order.index("neo4j"), (
-        f"lock must precede neo4j write; got order={call_order}"
-    )
+    assert call_order.index("lock") < call_order.index(
+        "neo4j"
+    ), f"lock must precede neo4j write; got order={call_order}"
+
+
+def test_refresh_snmp_collection_failures_passes_context_and_keeps_sorted_lock_order():
+    from unittest.mock import MagicMock, patch
+
+    from engines.snmp_worker import _refresh_snmp_collection_failures
+
+    session = MockNeo4jSession()
+    lock_db = MagicMock()
+    lock_calls: list[tuple[str, str, str, str]] = []
+
+    def capture_lock(_lock_db, ci_id, metric_id, event_type, *, writer_context):
+        lock_calls.append((ci_id, metric_id, event_type, writer_context))
+
+    failures = [
+        {
+            "node_id": "ci-Z",
+            "metric_id": "metric-Z",
+            "event_type": "COLLECTION_FAILURE",
+            "failure_family": "SNMP_NO_RESPONSE",
+            "source_protocol": "SNMP",
+            "severity": "WARNING",
+            "message": "Metric Collection Failed: timeout",
+        },
+        {
+            "node_id": "ci-A",
+            "metric_id": "metric-A",
+            "event_type": "COLLECTION_FAILURE",
+            "failure_family": "SNMP_NO_RESPONSE",
+            "source_protocol": "SNMP",
+            "severity": "WARNING",
+            "message": "Metric Collection Failed: timeout",
+        },
+    ]
+
+    with patch("engines.snmp_worker.acquire_event_triplet_lock", side_effect=capture_lock):
+        _refresh_snmp_collection_failures(session, failures, lock_db=lock_db)
+
+    assert lock_calls == [
+        ("ci-A", "metric-A", "COLLECTION_FAILURE", "snmp_worker_collection_failure"),
+        ("ci-Z", "metric-Z", "COLLECTION_FAILURE", "snmp_worker_collection_failure"),
+    ]
+
+
+def test_refresh_icmp_availability_events_passes_context_and_keeps_lock_count():
+    from unittest.mock import MagicMock, patch
+
+    from engines.snmp_worker import _refresh_icmp_availability_events
+
+    session = MockNeo4jSession()
+    lock_db = MagicMock()
+
+    with patch("engines.snmp_worker.acquire_event_triplet_lock") as mock_lock:
+        _refresh_icmp_availability_events(
+            session,
+            [
+                {
+                    "node_id": "ci-001",
+                    "metric_id": "PING-CHECK",
+                    "protocol": "ICMP",
+                    "source_protocol": "ICMP",
+                    "availability_source": "PING",
+                    "event_type": "AVAILABILITY",
+                    "severity": "CRITICAL",
+                    "message": "Service/Host Down: PING-CHECK",
+                    "value": 0.0,
+                }
+            ],
+            lock_db=lock_db,
+        )
+
+    assert mock_lock.call_count == 1
+    assert mock_lock.call_args.kwargs["writer_context"] == "snmp_worker_icmp_availability"
 
 
 def test_recover_icmp_availability_events_excludes_propagated_direct_match_and_recovers_descendants():
     from engines.snmp_worker import _recover_icmp_availability_events
 
     session = MockNeo4jSession()
-    _recover_icmp_availability_events(session, [{
-        "node_id": "ci-001",
-        "metric_id": "PING-CHECK",
-        "protocol": "ICMP",
-        "source_protocol": "ICMP",
-        "availability_source": "PING",
-        "value": 1.0,
-    }])
+    _recover_icmp_availability_events(
+        session,
+        [
+            {
+                "node_id": "ci-001",
+                "metric_id": "PING-CHECK",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "availability_source": "PING",
+                "value": 1.0,
+            }
+        ],
+    )
 
     query = session.queries[0]["query"]
     assert "coalesce(e.correlation_type, 'ROOT') = 'ROOT'" in query
@@ -959,17 +1167,22 @@ def test_refresh_icmp_availability_events_excludes_propagated_direct_match():
     from engines.snmp_worker import _refresh_icmp_availability_events
 
     session = MockNeo4jSession()
-    _refresh_icmp_availability_events(session, [{
-        "node_id": "ci-001",
-        "metric_id": "PING-CHECK",
-        "protocol": "ICMP",
-        "source_protocol": "ICMP",
-        "availability_source": "PING",
-        "event_type": "AVAILABILITY",
-        "severity": "CRITICAL",
-        "message": "Service/Host Down: PING-CHECK",
-        "value": 0.0,
-    }])
+    _refresh_icmp_availability_events(
+        session,
+        [
+            {
+                "node_id": "ci-001",
+                "metric_id": "PING-CHECK",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "availability_source": "PING",
+                "event_type": "AVAILABILITY",
+                "severity": "CRITICAL",
+                "message": "Service/Host Down: PING-CHECK",
+                "value": 0.0,
+            }
+        ],
+    )
 
     query = session.queries[0]["query"]
     assert "coalesce(existing.correlation_type, 'ROOT') = 'ROOT'" in query
@@ -979,14 +1192,19 @@ def test_recover_icmp_latency_events_excludes_propagated_direct_match_and_recove
     from engines.snmp_worker import _recover_icmp_latency_events
 
     session = MockNeo4jSession()
-    _recover_icmp_latency_events(session, [{
-        "node_id": "ci-001",
-        "metric_id": "icmp_latency_ms",
-        "protocol": "ICMP",
-        "source_protocol": "ICMP",
-        "status": "OK",
-        "message": "Metric ICMP Latency is OK. Value: 42.0",
-    }])
+    _recover_icmp_latency_events(
+        session,
+        [
+            {
+                "node_id": "ci-001",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "status": "OK",
+                "message": "Metric ICMP Latency is OK. Value: 42.0",
+            }
+        ],
+    )
 
     query = session.queries[0]["query"]
     assert "coalesce(e.correlation_type, 'ROOT') = 'ROOT'" in query
@@ -1004,56 +1222,64 @@ def test_poll_snmp_skips_icmp_sidecar_metrics_as_primary_poll_targets():
     mock_db = MagicMock()
     mock_db.execute.return_value.first.return_value = None
     mock_session = MockNeo4jSession()
-    mock_session.set_response("match", [
-        {
-            "node_id": "ci-001",
-            "metric_id": "PING-CHECK",
-            "availability_source": "ICMP",
-            "protocol": "ICMP",
-            "metric_kind": "availability",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "Ping availability",
-            "criticality": 3,
-        },
-        {
-            "node_id": "ci-001",
-            "metric_id": "icmp_latency_ms",
-            "protocol": "ICMP",
-            "metric_kind": "telemetry",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "ICMP Latency",
-            "criticality": 1,
-        },
-        {
-            "node_id": "ci-001",
-            "metric_id": "icmp_jitter_ms",
-            "protocol": "ICMP",
-            "metric_kind": "telemetry",
-            "ip": "192.168.1.1",
-            "community": "public",
-            "oid": None,
-            "port": 161,
-            "metric_name": "ICMP Jitter",
-            "criticality": 1,
-        },
-    ])
+    mock_session.set_response(
+        "match",
+        [
+            {
+                "node_id": "ci-001",
+                "metric_id": "PING-CHECK",
+                "availability_source": "ICMP",
+                "protocol": "ICMP",
+                "metric_kind": "availability",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": None,
+                "port": 161,
+                "metric_name": "Ping availability",
+                "criticality": 3,
+            },
+            {
+                "node_id": "ci-001",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "metric_kind": "telemetry",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": None,
+                "port": 161,
+                "metric_name": "ICMP Latency",
+                "criticality": 1,
+            },
+            {
+                "node_id": "ci-001",
+                "metric_id": "icmp_jitter_ms",
+                "protocol": "ICMP",
+                "metric_kind": "telemetry",
+                "ip": "192.168.1.1",
+                "community": "public",
+                "oid": None,
+                "port": 161,
+                "metric_name": "ICMP Jitter",
+                "criticality": 1,
+            },
+        ],
+    )
     mock_session.set_default_response([])
 
     mock_driver = MagicMock()
     mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
     mock_driver.session.return_value.__exit__ = MagicMock(return_value=None)
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=mock_db), \
-         patch("engines.snmp_worker.bulk_insert_metrics") as mock_bulk_insert, \
-         patch("engines.snmp_worker.fetch_icmp_ping", return_value=PingMeasurement(True, 12.0)) as mock_fetch_icmp:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=mock_db),
+        patch("engines.snmp_worker.bulk_insert_metrics") as mock_bulk_insert,
+        patch(
+            "engines.snmp_worker.fetch_icmp_ping", return_value=PingMeasurement(True, 12.0)
+        ) as mock_fetch_icmp,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()
 
     mock_fetch_icmp.assert_called_once()
@@ -1062,4 +1288,6 @@ def test_poll_snmp_skips_icmp_sidecar_metrics_as_primary_poll_targets():
     assert any(row["metric_id"] == "PING-CHECK" and row["value"] == 1.0 for row in rows)
     assert any(row["metric_id"] == "icmp_latency_ms" and row["value"] == 12.0 for row in rows)
     assert not any(row["metric_id"] == "icmp_latency_ms" and row["value"] == 1.0 for row in rows)
-    assert not any(row["metric_id"] == "icmp_jitter_ms" and row["value"] in (0.0, 1.0) for row in rows)
+    assert not any(
+        row["metric_id"] == "icmp_jitter_ms" and row["value"] in (0.0, 1.0) for row in rows
+    )

--- a/backend/tests/test_system_status.py
+++ b/backend/tests/test_system_status.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -157,8 +158,18 @@ def test_should_record_system_status_snapshot_honors_fifteen_minute_throttle():
 def test_system_status_history_staleness_calculation():
     now = datetime(2026, 1, 1, 12, 0, 0)
 
-    assert _is_system_status_history_stale(now - timedelta(minutes=29), now, stale_threshold_seconds=1800) is False
-    assert _is_system_status_history_stale(now - timedelta(minutes=31), now, stale_threshold_seconds=1800) is True
+    assert (
+        _is_system_status_history_stale(
+            now - timedelta(minutes=29), now, stale_threshold_seconds=1800
+        )
+        is False
+    )
+    assert (
+        _is_system_status_history_stale(
+            now - timedelta(minutes=31), now, stale_threshold_seconds=1800
+        )
+        is True
+    )
     assert _is_system_status_history_stale(None, now, stale_threshold_seconds=1800) is True
 
 
@@ -176,7 +187,11 @@ def test_get_system_status_does_not_record_snapshot_on_request(monkeypatch):
     record_calls = []
 
     monkeypatch.setattr(main, "_build_system_status_payload", lambda: payload)
-    monkeypatch.setattr(main, "_record_system_status_snapshot", lambda *args, **kwargs: record_calls.append((args, kwargs)))
+    monkeypatch.setattr(
+        main,
+        "_record_system_status_snapshot",
+        lambda *args, **kwargs: record_calls.append((args, kwargs)),
+    )
 
     status = main.get_system_status()
 
@@ -184,33 +199,164 @@ def test_get_system_status_does_not_record_snapshot_on_request(monkeypatch):
     assert len(record_calls) == 0
 
 
+def test_build_system_status_payload_includes_event_lock_snapshot_without_changing_service_status(
+    monkeypatch,
+):
+    expected_event_lock = {
+        "acquisitions_total": 2,
+        "wait_ms": {"count": 2, "p95": 1200.0, "p99": 1200.0, "max": 1200.0},
+        "alert_state": "WARNING",
+        "thresholds_ms": {"info": 250, "warning_p95": 1000, "critical_p99": 5000},
+        "by_writer": {"snmp_worker_icmp_latency": {"acquisitions_total": 2}},
+    }
+
+    monkeypatch.setattr(main, "verify_connection", lambda max_retries=1, retry_delay=0: None)
+    monkeypatch.setattr(main, "_get_disk_io_status", lambda: {"supported": False})
+    monkeypatch.setattr(main, "get_collector_status", lambda: {"status": "RUNNING", "stats": {}})
+    monkeypatch.setattr(
+        "services.event_lock.get_event_lock_observability_snapshot",
+        lambda: expected_event_lock,
+    )
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def execute(self, *_args, **_kwargs):
+            return None
+
+    class FakeEngine:
+        def connect(self):
+            return FakeConnection()
+
+    monkeypatch.setattr("postgres_db.engine", FakeEngine())
+
+    status = main._build_system_status_payload()
+
+    assert status["event_lock"] == expected_event_lock
+    assert status["neo4j"] == "CONNECTED"
+    assert status["postgres"] == "CONNECTED"
+    assert status["collector"]["status"] == "RUNNING"
+
+
+def test_build_system_status_payload_falls_back_when_event_lock_snapshot_fails(monkeypatch, caplog):
+    monkeypatch.setattr(main, "verify_connection", lambda max_retries=1, retry_delay=0: None)
+    monkeypatch.setattr(main, "_get_disk_io_status", lambda: {"supported": False})
+    monkeypatch.setattr(main, "get_collector_status", lambda: {"status": "RUNNING", "stats": {}})
+
+    def raise_snapshot_error():
+        raise RuntimeError("snapshot unavailable")
+
+    monkeypatch.setattr(
+        "services.event_lock.get_event_lock_observability_snapshot",
+        raise_snapshot_error,
+    )
+
+    class FakeConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def execute(self, *_args, **_kwargs):
+            return None
+
+    class FakeEngine:
+        def connect(self):
+            return FakeConnection()
+
+    monkeypatch.setattr("postgres_db.engine", FakeEngine())
+
+    with caplog.at_level(logging.WARNING, logger="main"):
+        status = main._build_system_status_payload()
+
+    assert status["event_lock"] == {"alert_state": "UNKNOWN", "snapshot_error": True}
+    assert status["neo4j"] == "CONNECTED"
+    assert status["postgres"] == "CONNECTED"
+    assert status["collector"]["status"] == "RUNNING"
+    assert "Failed to build event lock observability snapshot" in caplog.text
+    assert "snapshot unavailable" in caplog.text
+
+
+def test_get_system_status_returns_event_lock_snapshot_without_recording_history(monkeypatch):
+    payload = {
+        "cpu": 1.1,
+        "ram": 2.2,
+        "disk": 3.3,
+        "disk_io": {"supported": False},
+        "neo4j": "CONNECTED",
+        "postgres": "CONNECTED",
+        "collector": {"status": "RUNNING", "stats": {}},
+        "event_lock": {"alert_state": "CRITICAL"},
+        "startup_time": "startup",
+    }
+    record_calls = []
+
+    monkeypatch.setattr(main, "_build_system_status_payload", lambda: payload)
+    monkeypatch.setattr(
+        main,
+        "_record_system_status_snapshot",
+        lambda *args, **kwargs: record_calls.append((args, kwargs)),
+    )
+
+    status = main.get_system_status()
+
+    assert status["event_lock"] == {"alert_state": "CRITICAL"}
+    assert status["neo4j"] == "CONNECTED"
+    assert len(record_calls) == 0
+
+
 def _patch_status_history_rows(monkeypatch, rows):
     class FakeQuery:
-        def filter(self, *_args, **_kwargs): return self
-        def order_by(self, *_args, **_kwargs): return self
-        def limit(self, *_args, **_kwargs): return self
-        def all(self): return rows
+        def filter(self, *_args, **_kwargs):
+            return self
+
+        def order_by(self, *_args, **_kwargs):
+            return self
+
+        def limit(self, *_args, **_kwargs):
+            return self
+
+        def all(self):
+            return rows
 
     class FakeDb:
-        def query(self, *_args, **_kwargs): return FakeQuery()
-        def close(self): pass
+        def query(self, *_args, **_kwargs):
+            return FakeQuery()
+
+        def close(self):
+            pass
 
     monkeypatch.setattr("postgres_db.SessionLocal", lambda: FakeDb())
 
 
 def test_fetch_system_status_history_includes_freshness_metadata(monkeypatch):
-    snapshot = type("Snapshot", (), {
-        "recorded_at": datetime(2026, 1, 1, 11, 31, 0),
-        "cpu": 24.5, "ram": 61.2, "disk": 40.0,
-        "disk_io_supported": True,
-        "disk_read_bytes_per_sec": 1024.0,
-        "disk_write_bytes_per_sec": 2048.0,
-        "disk_busy_percentage": 12.5,
-        "neo4j_status": "CONNECTED", "postgres_status": "CONNECTED",
-        "collector_status": "RUNNING", "collector_cis_monitored": 8,
-        "collector_metrics_collected": 120, "collector_metrics_failed": 1,
-        "collector_jobs_per_min": 44.0, "collector_cycle_duration": 3.0,
-    })()
+    snapshot = type(
+        "Snapshot",
+        (),
+        {
+            "recorded_at": datetime(2026, 1, 1, 11, 31, 0),
+            "cpu": 24.5,
+            "ram": 61.2,
+            "disk": 40.0,
+            "disk_io_supported": True,
+            "disk_read_bytes_per_sec": 1024.0,
+            "disk_write_bytes_per_sec": 2048.0,
+            "disk_busy_percentage": 12.5,
+            "neo4j_status": "CONNECTED",
+            "postgres_status": "CONNECTED",
+            "collector_status": "RUNNING",
+            "collector_cis_monitored": 8,
+            "collector_metrics_collected": 120,
+            "collector_metrics_failed": 1,
+            "collector_jobs_per_min": 44.0,
+            "collector_cycle_duration": 3.0,
+        },
+    )()
     _patch_status_history_rows(monkeypatch, [snapshot])
     monkeypatch.setattr(main, "_SYSTEM_STATUS_HISTORY_MIN_INTERVAL_SECONDS", 900)
     monkeypatch.setattr(main, "_SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS", 1800)

--- a/openspec/changes/event-writer-coordination-observability/tasks.md
+++ b/openspec/changes/event-writer-coordination-observability/tasks.md
@@ -40,10 +40,10 @@ PR1 boundary: this slice is complete when metrics/settings/logging core and focu
 
 ## Phase 3: RED/GREEN Writer and Status Wiring
 
-- [ ] 3.1 Add failing assertions in `backend/tests/test_snmp_worker.py`, `backend/tests/test_snmp_service_collection_failures.py`, and `backend/tests/test_polling_event_writer.py` for expected writer contexts and unchanged lock counts/order.
-- [ ] 3.2 Thread writer contexts through `backend/engines/snmp_worker.py`, `backend/services/snmp_service.py`, and `backend/polling/event_writer.py` without changing sorted acquisition or session lifetime.
-- [ ] 3.3 Add failing status tests in `backend/tests/test_system_status.py` for `event_lock` snapshot presence and unchanged health/status behavior.
-- [ ] 3.4 Expose `get_event_lock_observability_snapshot()` from `backend/services/event_lock.py` through `/api/system/status` in `backend/main.py` only.
+- [x] 3.1 Add failing assertions in `backend/tests/test_snmp_worker.py`, `backend/tests/test_snmp_service_collection_failures.py`, and `backend/tests/test_polling_event_writer.py` for expected writer contexts and unchanged lock counts/order.
+- [x] 3.2 Thread writer contexts through `backend/engines/snmp_worker.py`, `backend/services/snmp_service.py`, and `backend/polling/event_writer.py` without changing sorted acquisition or session lifetime.
+- [x] 3.3 Add failing status tests in `backend/tests/test_system_status.py` for `event_lock` snapshot presence and unchanged health/status behavior.
+- [x] 3.4 Expose `get_event_lock_observability_snapshot()` from `backend/services/event_lock.py` through `/api/system/status` in `backend/main.py` only.
 
 ## Phase 4: Documentation, Verification
 

--- a/openspec/changes/event-writer-coordination-observability/verify-report-pr2.md
+++ b/openspec/changes/event-writer-coordination-observability/verify-report-pr2.md
@@ -1,0 +1,211 @@
+## Verification Report
+
+**Change**: event-writer-coordination-observability
+**Slice**: PR2 — writer context propagation and `/api/system/status` event lock exposure/fallback
+**Version**: N/A
+**Mode**: Strict TDD
+**Artifact Store**: OpenSpec
+**Final Verdict**: PASS WITH WARNINGS
+
+### Executive Summary
+
+PR2 tasks 3.1 through 3.4 are complete and verified with runtime evidence. Writer context propagation, sorted lock-order preservation, `/api/system/status` event lock snapshot exposure, and snapshot-failure fallback all have passing targeted tests. PR3 documentation/final verification tasks remain intentionally unchecked and were not implemented in this slice.
+
+### Scope Boundary
+
+| Area | Status | Notes |
+|------|--------|-------|
+| PR1 metrics/settings/logging core | ✅ Already merged into tracker | Used as dependency; not re-verified as a full archive gate. |
+| PR2 writer/status wiring | ✅ Verified | Tasks 3.1-3.4 checked and tested. |
+| PR3 docs/runbook/final verification | 🔲 Pending | Tasks 4.1-4.3 remain unchecked by design and are not PR2 blockers. |
+| PR3 docs/runbook implementation in PR2 | ✅ Not present | No docs/runbook files were modified in the current worktree status. |
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| PR2 tasks total | 4 |
+| PR2 tasks complete | 4 |
+| PR2 tasks incomplete | 0 |
+| Out-of-scope PR3 tasks pending | 3 |
+
+Task evidence from `tasks.md`:
+- ✅ 3.1 writer context tests added for `test_snmp_worker.py`, `test_snmp_service_collection_failures.py`, and `test_polling_event_writer.py`.
+- ✅ 3.2 writer contexts threaded through `backend/engines/snmp_worker.py`, `backend/services/snmp_service.py`, and `backend/polling/event_writer.py` without changing sorted acquisition or session lifetime.
+- ✅ 3.3 status tests added for `event_lock` snapshot presence and unchanged status behavior.
+- ✅ 3.4 `get_event_lock_observability_snapshot()` exposed through `/api/system/status` in `backend/main.py` only.
+- 🔲 4.1-4.3 remain pending for PR3.
+
+### Build & Tests Execution
+
+**Ruff/Black**: ✅ Passed
+
+```text
+Command:
+cd backend && ../.venv/bin/python -m ruff check engines/snmp_worker.py main.py polling/event_writer.py services/snmp_service.py tests/test_neo4j_write_guard.py tests/test_polling_event_writer.py tests/test_snmp_service_collection_failures.py tests/test_snmp_worker.py tests/test_system_status.py && ../.venv/bin/python -m black --check engines/snmp_worker.py main.py polling/event_writer.py services/snmp_service.py tests/test_neo4j_write_guard.py tests/test_polling_event_writer.py tests/test_snmp_service_collection_failures.py tests/test_snmp_worker.py tests/test_system_status.py
+
+Result:
+All checks passed!
+All done! ✨ 🍰 ✨
+9 files would be left unchanged.
+```
+
+**Targeted PR2 tests**: ✅ 100 passed, 7 warnings
+
+```text
+Command:
+cd backend && ../.venv/bin/python -m pytest tests/test_neo4j_write_guard.py tests/test_polling_event_writer.py tests/test_snmp_service_collection_failures.py tests/test_snmp_worker.py tests/test_system_status.py
+
+Result:
+100 passed, 7 warnings in 14.21s
+```
+
+**py_compile**: ✅ Passed
+
+```text
+Command:
+cd backend && ../.venv/bin/python -m py_compile engines/snmp_worker.py main.py polling/event_writer.py services/snmp_service.py tests/test_neo4j_write_guard.py tests/test_polling_event_writer.py tests/test_snmp_service_collection_failures.py tests/test_snmp_worker.py tests/test_system_status.py
+
+Result:
+No output; command exited successfully.
+```
+
+**Coverage**: ⚠️ Informational targeted coverage only
+
+```text
+Command:
+cd backend && ../.venv/bin/python -m pytest tests/test_neo4j_write_guard.py tests/test_polling_event_writer.py tests/test_snmp_service_collection_failures.py tests/test_snmp_worker.py tests/test_system_status.py --cov=engines.snmp_worker --cov=main --cov=polling.event_writer --cov=services.snmp_service --cov-report=term-missing
+
+Result:
+100 passed, 7 warnings in 5.85s
+CoverageWarning: Module engines.snmp_worker was previously imported, but not measured.
+
+main.py: 58%
+polling/event_writer.py: 91%
+services/snmp_service.py: 42%
+TOTAL: 59%
+```
+
+Coverage is not used as a blocking gate for this PR2 slice because the command is targeted to changed writer/status tests and `engines.snmp_worker` was not measured due prior import timing.
+
+### TDD Compliance
+
+| Check | Result | Details |
+|-------|--------|---------|
+| TDD Evidence reported | ✅ | Apply-progress artifact contains a TDD Cycle Evidence table. |
+| All PR2 tasks have tests | ✅ | 4/4 PR2 tasks have associated test files. |
+| RED confirmed | ✅ | Apply-progress records failing-first assertions for tasks 3.1 and 3.3 plus remediation fallback failure. Test files exist. |
+| GREEN confirmed | ✅ | Targeted PR2 suite passed: 100/100 tests. |
+| Triangulation adequate | ✅ | Writer contexts covered across SNMP worker collection failure, ICMP availability, ICMP latency, legacy SNMP service, polling event writer, status success, and status fallback paths. |
+| Safety Net for modified files | ✅ | Apply-progress reports 87/87 baseline before PR2 and 92/92 targeted after initial PR2; current verification expands to 100/100 with `test_neo4j_write_guard.py`. |
+
+**Strict TDD Evidence Verdict**: PASS. The required TDD evidence exists, the referenced test files exist, and the current targeted tests pass at runtime.
+
+---
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|-------|-------|-------|-------|
+| Unit / API-unit / integration-ish | 100 | 5 | pytest |
+| Integration | 0 | 0 | Not used for PR2 targeted slice |
+| E2E | 0 | 0 | Not used for PR2 targeted slice |
+| **Total** | **100** | **5** | |
+
+Test files executed:
+- `backend/tests/test_neo4j_write_guard.py`
+- `backend/tests/test_polling_event_writer.py`
+- `backend/tests/test_snmp_service_collection_failures.py`
+- `backend/tests/test_snmp_worker.py`
+- `backend/tests/test_system_status.py`
+
+---
+
+### Changed File Coverage
+
+| File | Line % | Branch % | Uncovered Lines | Rating |
+|------|--------|----------|-----------------|--------|
+| `backend/main.py` | 58% | N/A | See coverage output above | ⚠️ Low |
+| `backend/polling/event_writer.py` | 91% | N/A | See coverage output above | ✅ Excellent |
+| `backend/services/snmp_service.py` | 42% | N/A | See coverage output above | ⚠️ Low |
+| `backend/engines/snmp_worker.py` | Not measured | N/A | Coverage warning: module previously imported | ⚠️ Informational |
+
+**Average changed source coverage from measured files**: 59% targeted command total. This is a warning only under Strict TDD rules; runtime behavior is covered by focused assertions.
+
+---
+
+### Assertion Quality
+
+**Assertion quality**: ✅ All PR2-specific assertions verify observable behavior. No tautologies, assertion-only tests without production calls, or ghost loops were found in the PR2-specific evidence inspected. Empty-list assertions found in broader existing tests have companion setup/result context and were not counted as PR2 blockers.
+
+---
+
+### Quality Metrics
+
+**Linter**: ✅ No errors
+**Formatter**: ✅ Black check passed
+**Type Checker**: ➖ Not run; no type-check command was required or identified for this PR2 Python slice
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| Lock Acquisition Metrics | Successful acquisition is measured | PR1 dependency tests in `test_writer_advisory_lock.py`; PR2 verifies writer contexts reach the helper through `test_snmp_worker.py`, `test_snmp_service_collection_failures.py`, `test_polling_event_writer.py` | ✅ COMPLIANT for PR2 wiring scope |
+| Lock Acquisition Metrics | High-cardinality identifiers are excluded | PR1 dependency tests in `test_writer_advisory_lock.py`; PR2 only passes bounded writer contexts | ✅ COMPLIANT for PR2 wiring scope |
+| Structured Slow-Lock Logging | Slow lock is logged | PR1 dependency; PR2 does not change slow-log helper semantics | ✅ COMPLIANT by dependency, not PR2-modified |
+| Structured Slow-Lock Logging | Normal wait avoids noisy logs | PR1 dependency; PR2 does not change slow-log helper semantics | ✅ COMPLIANT by dependency, not PR2-modified |
+| Derived Lock Alert State | Warning threshold is exceeded | PR1 dependency; PR2 exposes helper output through status payload | ✅ COMPLIANT for PR2 exposure scope |
+| Derived Lock Alert State | Critical threshold is exceeded | `test_get_system_status_returns_event_lock_snapshot_without_recording_history` covers `event_lock: {alert_state: CRITICAL}` in status response | ✅ COMPLIANT |
+| Derived Lock Alert State | Alert state does not fail healthchecks | `test_build_system_status_payload_includes_event_lock_snapshot_without_changing_service_status`; fallback test also preserves `neo4j`, `postgres`, and `collector` statuses | ✅ COMPLIANT |
+| Coordination Invariants Documentation | Operator reviews invariants | Not in PR2 scope; tasks 4.1 and 4.2 pending | ⚠️ PENDING FOR PR3 |
+| Coordination Invariants Documentation | Timeout policy remains unchanged | PR1 dependency for no timeout behavior; PR2 source inspection shows only context kwargs and status payload/fallback | ✅ COMPLIANT for PR2 scope |
+| PR2 resilience extension | Snapshot helper failure fallback | `test_build_system_status_payload_falls_back_when_event_lock_snapshot_fails` | ✅ COMPLIANT |
+
+**Compliance summary**: 7/7 PR2-applicable scenarios compliant; 1 documentation scenario pending for PR3; PR1-only scenarios treated as dependency evidence rather than PR2 blockers.
+
+### Correctness (Static Evidence)
+
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| Writer context propagation | ✅ Implemented | `snmp_worker_collection_failure`, `snmp_worker_icmp_availability`, `snmp_worker_icmp_latency`, `snmp_service`, and `polling_event_writer` contexts are passed to `acquire_event_triplet_lock`. |
+| Sorted acquisition preserved | ✅ Implemented | `snmp_worker.py` and `polling/event_writer.py` still sort distinct triplets before lock acquisition. |
+| SNMP service session lifetime preserved | ✅ Implemented | `store_metric_result` acquires the lock inside the open PostgreSQL session before Neo4j Event lookup/write. |
+| Status payload exposes `event_lock` | ✅ Implemented | `_build_system_status_payload()` imports and calls `get_event_lock_observability_snapshot()` and includes `event_lock` in the returned payload. |
+| Snapshot fallback behavior | ✅ Implemented | Narrow `try/except` around snapshot construction logs a warning and returns `{"alert_state": "UNKNOWN", "snapshot_error": True}`. |
+| Health/status behavior unchanged | ✅ Implemented | Tests assert `neo4j`, `postgres`, and `collector` statuses are preserved on success and fallback paths. |
+| PR3 docs not implemented | ✅ Correct for PR2 | No docs/runbook changes observed. |
+
+### Coherence (Design)
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| Instrument centrally in `event_lock.py`; call sites only add stable writer contexts | ✅ Yes | PR2 call sites only pass bounded `writer_context` values. |
+| Do not add exporter dependency | ✅ Yes | No exporter dependency or endpoint added. |
+| Do not degrade healthcheck/liveness from lock alert state | ✅ Yes | Status payload carries `event_lock`; tests verify service statuses remain unchanged. |
+| Do not introduce timeout/fail-open/fail-closed policy | ✅ Yes | PR2 source changes do not add timeout policy. |
+| Preserve sorted acquisition for batched writers | ✅ Yes | Sorted distinct triplet acquisition remains present and tested. |
+| Expose snapshot through `/api/system/status` only | ✅ Yes | `backend/main.py` status payload is the PR2 exposure point. |
+
+### Issues Found
+
+**CRITICAL**: None.
+
+**WARNING**:
+- Targeted coverage for large legacy files remains low (`main.py` 58%, `services/snmp_service.py` 42%) and `engines.snmp_worker` was not measured due coverage import timing. This is informational under Strict TDD rules and does not override passing focused tests.
+- `event_lock` status remains backend-process-local in the default compose topology until future cross-process aggregation/exporter work exists.
+- Full backend pytest was not run for this PR2 gate due known unrelated/pre-existing local failures and Docker/testcontainers limits; targeted PR2 evidence passed.
+
+**SUGGESTION**:
+- PR3 should document the backend-process-local status limitation and the stable snapshot contract in the runbook.
+
+### Pending Items for PR3
+
+- [ ] 4.1 Review and document the stable snapshot contract after PR2 status wiring.
+- [ ] 4.2 Update `docs/polling-pipeline-runbook.md` with PostgreSQL identity, session lifetime, sorted locks, thresholds, and #334 CI-guard relationship.
+- [ ] 4.3 Run final full verification or document targeted/manual evidence if a relevant automated test cannot reasonably run.
+
+### Verdict
+
+PASS WITH WARNINGS
+
+PR2 satisfies its scoped SDD tasks and has passing runtime evidence for writer context propagation, sorted lock-order preservation, status snapshot exposure, and fallback behavior. Remaining warnings are coverage/topology/full-suite limitations and pending PR3 documentation/final verification work, not PR2 correctness blockers.


### PR DESCRIPTION
## Descripción del Cambio
Closes #326

PR 2 de la cadena de #326. Este slice conecta el núcleo de observabilidad del lock entregado en PR #354 con los writers y el payload de estado:
- pasa `writer_context` estable en SNMP worker, legacy SNMP service y polling event writer;
- expone `event_lock` en `/api/system/status` sin cambiar healthchecks ni HTTP status;
- agrega fallback acotado si el snapshot de observabilidad falla;
- cubre propagación, orden de locks, payload de status y fallback con tests.

### Chain Context
Estrategia: feature-branch-chain.

```text
main
└── fix/issue-326-event-coordination-observability   [tracker]
    ├── PR #354: metrics/settings/logging core       ✅ merged
    └── fix/issue-326-writer-status-wiring           📍 PR 2: writer/status wiring
        └── PR 3: docs/final verification            [pendiente]
```

Base de este PR: `fix/issue-326-event-coordination-observability`.
Fuera de scope: docs/runbook finales, agregación cross-process/exporter, timeout/fail-open/fail-closed y cierre completo del cambio.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?
- [x] Ruff + Black en los 9 archivos backend modificados → passed
- [x] Targeted PR2 pytest → `100 passed, 7 warnings`
- [x] `py_compile` de archivos modificados → passed
- [x] SDD verify PR2 → PASS WITH WARNINGS (`openspec/changes/event-writer-coordination-observability/verify-report-pr2.md`)
- [x] Fresh reliability/resilience/risk/readability reviews → no blockers

Advertencias conocidas:
- `event_lock` en `/api/system/status` es backend-process-local; agregación cross-process/exporter queda fuera de este slice.
- Diff grande por Black/Ruff cleanup en archivos backend ya tocados; revisar primero cambios lógicos en `main.py`, writers y tests nuevos.
- PR3 queda pendiente para documentación/runbook/final verification.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
