### PR TITLE
feat(events): validate legacy backfill smoke fixtures

### DIFF
--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md
@@ -4,15 +4,20 @@
 
 - Delivery strategy: ask-on-risk
 - Chain strategy: stacked-to-main
-- Current slice: PR 1 / Work Unit 1 only
-- Boundary: local-only seed/cleanup harness from updated `origin/main` / `v1.13.9+`
-- Explicitly not implemented: validation/reporting tasks 2.x, 3.x, and 4.x
+- Current slice: PR 2 / Work Unit 2 only
+- Base: `origin/main` after PR #365 (`fe99822`)
+- Branch: `feat/issue-155-smoke-fixtures-pr2`
+- Boundary: extend the PR1 local-only seed/cleanup harness with read-only audit JSON execution bound to the same validated local Neo4j target, sanitized smoke-scoped audit evidence, direct classifier validation for smoke-only fixtures, and explicit aggregate recommendation gap evidence.
+- Explicitly not implemented: Phase 3 evidence/wiring tasks and Phase 4 verification/cleanup tasks remain pending.
 
 ## Completed Tasks
 
 - [x] 1.1 Created `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py` as a local-only runner with run-id generation, seeded fixture plan, and `finally` cleanup.
 - [x] 1.2 Seeded marker-scoped `Event` fixtures only in shared local Neo4j using `issue155_smoke=true` and `issue155_smoke_run_id`.
 - [x] 1.3 Added post-cleanup verification query proving `MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id}) RETURN count(e)=0`.
+- [x] 2.1 Ran `backend/scripts/audit_legacy_event_discriminators.py --report audit --format json` through the harness with explicit local Neo4j environment overrides, kept broad CLI output temporary, and persisted only sanitized smoke-scoped audit JSON evidence.
+- [x] 2.2 Validated expected vs actual buckets for safe, ambiguous, and no-touch fixtures by parsing persisted smoke-scoped audit evidence for ambiguous/no-touch findings and directly reusing the read-only classifier for the safe fixture.
+- [x] 2.3 Recorded the aggregate recommendation JSON per-fixture isolation gap explicitly in validation evidence.
 
 ## TDD Cycle Evidence
 
@@ -21,29 +26,35 @@
 | 1.1 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit | N/A (new files) | ✅ Test referenced missing runner first; failed with `FileNotFoundError` | ✅ `python3 .../test_validate_smoke_fixtures.py` passed 4/4 after runner creation | ✅ Added URI and fixture-plan cases | ✅ Reworked Python 3.9-compatible UTC handling |
 | 1.2 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | N/A (new files) | ✅ Fixture plan test required marker/run-id fields before implementation | ✅ Unit tests passed 5/5 and live helper seeded 3 local fixtures | ✅ Fake driver verified seed query receives marked fixtures and live run seeded all three buckets | ✅ Kept seed scope in one query and local URI guard |
 | 1.3 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | N/A (new files) | ✅ Cleanup query test required exact marker/run-id zero-count proof | ✅ Unit tests passed 5/5 and live helper cleanup returned `cleanup_verified=true` | ✅ Fake driver verified cleanup and post-cleanup query order | ✅ Cleanup proof is returned and persisted in JSON evidence |
+| 2.1 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | ✅ 16/16 baseline | ✅ Added tests requiring smoke-scoped audit persistence and no absolute output paths in metadata; failed before implementation | ✅ 24/24 unit tests passed and live helper persisted `pr2-smoke-audit.json` | ✅ Test covers broad temporary CLI output, smoke-only persisted findings, omitted non-smoke count, and sanitized command metadata | ✅ Broad audit output is temporary/non-committed; persisted evidence is smoke-scoped only |
+| 2.2 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | ✅ 16/16 baseline | ✅ Added validation tests requiring persisted audit evidence for ambiguous/no-touch fixtures; failed before implementation | ✅ 24/24 unit tests passed and live validation matched safe/ambiguous/no-touch counts 1/1/1 | ✅ Covered all three buckets plus missing audit-finding invalidation | ✅ Validation summary now separates audit evidence inspection from safe fixture direct-classifier validation |
+| 2.3 | `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Unit + local runtime evidence | ✅ 16/16 baseline | ✅ Added cleanup-on-audit-failure and cleanup-on-classifier-failure tests; failed before implementation | ✅ 24/24 unit tests passed and live manifest records `recommendation_gap.status=gap_recorded` | ✅ Failure-path tests prove cleanup still runs after audit generation or classifier validation errors | ✅ Gap wording is centralized in validation summary evidence |
 
 ## Test Summary
 
-- Total tests written: 5
-- Total tests passing: 5
-- Layers used: Unit (5), local shared Neo4j runtime evidence (1 run)
+- Total tests written: 24 cumulative (`+12` in PR2)
+- Total tests passing: 24
+- Layers used: Unit (24), local shared Neo4j runtime evidence (1 regenerated PR2 run)
 - Approval tests: None — no refactoring tasks
-- Pure functions created: `generate_run_id`, `validate_local_neo4j_uri`, `build_fixture_plan`
+- Pure functions created in PR2: `classify_fixture_buckets`, `build_smoke_scoped_audit_evidence`, `build_validation_summary`
+- Side-effectful helper added in PR2: `run_audit_json_report` runs the read-only CLI subprocess with the same validated local Neo4j target used by seed/cleanup, parses temporary broad output, and writes sanitized smoke-scoped audit evidence without persisting Neo4j credentials or broad raw-audit counts.
 
 ## Runtime Evidence
 
-- Command: `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py --output openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr1-seed-cleanup-smoke.json`
-- Environment source: approved `config/test-env/worktree-host.sample` export path from the existing root checkout; no denied `.env` file was read.
-- Evidence file: `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr1-seed-cleanup-smoke.json`
+- Command: `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py --output pr2-validation-smoke-<fresh-run-id>.json --audit-json-output pr2-smoke-audit-<fresh-run-id>.json` (use fresh output filenames for every runtime run; existing evidence files are rejected to prevent accidental overwrite).
+- Environment source: approved `config/test-env/worktree-host.sample` export path from the root checkout; no denied `.env` file was read.
+- Sanitized smoke-scoped audit JSON evidence: `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-smoke-audit.json`
+- Validation manifest: `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-validation-smoke.json`
 - Seeded count: 3 marker-scoped `Event` nodes
+- Expected counts: safe candidates = 1, ambiguous records = 1, no-touch records = 1
+- Actual direct-classifier counts: safe candidates = 1, ambiguous records = 1, no-touch records = 1
+- Validation status: `valid_for_planning=true`, `mismatches=[]`
+- Gap recorded: existing aggregate recommendation JSON does not expose per-record smoke fixture IDs; smoke-only validation parses persisted sanitized audit evidence for ambiguous/no-touch fixtures and uses direct classifier reuse for the safe fixture, which has no finding by design.
 - Cleanup proof: `cleanup_verified=true`, `remaining_count=0`
-- Scope statement: local shared Neo4j only; no production mutation or production conclusion.
+- Scope statement: local shared Neo4j only; no production mutation, no production conclusion, no `--apply`, no migration path, and no new Docker/test environment.
 
 ## Remaining Tasks
 
-- [ ] 2.1 Run `backend/scripts/audit_legacy_event_discriminators.py --report audit --format json` and persist raw JSON evidence.
-- [ ] 2.2 Validate expected vs actual buckets for safe, ambiguous, and no-touch fixtures using audit JSON/direct classifier reuse when CLI lacks per-fixture marker filtering.
-- [ ] 2.3 Record the validation gap explicitly if smoke IDs cannot be isolated from aggregate recommendation JSON.
 - [ ] 3.1 Persist Markdown and JSON evidence under `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` for seeded plan, report output, and classification comparison.
 - [ ] 3.2 Capture cleanup evidence showing deleted marker-scoped records and zero remaining marked nodes.
 - [ ] 3.3 Ensure the run summary states local-only validation, no production mutation, and no `--apply`/migration path.
@@ -53,12 +64,21 @@
 
 ## Deviations
 
-None — PR1 stayed within the design boundary for seed/cleanup harness safety.
+- The sanitized audit JSON contains smoke fixture findings for ambiguous and no-touch fixtures only; safe fixtures naturally have no finding rows. Per-fixture safe validation therefore comes from direct classifier reuse, matching the design's fallback.
+- PR2 did not generate Markdown recommendation evidence because Phase 3 evidence/wiring tasks are intentionally out of scope for this work unit.
 
 ## Issues
 
-- `python` is unavailable in this shell; commands used `python3`.
-- `python3 -m pytest` is unavailable because pytest is not installed for the system Python. The committed helper tests use stdlib `unittest` and run directly with `python3`.
+- `config/test-env/worktree-host.sample` was available from the root checkout path, not inside this PR2 worktree.
+- The existing audit CLI emits a masked Neo4j debug connection line to stdout; the harness records only `stdout_captured=true`, keeps broad audit output in a temporary file, passes explicit local Neo4j env overrides to the subprocess, and persists sanitized smoke-scoped findings in `pr2-smoke-audit.json`.
+
+## Final PR2 Review Fixes
+
+- Bound the read-only audit subprocess to the same validated local `NEO4J_URI` used by seed/cleanup by passing explicit subprocess environment overrides for `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD`.
+- Kept credentials out of persisted evidence metadata; evidence records only sanitized command/output metadata.
+- Removed `raw_total_findings` and broad non-smoke aggregate counts from persisted sanitized audit evidence.
+- Updated task/help/progress wording to consistently describe sanitized smoke-scoped audit JSON evidence.
+- Surfaced cleanup verification failure (`cleanup_verified=false` / remaining fixtures) ahead of prior audit/classifier errors so leftover local smoke fixtures cannot be hidden by an earlier exception.
 
 ## PR1 Review Warning Cleanup
 

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-smoke-audit.json
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-smoke-audit.json
@@ -1,0 +1,66 @@
+{
+  "findings": [
+    {
+      "code": "ambiguous_collection_failure_boundary",
+      "event_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "field": null,
+      "finding_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous:ambiguous_collection_failure_boundary",
+      "recommended_value": null,
+      "severity": "ambiguous"
+    },
+    {
+      "code": "ambiguous_threshold_or_availability",
+      "event_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "field": null,
+      "finding_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous:ambiguous_threshold_or_availability",
+      "recommended_value": null,
+      "severity": "ambiguous"
+    },
+    {
+      "code": "missing_event_type",
+      "event_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "field": "event_type",
+      "finding_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous:missing_event_type",
+      "recommended_value": null,
+      "severity": "missing"
+    },
+    {
+      "code": "missing_failure_family",
+      "event_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "field": "failure_family",
+      "finding_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous:missing_failure_family",
+      "recommended_value": null,
+      "severity": "missing"
+    },
+    {
+      "code": "missing_source_protocol",
+      "event_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "field": "source_protocol",
+      "finding_id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous:missing_source_protocol",
+      "recommended_value": null,
+      "severity": "missing"
+    },
+    {
+      "code": "missing_failure_family",
+      "event_id": "issue155-smoke-20260705T194559Z-d0063d11-no-touch",
+      "field": "failure_family",
+      "finding_id": "issue155-smoke-20260705T194559Z-d0063d11-no-touch:missing_failure_family",
+      "recommended_value": null,
+      "severity": "missing"
+    }
+  ],
+  "schema": "issue155_smoke_scoped_audit_v1",
+  "scope": "smoke fixture findings only; non-smoke finding details omitted",
+  "summary": {
+    "smoke_event_ids": [
+      "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "issue155-smoke-20260705T194559Z-d0063d11-no-touch",
+      "issue155-smoke-20260705T194559Z-d0063d11-safe"
+    ],
+    "smoke_event_ids_with_findings": [
+      "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "issue155-smoke-20260705T194559Z-d0063d11-no-touch"
+    ],
+    "smoke_findings_count": 6
+  }
+}

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-validation-smoke.json
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-validation-smoke.json
@@ -1,0 +1,138 @@
+{
+  "audit_json_report": {
+    "command": [
+      "python3",
+      "backend/scripts/audit_legacy_event_discriminators.py",
+      "--report",
+      "audit",
+      "--format",
+      "json",
+      "--output",
+      "<temporary-broad-audit-json>"
+    ],
+    "format": "json",
+    "output": "pr2-smoke-audit.json",
+    "output_path_kind": "evidence-relative",
+    "persisted_schema": "issue155_smoke_scoped_audit_v1",
+    "persisted_scope": "smoke fixture findings only",
+    "report": "audit",
+    "smoke_findings_count": 6,
+    "stderr_captured": false,
+    "stdout_captured": true
+  },
+  "cleanup": {
+    "cleanup_verified": true,
+    "deleted_count": 3,
+    "query": "MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id})\nRETURN count(e)=0 AS cleanup_verified, count(e) AS remaining_count",
+    "remaining_count": 0
+  },
+  "fixture_plan": [
+    {
+      "availability_source": "snmp",
+      "ci_id": "issue155-smoke-20260705T194559Z-d0063d11-ci-safe",
+      "created_at": "2026-07-05T19:45:59.975382+00:00",
+      "event_type": "AVAILABILITY",
+      "expected_bucket": "safe_candidates",
+      "failure_family": "COLLECTION",
+      "id": "issue155-smoke-20260705T194559Z-d0063d11-safe",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-20260705T194559Z-d0063d11",
+      "last_seen": "2026-07-05T19:45:59.975382+00:00",
+      "message": "SNMP availability event with complete discriminator fields.",
+      "metric_id": "availability.safe",
+      "metric_name": "Availability Safe Fixture",
+      "severity": "warning",
+      "source_protocol": "SNMP",
+      "status": "ACTIVE"
+    },
+    {
+      "availability_source": null,
+      "ci_id": "issue155-smoke-20260705T194559Z-d0063d11-ci-ambiguous",
+      "created_at": "2026-07-05T19:45:59.975382+00:00",
+      "event_type": null,
+      "expected_bucket": "ambiguous_records",
+      "failure_family": null,
+      "id": "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-20260705T194559Z-d0063d11",
+      "last_seen": "2026-07-05T19:45:59.975382+00:00",
+      "message": "PING availability timeout; host down boundary needs reviewer decision.",
+      "metric_id": "availability.ping.timeout",
+      "metric_name": "PING Timeout Fixture",
+      "severity": "warning",
+      "source_protocol": null,
+      "status": "ACTIVE"
+    },
+    {
+      "availability_source": "snmp",
+      "ci_id": "issue155-smoke-20260705T194559Z-d0063d11-ci-no-touch",
+      "created_at": "2026-07-05T19:45:59.975382+00:00",
+      "event_type": "THRESHOLD",
+      "expected_bucket": "no_touch_records",
+      "failure_family": null,
+      "id": "issue155-smoke-20260705T194559Z-d0063d11-no-touch",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-20260705T194559Z-d0063d11",
+      "last_seen": "2026-07-05T19:45:59.975382+00:00",
+      "message": "Threshold signal with one missing discriminator and no ambiguity hint.",
+      "metric_id": "threshold.partial",
+      "metric_name": "Threshold Partial Fixture",
+      "severity": "warning",
+      "source_protocol": "SNMP",
+      "status": "ACTIVE"
+    }
+  ],
+  "run_id": "issue155-smoke-20260705T194559Z-d0063d11",
+  "scope": "local shared Neo4j only; no production mutation",
+  "seeded_count": 3,
+  "status": "validation_complete_cleanup_verified",
+  "validation_summary": {
+    "actual_buckets": {
+      "issue155-smoke-20260705T194559Z-d0063d11-ambiguous": "ambiguous_records",
+      "issue155-smoke-20260705T194559Z-d0063d11-no-touch": "no_touch_records",
+      "issue155-smoke-20260705T194559Z-d0063d11-safe": "safe_candidates"
+    },
+    "actual_counts": {
+      "ambiguous_records": 1,
+      "no_touch_records": 1,
+      "safe_candidates": 1
+    },
+    "audit_evidence": {
+      "event_ids_with_findings": [
+        "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+        "issue155-smoke-20260705T194559Z-d0063d11-no-touch"
+      ],
+      "expected_finding_event_ids": [
+        "issue155-smoke-20260705T194559Z-d0063d11-ambiguous",
+        "issue155-smoke-20260705T194559Z-d0063d11-no-touch"
+      ],
+      "missing_expected_finding_event_ids": [],
+      "schema": "issue155_smoke_scoped_audit_v1",
+      "status": "inspected"
+    },
+    "classification_source": "direct classifier reuse for smoke-only fixture rows",
+    "expected_buckets": {
+      "issue155-smoke-20260705T194559Z-d0063d11-ambiguous": "ambiguous_records",
+      "issue155-smoke-20260705T194559Z-d0063d11-no-touch": "no_touch_records",
+      "issue155-smoke-20260705T194559Z-d0063d11-safe": "safe_candidates"
+    },
+    "expected_counts": {
+      "ambiguous_records": 1,
+      "no_touch_records": 1,
+      "safe_candidates": 1
+    },
+    "mismatches": [],
+    "recommendation_gap": {
+      "description": "The existing aggregate recommendation JSON does not expose per-record smoke fixture IDs; smoke-only expected-vs-actual validation therefore parses sanitized audit JSON for ambiguous/no-touch findings and reuses the read-only classifier directly for safe fixtures, which have no finding by design.",
+      "status": "gap_recorded"
+    },
+    "safe_fixture_validation": {
+      "event_ids": [
+        "issue155-smoke-20260705T194559Z-d0063d11-safe"
+      ],
+      "source": "direct classifier reuse; safe fixtures have no audit finding by design"
+    },
+    "scope": "local shared Neo4j only; no production mutation or production-scale conclusion",
+    "valid_for_planning": true
+  }
+}

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py
@@ -27,9 +27,18 @@ class _FakeResult:
 
 
 class _FakeSession:
-    def __init__(self, fail_seed=False):
+    def __init__(
+        self,
+        fail_seed=False,
+        fail_cleanup=False,
+        cleanup_verified=True,
+        remaining_count=0,
+    ):
         self.calls = []
         self.fail_seed = fail_seed
+        self.fail_cleanup = fail_cleanup
+        self.cleanup_verified = cleanup_verified
+        self.remaining_count = remaining_count
         self.execute_write_calls = 0
 
     def execute_write(self, callback):
@@ -49,21 +58,57 @@ class _FakeSession:
                 raise RuntimeError("forced seed failure")
             return _FakeResult({"seeded_count": len(params["fixtures"])})
         if query == smoke.CLEANUP_QUERY:
+            if self.fail_cleanup:
+                raise RuntimeError("forced cleanup failure")
             return _FakeResult({"deleted_count": 3})
         if query == smoke.POST_CLEANUP_QUERY:
-            return _FakeResult({"cleanup_verified": True, "remaining_count": 0})
+            return _FakeResult(
+                {
+                    "cleanup_verified": self.cleanup_verified,
+                    "remaining_count": self.remaining_count,
+                }
+            )
         raise AssertionError(f"unexpected query: {query}")
 
 
 class _FakeDriver:
-    def __init__(self, fail_seed=False):
+    def __init__(
+        self,
+        fail_seed=False,
+        fail_cleanup=False,
+        cleanup_verified=True,
+        remaining_count=0,
+    ):
         self.sessions = []
         self.fail_seed = fail_seed
+        self.fail_cleanup = fail_cleanup
+        self.cleanup_verified = cleanup_verified
+        self.remaining_count = remaining_count
 
     def session(self):
-        session = _FakeSession(fail_seed=self.fail_seed and not self.sessions)
+        session = _FakeSession(
+            fail_seed=self.fail_seed and not self.sessions,
+            fail_cleanup=self.fail_cleanup and bool(self.sessions),
+            cleanup_verified=self.cleanup_verified,
+            remaining_count=self.remaining_count,
+        )
         self.sessions.append(session)
         return session
+
+
+def _assert_no_absolute_path(test_case, value):
+    if isinstance(value, dict):
+        for nested in value.values():
+            _assert_no_absolute_path(test_case, nested)
+    elif isinstance(value, list):
+        for nested in value:
+            _assert_no_absolute_path(test_case, nested)
+    elif isinstance(value, str):
+        test_case.assertFalse(
+            value.startswith("/"),
+            f"absolute path leaked in audit metadata: {value}",
+        )
+        test_case.assertNotIn("/Users/", value)
 
 
 class SmokeFixtureHarnessTests(unittest.TestCase):
@@ -205,6 +250,371 @@ class SmokeFixtureHarnessTests(unittest.TestCase):
         self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
         self.assertEqual(all_calls[1][1]["run_id"], "issue155-smoke-test")
         self.assertEqual(all_calls[2][1]["run_id"], "issue155-smoke-test")
+
+    def test_direct_classifier_maps_fixture_plan_to_expected_buckets(self):
+        fixtures = smoke.build_fixture_plan("issue155-smoke-test")
+
+        actual = smoke.classify_fixture_buckets(fixtures)
+
+        self.assertEqual(
+            actual,
+            {
+                "issue155-smoke-test-safe": "safe_candidates",
+                "issue155-smoke-test-ambiguous": "ambiguous_records",
+                "issue155-smoke-test-no-touch": "no_touch_records",
+            },
+        )
+
+    def test_validation_summary_records_expected_actual_and_audit_binding(self):
+        fixtures = smoke.build_fixture_plan("issue155-smoke-test")
+        audit_evidence = smoke.build_smoke_scoped_audit_evidence(
+            {
+                "findings": [
+                    {
+                        "code": "missing_event_type",
+                        "field": "event_type",
+                        "id": "issue155-smoke-test-ambiguous:missing_event_type",
+                        "record": {"event_id": "issue155-smoke-test-ambiguous"},
+                        "severity": "missing",
+                    },
+                    {
+                        "code": "missing_failure_family",
+                        "field": "failure_family",
+                        "id": "issue155-smoke-test-no-touch:missing_failure_family",
+                        "record": {"event_id": "issue155-smoke-test-no-touch"},
+                        "severity": "missing",
+                    },
+                ],
+                "summary": {"total_findings": 2},
+            },
+            {fixture["id"] for fixture in fixtures},
+        )
+
+        summary = smoke.build_validation_summary(
+            fixtures,
+            smoke.classify_fixture_buckets(fixtures),
+            audit_evidence,
+        )
+
+        self.assertTrue(summary["valid_for_planning"])
+        self.assertEqual(summary["expected_counts"], summary["actual_counts"])
+        self.assertEqual(summary["mismatches"], [])
+        self.assertEqual(summary["audit_evidence"]["status"], "inspected")
+        self.assertEqual(summary["audit_evidence"]["missing_expected_finding_event_ids"], [])
+        self.assertEqual(
+            summary["safe_fixture_validation"]["source"],
+            "direct classifier reuse; safe fixtures have no audit finding by design",
+        )
+        self.assertEqual(
+            summary["recommendation_gap"]["status"],
+            "gap_recorded",
+        )
+        self.assertIn("aggregate recommendation JSON", summary["recommendation_gap"]["description"])
+
+    def test_validation_summary_marks_mismatched_bucket_invalid_for_planning(self):
+        fixtures = smoke.build_fixture_plan("issue155-smoke-test")
+        actual = smoke.classify_fixture_buckets(fixtures)
+        actual["issue155-smoke-test-safe"] = "ambiguous_records"
+
+        summary = smoke.build_validation_summary(fixtures, actual, {"findings": []})
+
+        self.assertFalse(summary["valid_for_planning"])
+        self.assertEqual(
+            summary["mismatches"],
+            [
+                {
+                    "event_id": "issue155-smoke-test-safe",
+                    "expected_bucket": "safe_candidates",
+                    "actual_bucket": "ambiguous_records",
+                }
+            ],
+        )
+
+    def test_validation_summary_requires_ambiguous_and_no_touch_audit_findings(self):
+        fixtures = smoke.build_fixture_plan("issue155-smoke-test")
+        audit_evidence = smoke.build_smoke_scoped_audit_evidence(
+            {
+                "findings": [
+                    {
+                        "code": "missing_event_type",
+                        "field": "event_type",
+                        "id": "issue155-smoke-test-ambiguous:missing_event_type",
+                        "record": {"event_id": "issue155-smoke-test-ambiguous"},
+                        "severity": "missing",
+                    }
+                ],
+                "summary": {"total_findings": 1},
+            },
+            {fixture["id"] for fixture in fixtures},
+        )
+
+        summary = smoke.build_validation_summary(
+            fixtures,
+            smoke.classify_fixture_buckets(fixtures),
+            audit_evidence,
+        )
+
+        self.assertFalse(summary["valid_for_planning"])
+        self.assertEqual(
+            summary["audit_evidence"]["missing_expected_finding_event_ids"],
+            ["issue155-smoke-test-no-touch"],
+        )
+
+    def test_smoke_scoped_audit_evidence_omits_non_smoke_details_and_raw_counts(self):
+        raw_audit = {
+            "findings": [
+                {
+                    "code": "missing_event_type",
+                    "field": "event_type",
+                    "id": "issue155-smoke-test-ambiguous:missing_event_type",
+                    "record": {
+                        "event_id": "issue155-smoke-test-ambiguous",
+                        "message": "smoke fixture text",
+                    },
+                    "severity": "missing",
+                },
+                {
+                    "code": "missing_event_type",
+                    "field": "event_type",
+                    "id": "prod-like-event:missing_event_type",
+                    "record": {
+                        "event_id": "prod-like-event",
+                        "message": "sensitive non-smoke message",
+                        "metric_name": "non-smoke metric",
+                        "created_at": "2026-07-05T12:00:00Z",
+                    },
+                    "severity": "missing",
+                },
+            ],
+            "summary": {"total_findings": 2},
+        }
+
+        evidence = smoke.build_smoke_scoped_audit_evidence(raw_audit, {"issue155-smoke-test-ambiguous"})
+
+        self.assertEqual(evidence["summary"]["smoke_findings_count"], 1)
+        self.assertEqual(evidence["findings"][0]["event_id"], "issue155-smoke-test-ambiguous")
+        serialized = json.dumps(evidence, sort_keys=True)
+        self.assertNotIn("raw_total_findings", serialized)
+        self.assertNotIn("omitted_non_smoke_findings_count", serialized)
+        self.assertNotIn("prod-like-event", serialized)
+        self.assertNotIn("sensitive non-smoke message", serialized)
+        self.assertNotIn("non-smoke metric", serialized)
+        self.assertNotIn("2026-07-05T12:00:00Z", serialized)
+
+    def test_audit_json_command_persists_smoke_scoped_output_with_safe_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+            output_path = evidence_dir / "smoke-audit.json"
+
+            with mock.patch.object(smoke.subprocess, "run") as run:
+                def fake_run(command, **kwargs):
+                    raw_output = Path(command[-1])
+                    raw_output.write_text(
+                        json.dumps(
+                            {
+                                "findings": [
+                                    {
+                                        "code": "missing_event_type",
+                                        "field": "event_type",
+                                        "id": "issue155-smoke-test-ambiguous:missing_event_type",
+                                        "record": {"event_id": "issue155-smoke-test-ambiguous"},
+                                        "severity": "missing",
+                                    },
+                                    {
+                                        "code": "missing_event_type",
+                                        "field": "event_type",
+                                        "id": "non-smoke:missing_event_type",
+                                        "record": {"event_id": "non-smoke", "message": "do not persist"},
+                                        "severity": "missing",
+                                    },
+                                ],
+                                "summary": {"total_findings": 2},
+                            }
+                        ),
+                        encoding="utf-8",
+                    )
+                    return mock.Mock(returncode=0, stdout="", stderr="")
+
+                run.side_effect = fake_run
+
+                result = smoke.run_audit_json_report(
+                    output_path,
+                    smoke_event_ids={"issue155-smoke-test-ambiguous"},
+                    neo4j_uri="bolt://127.0.0.1:17687",
+                    neo4j_user="neo4j",
+                    neo4j_password="local-secret",
+                    repo_root=Path("/repo"),
+                    evidence_dir=evidence_dir,
+                )
+
+            self.assertEqual(result["report"], "audit")
+            self.assertEqual(result["format"], "json")
+            self.assertEqual(result["output"], "smoke-audit.json")
+            self.assertEqual(result["output_path_kind"], "evidence-relative")
+            _assert_no_absolute_path(self, result)
+            persisted = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["summary"]["smoke_findings_count"], 1)
+            persisted_text = json.dumps(persisted, sort_keys=True)
+            result_text = json.dumps(result, sort_keys=True)
+            self.assertNotIn("non-smoke:missing_event_type", persisted_text)
+            self.assertNotIn("do not persist", persisted_text)
+            self.assertNotIn("raw_total_findings", persisted_text)
+            self.assertNotIn("omitted_non_smoke_findings_count", persisted_text)
+            self.assertNotIn("local-secret", persisted_text)
+            self.assertNotIn("local-secret", result_text)
+            self.assertNotIn("NEO4J_PASSWORD", result_text)
+        self.assertEqual(result["stdout_captured"], False)
+        self.assertEqual(result["stderr_captured"], False)
+        self.assertNotIn("stdout", result)
+        self.assertNotIn("stderr", result)
+        self.assertEqual(result["command"], [
+            "python3",
+            "backend/scripts/audit_legacy_event_discriminators.py",
+            "--report",
+            "audit",
+            "--format",
+            "json",
+            "--output",
+            "<temporary-broad-audit-json>",
+        ])
+        self.assertEqual(run.call_args.args[0][0], smoke.PYTHON_EXECUTABLE)
+        self.assertEqual(run.call_args.kwargs["cwd"], Path("/repo"))
+        self.assertTrue(run.call_args.kwargs["capture_output"])
+        self.assertEqual(
+            run.call_args.kwargs["env"]["NEO4J_URI"],
+            "bolt://127.0.0.1:17687",
+        )
+        self.assertEqual(run.call_args.kwargs["env"]["NEO4J_USER"], "neo4j")
+        self.assertEqual(run.call_args.kwargs["env"]["NEO4J_PASSWORD"], "local-secret")
+
+    def test_audit_json_command_rejects_non_local_target_before_subprocess(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+
+            with mock.patch.object(smoke.subprocess, "run") as run:
+                with self.assertRaisesRegex(smoke.UnsafeTargetError, "shared local Neo4j"):
+                    smoke.run_audit_json_report(
+                        evidence_dir / "smoke-audit.json",
+                        smoke_event_ids={"issue155-smoke-test-ambiguous"},
+                        neo4j_uri="bolt://prod.example.com:7687",
+                        neo4j_user="neo4j",
+                        neo4j_password="local-secret",
+                        repo_root=Path("/repo"),
+                        evidence_dir=evidence_dir,
+                    )
+
+            run.assert_not_called()
+
+    def test_run_seed_cleanup_executes_cleanup_after_audit_generation_failure(self):
+        driver = _FakeDriver()
+
+        with mock.patch.object(smoke, "run_audit_json_report", side_effect=smoke.CliError("audit failed")):
+            with self.assertRaisesRegex(smoke.CliError, "audit failed"):
+                smoke.run_seed_cleanup(driver, "issue155-smoke-test", audit_json_output="smoke-audit.json")
+
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+        self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
+
+    def test_run_seed_cleanup_executes_cleanup_after_classifier_failure(self):
+        driver = _FakeDriver()
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+            audit_path = evidence_dir / "smoke-audit.json"
+            audit_path.write_text(
+                json.dumps(
+                    smoke.build_smoke_scoped_audit_evidence(
+                        {"findings": [], "summary": {"total_findings": 0}},
+                        set(),
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                smoke,
+                "run_audit_json_report",
+                return_value={"output": "smoke-audit.json", "output_path_kind": "evidence-relative"},
+            ), mock.patch.object(
+                smoke,
+                "classify_fixture_buckets",
+                side_effect=RuntimeError("classifier failed"),
+            ), mock.patch.object(smoke, "EVIDENCE_DIR", evidence_dir):
+                with self.assertRaisesRegex(RuntimeError, "classifier failed"):
+                    smoke.run_seed_cleanup(
+                        driver,
+                        "issue155-smoke-test",
+                        audit_json_output="smoke-audit.json",
+                    )
+
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+        self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
+
+    def test_run_seed_cleanup_reports_cleanup_failure_after_prior_error(self):
+        driver = _FakeDriver(fail_cleanup=True)
+
+        with mock.patch.object(smoke, "run_audit_json_report", side_effect=smoke.CliError("audit failed")):
+            with self.assertRaisesRegex(RuntimeError, "cleanup failed after prior error"):
+                smoke.run_seed_cleanup(driver, "issue155-smoke-test", audit_json_output="smoke-audit.json")
+
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+
+    def test_run_seed_cleanup_reports_cleanup_verification_failure_after_audit_error(self):
+        driver = _FakeDriver(cleanup_verified=False, remaining_count=2)
+
+        with mock.patch.object(smoke, "run_audit_json_report", side_effect=smoke.CliError("audit failed")):
+            with self.assertRaisesRegex(RuntimeError, "cleanup verification failed"):
+                smoke.run_seed_cleanup(driver, "issue155-smoke-test", audit_json_output="smoke-audit.json")
+
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+        self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
+
+    def test_run_seed_cleanup_reports_cleanup_verification_failure_after_classifier_error(self):
+        driver = _FakeDriver(cleanup_verified=False, remaining_count=1)
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence_dir = Path(tmp) / "evidence"
+            evidence_dir.mkdir()
+            audit_path = evidence_dir / "smoke-audit.json"
+            audit_path.write_text(
+                json.dumps(
+                    smoke.build_smoke_scoped_audit_evidence(
+                        {"findings": [], "summary": {"total_findings": 0}},
+                        set(),
+                    )
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                smoke,
+                "run_audit_json_report",
+                return_value={"output": "smoke-audit.json", "output_path_kind": "evidence-relative"},
+            ), mock.patch.object(
+                smoke,
+                "classify_fixture_buckets",
+                side_effect=RuntimeError("classifier failed"),
+            ), mock.patch.object(smoke, "EVIDENCE_DIR", evidence_dir):
+                with self.assertRaisesRegex(RuntimeError, "cleanup verification failed"):
+                    smoke.run_seed_cleanup(
+                        driver,
+                        "issue155-smoke-test",
+                        audit_json_output="smoke-audit.json",
+                    )
+
+        all_calls = [call for session in driver.sessions for call in session.calls]
+        self.assertEqual(all_calls[0][0], smoke.SEED_QUERY)
+        self.assertEqual(all_calls[1][0], smoke.CLEANUP_QUERY)
+        self.assertEqual(all_calls[2][0], smoke.POST_CLEANUP_QUERY)
 
 
 if __name__ == "__main__":

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py
@@ -9,9 +9,12 @@ claim any production safety conclusion.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import json
 import os
+import subprocess
 import sys
+import tempfile
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -22,6 +25,9 @@ LOCAL_NEO4J_URI = "bolt://127.0.0.1:17687"
 SMOKE_MARKER = "issue155_smoke"
 RUN_ID_FIELD = "issue155_smoke_run_id"
 EVIDENCE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = EVIDENCE_DIR.parents[3]
+PYTHON_EXECUTABLE = sys.executable or "python3"
+SMOKE_AUDIT_SCHEMA = "issue155_smoke_scoped_audit_v1"
 
 SEED_QUERY = """
 UNWIND $fixtures AS fixture
@@ -127,6 +133,257 @@ def build_fixture_plan(run_id: str) -> list[dict[str, Any]]:
     ]
 
 
+def _load_audit_service(repo_root: Path = REPO_ROOT) -> Any:
+    backend_path = repo_root / "backend"
+    if str(backend_path) not in sys.path:
+        sys.path.insert(0, str(backend_path))
+    from services import legacy_event_discriminator_audit
+
+    return legacy_event_discriminator_audit
+
+
+def classify_fixture_buckets(
+    fixtures: list[dict[str, Any]], repo_root: Path = REPO_ROOT
+) -> dict[str, str]:
+    """Classify smoke-only fixtures by directly reusing the read-only audit service."""
+    audit_service = _load_audit_service(repo_root)
+    audit = audit_service.classify_legacy_event_records(fixtures)
+    ambiguous_event_ids = {
+        finding.record.event_id
+        for finding in audit.findings
+        if finding.severity.lower() == "ambiguous"
+    }
+    finding_event_ids = {finding.record.event_id for finding in audit.findings}
+    no_touch_event_ids = finding_event_ids - ambiguous_event_ids
+
+    bucket_by_event_id: dict[str, str] = {}
+    for fixture in fixtures:
+        event_id = str(fixture["id"])
+        if event_id in ambiguous_event_ids:
+            bucket_by_event_id[event_id] = "ambiguous_records"
+        elif event_id in no_touch_event_ids:
+            bucket_by_event_id[event_id] = "no_touch_records"
+        else:
+            bucket_by_event_id[event_id] = "safe_candidates"
+    return bucket_by_event_id
+
+
+def _evidence_relative_path(path: Path, evidence_dir: Path | None = None) -> str:
+    """Render evidence paths without leaking absolute local worktree paths."""
+    evidence_root = evidence_dir or EVIDENCE_DIR
+    return path.resolve(strict=False).relative_to(evidence_root.resolve()).as_posix()
+
+
+def _smoke_finding_event_id(finding: dict[str, Any]) -> str | None:
+    record = finding.get("record") if isinstance(finding.get("record"), dict) else {}
+    event_id = record.get("event_id")
+    return str(event_id) if event_id else None
+
+
+def build_smoke_scoped_audit_evidence(
+    raw_audit: dict[str, Any], smoke_event_ids: set[str]
+) -> dict[str, Any]:
+    """Return sanitized audit evidence containing only smoke fixture findings."""
+    smoke_ids = {str(event_id) for event_id in smoke_event_ids}
+    smoke_findings: list[dict[str, Any]] = []
+
+    for finding in raw_audit.get("findings", []):
+        if not isinstance(finding, dict):
+            continue
+        event_id = _smoke_finding_event_id(finding)
+        if event_id not in smoke_ids:
+            continue
+        smoke_findings.append(
+            {
+                "event_id": event_id,
+                "finding_id": str(finding.get("id", "")),
+                "code": finding.get("code"),
+                "field": finding.get("field"),
+                "severity": finding.get("severity"),
+                "recommended_value": finding.get("recommended_value"),
+            }
+        )
+
+    smoke_findings.sort(key=lambda item: (str(item["event_id"]), str(item["code"])))
+    smoke_event_ids_with_findings = sorted(
+        {str(finding["event_id"]) for finding in smoke_findings}
+    )
+    return {
+        "schema": SMOKE_AUDIT_SCHEMA,
+        "scope": "smoke fixture findings only; non-smoke finding details omitted",
+        "findings": smoke_findings,
+        "summary": {
+            "smoke_event_ids": sorted(smoke_ids),
+            "smoke_event_ids_with_findings": smoke_event_ids_with_findings,
+            "smoke_findings_count": len(smoke_findings),
+        },
+    }
+
+
+def read_json_evidence(path: str | Path, evidence_dir: Path | None = None) -> dict[str, Any]:
+    """Read JSON evidence from an evidence-scoped path."""
+    evidence_root = evidence_dir or EVIDENCE_DIR
+    resolved = resolve_evidence_output_path(path, evidence_dir=evidence_root)
+    with resolved.open(encoding="utf-8") as evidence_file:
+        payload = json.load(evidence_file)
+    if not isinstance(payload, dict):
+        raise CliError(f"JSON evidence must be an object: {_evidence_relative_path(resolved, evidence_root)}")
+    return payload
+
+
+def build_validation_summary(
+    fixtures: list[dict[str, Any]],
+    actual_buckets: dict[str, str],
+    audit_evidence: dict[str, Any],
+) -> dict[str, Any]:
+    """Compare expected fixture buckets with classifier and persisted audit evidence."""
+    expected_by_event_id = {
+        str(fixture["id"]): str(fixture["expected_bucket"]) for fixture in fixtures
+    }
+    expected_finding_event_ids = sorted(
+        event_id
+        for event_id, expected_bucket in expected_by_event_id.items()
+        if expected_bucket in {"ambiguous_records", "no_touch_records"}
+    )
+    audit_event_ids_with_findings = sorted(
+        {
+            str(finding.get("event_id"))
+            for finding in audit_evidence.get("findings", [])
+            if isinstance(finding, dict) and finding.get("event_id")
+        }
+    )
+    missing_expected_finding_event_ids = sorted(
+        set(expected_finding_event_ids) - set(audit_event_ids_with_findings)
+    )
+    safe_event_ids = sorted(
+        event_id
+        for event_id, expected_bucket in expected_by_event_id.items()
+        if expected_bucket == "safe_candidates"
+    )
+    mismatches = [
+        {
+            "event_id": event_id,
+            "expected_bucket": expected_bucket,
+            "actual_bucket": actual_buckets.get(event_id, "missing"),
+        }
+        for event_id, expected_bucket in expected_by_event_id.items()
+        if actual_buckets.get(event_id) != expected_bucket
+    ]
+    audit_evidence_status = (
+        "inspected" if not missing_expected_finding_event_ids else "missing_expected_findings"
+    )
+    return {
+        "valid_for_planning": not mismatches and not missing_expected_finding_event_ids,
+        "classification_source": "direct classifier reuse for smoke-only fixture rows",
+        "expected_buckets": expected_by_event_id,
+        "actual_buckets": dict(sorted(actual_buckets.items())),
+        "expected_counts": dict(sorted(Counter(expected_by_event_id.values()).items())),
+        "actual_counts": dict(sorted(Counter(actual_buckets.values()).items())),
+        "mismatches": mismatches,
+        "audit_evidence": {
+            "status": audit_evidence_status,
+            "schema": audit_evidence.get("schema"),
+            "expected_finding_event_ids": expected_finding_event_ids,
+            "event_ids_with_findings": audit_event_ids_with_findings,
+            "missing_expected_finding_event_ids": missing_expected_finding_event_ids,
+        },
+        "safe_fixture_validation": {
+            "event_ids": safe_event_ids,
+            "source": "direct classifier reuse; safe fixtures have no audit finding by design",
+        },
+        "recommendation_gap": {
+            "status": "gap_recorded",
+            "description": (
+                "The existing aggregate recommendation JSON does not expose per-record "
+                "smoke fixture IDs; smoke-only expected-vs-actual validation therefore parses "
+                "sanitized audit JSON for ambiguous/no-touch findings and reuses the read-only "
+                "classifier directly for safe fixtures, which have no finding by design."
+            ),
+        },
+        "scope": "local shared Neo4j only; no production mutation or production-scale conclusion",
+    }
+
+
+def run_audit_json_report(
+    output: str | Path,
+    *,
+    smoke_event_ids: set[str],
+    neo4j_uri: str,
+    neo4j_user: str,
+    neo4j_password: str,
+    repo_root: Path = REPO_ROOT,
+    evidence_dir: Path = EVIDENCE_DIR,
+) -> dict[str, Any]:
+    """Run the read-only audit CLI, then persist only smoke-scoped sanitized evidence."""
+    validated_neo4j_uri = validate_local_neo4j_uri(neo4j_uri)
+    output_path = resolve_evidence_output_path(output, evidence_dir=evidence_dir)
+    if output_path.exists():
+        raise OutputTargetError(f"evidence output already exists: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sanitized_command = [
+        "python3",
+        "backend/scripts/audit_legacy_event_discriminators.py",
+        "--report",
+        "audit",
+        "--format",
+        "json",
+        "--output",
+        "<temporary-broad-audit-json>",
+    ]
+    with tempfile.TemporaryDirectory(prefix="issue155-smoke-audit-") as temp_dir:
+        temporary_audit_path = Path(temp_dir) / "broad-audit.json"
+        command = [
+            PYTHON_EXECUTABLE,
+            "backend/scripts/audit_legacy_event_discriminators.py",
+            "--report",
+            "audit",
+            "--format",
+            "json",
+            "--output",
+            str(temporary_audit_path),
+        ]
+        audit_env = os.environ.copy()
+        audit_env.update(
+            {
+                "NEO4J_URI": validated_neo4j_uri,
+                "NEO4J_USER": neo4j_user,
+                "NEO4J_PASSWORD": neo4j_password,
+            }
+        )
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            env=audit_env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise CliError(
+                "read-only audit JSON report failed: "
+                f"exit={completed.returncode} stderr={completed.stderr.strip()}"
+            )
+        with temporary_audit_path.open(encoding="utf-8") as raw_audit_file:
+            raw_audit = json.load(raw_audit_file)
+        if not isinstance(raw_audit, dict):
+            raise CliError("read-only audit JSON report did not produce a JSON object")
+        sanitized_audit = build_smoke_scoped_audit_evidence(raw_audit, smoke_event_ids)
+        write_json_exclusive(output_path, sanitized_audit, evidence_dir=evidence_dir)
+
+    return {
+        "report": "audit",
+        "format": "json",
+        "output": _evidence_relative_path(output_path, evidence_dir=evidence_dir),
+        "output_path_kind": "evidence-relative",
+        "command": sanitized_command,
+        "persisted_scope": "smoke fixture findings only",
+        "persisted_schema": SMOKE_AUDIT_SCHEMA,
+        "smoke_findings_count": sanitized_audit["summary"]["smoke_findings_count"],
+        "stdout_captured": bool(completed.stdout),
+        "stderr_captured": bool(completed.stderr),
+    }
+
+
 def _single_value(summary: Any, key: str) -> Any:
     record = summary.single(strict=True)
     return record[key]
@@ -205,30 +462,88 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Seed and clean issue #155 local smoke fixtures.")
     parser.add_argument("--run-id", default=None, help="Optional unique run id for repeatable cleanup.")
     parser.add_argument("--output", default=None, help="Optional JSON manifest path for seed/cleanup evidence.")
+    parser.add_argument(
+        "--audit-json-output",
+        default=None,
+        help="Optional sanitized smoke-scoped audit JSON path for PR2 validation evidence.",
+    )
     parser.add_argument("--neo4j-uri", default=os.getenv("NEO4J_URI", LOCAL_NEO4J_URI))
     parser.add_argument("--neo4j-user", default=os.getenv("NEO4J_USER", "neo4j"))
     parser.add_argument("--neo4j-password", default=os.getenv("NEO4J_PASSWORD", ""))
     return parser
 
 
-def run_seed_cleanup(driver: Any, run_id: str) -> dict[str, Any]:
-    """Run the PR1 seed/cleanup flow with failure-safe cleanup."""
+def run_seed_cleanup(
+    driver: Any,
+    run_id: str,
+    *,
+    audit_json_output: str | Path | None = None,
+    neo4j_uri: str = LOCAL_NEO4J_URI,
+    neo4j_user: str = "neo4j",
+    neo4j_password: str = "",
+    repo_root: Path = REPO_ROOT,
+    evidence_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Run the seed/cleanup flow with optional PR2 read-only validation evidence."""
+    evidence_root = evidence_dir or EVIDENCE_DIR
     fixtures = build_fixture_plan(run_id)
     seeded_count = 0
     cleanup: dict[str, Any] | None = None
+    audit_json_report: dict[str, Any] | None = None
+    validation_summary: dict[str, Any] | None = None
+    primary_error: BaseException | None = None
     try:
         seeded_count = seed_fixtures(driver, fixtures)
+        if audit_json_output:
+            smoke_event_ids = {str(fixture["id"]) for fixture in fixtures}
+            audit_json_report = run_audit_json_report(
+                audit_json_output,
+                smoke_event_ids=smoke_event_ids,
+                neo4j_uri=neo4j_uri,
+                neo4j_user=neo4j_user,
+                neo4j_password=neo4j_password,
+                repo_root=repo_root,
+                evidence_dir=evidence_root,
+            )
+            audit_evidence = read_json_evidence(audit_json_output, evidence_dir=evidence_root)
+            validation_summary = build_validation_summary(
+                fixtures,
+                classify_fixture_buckets(fixtures, repo_root=repo_root),
+                audit_evidence,
+            )
+    except BaseException as exc:
+        primary_error = exc
     finally:
-        cleanup = cleanup_fixtures(driver, run_id)
+        try:
+            cleanup = cleanup_fixtures(driver, run_id)
+        except BaseException as cleanup_exc:
+            if primary_error is not None:
+                raise RuntimeError(
+                    f"cleanup failed after prior error {primary_error!r}: {cleanup_exc}"
+                ) from cleanup_exc
+            raise
 
     if not cleanup["cleanup_verified"]:
-        raise RuntimeError(f"cleanup verification failed for run id {run_id}: {cleanup}")
+        message = f"cleanup verification failed for run id {run_id}: {cleanup}"
+        if primary_error is not None:
+            raise RuntimeError(
+                f"{message}; prior error was {primary_error!r}"
+            ) from primary_error
+        raise RuntimeError(message)
+    if primary_error is not None:
+        raise primary_error
     return {
         "run_id": run_id,
         "seeded_count": seeded_count,
         "fixture_plan": fixtures,
+        "audit_json_report": audit_json_report,
+        "validation_summary": validation_summary,
         "cleanup": cleanup,
-        "status": "cleanup_verified",
+        "status": (
+            "validation_complete_cleanup_verified"
+            if validation_summary and validation_summary["valid_for_planning"]
+            else "cleanup_verified"
+        ),
         "scope": "local shared Neo4j only; no production mutation",
     }
 
@@ -252,7 +567,14 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         try:
-            payload = run_seed_cleanup(driver, run_id)
+            payload = run_seed_cleanup(
+                driver,
+                run_id,
+                audit_json_output=args.audit_json_output,
+                neo4j_uri=uri,
+                neo4j_user=args.neo4j_user,
+                neo4j_password=args.neo4j_password,
+            )
         except Exception as exc:
             raise CliError(f"local smoke fixture run failed: {exc}") from exc
     finally:

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md
@@ -9,11 +9,11 @@
 | Chained PRs recommended | Yes |
 | Suggested split | PR 1 evidence helper + seed/cleanup, PR 2 validation reports + evidence, PR 3 docs/cleanup |
 | Delivery strategy | ask-on-risk |
-| Chain strategy | pending |
+| Chain strategy | stacked-to-main |
 
 Decision needed before apply: Yes
 Chained PRs recommended: Yes
-Chain strategy: pending
+Chain strategy: stacked-to-main
 400-line budget risk: High
 
 ### Suggested Work Units
@@ -32,9 +32,9 @@ Chain strategy: pending
 
 ## Phase 2: Validation Logic
 
-- [ ] 2.1 Run `backend/scripts/audit_legacy_event_discriminators.py --report audit --format json` and persist raw JSON evidence.
-- [ ] 2.2 Validate expected vs actual buckets for safe, ambiguous, and no-touch fixtures using audit JSON/direct classifier reuse when CLI lacks per-fixture marker filtering.
-- [ ] 2.3 Record the validation gap explicitly if smoke IDs cannot be isolated from aggregate recommendation JSON.
+- [x] 2.1 Run `backend/scripts/audit_legacy_event_discriminators.py --report audit --format json` and persist sanitized smoke-scoped audit JSON evidence.
+- [x] 2.2 Validate expected vs actual buckets for safe, ambiguous, and no-touch fixtures using audit JSON/direct classifier reuse when CLI lacks per-fixture marker filtering.
+- [x] 2.3 Record the validation gap explicitly if smoke IDs cannot be isolated from aggregate recommendation JSON.
 
 ## Phase 3: Evidence / Wiring
 


### PR DESCRIPTION
Refs #155

## Summary
- Adds PR2 validation for issue #155 smoke fixtures using sanitized, smoke-scoped audit evidence.
- Validates expected vs actual safe/ambiguous/no-touch fixture buckets without running apply/backfill migration.
- Records the recommendation JSON gap and preserves local cleanup verification evidence.

## Changes
| File | Change |
|------|--------|
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py` | Adds smoke-scoped audit generation, validation summary, explicit local Neo4j env binding, and cleanup verification safeguards. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` | Adds unit coverage for audit evidence hygiene, env binding, validation buckets, and cleanup failure paths. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-smoke-audit.json` | Stores sanitized smoke-scoped audit evidence. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr2-validation-smoke.json` | Stores PR2 validation evidence. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md` | Marks tasks 2.1–2.3 complete. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md` | Records PR2 implementation and verification progress. |

## Test Plan
- [x] `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py`
- [x] `python3 -m py_compile openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py`
- [x] `git diff --check`
- [x] PR2 generated evidence checked for local path/password leaks.
- [x] Fresh risk review: 0 critical / 0 warning / 0 suggestion.
- [x] Fresh reliability review: 0 critical / 0 warning / 0 suggestion.

## Notes
- No production mutation, no migration, and no `--apply` path were used.
- OpenSpec/evidence lines are documentation/review evidence and are not counted as productive code lines for PR splitting.
