### PR TITLE
feat(events): add legacy backfill smoke fixture harness

### DIFF
--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md
@@ -1,0 +1,75 @@
+# Apply Progress: Validate Legacy Backfill Smoke Fixtures
+
+## Workload Boundary
+
+- Delivery strategy: ask-on-risk
+- Chain strategy: stacked-to-main
+- Current slice: PR 1 / Work Unit 1 only
+- Boundary: local-only seed/cleanup harness from updated `origin/main` / `v1.13.9+`
+- Explicitly not implemented: validation/reporting tasks 2.x, 3.x, and 4.x
+
+## Completed Tasks
+
+- [x] 1.1 Created `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py` as a local-only runner with run-id generation, seeded fixture plan, and `finally` cleanup.
+- [x] 1.2 Seeded marker-scoped `Event` fixtures only in shared local Neo4j using `issue155_smoke=true` and `issue155_smoke_run_id`.
+- [x] 1.3 Added post-cleanup verification query proving `MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id}) RETURN count(e)=0`.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 1.1 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit | N/A (new files) | ✅ Test referenced missing runner first; failed with `FileNotFoundError` | ✅ `python3 .../test_validate_smoke_fixtures.py` passed 4/4 after runner creation | ✅ Added URI and fixture-plan cases | ✅ Reworked Python 3.9-compatible UTC handling |
+| 1.2 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | N/A (new files) | ✅ Fixture plan test required marker/run-id fields before implementation | ✅ Unit tests passed 5/5 and live helper seeded 3 local fixtures | ✅ Fake driver verified seed query receives marked fixtures and live run seeded all three buckets | ✅ Kept seed scope in one query and local URI guard |
+| 1.3 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | N/A (new files) | ✅ Cleanup query test required exact marker/run-id zero-count proof | ✅ Unit tests passed 5/5 and live helper cleanup returned `cleanup_verified=true` | ✅ Fake driver verified cleanup and post-cleanup query order | ✅ Cleanup proof is returned and persisted in JSON evidence |
+
+## Test Summary
+
+- Total tests written: 5
+- Total tests passing: 5
+- Layers used: Unit (5), local shared Neo4j runtime evidence (1 run)
+- Approval tests: None — no refactoring tasks
+- Pure functions created: `generate_run_id`, `validate_local_neo4j_uri`, `build_fixture_plan`
+
+## Runtime Evidence
+
+- Command: `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py --output openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr1-seed-cleanup-smoke.json`
+- Environment source: approved `config/test-env/worktree-host.sample` export path from the existing root checkout; no denied `.env` file was read.
+- Evidence file: `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr1-seed-cleanup-smoke.json`
+- Seeded count: 3 marker-scoped `Event` nodes
+- Cleanup proof: `cleanup_verified=true`, `remaining_count=0`
+- Scope statement: local shared Neo4j only; no production mutation or production conclusion.
+
+## Remaining Tasks
+
+- [ ] 2.1 Run `backend/scripts/audit_legacy_event_discriminators.py --report audit --format json` and persist raw JSON evidence.
+- [ ] 2.2 Validate expected vs actual buckets for safe, ambiguous, and no-touch fixtures using audit JSON/direct classifier reuse when CLI lacks per-fixture marker filtering.
+- [ ] 2.3 Record the validation gap explicitly if smoke IDs cannot be isolated from aggregate recommendation JSON.
+- [ ] 3.1 Persist Markdown and JSON evidence under `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` for seeded plan, report output, and classification comparison.
+- [ ] 3.2 Capture cleanup evidence showing deleted marker-scoped records and zero remaining marked nodes.
+- [ ] 3.3 Ensure the run summary states local-only validation, no production mutation, and no `--apply`/migration path.
+- [ ] 4.1 Re-run the helper in failure-safe mode to verify `finally`/trap cleanup still executes after a report or validation error.
+- [ ] 4.2 Confirm evidence artifacts are complete, readable, and tied to one unique run id.
+- [ ] 4.3 Keep the tasks scoped to local/shared Neo4j only; do not add Docker, new test env, or production-write paths.
+
+## Deviations
+
+None — PR1 stayed within the design boundary for seed/cleanup harness safety.
+
+## Issues
+
+- `python` is unavailable in this shell; commands used `python3`.
+- `python3 -m pytest` is unavailable because pytest is not installed for the system Python. The committed helper tests use stdlib `unittest` and run directly with `python3`.
+
+## PR1 Review Warning Cleanup
+
+- Restricted `--output` to paths resolving under the change evidence directory and made evidence writes exclusive so existing local files are not overwritten.
+- Switched seed/cleanup operations to Neo4j managed write transactions when the installed driver exposes `execute_write`/`write_transaction`, preserving the marker/run-id scoped cleanup query and post-cleanup ordering.
+- Converted expected local runtime failures, including missing `neo4j` package, missing password, unsafe output path, and local driver/run failures, into concise `ERROR:` CLI exits instead of tracebacks.
+
+### Warning Cleanup TDD Evidence
+
+| Warning | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|---------|-----------|-------|------------|-----|-------|-------------|----------|
+| Evidence output safety | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit | ✅ 7/7 baseline | ✅ Added missing `resolve_evidence_output_path` / `write_json_exclusive` coverage; failed before implementation | ✅ 12/12 passing after implementation | ✅ Covered accepted relative path, traversal/absolute outside rejection, accepted write, and overwrite rejection | ✅ Extracted pure path resolver and exclusive writer |
+| Managed cleanup transaction compatibility | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit | ✅ 7/7 baseline | ✅ Fake session exposes managed transaction path while preserving query-order assertions | ✅ 12/12 passing | ✅ Existing seed, cleanup, post-cleanup ordering assertions still prove the transaction path | ✅ Added driver-version fallback helper |
+| Concise CLI dependency errors | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit | ✅ 7/7 baseline | ✅ Missing `neo4j` import test required a CLI-oriented error type | ✅ 12/12 passing | ✅ Main now also wraps local driver/run failures into concise `CliError` messages | ✅ Kept direct `run_seed_cleanup` behavior testable without CLI wrapping |

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/design.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/design.md
@@ -1,0 +1,69 @@
+# Design: Validate Legacy Backfill Smoke Fixtures
+
+## Technical Approach
+
+Run the smoke validation from a clean worktree checked out at `origin/main` / `v1.13.9` or later, because the dirty root is on `fix/pingcheck-packet-loss` and the required CLI files are only verified on `origin/main`. Use the existing shared local Neo4j stack documented in `docs/worktree-test-environment.md`, managed by `scripts/shared-test-env.sh`, `docker-compose.test-env.yml`, and `config/test-env/worktree-host.sample`. Do not read denied `.env` files; source approved exports or copy the sample in the clean worktree only.
+
+The validation seeds minimal, marker-scoped `Event` nodes, runs the existing read-only audit/recommendation pipeline, validates expected buckets, persists evidence under this change, and deletes all marked records in `finally`/`trap` cleanup.
+
+## Architecture Decisions
+
+| Decision | Choice | Alternatives considered | Rationale |
+|---|---|---|---|
+| Execution checkout | Require clean worktree at `origin/main` / `v1.13.9+` before touching local data. | Use dirty root. | Prevents unrelated branch changes from contaminating evidence and guarantees `backend/scripts/audit_legacy_event_discriminators.py` exists. |
+| Environment | Reuse shared local Neo4j at `bolt://127.0.0.1:17687`. | Start new Docker/test DB. | Scope explicitly forbids new environments; the shared stack is already documented. |
+| Fixture shape | Directly create tagged `Event` records with `issue155_smoke=true`, `issue155_smoke_run_id`, stable `id`, `ci_id`, `metric_id`, `status`, `severity`, `message`, discriminator fields, and timestamps. | Use polling writer paths. | The classifier query reads `Event` properties directly and only optionally joins `(:CI)-[:HAS_EVENT]->(e)`. Minimal nodes reduce cleanup risk. |
+| Classification validation | Use existing service functions for marker rows plus existing CLI reports for pipeline smoke. | Trust aggregate CLI recommendation only. | Current CLI supports `--limit` but no marker filter, and recommendation JSON has bucket counts but no per-record ids. Per-fixture validation needs marker extraction or direct classifier reuse. |
+
+## Data Flow
+
+```
+clean worktree + approved env
+  -> seed tagged Event fixtures
+  -> run CLI audit/recommendation read-only
+  -> extract/compute smoke-only classifications
+  -> compare expected buckets and Markdown/JSON parity
+  -> cleanup marked records and verify zero remain
+  -> write evidence files
+```
+
+Known classifier triggers from `backend/services/legacy_event_discriminator_audit.py`:
+- safe: fully populated `event_type`, `failure_family`, and `source_protocol`, with no ambiguity trigger.
+- ambiguous: missing discriminator plus message/source hints for collection failure, timeout, ICMP/PING availability, threshold, breached, host down, or availability.
+- no-touch: non-ambiguous missing discriminator findings, e.g. populated `event_type="THRESHOLD"` with missing `failure_family` and no ambiguous text.
+
+## File Changes
+
+| File | Action | Description |
+|---|---|---|
+| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` | Create | Store run manifest, seeded fixture plan, CLI stdout/stderr, Markdown/JSON reports, validation summary, and cleanup proof. |
+| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py` | Create | Local-only evidence runner that seeds, validates, and cleans up marker-scoped fixtures. |
+| `openspec/changes/validate-legacy-backfill-smoke-fixtures/design.md` | Create | This design. |
+
+## Interfaces / Contracts
+
+Fixture contract:
+- every fixture MUST include `issue155_smoke=true` and unique `issue155_smoke_run_id`.
+- expected bucket map MUST include `safe_candidates`, `ambiguous_records`, and `no_touch_records`.
+- cleanup query MUST delete only records matching both marker fields, then verify `MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id}) RETURN count(e)` is zero.
+
+CLI contract:
+- run `python backend/scripts/audit_legacy_event_discriminators.py --report audit --format json --output ...` for record-level finding evidence.
+- run `python backend/scripts/audit_legacy_event_discriminators.py --report recommendation --format json|markdown --output ...` for existing pipeline evidence.
+- if smoke IDs are absent from audit JSON because CLI lacks marker filtering, mark the run invalid and record the filter gap.
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|---|---|---|
+| Unit | Expected bucket derivation for seeded rows | Add focused tests around fixture definitions and classifier output if helper logic is committed. |
+| Integration/manual evidence | Shared Neo4j seed/report/cleanup flow | Run evidence helper from clean worktree using approved sample/export env. |
+| Consistency | Markdown/JSON report parity | Compare counts, schema version, bucket labels, confidence, and finding codes. |
+
+## Migration / Rollout
+
+No migration required. This is local evidence only and does not authorize production mutation or production-scale safety claims.
+
+## Open Questions
+
+- [ ] Whether to upstream a CLI marker filter later; current design treats the missing filter as a validation gap to record, not a blocker to safe cleanup.

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr1-seed-cleanup-smoke.json
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr1-seed-cleanup-smoke.json
@@ -1,0 +1,68 @@
+{
+  "cleanup": {
+    "cleanup_verified": true,
+    "deleted_count": 3,
+    "query": "MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id})\nRETURN count(e)=0 AS cleanup_verified, count(e) AS remaining_count",
+    "remaining_count": 0
+  },
+  "fixture_plan": [
+    {
+      "availability_source": "snmp",
+      "ci_id": "issue155-smoke-20260705T180156Z-dd32e897-ci-safe",
+      "created_at": "2026-07-05T18:01:56.607801+00:00",
+      "event_type": "AVAILABILITY",
+      "expected_bucket": "safe_candidates",
+      "failure_family": "COLLECTION",
+      "id": "issue155-smoke-20260705T180156Z-dd32e897-safe",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-20260705T180156Z-dd32e897",
+      "last_seen": "2026-07-05T18:01:56.607801+00:00",
+      "message": "SNMP availability event with complete discriminator fields.",
+      "metric_id": "availability.safe",
+      "metric_name": "Availability Safe Fixture",
+      "severity": "warning",
+      "source_protocol": "SNMP",
+      "status": "ACTIVE"
+    },
+    {
+      "availability_source": null,
+      "ci_id": "issue155-smoke-20260705T180156Z-dd32e897-ci-ambiguous",
+      "created_at": "2026-07-05T18:01:56.607801+00:00",
+      "event_type": null,
+      "expected_bucket": "ambiguous_records",
+      "failure_family": null,
+      "id": "issue155-smoke-20260705T180156Z-dd32e897-ambiguous",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-20260705T180156Z-dd32e897",
+      "last_seen": "2026-07-05T18:01:56.607801+00:00",
+      "message": "PING availability timeout; host down boundary needs reviewer decision.",
+      "metric_id": "availability.ping.timeout",
+      "metric_name": "PING Timeout Fixture",
+      "severity": "warning",
+      "source_protocol": null,
+      "status": "ACTIVE"
+    },
+    {
+      "availability_source": "snmp",
+      "ci_id": "issue155-smoke-20260705T180156Z-dd32e897-ci-no-touch",
+      "created_at": "2026-07-05T18:01:56.607801+00:00",
+      "event_type": "THRESHOLD",
+      "expected_bucket": "no_touch_records",
+      "failure_family": null,
+      "id": "issue155-smoke-20260705T180156Z-dd32e897-no-touch",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-20260705T180156Z-dd32e897",
+      "last_seen": "2026-07-05T18:01:56.607801+00:00",
+      "message": "Threshold signal with one missing discriminator and no ambiguity hint.",
+      "metric_id": "threshold.partial",
+      "metric_name": "Threshold Partial Fixture",
+      "severity": "warning",
+      "source_protocol": "SNMP",
+      "status": "ACTIVE"
+    }
+  ],
+  "run_id": "issue155-smoke-20260705T180156Z-dd32e897",
+  "scope": "local shared Neo4j only; no production mutation",
+  "seeded_count": 3,
+  "status": "cleanup_verified"
+}

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from unittest import mock
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("validate_smoke_fixtures.py")
+spec = importlib.util.spec_from_file_location("validate_smoke_fixtures", MODULE_PATH)
+smoke = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(smoke)
+
+
+class _FakeRecord(dict):
+    pass
+
+
+class _FakeResult:
+    def __init__(self, record):
+        self._record = _FakeRecord(record)
+
+    def single(self, strict=False):
+        return self._record
+
+
+class _FakeSession:
+    def __init__(self, fail_seed=False):
+        self.calls = []
+        self.fail_seed = fail_seed
+        self.execute_write_calls = 0
+
+    def execute_write(self, callback):
+        self.execute_write_calls += 1
+        return callback(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        if query == smoke.SEED_QUERY:
+            if self.fail_seed:
+                raise RuntimeError("forced seed failure")
+            return _FakeResult({"seeded_count": len(params["fixtures"])})
+        if query == smoke.CLEANUP_QUERY:
+            return _FakeResult({"deleted_count": 3})
+        if query == smoke.POST_CLEANUP_QUERY:
+            return _FakeResult({"cleanup_verified": True, "remaining_count": 0})
+        raise AssertionError(f"unexpected query: {query}")
+
+
+class _FakeDriver:
+    def __init__(self, fail_seed=False):
+        self.sessions = []
+        self.fail_seed = fail_seed
+
+    def session(self):
+        session = _FakeSession(fail_seed=self.fail_seed and not self.sessions)
+        self.sessions.append(session)
+        return session
+
+
+class SmokeFixtureHarnessTests(unittest.TestCase):
+    def test_fixture_plan_marks_every_event_with_run_id_and_covers_expected_buckets(self):
+        fixtures = smoke.build_fixture_plan("issue155-smoke-test")
+
+        self.assertEqual(
+            [fixture["expected_bucket"] for fixture in fixtures],
+            ["safe_candidates", "ambiguous_records", "no_touch_records"],
+        )
+        self.assertEqual({fixture["issue155_smoke"] for fixture in fixtures}, {True})
+        self.assertEqual(
+            {fixture["issue155_smoke_run_id"] for fixture in fixtures},
+            {"issue155-smoke-test"},
+        )
+        self.assertEqual(
+            [fixture["id"] for fixture in fixtures],
+            [
+                "issue155-smoke-test-safe",
+                "issue155-smoke-test-ambiguous",
+                "issue155-smoke-test-no-touch",
+            ],
+        )
+
+    def test_local_uri_guard_accepts_shared_local_neo4j_only(self):
+        self.assertEqual(
+            smoke.validate_local_neo4j_uri("bolt://127.0.0.1:17687"),
+            "bolt://127.0.0.1:17687",
+        )
+        self.assertEqual(
+            smoke.validate_local_neo4j_uri("neo4j://localhost:17687"),
+            "neo4j://localhost:17687",
+        )
+
+    def test_local_uri_guard_rejects_default_container_and_remote_targets(self):
+        for uri in (
+            "bolt://neo4j:7687",
+            "bolt://10.1.2.3:17687",
+            "neo4j+s://db.example.com:7687",
+        ):
+            with self.subTest(uri=uri):
+                with self.assertRaisesRegex(smoke.UnsafeTargetError, "shared local Neo4j"):
+                    smoke.validate_local_neo4j_uri(uri)
+
+    def test_cleanup_verification_query_proves_zero_marked_events_for_run_id(self):
+        self.assertIn("issue155_smoke:true", smoke.POST_CLEANUP_QUERY)
+        self.assertIn("issue155_smoke_run_id:$run_id", smoke.POST_CLEANUP_QUERY)
+        self.assertIn("RETURN count(e)=0", smoke.POST_CLEANUP_QUERY)
+
+    def test_cleanup_query_deletes_only_marker_and_run_id_scoped_events(self):
+        self.assertIn("issue155_smoke:true", smoke.CLEANUP_QUERY)
+        self.assertIn("issue155_smoke_run_id:$run_id", smoke.CLEANUP_QUERY)
+        self.assertIn("DETACH DELETE", smoke.CLEANUP_QUERY)
+        self.assertNotIn("MATCH (e:Event)\n", smoke.CLEANUP_QUERY)
+
+
+    def test_resolve_evidence_output_accepts_relative_path_under_evidence_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+
+            output_path = smoke.resolve_evidence_output_path("manifest.json", evidence_dir=evidence_dir)
+
+            self.assertEqual(output_path, (evidence_dir / "manifest.json").resolve())
+
+    def test_resolve_evidence_output_rejects_traversal_and_absolute_paths_outside_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            outside_dir = Path(tmp) / "outside"
+            evidence_dir.mkdir()
+            outside_dir.mkdir()
+
+            for requested in ("../outside/manifest.json", outside_dir / "manifest.json"):
+                with self.subTest(requested=str(requested)):
+                    with self.assertRaisesRegex(smoke.OutputTargetError, "evidence directory"):
+                        smoke.resolve_evidence_output_path(requested, evidence_dir=evidence_dir)
+
+
+    def test_write_json_accepts_new_output_under_evidence_directory(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+            output_path = smoke.resolve_evidence_output_path("nested/manifest.json", evidence_dir=evidence_dir)
+
+            smoke.write_json_exclusive(output_path, {"status": "ok"}, evidence_dir=evidence_dir)
+
+            self.assertEqual(json.loads(output_path.read_text(encoding="utf-8")), {"status": "ok"})
+
+    def test_missing_neo4j_dependency_raises_concise_cli_error(self):
+        real_import = __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "neo4j":
+                raise ImportError("missing neo4j")
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            with self.assertRaisesRegex(smoke.CliError, "neo4j package is required"):
+                smoke._load_driver("bolt://127.0.0.1:17687", "neo4j", "password")
+
+    def test_write_json_rejects_existing_output_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+            output_path = evidence_dir / "manifest.json"
+            output_path.write_text("existing\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(smoke.OutputTargetError, "already exists"):
+                smoke.write_json_exclusive(output_path, {"status": "new"}, evidence_dir=evidence_dir)
+
+            self.assertEqual(output_path.read_text(encoding="utf-8"), "existing\n")
+
+    def test_run_seed_cleanup_seeds_marker_fixtures_then_verifies_cleanup(self):
+        driver = _FakeDriver()
+
+        payload = smoke.run_seed_cleanup(driver, "issue155-smoke-test")
+
+        self.assertEqual(payload["seeded_count"], 3)
+        self.assertEqual(payload["cleanup"]["remaining_count"], 0)
+        self.assertTrue(payload["cleanup"]["cleanup_verified"])
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+        self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
+        self.assertEqual([session.execute_write_calls for session in driver.sessions], [1, 1])
+        self.assertEqual(all_calls[0][1]["fixtures"][0]["issue155_smoke_run_id"], "issue155-smoke-test")
+        self.assertEqual(all_calls[1][1]["run_id"], "issue155-smoke-test")
+        self.assertEqual(all_calls[2][1]["run_id"], "issue155-smoke-test")
+
+    def test_run_seed_cleanup_executes_cleanup_after_seed_failure(self):
+        driver = _FakeDriver(fail_seed=True)
+
+        with self.assertRaisesRegex(RuntimeError, "forced seed failure"):
+            smoke.run_seed_cleanup(driver, "issue155-smoke-test")
+
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+        self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
+        self.assertEqual(all_calls[1][1]["run_id"], "issue155-smoke-test")
+        self.assertEqual(all_calls[2][1]["run_id"], "issue155-smoke-test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Local-only smoke fixture seed/cleanup harness for issue #155.
+
+This helper intentionally mutates only the shared local Neo4j instance. It does
+not read .env files, start Docker, run migrations, invoke backfill --apply, or
+claim any production safety conclusion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+LOCAL_NEO4J_URI = "bolt://127.0.0.1:17687"
+SMOKE_MARKER = "issue155_smoke"
+RUN_ID_FIELD = "issue155_smoke_run_id"
+EVIDENCE_DIR = Path(__file__).resolve().parent
+
+SEED_QUERY = """
+UNWIND $fixtures AS fixture
+CREATE (e:Event)
+SET e = fixture
+RETURN count(e) AS seeded_count
+""".strip()
+
+CLEANUP_QUERY = """
+MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id})
+WITH collect(e) AS events, count(e) AS deleted_count
+FOREACH (event IN events | DETACH DELETE event)
+RETURN deleted_count
+""".strip()
+
+POST_CLEANUP_QUERY = """
+MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id})
+RETURN count(e)=0 AS cleanup_verified, count(e) AS remaining_count
+""".strip()
+
+
+class UnsafeTargetError(RuntimeError):
+    """Raised when the requested Neo4j target is not the shared local instance."""
+
+
+class OutputTargetError(RuntimeError):
+    """Raised when an evidence output path is outside the allowed directory."""
+
+
+class CliError(RuntimeError):
+    """Raised for expected local runtime failures that should not print tracebacks."""
+
+
+def generate_run_id(now: datetime | None = None) -> str:
+    """Generate a unique, marker-friendly run id."""
+    timestamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+    return f"issue155-smoke-{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def validate_local_neo4j_uri(uri: str) -> str:
+    """Allow only the approved shared local Neo4j endpoint."""
+    parsed = urlparse(uri)
+    if parsed.scheme not in {"bolt", "neo4j"}:
+        raise UnsafeTargetError("Smoke fixtures may target only shared local Neo4j.")
+    if parsed.hostname not in {"127.0.0.1", "localhost"} or parsed.port != 17687:
+        raise UnsafeTargetError(
+            "Smoke fixtures may target only shared local Neo4j at 127.0.0.1:17687."
+        )
+    return uri
+
+
+def build_fixture_plan(run_id: str) -> list[dict[str, Any]]:
+    """Build marker-scoped Event fixtures covering safe, ambiguous, and no-touch buckets."""
+    created_at = datetime.now(timezone.utc).isoformat()
+    base = {
+        SMOKE_MARKER: True,
+        RUN_ID_FIELD: run_id,
+        "status": "ACTIVE",
+        "severity": "warning",
+        "created_at": created_at,
+        "last_seen": created_at,
+    }
+    return [
+        {
+            **base,
+            "id": f"{run_id}-safe",
+            "ci_id": f"{run_id}-ci-safe",
+            "metric_id": "availability.safe",
+            "metric_name": "Availability Safe Fixture",
+            "message": "SNMP availability event with complete discriminator fields.",
+            "event_type": "AVAILABILITY",
+            "failure_family": "COLLECTION",
+            "source_protocol": "SNMP",
+            "availability_source": "snmp",
+            "expected_bucket": "safe_candidates",
+        },
+        {
+            **base,
+            "id": f"{run_id}-ambiguous",
+            "ci_id": f"{run_id}-ci-ambiguous",
+            "metric_id": "availability.ping.timeout",
+            "metric_name": "PING Timeout Fixture",
+            "message": "PING availability timeout; host down boundary needs reviewer decision.",
+            "event_type": None,
+            "failure_family": None,
+            "source_protocol": None,
+            "availability_source": None,
+            "expected_bucket": "ambiguous_records",
+        },
+        {
+            **base,
+            "id": f"{run_id}-no-touch",
+            "ci_id": f"{run_id}-ci-no-touch",
+            "metric_id": "threshold.partial",
+            "metric_name": "Threshold Partial Fixture",
+            "message": "Threshold signal with one missing discriminator and no ambiguity hint.",
+            "event_type": "THRESHOLD",
+            "failure_family": None,
+            "source_protocol": "SNMP",
+            "availability_source": "snmp",
+            "expected_bucket": "no_touch_records",
+        },
+    ]
+
+
+def _single_value(summary: Any, key: str) -> Any:
+    record = summary.single(strict=True)
+    return record[key]
+
+
+def _write_transaction(session: Any, callback: Any) -> Any:
+    """Use Neo4j managed write transactions when the installed driver supports them."""
+    if hasattr(session, "execute_write"):
+        return session.execute_write(callback)
+    if hasattr(session, "write_transaction"):
+        return session.write_transaction(callback)
+    return callback(session)
+
+
+def seed_fixtures(driver: Any, fixtures: list[dict[str, Any]]) -> int:
+    """Create marker-scoped Event nodes in the shared local database only."""
+
+    def seed(tx: Any) -> int:
+        return int(_single_value(tx.run(SEED_QUERY, fixtures=fixtures), "seeded_count"))
+
+    with driver.session() as session:
+        return _write_transaction(session, seed)
+
+
+def cleanup_fixtures(driver: Any, run_id: str) -> dict[str, Any]:
+    """Delete only marker/run-id scoped fixtures and verify zero remain."""
+
+    def cleanup(tx: Any) -> tuple[int, Any]:
+        deleted = int(_single_value(tx.run(CLEANUP_QUERY, run_id=run_id), "deleted_count"))
+        verification_record = tx.run(POST_CLEANUP_QUERY, run_id=run_id).single(strict=True)
+        return deleted, verification_record
+
+    with driver.session() as session:
+        deleted_count, verification = _write_transaction(session, cleanup)
+    return {
+        "deleted_count": deleted_count,
+        "cleanup_verified": bool(verification["cleanup_verified"]),
+        "remaining_count": int(verification["remaining_count"]),
+        "query": POST_CLEANUP_QUERY,
+    }
+
+
+def _load_driver(uri: str, user: str, password: str) -> Any:
+    try:
+        from neo4j import GraphDatabase
+    except ImportError as exc:  # pragma: no cover - depends on local environment.
+        raise CliError("neo4j package is required to run the live smoke fixture harness") from exc
+    return GraphDatabase.driver(uri, auth=(user, password))
+
+
+def resolve_evidence_output_path(output: str | Path, evidence_dir: Path = EVIDENCE_DIR) -> Path:
+    """Resolve an output path that must remain under this change's evidence directory."""
+    evidence_root = evidence_dir.resolve()
+    requested = Path(output)
+    candidate = requested if requested.is_absolute() else evidence_root / requested
+    resolved = candidate.resolve(strict=False)
+    if not resolved.is_relative_to(evidence_root):
+        raise OutputTargetError("--output must resolve under this change's evidence directory")
+    return resolved
+
+
+def write_json_exclusive(
+    path: Path, payload: dict[str, Any], evidence_dir: Path = EVIDENCE_DIR
+) -> None:
+    """Write JSON evidence without overwriting existing files."""
+    resolved = resolve_evidence_output_path(path, evidence_dir=evidence_dir)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with resolved.open("x", encoding="utf-8") as output_file:
+            output_file.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    except FileExistsError as exc:
+        raise OutputTargetError(f"evidence output already exists: {resolved}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed and clean issue #155 local smoke fixtures.")
+    parser.add_argument("--run-id", default=None, help="Optional unique run id for repeatable cleanup.")
+    parser.add_argument("--output", default=None, help="Optional JSON manifest path for seed/cleanup evidence.")
+    parser.add_argument("--neo4j-uri", default=os.getenv("NEO4J_URI", LOCAL_NEO4J_URI))
+    parser.add_argument("--neo4j-user", default=os.getenv("NEO4J_USER", "neo4j"))
+    parser.add_argument("--neo4j-password", default=os.getenv("NEO4J_PASSWORD", ""))
+    return parser
+
+
+def run_seed_cleanup(driver: Any, run_id: str) -> dict[str, Any]:
+    """Run the PR1 seed/cleanup flow with failure-safe cleanup."""
+    fixtures = build_fixture_plan(run_id)
+    seeded_count = 0
+    cleanup: dict[str, Any] | None = None
+    try:
+        seeded_count = seed_fixtures(driver, fixtures)
+    finally:
+        cleanup = cleanup_fixtures(driver, run_id)
+
+    if not cleanup["cleanup_verified"]:
+        raise RuntimeError(f"cleanup verification failed for run id {run_id}: {cleanup}")
+    return {
+        "run_id": run_id,
+        "seeded_count": seeded_count,
+        "fixture_plan": fixtures,
+        "cleanup": cleanup,
+        "status": "cleanup_verified",
+        "scope": "local shared Neo4j only; no production mutation",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    run_id = args.run_id or generate_run_id()
+    uri = validate_local_neo4j_uri(args.neo4j_uri)
+    output_path = resolve_evidence_output_path(args.output) if args.output else None
+    if output_path and output_path.exists():
+        raise OutputTargetError(f"evidence output already exists: {output_path}")
+    if not args.neo4j_password:
+        raise CliError("NEO4J_PASSWORD must be exported; this helper does not read .env files.")
+
+    try:
+        driver = _load_driver(uri, args.neo4j_user, args.neo4j_password)
+    except Exception as exc:
+        if isinstance(exc, CliError):
+            raise
+        raise CliError(f"could not create Neo4j driver for local smoke fixtures: {exc}") from exc
+
+    try:
+        try:
+            payload = run_seed_cleanup(driver, run_id)
+        except Exception as exc:
+            raise CliError(f"local smoke fixture run failed: {exc}") from exc
+    finally:
+        driver.close()
+
+    if output_path:
+        write_json_exclusive(output_path, payload)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (UnsafeTargetError, OutputTargetError, CliError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2)

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/proposal.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: Validate Legacy Backfill Smoke Fixtures
+
+## Intent
+
+Create a controlled local evidence slice that proves the existing read-only legacy Event backfill recommendation pipeline can inspect known marker-scoped fixtures and classify them into expected buckets before Slice 4 dry-run/apply design.
+
+## Scope
+
+### In Scope
+- Seed uniquely marked smoke fixture `Event` records in the existing local/shared Neo4j environment.
+- Run the existing read-only recommendation report against those fixtures.
+- Validate expected safe, ambiguous, and no-touch classifications across Markdown/JSON evidence.
+- Clean up all seeded data, including failure-path cleanup verification.
+
+### Out of Scope
+- Production data mutation or production risk conclusions.
+- New Docker, test, or isolated Neo4j environments.
+- Backfill `--apply`, migrations, or write-capable production code changes.
+- Proving scale/performance risk for production.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `legacy-event-backfill-local-evidence`: adds controlled smoke-fixture validation around the existing local read-only evidence report.
+
+## Approach
+
+Use the shared local environment only. Insert marker-scoped fixtures with `issue155_smoke=true` and a unique run id, execute the existing read-only recommendation report, compare actual classifications with expected buckets, persist evidence, and run cleanup in `finally`/trap-style flow. Verify no marked records remain before accepting the slice.
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `openspec/specs/legacy-event-backfill-local-evidence/spec.md` | Modified | Add smoke-fixture validation requirements. |
+| `openspec/changes/validate-legacy-backfill-smoke-fixtures/` | New | Store proposal, delta spec, design, tasks, and evidence references. |
+| Local/shared Neo4j data | Temporary | Seed and remove marker-scoped fixture `Event` records only. |
+| Evidence artifacts | New | Record report outputs, expected-vs-actual validation, and cleanup verification. |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Seeded data leaks in local DB | Medium | Unique marker/run id plus mandatory cleanup verification. |
+| Evidence overstates production confidence | Medium | State explicitly that results validate classifier behavior only. |
+| Failure interrupts cleanup | Medium | Require failure-path cleanup and post-cleanup query evidence. |
+
+## Rollback Plan
+
+Delete all records marked with `issue155_smoke=true` and the run id; rerun cleanup verification query. Revert only this change folder if planning artifacts are wrong.
+
+## Dependencies
+
+- Existing shared local Neo4j environment.
+- Existing Slice 2/Slice 3 read-only recommendation report.
+- No denied secret path reads; configuration must come from already-supported local execution paths.
+
+## Success Criteria
+
+- [ ] Smoke fixtures are seeded with marker and unique run id only in local/shared DB.
+- [ ] Read-only report classifies known fixtures into expected buckets.
+- [ ] Markdown/JSON evidence records counts, reasons, and validation status.
+- [ ] Cleanup verification proves no marked fixture records remain.
+- [ ] Output states no production mutation or production-scale conclusion was made.

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/specs/legacy-event-backfill-local-evidence/spec.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/specs/legacy-event-backfill-local-evidence/spec.md
@@ -1,0 +1,71 @@
+# Delta for legacy-event-backfill-local-evidence
+
+## ADDED Requirements
+
+### Requirement: Seed marker-scoped smoke fixtures for local validation
+The system MUST seed uniquely marked local/shared Neo4j smoke fixture `Event` records using `issue155_smoke=true` and a unique run id.
+The system MUST seed fixtures that cover expected safe, ambiguous, and no-touch recommendation buckets.
+The system MUST keep the seeded scope isolated to the local/shared environment.
+
+#### Scenario: Seeded fixtures cover all buckets
+- GIVEN a unique run id has been selected for the validation run
+- WHEN smoke fixtures are seeded
+- THEN each seeded `Event` record MUST include `issue155_smoke=true` and the run id
+- AND the fixture set MUST include safe, ambiguous, and no-touch cases
+
+#### Scenario: Seed scope remains local
+- GIVEN the validation run targets the shared local Neo4j environment
+- WHEN fixtures are seeded
+- THEN no production records are touched
+- AND no unmarked records are required for the validation slice
+
+### Requirement: Validate the existing read-only report against seeded fixtures
+The system MUST run the existing read-only recommendation report against the seeded fixtures.
+The system MUST persist Markdown and JSON evidence for the report output.
+The system MUST validate expected-versus-actual classification for each seeded fixture.
+
+#### Scenario: Report classifications match expectations
+- GIVEN seeded fixtures exist for all expected buckets
+- WHEN the read-only recommendation report runs
+- THEN the Markdown and JSON evidence MUST record the report output
+- AND the actual classifications MUST match the expected bucket mapping
+
+#### Scenario: Classification mismatch is visible
+- GIVEN a seeded fixture is classified into the wrong bucket
+- WHEN evidence validation runs
+- THEN the mismatch MUST be recorded in Markdown and JSON evidence
+- AND the run MUST be marked invalid for planning use
+
+### Requirement: Always clean up seeded fixtures and verify no markers remain
+The system MUST delete all fixtures seeded for the run, including on failure.
+The system MUST verify that no `issue155_smoke=true` records remain after cleanup.
+The system MUST persist cleanup verification evidence.
+
+#### Scenario: Cleanup succeeds after report execution
+- GIVEN smoke fixtures were seeded for a unique run id
+- WHEN cleanup runs after validation
+- THEN all `issue155_smoke=true` records for that run id MUST be removed
+- AND a post-cleanup check MUST confirm no marked records remain
+
+#### Scenario: Cleanup runs after failure
+- GIVEN the report or validation fails partway through
+- WHEN failure handling runs
+- THEN cleanup MUST still execute for the seeded run id
+- AND the post-cleanup verification MUST be persisted
+
+### Requirement: Prevent unsafe mutation, environment creation, and backfill paths
+The system MUST NOT mutate production data or draw production conclusions from the smoke run.
+The system MUST NOT create a new Docker, test, or isolated Neo4j environment.
+The system MUST NOT invoke any `--apply`, backfill, or migration path during this validation.
+
+#### Scenario: Unsafe path is blocked
+- GIVEN a validation request includes an apply or migration flag
+- WHEN the run is prepared
+- THEN the system MUST refuse the request
+- AND the evidence MUST state that only read-only local validation is allowed
+
+#### Scenario: No production conclusion is claimed
+- GIVEN the local smoke validation completes successfully
+- WHEN the result is summarized
+- THEN the summary MUST limit conclusions to classifier behavior on the seeded fixtures
+- AND it MUST NOT claim production safety or production-scale coverage

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md
@@ -1,0 +1,49 @@
+# Tasks: Validate Legacy Backfill Smoke Fixtures
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 500-800 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 evidence helper + seed/cleanup, PR 2 validation reports + evidence, PR 3 docs/cleanup |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | Likely PR | Notes |
+|------|------|-----------|-------|
+| 1 | Local-only seed/cleanup harness | PR 1 | Base from main; isolates marker-scoped fixtures and trap cleanup. |
+| 2 | Per-fixture validation and evidence output | PR 2 | Base on PR 1; uses audit JSON/direct classifier reuse for smoke IDs. |
+| 3 | Final evidence docs and verification | PR 3 | Base on PR 2; captures zero-marked-record proof and run summary. |
+
+## Phase 1: Foundation / Harness
+
+- [x] 1.1 Create `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py` as a local-only runner with run-id generation, seeded fixture plan, and cleanup trap/finally.
+- [x] 1.2 Seed marker-scoped `Event` fixtures only in shared local Neo4j using `issue155_smoke=true` and `issue155_smoke_run_id`.
+- [x] 1.3 Add a post-cleanup query that proves `MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id}) RETURN count(e)=0`.
+
+## Phase 2: Validation Logic
+
+- [ ] 2.1 Run `backend/scripts/audit_legacy_event_discriminators.py --report audit --format json` and persist raw JSON evidence.
+- [ ] 2.2 Validate expected vs actual buckets for safe, ambiguous, and no-touch fixtures using audit JSON/direct classifier reuse when CLI lacks per-fixture marker filtering.
+- [ ] 2.3 Record the validation gap explicitly if smoke IDs cannot be isolated from aggregate recommendation JSON.
+
+## Phase 3: Evidence / Wiring
+
+- [ ] 3.1 Persist Markdown and JSON evidence under `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` for seeded plan, report output, and classification comparison.
+- [ ] 3.2 Capture cleanup evidence showing deleted marker-scoped records and zero remaining marked nodes.
+- [ ] 3.3 Ensure the run summary states local-only validation, no production mutation, and no `--apply`/migration path.
+
+## Phase 4: Verification / Cleanup
+
+- [ ] 4.1 Re-run the helper in failure-safe mode to verify `finally`/trap cleanup still executes after a report or validation error.
+- [ ] 4.2 Confirm evidence artifacts are complete, readable, and tied to one unique run id.
+- [ ] 4.3 Keep the tasks scoped to local/shared Neo4j only; do not add Docker, new test env, or production-write paths.


### PR DESCRIPTION
Refs #155

## Summary
- Adds issue #155 Slice 3b PR1 SDD artifacts for local smoke fixture validation.
- Adds a local-only Neo4j seed/cleanup harness for marker-scoped smoke Events.
- Verifies cleanup safety, output safety, and local-only guardrails with unittest coverage.

## Test Plan
- [x] python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py
- [x] python3 -m py_compile openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py
- [x] Fresh risk/resilience review: 0 critical, 0 warnings

## Notes
This is PR1 only: seed/cleanup harness. It does not close #155 and does not implement PR2/PR3 validation/reporting.
