### PR TITLE
feat(tunnels): add scoped public ip editor medium PR2

### DIFF
--- a/backend/services/link_service.py
+++ b/backend/services/link_service.py
@@ -136,6 +136,9 @@ def get_full_graph(
     """
     is_admin = current_user.role == "ADMIN" if current_user else False
     allowed_locations = current_user.allowed_locations if current_user else None
+    if not is_admin and allowed_locations == []:
+        return {"nodes": [], "links": []}
+
     raw_nodes, raw_links = topology_repo.get_filtered_graph_data(
         layer=layer,
         location=location,
@@ -184,6 +187,7 @@ def get_full_graph(
                 "location": node_props.get("location"),
                 "location_name": node_props.get("location_name"),
                 "ip": node_props.get("ip"),
+                "public_ip": node_props.get("public_ip"),
                 "metrics": node_props.get("metrics", []),
                 "metadata": {k: v for k, v in node_props.items() if not k.startswith("_")},
             }

--- a/backend/services/node_service.py
+++ b/backend/services/node_service.py
@@ -120,6 +120,7 @@ def get_nodes(current_user: User) -> list[dict[str, Any]]:
             "category_icon_key": resolve_category_icon(category, record.get("category_icon_key")),
             "status": node.get("status", "OK"),
             "ip": node.get("ip"),
+            "public_ip": node.get("public_ip"),
             "owner": node.get("owner"),
             "brand": node.get("brand"),
             "model": node.get("model"),

--- a/backend/tests/test_routers_links.py
+++ b/backend/tests/test_routers_links.py
@@ -495,9 +495,7 @@ class TestGraphFull:
                 "layer": "vpn_hub",
             },
         ]
-        scoped_nodes = [
-            node for node in raw_nodes if node["location_name"] == "HQ-Madrid"
-        ]
+        scoped_nodes = [node for node in raw_nodes if node["location_name"] == "HQ-Madrid"]
 
         with patch("services.link_service.topology_repo") as mock_repo:
             mock_repo.get_filtered_graph_data.return_value = (scoped_nodes, [])

--- a/backend/tests/test_routers_links.py
+++ b/backend/tests/test_routers_links.py
@@ -437,6 +437,130 @@ class TestGraphFull:
         data = response.json()
         assert data["links"][0]["medium"] == "satellite"
 
+    def test_full_graph_admin_projects_public_ip_for_cidetailmodal_topology_consumer(self):
+        """Admin /graph/full topology data exposes public_ip after scoped repository access."""
+        raw_nodes = [
+            {
+                "id": "hub-a",
+                "name": "Hub-A",
+                "status": "OK",
+                "public_ip": "203.0.113.30",
+                "_labels": ["CI"],
+                "layer": "vpn_hub",
+            },
+        ]
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_filtered_graph_data.return_value = (raw_nodes, [])
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        node = response.json()["nodes"][0]
+        assert node["public_ip"] == "203.0.113.30"
+        assert node["metadata"]["public_ip"] == "203.0.113.30"
+        mock_repo.get_filtered_graph_data.assert_called_once_with(
+            layer=None,
+            location=None,
+            owner=None,
+            allowed_locations=[],
+            is_admin=True,
+        )
+
+    def test_full_graph_operator_limited_scope_projects_only_scoped_public_ips(self):
+        """Limited non-admin /graph/full data never includes out-of-scope public IPs."""
+        app.dependency_overrides[get_current_active_user] = lambda: User(
+            username="operator",
+            role="OPERATOR",
+            permissions=[],
+            allowed_locations=["HQ-Madrid"],
+        )
+        raw_nodes = [
+            {
+                "id": "hub-madrid",
+                "name": "Madrid Hub",
+                "status": "OK",
+                "public_ip": "203.0.113.40",
+                "location_name": "HQ-Madrid",
+                "_labels": ["CI"],
+                "layer": "vpn_hub",
+            },
+            {
+                "id": "hub-private",
+                "name": "Private Hub",
+                "status": "OK",
+                "public_ip": "203.0.113.99",
+                "location_name": "Private-Site",
+                "_labels": ["CI"],
+                "layer": "vpn_hub",
+            },
+        ]
+        scoped_nodes = [
+            node for node in raw_nodes if node["location_name"] == "HQ-Madrid"
+        ]
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_filtered_graph_data.return_value = (scoped_nodes, [])
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [node["id"] for node in data["nodes"]] == ["hub-madrid"]
+        assert data["nodes"][0]["public_ip"] == "203.0.113.40"
+        assert "203.0.113.99" not in response.text
+        mock_repo.get_filtered_graph_data.assert_called_once_with(
+            layer=None,
+            location=None,
+            owner=None,
+            allowed_locations=["HQ-Madrid"],
+            is_admin=False,
+        )
+
+    def test_full_graph_operator_empty_scope_has_no_topology_or_public_ip_leak(self):
+        """Empty non-admin scope returns no CIDetailModal topology public_ip data."""
+        app.dependency_overrides[get_current_active_user] = lambda: User(
+            username="operator",
+            role="OPERATOR",
+            permissions=[],
+            allowed_locations=[],
+        )
+        out_of_scope_nodes = [
+            {
+                "id": "hub-private",
+                "name": "Private Hub",
+                "status": "OK",
+                "public_ip": "203.0.113.99",
+                "location_name": "Private-Site",
+                "_labels": ["CI"],
+                "layer": "vpn_hub",
+            },
+        ]
+        out_of_scope_links = [
+            {
+                "source_node": {"id": "hub-private", "name": "Private Hub"},
+                "target_node": {"id": "router-private", "name": "Private Router"},
+                "type": "CONNECTS_TO",
+                "medium": "vpn",
+            },
+        ]
+
+        with patch("services.link_service.topology_repo") as mock_repo:
+            mock_repo.get_filtered_graph_data.return_value = (
+                out_of_scope_nodes,
+                out_of_scope_links,
+            )
+
+            response = client.get("/api/graph/full")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {"nodes": [], "links": []}
+        assert "public_ip" not in response.text
+        assert "203.0.113.99" not in response.text
+        assert "hub-private" not in response.text
+        mock_repo.get_filtered_graph_data.assert_not_called()
+
     def test_full_graph_does_not_change_node_status_or_event_fields(self):
         """Slice 1 / VPN-Rel R4 / Sc 8: existing node status/event fields stay
         untouched after Slice 1 changes."""

--- a/backend/tests/test_routers_nodes.py
+++ b/backend/tests/test_routers_nodes.py
@@ -198,9 +198,7 @@ class TestGetNodes:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
-    def test_list_nodes_admin_projects_public_ip_after_scoped_repo_result(
-        self, mock_neo4j_driver
-    ):
+    def test_list_nodes_admin_projects_public_ip_after_scoped_repo_result(self, mock_neo4j_driver):
         """Admin /nodes response exposes nullable public_ip without removing metadata."""
         fake_user = _make_pydantic_user(username="admin", role="ADMIN")
 

--- a/backend/tests/test_routers_nodes.py
+++ b/backend/tests/test_routers_nodes.py
@@ -198,6 +198,34 @@ class TestGetNodes:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
+    def test_list_nodes_admin_projects_public_ip_after_scoped_repo_result(
+        self, mock_neo4j_driver
+    ):
+        """Admin /nodes response exposes nullable public_ip without removing metadata."""
+        fake_user = _make_pydantic_user(username="admin", role="ADMIN")
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
+
+        node_record = _make_neo4j_node_record(node_id="hub-001", name="VPN Hub")
+        node_record["public_ip"] = "203.0.113.10"
+        full_record = _make_full_record(node_props=node_record, category="vpn_hub")
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [full_record]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data[0]["public_ip"] == "203.0.113.10"
+            assert data[0]["metadata"]["public_ip"] == "203.0.113.10"
+            mock_repo.get_nodes.assert_called_once_with([], True)
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
     def test_list_nodes_operator_scoped_by_location(self, mock_neo4j_driver):
         """Non-admin should have results scoped to allowed_locations."""
         fake_user = _make_pydantic_user(
@@ -236,6 +264,45 @@ class TestGetNodes:
 
         app.dependency_overrides.pop(get_current_active_user, None)
 
+    def test_list_nodes_operator_limited_scope_projects_only_returned_public_ips(
+        self, mock_neo4j_driver
+    ):
+        """Limited non-admin /nodes public_ip projection happens only on scoped results."""
+        fake_user = _make_pydantic_user(
+            username="operator",
+            role="OPERATOR",
+            allowed_locations=["HQ-Madrid"],
+        )
+
+        async def override_get_current_active_user():
+            return fake_user
+
+        app.dependency_overrides[get_current_active_user] = override_get_current_active_user
+
+        scoped_node = _make_neo4j_node_record(
+            node_id="hub-madrid",
+            name="Madrid Hub",
+            location_name="HQ-Madrid",
+        )
+        scoped_node["public_ip"] = "203.0.113.20"
+
+        with patch("services.node_service.topology_repo") as mock_repo:
+            mock_repo.get_nodes.return_value = [
+                _make_full_record(node_props=scoped_node, category="vpn_hub")
+            ]
+
+            response = client.get("/api/nodes")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert [node["id"] for node in data] == ["hub-madrid"]
+            assert data[0]["public_ip"] == "203.0.113.20"
+            assert data[0]["metadata"]["public_ip"] == "203.0.113.20"
+            assert "203.0.113.99" not in response.text
+            mock_repo.get_nodes.assert_called_once_with(["HQ-Madrid"], False)
+
+        app.dependency_overrides.pop(get_current_active_user, None)
+
     def test_list_nodes_operator_no_locations_returns_empty(self):
         """Operator with no allowed_locations should get empty list."""
         fake_user = _make_pydantic_user(
@@ -258,6 +325,7 @@ class TestGetNodes:
             assert response.status_code == 200
             data = response.json()
             assert data == []
+            assert "public_ip" not in response.text
 
         app.dependency_overrides.pop(get_current_active_user, None)
 

--- a/frontend/components/RelationshipManager.tsx
+++ b/frontend/components/RelationshipManager.tsx
@@ -1,12 +1,13 @@
-import type React from 'react';
-import { useState, useEffect, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import type { GraphNode } from '../types';
-import TopologyViewer from './TopologyViewer';
-import { api } from '../services/api';
-import RelationshipBadge from './RelationshipBadge';
-import RelationshipTooltip from './RelationshipTooltip';
-import { canDeleteRelationship, isReadOnlyRelationship } from './relationshipCapabilities';
+/* eslint-disable no-console */
+import type React from "react";
+import { useState, useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
+import type { GraphNode, TunnelHealthResponse, TunnelMedium } from "../types";
+import TopologyViewer from "./TopologyViewer";
+import { api } from "../services/api";
+import RelationshipBadge from "./RelationshipBadge";
+import RelationshipTooltip from "./RelationshipTooltip";
+import { canDeleteRelationship, isReadOnlyRelationship } from "./relationshipCapabilities";
 
 // ============================================================================
 // Relationship Indicators — Types & Utilities
@@ -31,18 +32,21 @@ export interface LinkData {
   target: string;
   target_label?: string;
   relationship: string;
+  medium?: TunnelMedium;
+  tunnel_health?: TunnelHealthResponse | null;
 }
 
 /**
  * Derives a Map<ciId, {asSource[], asTarget[]}> from raw link data.
  * O(n) per call — called inside useMemo in the component.
  */
+// eslint-disable-next-line react-refresh/only-export-components
 export const computeRelationshipMap = (links: LinkData[]): CiRelationshipMap => {
   const map: CiRelationshipMap = new Map();
 
   for (const link of links) {
     // Skip HAS_METRIC links — not relevant to CI-to-CI relationship topology
-    if (link.relationship === 'HAS_METRIC') continue;
+    if (link.relationship === "HAS_METRIC") continue;
 
     const sourceId = link.source;
     const targetId = link.target;
@@ -54,565 +58,632 @@ export const computeRelationshipMap = (links: LinkData[]): CiRelationshipMap => 
     if (!map.has(targetId)) map.set(targetId, { asSource: [], asTarget: [] });
 
     // source → target: source is "asSource", target is "asTarget"
-    map.get(sourceId)!.asSource.push({ otherId: targetId, otherLabel: targetLabel, type: link.relationship });
-    map.get(targetId)!.asTarget.push({ otherId: sourceId, otherLabel: sourceLabel, type: link.relationship });
+    map
+      .get(sourceId)!
+      .asSource.push({ otherId: targetId, otherLabel: targetLabel, type: link.relationship });
+    map
+      .get(targetId)!
+      .asTarget.push({ otherId: sourceId, otherLabel: sourceLabel, type: link.relationship });
   }
 
   return map;
 };
 
 interface RelationshipManagerProps {
-    onRefresh: () => void;
+  onRefresh: () => void;
+}
+
+interface CategoryResponse {
+  name: string;
+}
+
+interface MetricResponse {
+  name: string;
+  description?: string;
 }
 
 /**
  * RelationshipManager Component
- * 
+ *
  * Manages the creation, deletion, and visualization of relationships between Configuration Items (CIs).
  * Also handles the promotion of SNMP Metrics to Nodes (Graph Objects).
  */
 const RelationshipManager: React.FC<RelationshipManagerProps> = ({ onRefresh }) => {
-    // --- State: Data ---
-    const [nodes, setNodes] = useState<GraphNode[]>([]);
-    const [categories, setCategories] = useState<string[]>([]);
-    const [loading, setLoading] = useState(false);
+  // --- State: Data ---
+  const [nodes, setNodes] = useState<GraphNode[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
 
-    // --- State: Source Selection ---
-    const [sourceCategory, setSourceCategory] = useState<string>('');
-    const [sourceNodeId, setSourceNodeId] = useState<string>('');
+  // --- State: Source Selection ---
+  const [sourceCategory, setSourceCategory] = useState<string>("");
+  const [sourceNodeId, setSourceNodeId] = useState<string>("");
 
-    // --- State: Target Selection ---
-    const [targetCategory] = useState<string>('');
-    const [targetNodeIds, setTargetNodeIds] = useState<string[]>([]);
+  // --- State: Target Selection ---
+  const [targetCategory] = useState<string>("");
+  const [targetNodeIds, setTargetNodeIds] = useState<string[]>([]);
 
-    // --- State: Relationship Settings ---
-    const [relType, setRelType] = useState<string>('DEPENDS_ON');
+  // --- State: Relationship Settings ---
+  const [relType, setRelType] = useState<string>("DEPENDS_ON");
 
-    // --- State: Links & Graph ---
-    const [links, setLinks] = useState<LinkData[]>([]);
+  // --- State: Links & Graph ---
+  const [links, setLinks] = useState<LinkData[]>([]);
 
-    // --- State: Search ---
-    const [searchCiLinks, setSearchCiLinks] = useState('');
+  // --- State: Search ---
+  const [searchCiLinks, setSearchCiLinks] = useState("");
 
-    // --- Derived: Relationship map for indicators ---
-    // recomputes when links change, O(n) with typical CI counts (<1000)
-    const relationshipMap = useMemo(() => computeRelationshipMap(links), [links]);
+  // --- Derived: Relationship map for indicators ---
+  // recomputes when links change, O(n) with typical CI counts (<1000)
+  const relationshipMap = useMemo(() => computeRelationshipMap(links), [links]);
 
-    // --- Memoized: filtered link lists to avoid repeated filter calls ---
-    const ciLinks = useMemo(() => links.filter(l => l.relationship !== 'HAS_METRIC'), [links]);
-    const metricLinks = useMemo(() => links.filter(l => l.relationship === 'HAS_METRIC'), [links]);
+  // --- Memoized: filtered link lists to avoid repeated filter calls ---
+  const ciLinks = useMemo(() => links.filter((l) => l.relationship !== "HAS_METRIC"), [links]);
+  const metricLinks = useMemo(() => links.filter((l) => l.relationship === "HAS_METRIC"), [links]);
 
-    // --- Memoized: search-filtered CI links ---
-    const filteredCiLinks = useMemo(() => {
-        if (!searchCiLinks.trim()) return ciLinks;
-        const q = searchCiLinks.toLowerCase();
-        return ciLinks.filter(l =>
-            l.source.toLowerCase().includes(q) ||
-            (l.source_label || '').toLowerCase().includes(q) ||
-            l.target.toLowerCase().includes(q) ||
-            (l.target_label || '').toLowerCase().includes(q) ||
-            l.relationship.toLowerCase().includes(q)
-        );
-    }, [ciLinks, searchCiLinks]);
-
-    // --- State: Mode (Links/Metrics) ---
-    const [viewMode, setViewMode] = useState<'LINKS' | 'METRICS'>('LINKS');
-    const [availableMetrics, setAvailableMetrics] = useState<any[]>([]);
-    const [selectedMetrics, setSelectedMetrics] = useState<string[]>([]);
-
-    // --- State: Visualization Modal ---
-    const [visualizationTarget, setVisualizationTarget] = useState<string | null>(null);
-    const [showHelp, setShowHelp] = useState(false);
-
-    // --- Effects ---
-    useEffect(() => {
-        fetchData();
-        fetchLinks();
-    }, []);
-
-    // Fetch metrics when Source Node changes in Metrics Mode
-    useEffect(() => {
-        if (viewMode === 'METRICS' && sourceNodeId) {
-            fetchNodeMetrics(sourceNodeId);
-        } else {
-            setAvailableMetrics([]);
-        }
-    }, [viewMode, sourceNodeId]);
-
-    // --- API Interactions ---
-
-
-
-    const fetchData = async () => {
-        setLoading(true);
-        try {
-            const [nodesData, catsData] = await Promise.all([
-                api.get<GraphNode[]>('/nodes'),
-                api.get<any[]>('/categories')
-            ]);
-
-            setNodes(Array.isArray(nodesData) ? nodesData : []);
-            setCategories(Array.isArray(catsData) ? catsData.map((c: any) => c.name) : []);
-        } catch (error) {
-            console.error("Failed to fetch data", error);
-            setNodes([]); // Safety fallback
-            setCategories([]);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const fetchLinks = async () => {
-        try {
-            const data = await api.get<any[]>('/links');
-            setLinks(Array.isArray(data) ? data : []);
-        } catch (error) {
-            console.error("Failed to fetch links", error);
-            setLinks([]);
-        }
-    };
-
-    const fetchNodeMetrics = async (nodeId: string) => {
-        try {
-            const data = await api.get<any[]>(`/nodes/${nodeId}/metrics`);
-            setAvailableMetrics(Array.isArray(data) ? data : []);
-        } catch (e) {
-            console.error(e);
-            setAvailableMetrics([]);
-        }
-    };
-
-    // --- Action Handlers ---
-
-    const handlePromoteMetrics = async () => {
-        if (!sourceNodeId || selectedMetrics.length === 0) return;
-
-        setLoading(true);
-        try {
-            for (const metricName of selectedMetrics) {
-                const m = availableMetrics.find(am => am.name === metricName);
-                await api.post('/metrics/promote', {
-                    ci_id: sourceNodeId,
-                    metric_name: metricName,
-                    display_name: m?.description || metricName
-                });
-            }
-            alert("Metrics promoted to Nodes successfully!");
-            setSelectedMetrics([]);
-            // Refresh to show new nodes in list
-            fetchData();
-            fetchLinks();
-            onRefresh();
-        } catch (e) {
-            console.error(e);
-            alert("Error promoting metrics");
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    const handleCreate = async () => {
-        if (!sourceNodeId || targetNodeIds.length === 0 || !relType) {
-            alert("Please select a source, at least one target, and a relationship type.");
-            return;
-        }
-
-        if (confirm(`Create ${targetNodeIds.length} links from ${sourceNodeId}?`)) {
-            setLoading(true);
-            try {
-                // Batch create with concurrency limit of 10
-                const batchSize = 10;
-                for (let i = 0; i < targetNodeIds.length; i += batchSize) {
-                    const batch = targetNodeIds.slice(i, i + batchSize);
-                    await Promise.all(batch.map(targetId =>
-                        api.post('/links', {
-                            source: sourceNodeId,
-                            target: targetId,
-                            relationship: relType
-                        })
-                    ));
-                }
-                alert("Relationships created successfully!");
-                setTargetNodeIds([]); // Reset targets
-                fetchLinks();
-                onRefresh();
-            } catch (e) {
-                console.error(e);
-                alert("Error creating links");
-            } finally {
-                setLoading(false);
-            }
-        }
-    };
-
-    const handleDelete = async (link: any) => {
-        if (!canDeleteRelationship(link.relationship)) return;
-
-        if (confirm(`Delete link: ${link.source} -[${link.relationship}]-> ${link.target}?`)) {
-            try {
-                await api.delete('/links', link);
-                fetchLinks();
-                onRefresh();
-            } catch (e) {
-                console.error(e);
-            }
-        }
-    };
-
-    // --- Helpers ---
-
-    const toggleTarget = (id: string) => {
-        setTargetNodeIds(prev =>
-            prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
-        );
-    };
-
-    // Filter Logic
-    const sourceNodes = sourceCategory
-        ? nodes.filter(n => (n.type || '').toLowerCase() === sourceCategory.toLowerCase())
-        : nodes;
-
-    // Filter out the selected source node from targets to prevent self-linking
-    const targetNodes = targetCategory
-        ? nodes.filter(n => (n.type || '').toLowerCase() === targetCategory.toLowerCase() && n.id !== sourceNodeId)
-        : nodes.filter(n => n.id !== sourceNodeId);
-
-
-    return (
-        <div className="flex gap-6 h-[calc(100vh-250px)]">
-            {/* Help Modal */}
-            {showHelp && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4" onClick={() => setShowHelp(false)}>
-                    <div className="bg-surface-900 border border-white/10 rounded-2xl max-w-3xl w-full p-8 shadow-2xl space-y-6 relative" onClick={e => e.stopPropagation()}>
-                        <button
-                            onClick={() => setShowHelp(false)}
-                            className="absolute top-4 right-4 text-neutral-500 hover:text-white"
-                        >
-                            <span className="material-symbols-outlined">close</span>
-                        </button>
-                        <h2 className="text-2xl font-black text-white uppercase tracking-tight flex items-center gap-2">
-                            <span className="material-symbols-outlined text-brand-500">school</span>
-                            Relationship Guide
-                        </h2>
-                        {/* Simplified Help Content */}
-                        <div className="p-4 bg-black/30 text-neutral-400 text-sm rounded-lg">
-                            Defines how CIs interact. DEPENDS_ON drives the impact analysis.
-                        </div>
-                    </div>
-                </div>
-            )}
-
-            {/* Left Panel: Creator & Controls */}
-            <div className="w-1/3 glass p-6 rounded-2xl border border-white/5 flex flex-col gap-6 overflow-y-auto custom-scrollbar">
-                <div className="flex items-center justify-between">
-                    <h3 className="text-xl font-bold text-white uppercase flex items-center gap-2">
-                        <span className="material-symbols-outlined">hub</span>
-                        Topology Manager
-                    </h3>
-                    <div className="flex bg-black/40 rounded-lg p-1">
-                        <button
-                            onClick={() => setViewMode('LINKS')}
-                            className={`px-3 py-1 text-xs font-bold rounded-md transition-all ${viewMode === 'LINKS' ? 'bg-brand-500 text-white' : 'text-neutral-500 hover:text-white'}`}
-                        >LINKS</button>
-                        <button
-                            onClick={() => setViewMode('METRICS')}
-                            className={`px-3 py-1 text-xs font-bold rounded-md transition-all ${viewMode === 'METRICS' ? 'bg-blue-600 text-white' : 'text-neutral-500 hover:text-white'}`}
-                        >METRICS</button>
-                    </div>
-                </div>
-
-                {/* 1. Source Selection */}
-                <div className="space-y-3 p-4 bg-white/5 rounded-xl border border-white/5">
-                    <div className="flex items-center gap-2 text-brand-400 font-bold text-xs uppercase tracking-widest">
-                        <span className="material-symbols-outlined text-sm">output</span>
-                        1. Select Source (Parent/Host)
-                    </div>
-                    <select
-                        className="w-full bg-black/20 border border-white/10 rounded-lg p-2 text-sm text-white focus:border-brand-500 outline-none"
-                        value={sourceCategory}
-                        onChange={e => { setSourceCategory(e.target.value); setSourceNodeId(''); }}
-                    >
-                        <option value="">-- All Categories --</option>
-                        {categories.map(c => <option key={c} value={c}>{c}</option>)}
-                    </select>
-                    <select
-                        className="w-full bg-black/20 border border-white/10 rounded-lg p-2 text-sm text-white focus:border-brand-500 outline-none"
-                        value={sourceNodeId}
-                        onChange={e => setSourceNodeId(e.target.value)}
-                    >
-                        <option value="">-- Select Source CI --</option>
-                        {sourceNodes.map(n => (
-                            <option key={n.id} value={n.id}>{n.label}</option>
-                        ))}
-                    </select>
-                </div>
-
-                {viewMode === 'LINKS' ? (
-                    <>
-                        <div className="space-y-2">
-                            <label className="text-xs text-neutral-500 font-bold uppercase">Relationship Type</label>
-                            <select
-                                className="w-full bg-black/20 border border-white/10 rounded-lg p-2 text-sm text-white outline-none font-mono"
-                                value={relType}
-                                onChange={e => setRelType(e.target.value)}
-                            >
-                                <option value="DEPENDS_ON">DEPENDS_ON (Impact Flow)</option>
-                                <option value="HOSTED_ON">HOSTED_ON (Containment)</option>
-                                <option value="CONNECTS_TO">CONNECTS_TO (Network)</option>
-                            </select>
-                        </div>
-
-                        {/* 2. Target Selection (Multi-select) */}
-                        <div className="space-y-3 p-4 bg-white/5 rounded-xl border border-white/5 flex-1 flex flex-col min-h-[200px]">
-                            <div className="flex items-center gap-2 text-accent-cyan font-bold text-xs uppercase tracking-widest">
-                                <span className="material-symbols-outlined text-sm">input</span>
-                                2. Select Targets (Deepents)
-                            </div>
-                            <div className="flex-1 overflow-y-auto custom-scrollbar bg-black/20 rounded-lg p-2 border border-white/5">
-                                {targetNodes.map(n => (
-                                    <div
-                                        key={n.id}
-                                        onClick={() => toggleTarget(n.id)}
-                                        className={`p-2 rounded cursor-pointer text-xs flex items-center justify-between transition-colors ${targetNodeIds.includes(n.id) ? 'bg-accent-cyan/20 text-accent-cyan' : 'text-neutral-400 hover:bg-white/5'}`}
-                                    >
-                                        <RelationshipTooltip ciId={n.id} relationships={relationshipMap}>
-                                            <span>{n.label}</span>
-                                        </RelationshipTooltip>
-                                        <RelationshipBadge ciId={n.id} relationships={relationshipMap} />
-                                        {targetNodeIds.includes(n.id) && <span className="material-symbols-outlined text-sm">check</span>}
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-
-                        <button
-                            onClick={handleCreate}
-                            disabled={loading || !sourceNodeId || targetNodeIds.length === 0}
-                            className="w-full bg-brand-600 text-white font-bold py-3 rounded-xl uppercase tracking-wider text-xs"
-                        >
-                            {loading ? 'Processing...' : `Create ${targetNodeIds.length} Links`}
-                        </button>
-                    </>
-                ) : (
-                    <>
-                        {/* Metrics Selection */}
-                        <div className="space-y-3 p-4 bg-blue-900/10 rounded-xl border border-blue-500/20 flex-1 flex flex-col min-h-[200px]">
-                            <div className="flex items-center gap-2 text-blue-400 font-bold text-xs uppercase tracking-widest">
-                                <span className="material-symbols-outlined text-sm">list</span>
-                                2. Select Metrics to Promote
-                            </div>
-                            {!sourceNodeId ? (
-                                <div className="text-center text-neutral-500 p-4 text-xs">Select a Source Node first</div>
-                            ) : availableMetrics.length === 0 ? (
-                                <div className="text-center text-neutral-500 p-4 text-xs">No metrics found for this CI</div>
-                            ) : (
-                                <div className="flex-1 overflow-y-auto custom-scrollbar bg-black/20 rounded-lg p-2 border border-white/5 space-y-1">
-                                    {availableMetrics.map(m => (
-                                        <div
-                                            key={m.name}
-                                            onClick={() => {
-                                                if (selectedMetrics.includes(m.name)) setSelectedMetrics(prev => prev.filter(x => x !== m.name));
-                                                else setSelectedMetrics(prev => [...prev, m.name]);
-                                            }}
-                                            className={`p-2 rounded cursor-pointer text-xs flex items-center justify-between transition-colors ${selectedMetrics.includes(m.name) ? 'bg-blue-500/20 text-blue-400 border border-blue-500/30' : 'text-neutral-400 hover:bg-white/5'}`}
-                                        >
-                                            <div className="flex flex-col">
-                                                <span className="font-bold">{m.name}</span>
-                                                <span className="opacity-70 text-[10px]">{m.description}</span>
-                                            </div>
-                                            {selectedMetrics.includes(m.name) && <span className="material-symbols-outlined text-sm">check_circle</span>}
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
-
-                        <button
-                            onClick={handlePromoteMetrics}
-                            disabled={loading || selectedMetrics.length === 0}
-                            className="w-full bg-blue-600 hover:bg-blue-500 text-white font-bold py-3 rounded-xl uppercase tracking-wider text-xs flex items-center justify-center gap-2"
-                        >
-                            <span className="material-symbols-outlined">upgrade</span>
-                            Promote {selectedMetrics.length} Metrics
-                        </button>
-                    </>
-                )}
-            </div>
-
-            {/* Right Panel: List/Graph View */}
-            <div className="flex-1 glass p-6 rounded-2xl border border-white/5 overflow-hidden flex flex-col gap-6">
-
-                {/* CI Relationships Table */}
-                <div className="flex-1 flex flex-col min-h-0">
-                    <div className="flex items-center justify-between mb-4 gap-4">
-                        <h3 className="text-sm font-bold text-white uppercase flex items-center gap-2">
-                            <span className="material-symbols-outlined text-brand-500">hub</span>
-                            CI Relationships ({filteredCiLinks.length})
-                        </h3>
-                        <Link
-                            to="/admin/relationships/visual-editor"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="btn-primary text-xs"
-                        >
-                            <span className="material-symbols-outlined text-sm">account_tree</span>
-                            Visual editor
-                        </Link>
-                        <div className="relative">
-                            <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-neutral-500 text-sm">search</span>
-                            <input
-                                type="text"
-                                placeholder="Search links..."
-                                value={searchCiLinks}
-                                onChange={e => setSearchCiLinks(e.target.value)}
-                                className="bg-black/40 border border-white/10 rounded-lg pl-8 pr-3 py-1.5 text-xs text-neutral-300 placeholder-neutral-600 focus:outline-none focus:border-brand-500/50 w-48 transition-colors"
-                            />
-                            {searchCiLinks && (
-                                <button
-                                    onClick={() => setSearchCiLinks('')}
-                                    className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-white"
-                                >
-                                    <span className="material-symbols-outlined text-sm">close</span>
-                                </button>
-                            )}
-                        </div>
-                    </div>
-                    <div className="flex-1 overflow-y-auto custom-scrollbar border border-white/5 rounded-lg bg-black/20">
-                        <table className="w-full text-left border-collapse">
-                            <thead>
-                                <tr className="text-xs text-neutral-500 border-b border-white/10 sticky top-0 bg-surface-900 z-10">
-                                    <th className="p-3 uppercase tracking-wider">Source</th>
-                                    <th className="p-3 uppercase tracking-wider text-center">Relationship</th>
-                                    <th className="p-3 uppercase tracking-wider">Target</th>
-                                    <th className="p-3 text-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody className="text-sm">
-                                {filteredCiLinks.map((link, i) => {
-                                    const readOnly = isReadOnlyRelationship(link.relationship);
-
-                                    return (
-                                        <tr key={i} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
-                                            <td className="p-3 font-mono text-brand-400" title={link.source}>{link.source_label || link.source}</td>
-                                            <td className="p-3 text-center">
-                                                <span className="text-[10px] font-bold bg-white/10 px-2 py-1 rounded text-neutral-300 uppercase">{link.relationship}</span>
-                                                {readOnly && (
-                                                    <span className="ml-2 text-[10px] font-bold bg-amber-400/10 px-2 py-1 rounded text-amber-200 uppercase">Read-only</span>
-                                                )}
-                                            </td>
-                                            <td className="p-3 font-mono text-accent-cyan" title={link.target}>{link.target_label || link.target}</td>
-                                            <td className="p-3 text-right flex items-center justify-end gap-2">
-                                                <button
-                                                    onClick={() => {
-                                                        // Smart Root Selection: Select the "Superior" node as Root
-                                                        // For dependencies, the Target is the Provider (Superior)
-                                                        if (['DEPENDS_ON', 'HOSTED_ON'].includes(link.relationship)) {
-                                                            setVisualizationTarget(link.target);
-                                                        } else {
-                                                            setVisualizationTarget(link.source);
-                                                        }
-                                                    }}
-                                                    className="text-neutral-500 hover:text-brand-400 transition-colors"
-                                                    title="Visualize Correlation"
-                                                >
-                                                    <span className="material-symbols-outlined text-lg">hub</span>
-                                                </button>
-                                                {canDeleteRelationship(link.relationship) && (
-                                                    <button
-                                                        onClick={() => handleDelete(link)}
-                                                        className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
-                                                    >
-                                                        <span className="material-symbols-outlined text-lg">delete</span>
-                                                    </button>
-                                                )}
-                                            </td>
-                                        </tr>
-                                    );
-                                })}
-                                {filteredCiLinks.length === 0 && (
-                                    <tr>
-                                        <td colSpan={4} className="p-8 text-center text-neutral-500 text-xs">
-                                            {searchCiLinks ? `No links match "${searchCiLinks}"` : 'No CI-to-CI relationships found.'}
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-
-                {/* Metric Relationships Table */}
-                <div className="flex-1 flex flex-col min-h-0 border-t border-white/10 pt-4">
-                    <h3 className="text-sm font-bold text-blue-400 uppercase mb-4 flex items-center gap-2">
-                        <span className="material-symbols-outlined">bar_chart</span>
-                        Promoted Metrics ({metricLinks.length})
-                    </h3>
-                    <div className="flex-1 overflow-y-auto custom-scrollbar border border-white/5 rounded-lg bg-black/20">
-                        <table className="w-full text-left border-collapse">
-                            <thead>
-                                <tr className="text-xs text-neutral-500 border-b border-white/10 sticky top-0 bg-surface-900 z-10">
-                                    <th className="p-3 uppercase tracking-wider">Host CI</th>
-                                    <th className="p-3 uppercase tracking-wider">Metric Node</th>
-                                    <th className="p-3 text-right">Action</th>
-                                </tr>
-                            </thead>
-                            <tbody className="text-sm">
-                                {metricLinks.map((link, i) => (
-                                    <tr key={i} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
-                                        <td className="p-3 font-mono text-white" title={link.source}>{link.source_label || link.source}</td>
-                                        <td className="p-3 font-mono text-blue-400 flex items-center gap-2" title={link.target}>
-                                            <span className="material-symbols-outlined text-xs">analytics</span>
-                                            {link.target_label || link.target}
-                                        </td>
-                                        <td className="p-3 text-right">
-                                            <button
-                                                onClick={() => handleDelete(link)}
-                                                className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
-                                                title="Demote Metric (Delete Node)"
-                                            >
-                                                <span className="material-symbols-outlined text-lg">delete</span>
-                                            </button>
-                                        </td>
-                                    </tr>
-                                ))}
-                                {metricLinks.length === 0 && (
-                                    <tr>
-                                        <td colSpan={3} className="p-8 text-center text-neutral-500 text-xs text-italic">
-                                            No promoted metrics found.
-                                        </td>
-                                    </tr>
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-
-            </div>
-
-            {/* Visualization Modal */}
-            {visualizationTarget && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-xl p-8">
-                    <div className="w-full h-full max-w-6xl flex flex-col relative">
-                        <button
-                            onClick={() => setVisualizationTarget(null)}
-                            className="absolute top-0 right-0 p-4 text-white hover:text-red-500 z-50"
-                        >
-                            <span className="material-symbols-outlined text-3xl">close</span>
-                        </button>
-                        <h2 className="text-2xl font-black text-white uppercase tracking-tight flex items-center gap-2 mb-4 absolute top-0 left-0">
-                            <span className="material-symbols-outlined text-brand-500">hub</span>
-                            Correlation Explorer
-                        </h2>
-                        <div className="flex-1 mt-12 bg-black/20 rounded-2xl border border-white/5 overflow-hidden">
-                            {/* Uses the extracted TopologyViewer Component */}
-                            <TopologyViewer rootId={visualizationTarget} nodes={nodes} links={links} />
-                        </div>
-                    </div>
-                </div>
-            )}
-
-        </div>
+  // --- Memoized: search-filtered CI links ---
+  const filteredCiLinks = useMemo(() => {
+    if (!searchCiLinks.trim()) return ciLinks;
+    const q = searchCiLinks.toLowerCase();
+    return ciLinks.filter(
+      (l) =>
+        l.source.toLowerCase().includes(q) ||
+        (l.source_label || "").toLowerCase().includes(q) ||
+        l.target.toLowerCase().includes(q) ||
+        (l.target_label || "").toLowerCase().includes(q) ||
+        l.relationship.toLowerCase().includes(q),
     );
+  }, [ciLinks, searchCiLinks]);
+
+  // --- State: Mode (Links/Metrics) ---
+  const [viewMode, setViewMode] = useState<"LINKS" | "METRICS">("LINKS");
+  const [availableMetrics, setAvailableMetrics] = useState<MetricResponse[]>([]);
+  const [selectedMetrics, setSelectedMetrics] = useState<string[]>([]);
+
+  // --- State: Visualization Modal ---
+  const [visualizationTarget, setVisualizationTarget] = useState<string | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+
+  // --- Effects ---
+  useEffect(() => {
+    fetchData();
+    fetchLinks();
+  }, []);
+
+  // Fetch metrics when Source Node changes in Metrics Mode
+  useEffect(() => {
+    if (viewMode === "METRICS" && sourceNodeId) {
+      fetchNodeMetrics(sourceNodeId);
+    } else {
+      setAvailableMetrics([]);
+    }
+  }, [viewMode, sourceNodeId]);
+
+  // --- API Interactions ---
+
+  const fetchData = async () => {
+    setLoading(true);
+    try {
+      const [nodesData, catsData] = await Promise.all([
+        api.get<GraphNode[]>("/nodes"),
+        api.get<CategoryResponse[]>("/categories"),
+      ]);
+
+      setNodes(Array.isArray(nodesData) ? nodesData : []);
+      setCategories(Array.isArray(catsData) ? catsData.map((c) => c.name) : []);
+    } catch (error) {
+      console.error("Failed to fetch data", error);
+      setNodes([]); // Safety fallback
+      setCategories([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchLinks = async () => {
+    try {
+      const data = await api.get<LinkData[]>("/links");
+      setLinks(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error("Failed to fetch links", error);
+      setLinks([]);
+    }
+  };
+
+  const fetchNodeMetrics = async (nodeId: string) => {
+    try {
+      const data = await api.get<MetricResponse[]>(`/nodes/${nodeId}/metrics`);
+      setAvailableMetrics(Array.isArray(data) ? data : []);
+    } catch (e) {
+      console.error(e);
+      setAvailableMetrics([]);
+    }
+  };
+
+  // --- Action Handlers ---
+
+  const handlePromoteMetrics = async () => {
+    if (!sourceNodeId || selectedMetrics.length === 0) return;
+
+    setLoading(true);
+    try {
+      for (const metricName of selectedMetrics) {
+        const m = availableMetrics.find((am) => am.name === metricName);
+        await api.post("/metrics/promote", {
+          ci_id: sourceNodeId,
+          metric_name: metricName,
+          display_name: m?.description || metricName,
+        });
+      }
+      alert("Metrics promoted to Nodes successfully!");
+      setSelectedMetrics([]);
+      // Refresh to show new nodes in list
+      fetchData();
+      fetchLinks();
+      onRefresh();
+    } catch (e) {
+      console.error(e);
+      alert("Error promoting metrics");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!sourceNodeId || targetNodeIds.length === 0 || !relType) {
+      alert("Please select a source, at least one target, and a relationship type.");
+      return;
+    }
+
+    if (confirm(`Create ${targetNodeIds.length} links from ${sourceNodeId}?`)) {
+      setLoading(true);
+      try {
+        // Batch create with concurrency limit of 10
+        const batchSize = 10;
+        for (let i = 0; i < targetNodeIds.length; i += batchSize) {
+          const batch = targetNodeIds.slice(i, i + batchSize);
+          await Promise.all(
+            batch.map((targetId) =>
+              api.post("/links", {
+                source: sourceNodeId,
+                target: targetId,
+                relationship: relType,
+              }),
+            ),
+          );
+        }
+        alert("Relationships created successfully!");
+        setTargetNodeIds([]); // Reset targets
+        fetchLinks();
+        onRefresh();
+      } catch (e) {
+        console.error(e);
+        alert("Error creating links");
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  const handleDelete = async (link: LinkData) => {
+    if (!canDeleteRelationship(link.relationship)) return;
+
+    if (confirm(`Delete link: ${link.source} -[${link.relationship}]-> ${link.target}?`)) {
+      try {
+        await api.delete("/links", link);
+        fetchLinks();
+        onRefresh();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  // --- Helpers ---
+
+  const toggleTarget = (id: string) => {
+    setTargetNodeIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  };
+
+  // Filter Logic
+  const sourceNodes = sourceCategory
+    ? nodes.filter((n) => (n.type || "").toLowerCase() === sourceCategory.toLowerCase())
+    : nodes;
+
+  // Filter out the selected source node from targets to prevent self-linking
+  const targetNodes = targetCategory
+    ? nodes.filter(
+        (n) =>
+          (n.type || "").toLowerCase() === targetCategory.toLowerCase() && n.id !== sourceNodeId,
+      )
+    : nodes.filter((n) => n.id !== sourceNodeId);
+
+  return (
+    <div className="flex gap-6 h-[calc(100vh-250px)]">
+      {/* Help Modal */}
+      {showHelp && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm p-4"
+          onClick={() => setShowHelp(false)}
+        >
+          <div
+            className="bg-surface-900 border border-white/10 rounded-2xl max-w-3xl w-full p-8 shadow-2xl space-y-6 relative"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => setShowHelp(false)}
+              className="absolute top-4 right-4 text-neutral-500 hover:text-white"
+            >
+              <span className="material-symbols-outlined">close</span>
+            </button>
+            <h2 className="text-2xl font-black text-white uppercase tracking-tight flex items-center gap-2">
+              <span className="material-symbols-outlined text-brand-500">school</span>
+              Relationship Guide
+            </h2>
+            {/* Simplified Help Content */}
+            <div className="p-4 bg-black/30 text-neutral-400 text-sm rounded-lg">
+              Defines how CIs interact. DEPENDS_ON drives the impact analysis.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Left Panel: Creator & Controls */}
+      <div className="w-1/3 glass p-6 rounded-2xl border border-white/5 flex flex-col gap-6 overflow-y-auto custom-scrollbar">
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-bold text-white uppercase flex items-center gap-2">
+            <span className="material-symbols-outlined">hub</span>
+            Topology Manager
+          </h3>
+          <div className="flex bg-black/40 rounded-lg p-1">
+            <button
+              onClick={() => setViewMode("LINKS")}
+              className={`px-3 py-1 text-xs font-bold rounded-md transition-all ${viewMode === "LINKS" ? "bg-brand-500 text-white" : "text-neutral-500 hover:text-white"}`}
+            >
+              LINKS
+            </button>
+            <button
+              onClick={() => setViewMode("METRICS")}
+              className={`px-3 py-1 text-xs font-bold rounded-md transition-all ${viewMode === "METRICS" ? "bg-blue-600 text-white" : "text-neutral-500 hover:text-white"}`}
+            >
+              METRICS
+            </button>
+          </div>
+        </div>
+
+        {/* 1. Source Selection */}
+        <div className="space-y-3 p-4 bg-white/5 rounded-xl border border-white/5">
+          <div className="flex items-center gap-2 text-brand-400 font-bold text-xs uppercase tracking-widest">
+            <span className="material-symbols-outlined text-sm">output</span>
+            1. Select Source (Parent/Host)
+          </div>
+          <select
+            className="w-full bg-black/20 border border-white/10 rounded-lg p-2 text-sm text-white focus:border-brand-500 outline-none"
+            value={sourceCategory}
+            onChange={(e) => {
+              setSourceCategory(e.target.value);
+              setSourceNodeId("");
+            }}
+          >
+            <option value="">-- All Categories --</option>
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+          <select
+            className="w-full bg-black/20 border border-white/10 rounded-lg p-2 text-sm text-white focus:border-brand-500 outline-none"
+            value={sourceNodeId}
+            onChange={(e) => setSourceNodeId(e.target.value)}
+          >
+            <option value="">-- Select Source CI --</option>
+            {sourceNodes.map((n) => (
+              <option key={n.id} value={n.id}>
+                {n.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {viewMode === "LINKS" ? (
+          <>
+            <div className="space-y-2">
+              <label className="text-xs text-neutral-500 font-bold uppercase">
+                Relationship Type
+              </label>
+              <select
+                className="w-full bg-black/20 border border-white/10 rounded-lg p-2 text-sm text-white outline-none font-mono"
+                value={relType}
+                onChange={(e) => setRelType(e.target.value)}
+              >
+                <option value="DEPENDS_ON">DEPENDS_ON (Impact Flow)</option>
+                <option value="HOSTED_ON">HOSTED_ON (Containment)</option>
+                <option value="CONNECTS_TO">CONNECTS_TO (Network)</option>
+              </select>
+            </div>
+
+            {/* 2. Target Selection (Multi-select) */}
+            <div className="space-y-3 p-4 bg-white/5 rounded-xl border border-white/5 flex-1 flex flex-col min-h-[200px]">
+              <div className="flex items-center gap-2 text-accent-cyan font-bold text-xs uppercase tracking-widest">
+                <span className="material-symbols-outlined text-sm">input</span>
+                2. Select Targets (Deepents)
+              </div>
+              <div className="flex-1 overflow-y-auto custom-scrollbar bg-black/20 rounded-lg p-2 border border-white/5">
+                {targetNodes.map((n) => (
+                  <div
+                    key={n.id}
+                    onClick={() => toggleTarget(n.id)}
+                    className={`p-2 rounded cursor-pointer text-xs flex items-center justify-between transition-colors ${targetNodeIds.includes(n.id) ? "bg-accent-cyan/20 text-accent-cyan" : "text-neutral-400 hover:bg-white/5"}`}
+                  >
+                    <RelationshipTooltip ciId={n.id} relationships={relationshipMap}>
+                      <span>{n.label}</span>
+                    </RelationshipTooltip>
+                    <RelationshipBadge ciId={n.id} relationships={relationshipMap} />
+                    {targetNodeIds.includes(n.id) && (
+                      <span className="material-symbols-outlined text-sm">check</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <button
+              onClick={handleCreate}
+              disabled={loading || !sourceNodeId || targetNodeIds.length === 0}
+              className="w-full bg-brand-600 text-white font-bold py-3 rounded-xl uppercase tracking-wider text-xs"
+            >
+              {loading ? "Processing..." : `Create ${targetNodeIds.length} Links`}
+            </button>
+          </>
+        ) : (
+          <>
+            {/* Metrics Selection */}
+            <div className="space-y-3 p-4 bg-blue-900/10 rounded-xl border border-blue-500/20 flex-1 flex flex-col min-h-[200px]">
+              <div className="flex items-center gap-2 text-blue-400 font-bold text-xs uppercase tracking-widest">
+                <span className="material-symbols-outlined text-sm">list</span>
+                2. Select Metrics to Promote
+              </div>
+              {!sourceNodeId ? (
+                <div className="text-center text-neutral-500 p-4 text-xs">
+                  Select a Source Node first
+                </div>
+              ) : availableMetrics.length === 0 ? (
+                <div className="text-center text-neutral-500 p-4 text-xs">
+                  No metrics found for this CI
+                </div>
+              ) : (
+                <div className="flex-1 overflow-y-auto custom-scrollbar bg-black/20 rounded-lg p-2 border border-white/5 space-y-1">
+                  {availableMetrics.map((m) => (
+                    <div
+                      key={m.name}
+                      onClick={() => {
+                        if (selectedMetrics.includes(m.name))
+                          setSelectedMetrics((prev) => prev.filter((x) => x !== m.name));
+                        else setSelectedMetrics((prev) => [...prev, m.name]);
+                      }}
+                      className={`p-2 rounded cursor-pointer text-xs flex items-center justify-between transition-colors ${selectedMetrics.includes(m.name) ? "bg-blue-500/20 text-blue-400 border border-blue-500/30" : "text-neutral-400 hover:bg-white/5"}`}
+                    >
+                      <div className="flex flex-col">
+                        <span className="font-bold">{m.name}</span>
+                        <span className="opacity-70 text-[10px]">{m.description}</span>
+                      </div>
+                      {selectedMetrics.includes(m.name) && (
+                        <span className="material-symbols-outlined text-sm">check_circle</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <button
+              onClick={handlePromoteMetrics}
+              disabled={loading || selectedMetrics.length === 0}
+              className="w-full bg-blue-600 hover:bg-blue-500 text-white font-bold py-3 rounded-xl uppercase tracking-wider text-xs flex items-center justify-center gap-2"
+            >
+              <span className="material-symbols-outlined">upgrade</span>
+              Promote {selectedMetrics.length} Metrics
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Right Panel: List/Graph View */}
+      <div className="flex-1 glass p-6 rounded-2xl border border-white/5 overflow-hidden flex flex-col gap-6">
+        {/* CI Relationships Table */}
+        <div className="flex-1 flex flex-col min-h-0">
+          <div className="flex items-center justify-between mb-4 gap-4">
+            <h3 className="text-sm font-bold text-white uppercase flex items-center gap-2">
+              <span className="material-symbols-outlined text-brand-500">hub</span>
+              CI Relationships ({filteredCiLinks.length})
+            </h3>
+            <Link
+              to="/admin/relationships/visual-editor"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn-primary text-xs"
+            >
+              <span className="material-symbols-outlined text-sm">account_tree</span>
+              Visual editor
+            </Link>
+            <div className="relative">
+              <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-neutral-500 text-sm">
+                search
+              </span>
+              <input
+                type="text"
+                placeholder="Search links..."
+                value={searchCiLinks}
+                onChange={(e) => setSearchCiLinks(e.target.value)}
+                className="bg-black/40 border border-white/10 rounded-lg pl-8 pr-3 py-1.5 text-xs text-neutral-300 placeholder-neutral-600 focus:outline-none focus:border-brand-500/50 w-48 transition-colors"
+              />
+              {searchCiLinks && (
+                <button
+                  onClick={() => setSearchCiLinks("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-white"
+                >
+                  <span className="material-symbols-outlined text-sm">close</span>
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="flex-1 overflow-y-auto custom-scrollbar border border-white/5 rounded-lg bg-black/20">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="text-xs text-neutral-500 border-b border-white/10 sticky top-0 bg-surface-900 z-10">
+                  <th className="p-3 uppercase tracking-wider">Source</th>
+                  <th className="p-3 uppercase tracking-wider text-center">Relationship</th>
+                  <th className="p-3 uppercase tracking-wider">Target</th>
+                  <th className="p-3 text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody className="text-sm">
+                {filteredCiLinks.map((link, i) => {
+                  const readOnly = isReadOnlyRelationship(link.relationship);
+
+                  return (
+                    <tr
+                      key={i}
+                      className="border-b border-white/5 hover:bg-white/5 transition-colors group"
+                    >
+                      <td className="p-3 font-mono text-brand-400" title={link.source}>
+                        {link.source_label || link.source}
+                      </td>
+                      <td className="p-3 text-center">
+                        <span className="text-[10px] font-bold bg-white/10 px-2 py-1 rounded text-neutral-300 uppercase">
+                          {link.relationship}
+                        </span>
+                        {readOnly && (
+                          <span className="ml-2 text-[10px] font-bold bg-amber-400/10 px-2 py-1 rounded text-amber-200 uppercase">
+                            Read-only
+                          </span>
+                        )}
+                      </td>
+                      <td className="p-3 font-mono text-accent-cyan" title={link.target}>
+                        {link.target_label || link.target}
+                      </td>
+                      <td className="p-3 text-right flex items-center justify-end gap-2">
+                        <button
+                          onClick={() => {
+                            // Smart Root Selection: Select the "Superior" node as Root
+                            // For dependencies, the Target is the Provider (Superior)
+                            if (["DEPENDS_ON", "HOSTED_ON"].includes(link.relationship)) {
+                              setVisualizationTarget(link.target);
+                            } else {
+                              setVisualizationTarget(link.source);
+                            }
+                          }}
+                          className="text-neutral-500 hover:text-brand-400 transition-colors"
+                          title="Visualize Correlation"
+                        >
+                          <span className="material-symbols-outlined text-lg">hub</span>
+                        </button>
+                        {canDeleteRelationship(link.relationship) && (
+                          <button
+                            onClick={() => handleDelete(link)}
+                            className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                          >
+                            <span className="material-symbols-outlined text-lg">delete</span>
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+                {filteredCiLinks.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="p-8 text-center text-neutral-500 text-xs">
+                      {searchCiLinks
+                        ? `No links match "${searchCiLinks}"`
+                        : "No CI-to-CI relationships found."}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Metric Relationships Table */}
+        <div className="flex-1 flex flex-col min-h-0 border-t border-white/10 pt-4">
+          <h3 className="text-sm font-bold text-blue-400 uppercase mb-4 flex items-center gap-2">
+            <span className="material-symbols-outlined">bar_chart</span>
+            Promoted Metrics ({metricLinks.length})
+          </h3>
+          <div className="flex-1 overflow-y-auto custom-scrollbar border border-white/5 rounded-lg bg-black/20">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="text-xs text-neutral-500 border-b border-white/10 sticky top-0 bg-surface-900 z-10">
+                  <th className="p-3 uppercase tracking-wider">Host CI</th>
+                  <th className="p-3 uppercase tracking-wider">Metric Node</th>
+                  <th className="p-3 text-right">Action</th>
+                </tr>
+              </thead>
+              <tbody className="text-sm">
+                {metricLinks.map((link, i) => (
+                  <tr
+                    key={i}
+                    className="border-b border-white/5 hover:bg-white/5 transition-colors group"
+                  >
+                    <td className="p-3 font-mono text-white" title={link.source}>
+                      {link.source_label || link.source}
+                    </td>
+                    <td
+                      className="p-3 font-mono text-blue-400 flex items-center gap-2"
+                      title={link.target}
+                    >
+                      <span className="material-symbols-outlined text-xs">analytics</span>
+                      {link.target_label || link.target}
+                    </td>
+                    <td className="p-3 text-right">
+                      <button
+                        onClick={() => handleDelete(link)}
+                        className="text-neutral-600 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+                        title="Demote Metric (Delete Node)"
+                      >
+                        <span className="material-symbols-outlined text-lg">delete</span>
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+                {metricLinks.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={3}
+                      className="p-8 text-center text-neutral-500 text-xs text-italic"
+                    >
+                      No promoted metrics found.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      {/* Visualization Modal */}
+      {visualizationTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-xl p-8">
+          <div className="w-full h-full max-w-6xl flex flex-col relative">
+            <button
+              onClick={() => setVisualizationTarget(null)}
+              className="absolute top-0 right-0 p-4 text-white hover:text-red-500 z-50"
+            >
+              <span className="material-symbols-outlined text-3xl">close</span>
+            </button>
+            <h2 className="text-2xl font-black text-white uppercase tracking-tight flex items-center gap-2 mb-4 absolute top-0 left-0">
+              <span className="material-symbols-outlined text-brand-500">hub</span>
+              Correlation Explorer
+            </h2>
+            <div className="flex-1 mt-12 bg-black/20 rounded-2xl border border-white/5 overflow-hidden">
+              {/* Uses the extracted TopologyViewer Component */}
+              <TopologyViewer rootId={visualizationTarget} nodes={nodes} links={links} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default RelationshipManager;

--- a/frontend/components/VisualRelationshipEditor.test.tsx
+++ b/frontend/components/VisualRelationshipEditor.test.tsx
@@ -7,913 +7,919 @@ import VisualRelationshipEditor from "./VisualRelationshipEditor";
 import type { LinkData } from "./RelationshipManager";
 
 const { mockApiPost, mockApiDelete } = vi.hoisted(() => ({
-	mockApiPost: vi.fn(),
-	mockApiDelete: vi.fn(),
+  mockApiPost: vi.fn(),
+  mockApiDelete: vi.fn(),
 }));
 
 vi.mock("../services/api", () => ({
-	api: {
-		post: mockApiPost,
-		delete: mockApiDelete,
-	},
+  api: {
+    post: mockApiPost,
+    delete: mockApiDelete,
+  },
 }));
 
 const nodes: GraphNode[] = [
-	{
-		id: "ci-a",
-		label: "Router A",
-		type: "INFRASTRUCTURE",
-		status: "ACTIVE",
-		metadata: {},
-		ip: "10.0.0.1",
-	},
-	{
-		id: "ci-b",
-		label: "Switch B",
-		type: "INFRASTRUCTURE",
-		status: "ACTIVE",
-		metadata: {},
-		ip: "10.0.0.2",
-	},
+  {
+    id: "ci-a",
+    label: "Router A",
+    type: "INFRASTRUCTURE",
+    status: "ACTIVE",
+    metadata: {},
+    ip: "10.0.0.1",
+  },
+  {
+    id: "ci-b",
+    label: "Switch B",
+    type: "INFRASTRUCTURE",
+    status: "ACTIVE",
+    metadata: {},
+    ip: "10.0.0.2",
+  },
 ];
 
 const links: LinkData[] = [
-	{
-		source: "ci-a",
-		source_label: "Router A",
-		target: "ci-b",
-		target_label: "Switch B",
-		relationship: "CONNECTS_TO",
-	},
+  {
+    source: "ci-a",
+    source_label: "Router A",
+    target: "ci-b",
+    target_label: "Switch B",
+    relationship: "CONNECTS_TO",
+  },
+];
+
+const tunnelLinks: LinkData[] = [
+  {
+    source: "ci-a",
+    source_label: "Router A",
+    target: "ci-b",
+    target_label: "Switch B",
+    relationship: "CONNECTS_TO",
+    medium: "vpn",
+    tunnel_health: {
+      link_id: "vpn-link",
+      source: "ci-a",
+      target: "ci-b",
+      relationship: "CONNECTS_TO",
+      medium: "vpn",
+      status: "UP",
+      authority: { state: "UP" },
+      icmp: { available: false, reason: "icmp_failed" },
+      observed_at: "2026-07-05T00:00:00Z",
+    },
+  },
 ];
 
 const readOnlyLinks: LinkData[] = [
-	{
-		source: "ci-a",
-		source_label: "Router A",
-		target: "ci-b",
-		target_label: "Switch B",
-		relationship: "RUNS_ON",
-	},
+  {
+    source: "ci-a",
+    source_label: "Router A",
+    target: "ci-b",
+    target_label: "Switch B",
+    relationship: "RUNS_ON",
+  },
 ];
 
 const appNode: GraphNode = {
-	id: "app-1",
-	label: "App",
-	type: "APPLICATION",
-	category: "Application",
-	status: "ACTIVE",
-	metadata: {},
+  id: "app-1",
+  label: "App",
+  type: "APPLICATION",
+  category: "Application",
+  status: "ACTIVE",
+  metadata: {},
 };
 const dbNode: GraphNode = {
-	id: "db-1",
-	label: "DB",
-	type: "INFRASTRUCTURE",
-	category: "Database",
-	status: "ACTIVE",
-	metadata: {},
+  id: "db-1",
+  label: "DB",
+  type: "INFRASTRUCTURE",
+  category: "Database",
+  status: "ACTIVE",
+  metadata: {},
 };
 const infraNode: GraphNode = {
-	id: "infra-1",
-	label: "Infra",
-	type: "INFRASTRUCTURE",
-	status: "ACTIVE",
-	metadata: {},
+  id: "infra-1",
+  label: "Infra",
+  type: "INFRASTRUCTURE",
+  status: "ACTIVE",
+  metadata: {},
 };
 const layeredNodes: GraphNode[] = [appNode, dbNode, infraNode];
 const layeredLinks: LinkData[] = [
-	{
-		source: "app-1",
-		source_label: "App",
-		target: "db-1",
-		target_label: "DB",
-		relationship: "CONNECTS_TO",
-	},
-	{
-		source: "app-1",
-		source_label: "App",
-		target: "infra-1",
-		target_label: "Infra",
-		relationship: "USES",
-	},
+  {
+    source: "app-1",
+    source_label: "App",
+    target: "db-1",
+    target_label: "DB",
+    relationship: "CONNECTS_TO",
+  },
+  {
+    source: "app-1",
+    source_label: "App",
+    target: "infra-1",
+    target_label: "Infra",
+    relationship: "USES",
+  },
 ];
 
 describe("VisualRelationshipEditor", () => {
-	const onMutated = vi.fn();
-
-	beforeEach(() => {
-		mockApiPost.mockReset();
-		mockApiDelete.mockReset();
-		onMutated.mockReset();
-		mockApiPost.mockResolvedValue({});
-		mockApiDelete.mockResolvedValue({});
-	});
-
-	it("attaches session-only CI dragging and placement controls", () => {
-		const source = readFileSync(
-			path.resolve(process.cwd(), "components/VisualRelationshipEditor.tsx"),
-			"utf8",
-		);
-
-		expect(source).toMatch(/\.drag<SVGGElement, EditorGraphNodeDatum>\s*\(/);
-		expect(source).toContain("constrainNodeToCluster");
-		expect(source).toContain("nodePositionCacheRef.current.set(node.id");
-
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(
-			screen.getByRole("button", { name: "Auto Links" }),
-		).toBeInTheDocument();
-		expect(screen.getByRole("button", { name: "Radial" })).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: "Reset View" }),
-		).toBeInTheDocument();
-	});
-
-	it("uses GraphCMDB-style zoom root with relationship cluster bubbles", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const svg = screen.getByLabelText("Visual CI relationship map");
-		expect(svg.querySelector(".visual-editor-zoom-root")).toBeInTheDocument();
-		expect(svg.querySelector(".relationship-clusters")).toBeInTheDocument();
-		expect(svg.querySelector(".relationship-links")).toBeInTheDocument();
-		expect(svg.querySelector(".relationship-nodes")).toBeInTheDocument();
-	});
-
-	it("uses broad zoom bounds and removes zoom listeners on cleanup", () => {
-		const source = readFileSync(
-			path.resolve(process.cwd(), "components/VisualRelationshipEditor.tsx"),
-			"utf8",
-		);
-
-		expect(source).toContain(".scaleExtent([0.01, 12])");
-		expect(source).toContain('svg.on(".zoom", null)');
-	});
-
-	it("selects source then target by clicking static CI nodes", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-		expect(screen.getByText(/Source:/).parentElement).toHaveTextContent(
-			"Router A",
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
-		expect(screen.getByText(/Target:/).parentElement).toHaveTextContent(
-			"Switch B",
-		);
-	});
-
-	it("populates CI form from clicked visual node", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-
-		expect(screen.getByLabelText("CI ID")).toHaveValue("ci-a");
-		expect(screen.getByLabelText("CI label")).toHaveValue("Router A");
-		expect(screen.getByLabelText("CI type")).toHaveValue("INFRASTRUCTURE");
-		expect(screen.getByLabelText("CI status")).toHaveValue("ACTIVE");
-		expect(screen.getByRole("button", { name: "Save CI" })).toBeInTheDocument();
-	});
-
-	it("prevents create without required CI fields", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
-		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
-
-		expect(screen.getByText("CI ID is required.")).toBeInTheDocument();
-		expect(mockApiPost).not.toHaveBeenCalled();
-	});
-
-	it("creates CI via existing node upsert API", async () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
-		fireEvent.change(screen.getByLabelText("CI ID"), {
-			target: { value: "ci-c" },
-		});
-		fireEvent.change(screen.getByLabelText("CI label"), {
-			target: { value: "Firewall C" },
-		});
-		fireEvent.change(screen.getByLabelText("CI type"), {
-			target: { value: "INFRASTRUCTURE" },
-		});
-		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
-
-		await waitFor(() => {
-			expect(mockApiPost).toHaveBeenCalledWith(
-				"/nodes",
-				expect.objectContaining({
-					id: "ci-c",
-					label: "Firewall C",
-					type: "INFRASTRUCTURE",
-					status: "OK",
-					metadata: {},
-				}),
-			);
-		});
-		expect(onMutated).toHaveBeenCalledTimes(1);
-	});
-
-	it("updates selected CI via node upsert and preserves metadata", async () => {
-		const nodesWithMetadata: GraphNode[] = [
-			{ ...nodes[0], metadata: { rack: "R1" }, owner: "ops" },
-			nodes[1],
-		];
-		render(
-			<VisualRelationshipEditor
-				nodes={nodesWithMetadata}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-		fireEvent.change(screen.getByLabelText("CI label"), {
-			target: { value: "Router A Updated" },
-		});
-		fireEvent.click(screen.getByRole("button", { name: "Save CI" }));
-
-		await waitFor(() => {
-			expect(mockApiPost).toHaveBeenCalledWith(
-				"/nodes",
-				expect.objectContaining({
-					id: "ci-a",
-					label: "Router A Updated",
-					metadata: { rack: "R1" },
-					owner: "ops",
-				}),
-			);
-		});
-	});
-
-	it("preserves CI form state after save failure", async () => {
-		mockApiPost.mockRejectedValueOnce(new Error("boom"));
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "New CI" }));
-		fireEvent.change(screen.getByLabelText("CI ID"), {
-			target: { value: "ci-c" },
-		});
-		fireEvent.change(screen.getByLabelText("CI label"), {
-			target: { value: "Firewall C" },
-		});
-		fireEvent.change(screen.getByLabelText("CI type"), {
-			target: { value: "INFRASTRUCTURE" },
-		});
-		fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
-
-		expect(await screen.findByText("Could not save CI.")).toBeInTheDocument();
-		expect(screen.getByLabelText("CI ID")).toHaveValue("ci-c");
-		expect(screen.getByLabelText("CI label")).toHaveValue("Firewall C");
-		expect(onMutated).not.toHaveBeenCalled();
-	});
-
-	it("deletes selected CI using existing node delete API", async () => {
-		const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-		fireEvent.click(screen.getByRole("button", { name: "Delete CI" }));
-
-		await waitFor(() =>
-			expect(mockApiDelete).toHaveBeenCalledWith("/nodes/ci-a"),
-		);
-		expect(onMutated).toHaveBeenCalledTimes(1);
-		confirmSpy.mockRestore();
-	});
-
-	it("does not allow delete without selected CI", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(screen.getByRole("button", { name: "Delete CI" })).toBeDisabled();
-	});
-
-	it("renders layer filters from category/type and selects all by default", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const appLayer = screen.getByRole("checkbox", {
-			name: /Application layer \(1 CIs\)/,
-		});
-		const databaseLayer = screen.getByRole("checkbox", {
-			name: /Database layer \(1 CIs\)/,
-		});
-		expect(
-			screen.getByRole("checkbox", {
-				name: /INFRASTRUCTURE layer \(1 CIs\)/,
-			}),
-		).toBeChecked();
-
-		expect(appLayer).toBeChecked();
-		expect(databaseLayer).toBeChecked();
-		expect(
-			screen.getByRole("button", { name: "CI node App" }),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: "CI node DB" }),
-		).toBeInTheDocument();
-	});
-
-	it("renders CI nodes as D3 SVG circles instead of large visual cards", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const appNodeButton = screen.getByRole("button", { name: "CI node App" });
-		expect(appNodeButton).toHaveAttribute("title", "App · Application");
-		expect(appNodeButton.querySelector("circle.node-circle")).toHaveAttribute(
-			"r",
-			"24",
-		);
-		expect(appNodeButton).not.toHaveClass("w-36", "rounded-2xl");
-	});
-
-	it("renders shared technology icons from category_icon_key while keeping status separate", async () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={[
-					{
-						...nodes[0],
-						category: "Network",
-						category_icon_key: "router",
-					},
-					nodes[1],
-				]}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const icon = await screen.findByRole("img", {
-			name: "Router technology icon",
-		});
-
-		expect(icon).toHaveTextContent("router");
-		expect(icon).not.toHaveTextContent("ACTIVE");
-		expect(screen.getByLabelText("CI status")).toHaveValue("OK");
-	});
-
-	it("falls back to category-derived technology icons for visual graph nodes", async () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={[
-					{
-						...nodes[0],
-						category: "Layer 2 switch",
-						category_icon_key: null,
-					},
-					nodes[1],
-				]}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const icon = await screen.findByRole("img", {
-			name: "Layer 2 Switch technology icon",
-		});
-
-		expect(icon).toHaveTextContent("lan");
-	});
-
-	it("fades unrelated nodes and links while keeping related graph items prominent on hover", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const svg = screen.getByLabelText("Visual CI relationship map");
-		const appGroup = screen.getByRole("button", { name: "CI node App" });
-		const dbGroup = screen.getByRole("button", { name: "CI node DB" });
-		const infraGroup = screen.getByRole("button", { name: "CI node Infra" });
-		const relatedLink = svg.querySelector(
-			'[data-link-source="app-1"][data-link-target="db-1"] line',
-		);
-		const unrelatedLink = svg.querySelector(
-			'[data-link-source="app-1"][data-link-target="infra-1"] line',
-		);
-
-		expect(relatedLink).toHaveAttribute("stroke-opacity", "0.55");
-		expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.55");
-
-		fireEvent.mouseOver(dbGroup);
-
-		expect(dbGroup).toHaveAttribute("opacity", "1");
-		expect(appGroup).toHaveAttribute("opacity", "0.9");
-		expect(infraGroup).toHaveAttribute("opacity", "0.18");
-		expect(relatedLink).toHaveAttribute("stroke-opacity", "0.72");
-		expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.12");
-
-		fireEvent.mouseOut(dbGroup);
-
-		expect(appGroup).toHaveAttribute("opacity", "1");
-		expect(infraGroup).toHaveAttribute("opacity", "1");
-		expect(relatedLink).toHaveAttribute("stroke-opacity", "0.55");
-		expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.55");
-	});
-
-	it("expands truncated labels on hover and focus, then restores compact labels", () => {
-		const longLabelNode = {
-			...nodes[0],
-			label: "Very Long Router Label",
-		};
-		render(
-			<VisualRelationshipEditor
-				nodes={[longLabelNode, nodes[1]]}
-				links={[
-					{
-						...links[0],
-						source_label: longLabelNode.label,
-					},
-				]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const longNode = screen.getByRole("button", {
-			name: "CI node Very Long Router Label",
-		});
-		expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
-
-		fireEvent.mouseOver(longNode);
-		expect(screen.getByText("Very Long Router Label")).toBeInTheDocument();
-
-		fireEvent.mouseOut(longNode);
-		expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
-
-		fireEvent.focus(longNode);
-		expect(screen.getByText("Very Long Router Label")).toBeInTheDocument();
-
-		fireEvent.blur(longNode);
-		expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
-	});
-
-	it("keeps selected source and target styling distinguishable during hover focus", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-		fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
-
-		const routerNode = screen.getByRole("button", { name: "CI node Router A" });
-		const switchNode = screen.getByRole("button", { name: "CI node Switch B" });
-		const routerCircle = routerNode.querySelector("circle.node-circle");
-		const switchCircle = switchNode.querySelector("circle.node-circle");
-		expect(routerCircle).toHaveAttribute("fill", "#345bf2");
-		expect(switchCircle).toHaveAttribute("fill", "#06b6d4");
-
-		fireEvent.mouseOver(switchNode);
-
-		expect(routerCircle).toHaveAttribute("fill", "#345bf2");
-		expect(switchCircle).toHaveAttribute("fill", "#06b6d4");
-		expect(switchCircle).toHaveAttribute("stroke-width", "7");
-
-		fireEvent.mouseOut(switchNode);
-		expect(switchCircle).toHaveAttribute("stroke-width", "5");
-	});
-
-	it("positions D3 nodes from CI coordinates", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={[
-					{ ...nodes[0], x: 10, y: 30 },
-					{ ...nodes[1], x: 20, y: 40 },
-				]}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const routerTransform = screen
-			.getByRole("button", { name: "CI node Router A" })
-			.getAttribute("transform");
-		const switchTransform = screen
-			.getByRole("button", { name: "CI node Switch B" })
-			.getAttribute("transform");
-		expect(routerTransform).toMatch(/^translate\(/);
-		expect(switchTransform).toMatch(/^translate\(/);
-		expect(routerTransform).not.toBe(switchTransform);
-	});
-
-	it("uses CMDB lat/long projection and offsets duplicate coordinates", () => {
-		const colocatedNodes = Array.from({ length: 6 }, (_, index) => ({
-			...nodes[index % nodes.length],
-			id: `ci-${index}`,
-			label: `CI ${index}`,
-			location: { lat: 32.5, long: -117 },
-		}));
-		render(
-			<VisualRelationshipEditor
-				nodes={colocatedNodes}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		const transforms = colocatedNodes.map((node) =>
-			screen
-				.getByRole("button", { name: `CI node ${node.label}` })
-				.getAttribute("transform"),
-		);
-		expect(
-			transforms.every((transform) => transform?.startsWith("translate(")),
-		).toBe(true);
-		expect(new Set(transforms).size).toBe(colocatedNodes.length);
-	});
-
-	it("filters nodes and shows an empty state when all layers are hidden", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
-
-		expect(
-			screen.queryByRole("button", { name: "CI node DB" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: "CI node App" }),
-		).toBeInTheDocument();
-
-		fireEvent.click(screen.getByRole("button", { name: "None" }));
-
-		expect(
-			screen.queryByRole("button", { name: "CI node App" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.getByText("No CIs match selected layers"),
-		).toBeInTheDocument();
-	});
-
-	it("filters links whose endpoints are hidden", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(screen.getByText("App → DB")).toBeInTheDocument();
-		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
-
-		expect(screen.queryByText("App → DB")).not.toBeInTheDocument();
-		expect(screen.getByText("App → Infra")).toBeInTheDocument();
-	});
-
-	it("clears hidden selected endpoints and preserves visible relationship creation", async () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node App" }));
-		fireEvent.click(screen.getByRole("button", { name: "CI node DB" }));
-		expect(screen.getByText(/Target:/).parentElement).toHaveTextContent("DB");
-
-		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
-
-		expect(screen.getByText(/Target:/).parentElement).toHaveTextContent(
-			"Select target",
-		);
-		expect(
-			screen.getByRole("button", { name: "Create relationship" }),
-		).toBeDisabled();
-		expect(mockApiPost).not.toHaveBeenCalled();
-
-		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
-		fireEvent.click(screen.getByRole("button", { name: "CI node App" }));
-		fireEvent.click(screen.getByRole("button", { name: "CI node DB" }));
-		fireEvent.click(
-			screen.getByRole("button", { name: "Create relationship" }),
-		);
-
-		await waitFor(() => {
-			expect(mockApiPost).toHaveBeenCalledWith("/links", {
-				source: "app-1",
-				target: "db-1",
-				relationship: "CONNECTS_TO",
-			});
-		});
-	});
-
-	it("preserves deselected and none layer choices across node refreshes", () => {
-		const { rerender } = render(
-			<VisualRelationshipEditor
-				nodes={layeredNodes}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
-		rerender(
-			<VisualRelationshipEditor
-				nodes={[...layeredNodes]}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(
-			screen.getByRole("checkbox", { name: /Database layer/ }),
-		).not.toBeChecked();
-		expect(
-			screen.queryByRole("button", { name: "CI node DB" }),
-		).not.toBeInTheDocument();
-
-		fireEvent.click(screen.getByRole("button", { name: "None" }));
-		rerender(
-			<VisualRelationshipEditor
-				nodes={[...layeredNodes]}
-				links={layeredLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(
-			screen.getByText("No CIs match selected layers"),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("checkbox", { name: /Application layer/ }),
-		).not.toBeChecked();
-		expect(
-			screen.getByRole("checkbox", { name: /Database layer/ }),
-		).not.toBeChecked();
-		expect(
-			screen.getByRole("checkbox", { name: /INFRASTRUCTURE layer/ }),
-		).not.toBeChecked();
-	});
-
-	it("auto-selects newly discovered layers after node refresh", () => {
-		const { rerender } = render(
-			<VisualRelationshipEditor
-				nodes={[layeredNodes[0]]}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		rerender(
-			<VisualRelationshipEditor
-				nodes={[layeredNodes[0], layeredNodes[1]]}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(
-			screen.getByRole("checkbox", { name: /Database layer \(1 CIs\)/ }),
-		).toBeChecked();
-		expect(
-			screen.getByRole("button", { name: "CI node DB" }),
-		).toBeInTheDocument();
-	});
-
-	it("prevents self-links", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-
-		expect(
-			screen.getByText("Source and target must be different CIs."),
-		).toBeInTheDocument();
-		expect(
-			screen.getByRole("button", { name: "Create relationship" }),
-		).toBeDisabled();
-	});
-
-	it("creates a link with a supported relationship type and refreshes", async () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
-		fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
-		fireEvent.change(screen.getByLabelText("Relationship type"), {
-			target: { value: "DEPENDS_ON" },
-		});
-		fireEvent.click(
-			screen.getByRole("button", { name: "Create relationship" }),
-		);
-
-		await waitFor(() => {
-			expect(mockApiPost).toHaveBeenCalledWith("/links", {
-				source: "ci-a",
-				target: "ci-b",
-				relationship: "DEPENDS_ON",
-			});
-		});
-		expect(onMutated).toHaveBeenCalledTimes(1);
-	});
-
-	it("excludes HAS_METRIC relationships from visual editing", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={[
-					...links,
-					{
-						source: "ci-a",
-						source_label: "Router A",
-						target: "ci-b",
-						target_label: "Switch B",
-						relationship: "HAS_METRIC",
-					},
-				]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(screen.queryByText("HAS_METRIC")).not.toBeInTheDocument();
-		expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
-	});
-
-	it("keeps RUNS_ON visible and labeled read-only", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={readOnlyLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
-		expect(screen.getAllByText("RUNS_ON").length).toBeGreaterThan(0);
-		expect(screen.getByText("Read-only")).toBeInTheDocument();
-	});
-
-	it("does not offer delete for RUNS_ON links", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={readOnlyLinks}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(
-			screen.queryByRole("button", { name: "Delete" }),
-		).not.toBeInTheDocument();
-		expect(mockApiDelete).not.toHaveBeenCalled();
-	});
-
-	it("deletes an existing visual link and refreshes", async () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={links}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-
-		await waitFor(() =>
-			expect(mockApiDelete).toHaveBeenCalledWith("/links", links[0]),
-		);
-		expect(onMutated).toHaveBeenCalledTimes(1);
-	});
-
-	it("does not offer legacy CONNECTED_TO relationship type", () => {
-		render(
-			<VisualRelationshipEditor
-				nodes={nodes}
-				links={[]}
-				onClose={vi.fn()}
-				onMutated={onMutated}
-			/>,
-		);
-
-		expect(
-			screen.queryByRole("option", { name: "CONNECTED_TO" }),
-		).not.toBeInTheDocument();
-		expect(
-			screen.getByRole("option", { name: "CONNECTS_TO" }),
-		).toBeInTheDocument();
-	});
+  const onMutated = vi.fn();
+
+  beforeEach(() => {
+    mockApiPost.mockReset();
+    mockApiDelete.mockReset();
+    onMutated.mockReset();
+    mockApiPost.mockResolvedValue({});
+    mockApiDelete.mockResolvedValue({});
+  });
+
+  it("attaches session-only CI dragging and placement controls", () => {
+    const source = readFileSync(
+      path.resolve(process.cwd(), "components/VisualRelationshipEditor.tsx"),
+      "utf8",
+    );
+
+    expect(source).toMatch(/\.drag<SVGGElement, EditorGraphNodeDatum>\s*\(/);
+    expect(source).toContain("constrainNodeToCluster");
+    expect(source).toContain("nodePositionCacheRef.current.set(node.id");
+
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Auto Links" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Radial" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset View" })).toBeInTheDocument();
+  });
+
+  it("uses GraphCMDB-style zoom root with relationship cluster bubbles", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const svg = screen.getByLabelText("Visual CI relationship map");
+    expect(svg.querySelector(".visual-editor-zoom-root")).toBeInTheDocument();
+    expect(svg.querySelector(".relationship-clusters")).toBeInTheDocument();
+    expect(svg.querySelector(".relationship-links")).toBeInTheDocument();
+    expect(svg.querySelector(".relationship-nodes")).toBeInTheDocument();
+  });
+
+  it("uses broad zoom bounds and removes zoom listeners on cleanup", () => {
+    const source = readFileSync(
+      path.resolve(process.cwd(), "components/VisualRelationshipEditor.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain(".scaleExtent([0.01, 12])");
+    expect(source).toContain('svg.on(".zoom", null)');
+  });
+
+  it("selects source then target by clicking static CI nodes", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    expect(screen.getByText(/Source:/).parentElement).toHaveTextContent("Router A");
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+    expect(screen.getByText(/Target:/).parentElement).toHaveTextContent("Switch B");
+  });
+
+  it("populates CI form from clicked visual node", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+
+    expect(screen.getByLabelText("CI ID")).toHaveValue("ci-a");
+    expect(screen.getByLabelText("CI label")).toHaveValue("Router A");
+    expect(screen.getByLabelText("CI type")).toHaveValue("INFRASTRUCTURE");
+    expect(screen.getByLabelText("CI status")).toHaveValue("ACTIVE");
+    expect(screen.getByRole("button", { name: "Save CI" })).toBeInTheDocument();
+  });
+
+  it("prevents create without required CI fields", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+    expect(screen.getByText("CI ID is required.")).toBeInTheDocument();
+    expect(mockApiPost).not.toHaveBeenCalled();
+  });
+
+  it("creates CI via existing node upsert API", async () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+    fireEvent.change(screen.getByLabelText("CI ID"), {
+      target: { value: "ci-c" },
+    });
+    fireEvent.change(screen.getByLabelText("CI label"), {
+      target: { value: "Firewall C" },
+    });
+    fireEvent.change(screen.getByLabelText("CI type"), {
+      target: { value: "INFRASTRUCTURE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/nodes",
+        expect.objectContaining({
+          id: "ci-c",
+          label: "Firewall C",
+          type: "INFRASTRUCTURE",
+          status: "OK",
+          metadata: {},
+        }),
+      );
+    });
+    expect(onMutated).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates selected CI via node upsert and preserves metadata", async () => {
+    const nodesWithMetadata: GraphNode[] = [
+      { ...nodes[0], metadata: { rack: "R1" }, owner: "ops" },
+      nodes[1],
+    ];
+    render(
+      <VisualRelationshipEditor
+        nodes={nodesWithMetadata}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    fireEvent.change(screen.getByLabelText("CI label"), {
+      target: { value: "Router A Updated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save CI" }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/nodes",
+        expect.objectContaining({
+          id: "ci-a",
+          label: "Router A Updated",
+          metadata: { rack: "R1" },
+          owner: "ops",
+        }),
+      );
+    });
+  });
+
+  it("preserves CI form state after save failure", async () => {
+    mockApiPost.mockRejectedValueOnce(new Error("boom"));
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "New CI" }));
+    fireEvent.change(screen.getByLabelText("CI ID"), {
+      target: { value: "ci-c" },
+    });
+    fireEvent.change(screen.getByLabelText("CI label"), {
+      target: { value: "Firewall C" },
+    });
+    fireEvent.change(screen.getByLabelText("CI type"), {
+      target: { value: "INFRASTRUCTURE" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create CI" }));
+
+    expect(await screen.findByText("Could not save CI.")).toBeInTheDocument();
+    expect(screen.getByLabelText("CI ID")).toHaveValue("ci-c");
+    expect(screen.getByLabelText("CI label")).toHaveValue("Firewall C");
+    expect(onMutated).not.toHaveBeenCalled();
+  });
+
+  it("deletes selected CI using existing node delete API", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete CI" }));
+
+    await waitFor(() => expect(mockApiDelete).toHaveBeenCalledWith("/nodes/ci-a"));
+    expect(onMutated).toHaveBeenCalledTimes(1);
+    confirmSpy.mockRestore();
+  });
+
+  it("does not allow delete without selected CI", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Delete CI" })).toBeDisabled();
+  });
+
+  it("renders layer filters from category/type and selects all by default", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const appLayer = screen.getByRole("checkbox", {
+      name: /Application layer \(1 CIs\)/,
+    });
+    const databaseLayer = screen.getByRole("checkbox", {
+      name: /Database layer \(1 CIs\)/,
+    });
+    expect(
+      screen.getByRole("checkbox", {
+        name: /INFRASTRUCTURE layer \(1 CIs\)/,
+      }),
+    ).toBeChecked();
+
+    expect(appLayer).toBeChecked();
+    expect(databaseLayer).toBeChecked();
+    expect(screen.getByRole("button", { name: "CI node App" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "CI node DB" })).toBeInTheDocument();
+  });
+
+  it("renders CI nodes as D3 SVG circles instead of large visual cards", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const appNodeButton = screen.getByRole("button", { name: "CI node App" });
+    expect(appNodeButton).toHaveAttribute("title", "App · Application");
+    expect(appNodeButton.querySelector("circle.node-circle")).toHaveAttribute("r", "24");
+    expect(appNodeButton).not.toHaveClass("w-36", "rounded-2xl");
+  });
+
+  it("renders shared technology icons from category_icon_key while keeping status separate", async () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={[
+          {
+            ...nodes[0],
+            category: "Network",
+            category_icon_key: "router",
+          },
+          nodes[1],
+        ]}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const icon = await screen.findByRole("img", {
+      name: "Router technology icon",
+    });
+
+    expect(icon).toHaveTextContent("router");
+    expect(icon).not.toHaveTextContent("ACTIVE");
+    expect(screen.getByLabelText("CI status")).toHaveValue("OK");
+  });
+
+  it("falls back to category-derived technology icons for visual graph nodes", async () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={[
+          {
+            ...nodes[0],
+            category: "Layer 2 switch",
+            category_icon_key: null,
+          },
+          nodes[1],
+        ]}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const icon = await screen.findByRole("img", {
+      name: "Layer 2 Switch technology icon",
+    });
+
+    expect(icon).toHaveTextContent("lan");
+  });
+
+  it("fades unrelated nodes and links while keeping related graph items prominent on hover", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const svg = screen.getByLabelText("Visual CI relationship map");
+    const appGroup = screen.getByRole("button", { name: "CI node App" });
+    const dbGroup = screen.getByRole("button", { name: "CI node DB" });
+    const infraGroup = screen.getByRole("button", { name: "CI node Infra" });
+    const relatedLink = svg.querySelector(
+      '[data-link-source="app-1"][data-link-target="db-1"] line',
+    );
+    const unrelatedLink = svg.querySelector(
+      '[data-link-source="app-1"][data-link-target="infra-1"] line',
+    );
+
+    expect(relatedLink).toHaveAttribute("stroke-opacity", "0.55");
+    expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.55");
+
+    fireEvent.mouseOver(dbGroup);
+
+    expect(dbGroup).toHaveAttribute("opacity", "1");
+    expect(appGroup).toHaveAttribute("opacity", "0.9");
+    expect(infraGroup).toHaveAttribute("opacity", "0.18");
+    expect(relatedLink).toHaveAttribute("stroke-opacity", "0.72");
+    expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.12");
+
+    fireEvent.mouseOut(dbGroup);
+
+    expect(appGroup).toHaveAttribute("opacity", "1");
+    expect(infraGroup).toHaveAttribute("opacity", "1");
+    expect(relatedLink).toHaveAttribute("stroke-opacity", "0.55");
+    expect(unrelatedLink).toHaveAttribute("stroke-opacity", "0.55");
+  });
+
+  it("expands truncated labels on hover and focus, then restores compact labels", () => {
+    const longLabelNode = {
+      ...nodes[0],
+      label: "Very Long Router Label",
+    };
+    render(
+      <VisualRelationshipEditor
+        nodes={[longLabelNode, nodes[1]]}
+        links={[
+          {
+            ...links[0],
+            source_label: longLabelNode.label,
+          },
+        ]}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const longNode = screen.getByRole("button", {
+      name: "CI node Very Long Router Label",
+    });
+    expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
+
+    fireEvent.mouseOver(longNode);
+    expect(screen.getByText("Very Long Router Label")).toBeInTheDocument();
+
+    fireEvent.mouseOut(longNode);
+    expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
+
+    fireEvent.focus(longNode);
+    expect(screen.getByText("Very Long Router Label")).toBeInTheDocument();
+
+    fireEvent.blur(longNode);
+    expect(screen.getByText("Very Long Ro...")).toBeInTheDocument();
+  });
+
+  it("keeps selected source and target styling distinguishable during hover focus", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+
+    const routerNode = screen.getByRole("button", { name: "CI node Router A" });
+    const switchNode = screen.getByRole("button", { name: "CI node Switch B" });
+    const routerCircle = routerNode.querySelector("circle.node-circle");
+    const switchCircle = switchNode.querySelector("circle.node-circle");
+    expect(routerCircle).toHaveAttribute("fill", "#345bf2");
+    expect(switchCircle).toHaveAttribute("fill", "#06b6d4");
+
+    fireEvent.mouseOver(switchNode);
+
+    expect(routerCircle).toHaveAttribute("fill", "#345bf2");
+    expect(switchCircle).toHaveAttribute("fill", "#06b6d4");
+    expect(switchCircle).toHaveAttribute("stroke-width", "7");
+
+    fireEvent.mouseOut(switchNode);
+    expect(switchCircle).toHaveAttribute("stroke-width", "5");
+  });
+
+  it("positions D3 nodes from CI coordinates", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={[
+          { ...nodes[0], x: 10, y: 30 },
+          { ...nodes[1], x: 20, y: 40 },
+        ]}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const routerTransform = screen
+      .getByRole("button", { name: "CI node Router A" })
+      .getAttribute("transform");
+    const switchTransform = screen
+      .getByRole("button", { name: "CI node Switch B" })
+      .getAttribute("transform");
+    expect(routerTransform).toMatch(/^translate\(/);
+    expect(switchTransform).toMatch(/^translate\(/);
+    expect(routerTransform).not.toBe(switchTransform);
+  });
+
+  it("uses CMDB lat/long projection and offsets duplicate coordinates", () => {
+    const colocatedNodes = Array.from({ length: 6 }, (_, index) => ({
+      ...nodes[index % nodes.length],
+      id: `ci-${index}`,
+      label: `CI ${index}`,
+      location: { lat: 32.5, long: -117 },
+    }));
+    render(
+      <VisualRelationshipEditor
+        nodes={colocatedNodes}
+        links={[]}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    const transforms = colocatedNodes.map((node) =>
+      screen.getByRole("button", { name: `CI node ${node.label}` }).getAttribute("transform"),
+    );
+    expect(transforms.every((transform) => transform?.startsWith("translate("))).toBe(true);
+    expect(new Set(transforms).size).toBe(colocatedNodes.length);
+  });
+
+  it("filters nodes and shows an empty state when all layers are hidden", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+
+    expect(screen.queryByRole("button", { name: "CI node DB" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "CI node App" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "None" }));
+
+    expect(screen.queryByRole("button", { name: "CI node App" })).not.toBeInTheDocument();
+    expect(screen.getByText("No CIs match selected layers")).toBeInTheDocument();
+  });
+
+  it("filters links whose endpoints are hidden", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByText("App → DB")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+
+    expect(screen.queryByText("App → DB")).not.toBeInTheDocument();
+    expect(screen.getByText("App → Infra")).toBeInTheDocument();
+  });
+
+  it("clears hidden selected endpoints and preserves visible relationship creation", async () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={[]}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node App" }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node DB" }));
+    expect(screen.getByText(/Target:/).parentElement).toHaveTextContent("DB");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+
+    expect(screen.getByText(/Target:/).parentElement).toHaveTextContent("Select target");
+    expect(screen.getByRole("button", { name: "Create relationship" })).toBeDisabled();
+    expect(mockApiPost).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node App" }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node DB" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create relationship" }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith("/links", {
+        source: "app-1",
+        target: "db-1",
+        relationship: "CONNECTS_TO",
+      });
+    });
+  });
+
+  it("preserves deselected and none layer choices across node refreshes", () => {
+    const { rerender } = render(
+      <VisualRelationshipEditor
+        nodes={layeredNodes}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /Database layer/ }));
+    rerender(
+      <VisualRelationshipEditor
+        nodes={[...layeredNodes]}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: /Database layer/ })).not.toBeChecked();
+    expect(screen.queryByRole("button", { name: "CI node DB" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "None" }));
+    rerender(
+      <VisualRelationshipEditor
+        nodes={[...layeredNodes]}
+        links={layeredLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByText("No CIs match selected layers")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /Application layer/ })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /Database layer/ })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: /INFRASTRUCTURE layer/ })).not.toBeChecked();
+  });
+
+  it("auto-selects newly discovered layers after node refresh", () => {
+    const { rerender } = render(
+      <VisualRelationshipEditor
+        nodes={[layeredNodes[0]]}
+        links={[]}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    rerender(
+      <VisualRelationshipEditor
+        nodes={[layeredNodes[0], layeredNodes[1]]}
+        links={[]}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: /Database layer \(1 CIs\)/ })).toBeChecked();
+    expect(screen.getByRole("button", { name: "CI node DB" })).toBeInTheDocument();
+  });
+
+  it("prevents self-links", () => {
+    render(
+      <VisualRelationshipEditor nodes={nodes} links={[]} onClose={vi.fn()} onMutated={onMutated} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+
+    expect(screen.getByText("Source and target must be different CIs.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create relationship" })).toBeDisabled();
+  });
+
+  it("creates a link with a supported relationship type and refreshes", async () => {
+    render(
+      <VisualRelationshipEditor nodes={nodes} links={[]} onClose={vi.fn()} onMutated={onMutated} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+    fireEvent.change(screen.getByLabelText("Relationship type"), {
+      target: { value: "DEPENDS_ON" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create relationship" }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith("/links", {
+        source: "ci-a",
+        target: "ci-b",
+        relationship: "DEPENDS_ON",
+      });
+    });
+    expect(onMutated).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates tunnel links with the selected medium", async () => {
+    render(
+      <VisualRelationshipEditor nodes={nodes} links={[]} onClose={vi.fn()} onMutated={onMutated} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "CI node Router A" }));
+    fireEvent.click(screen.getByRole("button", { name: "CI node Switch B" }));
+    fireEvent.change(screen.getByLabelText("Tunnel medium"), {
+      target: { value: "sd_wan" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create relationship" }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith("/links", {
+        source: "ci-a",
+        target: "ci-b",
+        relationship: "CONNECTS_TO",
+        medium: "sd_wan",
+      });
+    });
+  });
+
+  it("edits an existing tunnel medium through the link contract", async () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={tunnelLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getAllByText("VPN tunnel").length).toBeGreaterThan(0);
+    fireEvent.change(screen.getByLabelText("Medium for Router A to Switch B"), {
+      target: { value: "satellite" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save medium" }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith("/links", {
+        source: "ci-a",
+        target: "ci-b",
+        relationship: "CONNECTS_TO",
+        medium: "satellite",
+      });
+    });
+  });
+
+  it("displays tunnel medium and non-authoritative health context", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={tunnelLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getAllByText("VPN tunnel").length).toBeGreaterThan(0);
+    expect(screen.getByText("Authority: UP")).toBeInTheDocument();
+    expect(screen.getByText("ICMP: ICMP failed")).toBeInTheDocument();
+    expect(screen.queryByText("DEGRADED")).not.toBeInTheDocument();
+  });
+
+  it("excludes HAS_METRIC relationships from visual editing", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={[
+          ...links,
+          {
+            source: "ci-a",
+            source_label: "Router A",
+            target: "ci-b",
+            target_label: "Switch B",
+            relationship: "HAS_METRIC",
+          },
+        ]}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.queryByText("HAS_METRIC")).not.toBeInTheDocument();
+    expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
+  });
+
+  it("keeps RUNS_ON visible and labeled read-only", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={readOnlyLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.getByText("Router A → Switch B")).toBeInTheDocument();
+    expect(screen.getAllByText("RUNS_ON").length).toBeGreaterThan(0);
+    expect(screen.getByText("Read-only")).toBeInTheDocument();
+  });
+
+  it("does not offer delete for RUNS_ON links", () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={readOnlyLinks}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+    expect(mockApiDelete).not.toHaveBeenCalled();
+  });
+
+  it("deletes an existing visual link and refreshes", async () => {
+    render(
+      <VisualRelationshipEditor
+        nodes={nodes}
+        links={links}
+        onClose={vi.fn()}
+        onMutated={onMutated}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mockApiDelete).toHaveBeenCalledWith("/links", links[0]));
+    expect(onMutated).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not offer legacy CONNECTED_TO relationship type", () => {
+    render(
+      <VisualRelationshipEditor nodes={nodes} links={[]} onClose={vi.fn()} onMutated={onMutated} />,
+    );
+
+    expect(screen.queryByRole("option", { name: "CONNECTED_TO" })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "CONNECTS_TO" })).toBeInTheDocument();
+  });
 });

--- a/frontend/components/VisualRelationshipEditor.tsx
+++ b/frontend/components/VisualRelationshipEditor.tsx
@@ -1,1349 +1,1358 @@
+/* eslint-disable no-console */
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import * as d3 from "d3";
-import type { GraphNode } from "../types";
+import type { GraphNode, TunnelMedium } from "../types";
 import { api } from "../services/api";
 import CategoryIcon from "./CategoryIcon";
 import type { LinkData } from "./RelationshipManager";
+import { canDeleteRelationship, isReadOnlyRelationship } from "./relationshipCapabilities";
 import {
-	canDeleteRelationship,
-	isReadOnlyRelationship,
-} from "./relationshipCapabilities";
-import {
-	buildEditorForceGraphLayout,
-	editorClusterName,
-	getEditorStatusVisual,
-	truncateGraphLabel,
-	type EditorClusterPlacementMode,
-	type EditorGraphNodeDatum,
-	type EditorNodePosition,
-	VISUAL_EDITOR_VIEWBOX_HEIGHT,
-	VISUAL_EDITOR_VIEWBOX_WIDTH,
+  buildEditorForceGraphLayout,
+  editorClusterName,
+  getEditorStatusVisual,
+  truncateGraphLabel,
+  type EditorClusterPlacementMode,
+  type EditorGraphNodeDatum,
+  type EditorNodePosition,
+  VISUAL_EDITOR_VIEWBOX_HEIGHT,
+  VISUAL_EDITOR_VIEWBOX_WIDTH,
 } from "./visualRelationshipLayout";
+import { isTunnelMedium, resolveTunnelVisual } from "../utils/tunnelVisuals";
 
 const SUPPORTED_RELATIONSHIP_TYPES = [
-	"CONNECTS_TO",
-	"DEPENDS_ON",
-	"HOSTED_ON",
-	"MANAGES",
-	"USES",
-	"PROVIDES",
+  "CONNECTS_TO",
+  "DEPENDS_ON",
+  "HOSTED_ON",
+  "MANAGES",
+  "USES",
+  "PROVIDES",
 ] as const;
 
-const CI_TYPES: GraphNode["type"][] = [
-	"SERVICE",
-	"INFRASTRUCTURE",
-	"APPLICATION",
-	"USER",
-	"CLOUD_RESOURCE",
+const TUNNEL_MEDIUM_OPTIONS: Array<{ value: TunnelMedium; label: string }> = [
+  { value: "vpn", label: "VPN tunnel" },
+  { value: "sd_wan", label: "SD-WAN tunnel" },
+  { value: "satellite", label: "Satellite link" },
 ];
 
-const CI_STATUSES: GraphNode["status"][] = [
-	"OK",
-	"ACTIVE",
-	"EXCEPTION",
-	"MAINTENANCE",
+const CI_TYPES: GraphNode["type"][] = [
+  "SERVICE",
+  "INFRASTRUCTURE",
+  "APPLICATION",
+  "USER",
+  "CLOUD_RESOURCE",
 ];
+
+const CI_STATUSES: GraphNode["status"][] = ["OK", "ACTIVE", "EXCEPTION", "MAINTENANCE"];
 
 type CiFormState = {
-	id: string;
-	label: string;
-	type: GraphNode["type"] | "";
-	status: GraphNode["status"];
-	ip: string;
-	owner: string;
-	location_name: string;
+  id: string;
+  label: string;
+  type: GraphNode["type"] | "";
+  status: GraphNode["status"];
+  ip: string;
+  owner: string;
+  location_name: string;
 };
 
 const EMPTY_CI_FORM: CiFormState = {
-	id: "",
-	label: "",
-	type: "",
-	status: "OK",
-	ip: "",
-	owner: "",
-	location_name: "",
+  id: "",
+  label: "",
+  type: "",
+  status: "OK",
+  ip: "",
+  owner: "",
+  location_name: "",
 };
 
 interface VisualRelationshipEditorProps {
-	nodes: GraphNode[];
-	links: LinkData[];
-	onClose: () => void;
-	onMutated: () => void | Promise<void>;
-	mode?: "modal" | "page";
+  nodes: GraphNode[];
+  links: LinkData[];
+  onClose: () => void;
+  onMutated: () => void | Promise<void>;
+  mode?: "modal" | "page";
 }
 
 const nodeLabel = (node?: GraphNode) => node?.label || node?.id || "Unknown CI";
 const nodeLayer = (node: GraphNode) => node.category ?? node.type;
 const sameLayers = (a: string[], b: string[]) =>
-	a.length === b.length && a.every((layer, index) => layer === b[index]);
+  a.length === b.length && a.every((layer, index) => layer === b[index]);
 
 const toCiForm = (node: GraphNode): CiFormState => ({
-	id: node.id,
-	label: node.label,
-	type: node.type,
-	status: node.status || "OK",
-	ip: node.ip || "",
-	owner: node.owner || "",
-	location_name: node.location_name || "",
+  id: node.id,
+  label: node.label,
+  type: node.type,
+  status: node.status || "OK",
+  ip: node.ip || "",
+  owner: node.owner || "",
+  location_name: node.location_name || "",
 });
 
+const searchableText = (value: unknown): string => {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) return value.map(searchableText).join(" ");
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, entryValue]) => `${key} ${searchableText(entryValue)}`)
+      .join(" ");
+  }
+  return "";
+};
+
 const VisualRelationshipEditor: React.FC<VisualRelationshipEditorProps> = ({
-	nodes,
-	links,
-	onClose,
-	onMutated,
-	mode = "modal",
+  nodes,
+  links,
+  onClose,
+  onMutated,
+  mode = "modal",
 }) => {
-	const [sourceId, setSourceId] = useState("");
-	const [targetId, setTargetId] = useState("");
-	const [relationship, setRelationship] =
-		useState<(typeof SUPPORTED_RELATIONSHIP_TYPES)[number]>("CONNECTS_TO");
-	const [error, setError] = useState("");
-	const [saving, setSaving] = useState(false);
-	const [selectedCiId, setSelectedCiId] = useState("");
-	const [ciForm, setCiForm] = useState<CiFormState>(EMPTY_CI_FORM);
-	const [ciError, setCiError] = useState("");
-	const [ciSaving, setCiSaving] = useState(false);
-	const [selectedLayers, setSelectedLayers] = useState<string[]>([]);
-	const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
-	const [locationSearch, setLocationSearch] = useState("");
-	const [graphSearch, setGraphSearch] = useState("");
-	const [clusterPlacementMode, setClusterPlacementMode] =
-		useState<EditorClusterPlacementMode>("relationshipAware");
-	const [viewResetNonce, setViewResetNonce] = useState(0);
-	const knownLayerLabelsRef = useRef<string[]>([]);
-	const knownLocationLabelsRef = useRef<string[]>([]);
-	const graphSvgRef = useRef<SVGSVGElement>(null);
-	const zoomTransformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity);
-	const nodePositionCacheRef = useRef<Map<string, EditorNodePosition>>(
-		new Map(),
-	);
-	const graphLayoutKeyRef = useRef("");
+  const [sourceId, setSourceId] = useState("");
+  const [targetId, setTargetId] = useState("");
+  const [relationship, setRelationship] =
+    useState<(typeof SUPPORTED_RELATIONSHIP_TYPES)[number]>("CONNECTS_TO");
+  const [tunnelMedium, setTunnelMedium] = useState<TunnelMedium | "">("");
+  const [editedMediumByLink, setEditedMediumByLink] = useState<Record<string, TunnelMedium | "">>(
+    {},
+  );
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [selectedCiId, setSelectedCiId] = useState("");
+  const [ciForm, setCiForm] = useState<CiFormState>(EMPTY_CI_FORM);
+  const [ciError, setCiError] = useState("");
+  const [ciSaving, setCiSaving] = useState(false);
+  const [selectedLayers, setSelectedLayers] = useState<string[]>([]);
+  const [selectedLocations, setSelectedLocations] = useState<string[]>([]);
+  const [locationSearch, setLocationSearch] = useState("");
+  const [graphSearch, setGraphSearch] = useState("");
+  const [clusterPlacementMode, setClusterPlacementMode] =
+    useState<EditorClusterPlacementMode>("relationshipAware");
+  const [viewResetNonce, setViewResetNonce] = useState(0);
+  const knownLayerLabelsRef = useRef<string[]>([]);
+  const knownLocationLabelsRef = useRef<string[]>([]);
+  const graphSvgRef = useRef<SVGSVGElement>(null);
+  const zoomTransformRef = useRef<d3.ZoomTransform>(d3.zoomIdentity);
+  const nodePositionCacheRef = useRef<Map<string, EditorNodePosition>>(new Map());
+  const graphLayoutKeyRef = useRef("");
 
-	const ciLinks = useMemo(
-		() => links.filter((link) => link.relationship !== "HAS_METRIC"),
-		[links],
-	);
-	const layerOptions = useMemo(() => {
-		const counts = new Map<string, number>();
-		for (const node of nodes) {
-			const layer = nodeLayer(node);
-			counts.set(layer, (counts.get(layer) ?? 0) + 1);
-		}
-		return Array.from(counts.entries())
-			.map(([label, count]) => ({ label, count }))
-			.sort((a, b) => a.label.localeCompare(b.label));
-	}, [nodes]);
-	const locationOptions = useMemo(() => {
-		const counts = new Map<string, number>();
-		for (const node of nodes) {
-			const location = node.location_name || "Unassigned";
-			counts.set(location, (counts.get(location) ?? 0) + 1);
-		}
-		return Array.from(counts.entries())
-			.map(([label, count]) => ({ label, count }))
-			.sort((a, b) => a.label.localeCompare(b.label));
-	}, [nodes]);
-	const filteredLocationOptions = useMemo(() => {
-		const query = locationSearch.trim().toLowerCase();
-		if (!query) return locationOptions;
-		return locationOptions.filter((option) =>
-			option.label.toLowerCase().includes(query),
-		);
-	}, [locationOptions, locationSearch]);
+  const ciLinks = useMemo(
+    () => links.filter((link) => link.relationship !== "HAS_METRIC"),
+    [links],
+  );
+  const layerOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const node of nodes) {
+      const layer = nodeLayer(node);
+      counts.set(layer, (counts.get(layer) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [nodes]);
+  const locationOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const node of nodes) {
+      const location = node.location_name || "Unassigned";
+      counts.set(location, (counts.get(location) ?? 0) + 1);
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [nodes]);
+  const filteredLocationOptions = useMemo(() => {
+    const query = locationSearch.trim().toLowerCase();
+    if (!query) return locationOptions;
+    return locationOptions.filter((option) => option.label.toLowerCase().includes(query));
+  }, [locationOptions, locationSearch]);
 
-	useEffect(() => {
-		const available = layerOptions.map((option) => option.label);
-		const previousAvailable = knownLayerLabelsRef.current;
-		knownLayerLabelsRef.current = available;
+  useEffect(() => {
+    const available = layerOptions.map((option) => option.label);
+    const previousAvailable = knownLayerLabelsRef.current;
+    knownLayerLabelsRef.current = available;
 
-		setSelectedLayers((current) => {
-			const availableSet = new Set(available);
-			const previousAvailableSet = new Set(previousAvailable);
-			const preserved = current.filter((layer) => availableSet.has(layer));
-			const newlyDiscovered = available.filter(
-				(layer) => !previousAvailableSet.has(layer),
-			);
-			const next = [...preserved, ...newlyDiscovered];
-			return sameLayers(current, next) ? current : next;
-		});
-	}, [layerOptions]);
+    setSelectedLayers((current) => {
+      const availableSet = new Set(available);
+      const previousAvailableSet = new Set(previousAvailable);
+      const preserved = current.filter((layer) => availableSet.has(layer));
+      const newlyDiscovered = available.filter((layer) => !previousAvailableSet.has(layer));
+      const next = [...preserved, ...newlyDiscovered];
+      return sameLayers(current, next) ? current : next;
+    });
+  }, [layerOptions]);
 
-	useEffect(() => {
-		const available = locationOptions.map((option) => option.label);
-		const previousAvailable = knownLocationLabelsRef.current;
-		knownLocationLabelsRef.current = available;
+  useEffect(() => {
+    const available = locationOptions.map((option) => option.label);
+    const previousAvailable = knownLocationLabelsRef.current;
+    knownLocationLabelsRef.current = available;
 
-		setSelectedLocations((current) => {
-			const availableSet = new Set(available);
-			const previousAvailableSet = new Set(previousAvailable);
-			const preserved = current.filter((location) =>
-				availableSet.has(location),
-			);
-			const newlyDiscovered = available.filter(
-				(location) => !previousAvailableSet.has(location),
-			);
-			const next = [...preserved, ...newlyDiscovered];
-			return sameLayers(current, next) ? current : next;
-		});
-	}, [locationOptions]);
+    setSelectedLocations((current) => {
+      const availableSet = new Set(available);
+      const previousAvailableSet = new Set(previousAvailable);
+      const preserved = current.filter((location) => availableSet.has(location));
+      const newlyDiscovered = available.filter((location) => !previousAvailableSet.has(location));
+      const next = [...preserved, ...newlyDiscovered];
+      return sameLayers(current, next) ? current : next;
+    });
+  }, [locationOptions]);
 
-	const searchableText = (value: unknown): string => {
-		if (value === null || value === undefined) return "";
-		if (
-			typeof value === "string" ||
-			typeof value === "number" ||
-			typeof value === "boolean"
-		) {
-			return String(value);
-		}
-		if (Array.isArray(value)) return value.map(searchableText).join(" ");
-		if (typeof value === "object") {
-			return Object.entries(value as Record<string, unknown>)
-				.map(([key, entryValue]) => `${key} ${searchableText(entryValue)}`)
-				.join(" ");
-		}
-		return "";
-	};
-	const normalizedGraphSearch = graphSearch.trim().toLowerCase();
-	const nodeMatchesGraphSearch = useCallback(
-		(node: GraphNode) => {
-			if (!normalizedGraphSearch) return true;
-			return searchableText({
-				...node,
-				metadata: node.metadata,
-				clusterName: editorClusterName(node),
-			})
-				.toLowerCase()
-				.includes(normalizedGraphSearch);
-		},
-		[normalizedGraphSearch],
-	);
-	const matchingNodeIds = useMemo(() => {
-		if (!normalizedGraphSearch) return new Set<string>();
-		return new Set(nodes.filter(nodeMatchesGraphSearch).map((node) => node.id));
-	}, [nodes, nodeMatchesGraphSearch, normalizedGraphSearch]);
-	const visibleNodes = useMemo(
-		() =>
-			nodes.filter(
-				(node) =>
-					selectedLayers.includes(nodeLayer(node)) &&
-					selectedLocations.includes(node.location_name || "Unassigned") &&
-					nodeMatchesGraphSearch(node),
-			),
-		[nodes, selectedLayers, selectedLocations, nodeMatchesGraphSearch],
-	);
-	const visibleNodeIds = useMemo(
-		() => new Set(visibleNodes.map((node) => node.id)),
-		[visibleNodes],
-	);
-	const visibleCiLinks = useMemo(
-		() =>
-			ciLinks.filter(
-				(link) =>
-					visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target),
-			),
-		[ciLinks, visibleNodeIds],
-	);
-	const compactLocationClusters =
-		selectedLocations.length > 0 &&
-		selectedLocations.length < locationOptions.length;
-	const nodeMap = useMemo(
-		() => new Map(nodes.map((node) => [node.id, node])),
-		[nodes],
-	);
+  const normalizedGraphSearch = graphSearch.trim().toLowerCase();
+  const nodeMatchesGraphSearch = useCallback(
+    (node: GraphNode) => {
+      if (!normalizedGraphSearch) return true;
+      return searchableText({
+        ...node,
+        metadata: node.metadata,
+        clusterName: editorClusterName(node),
+      })
+        .toLowerCase()
+        .includes(normalizedGraphSearch);
+    },
+    [normalizedGraphSearch],
+  );
+  const matchingNodeIds = useMemo(() => {
+    if (!normalizedGraphSearch) return new Set<string>();
+    return new Set(nodes.filter(nodeMatchesGraphSearch).map((node) => node.id));
+  }, [nodes, nodeMatchesGraphSearch, normalizedGraphSearch]);
+  const visibleNodes = useMemo(
+    () =>
+      nodes.filter(
+        (node) =>
+          selectedLayers.includes(nodeLayer(node)) &&
+          selectedLocations.includes(node.location_name || "Unassigned") &&
+          nodeMatchesGraphSearch(node),
+      ),
+    [nodes, selectedLayers, selectedLocations, nodeMatchesGraphSearch],
+  );
+  const visibleNodeIds = useMemo(
+    () => new Set(visibleNodes.map((node) => node.id)),
+    [visibleNodes],
+  );
+  const visibleCiLinks = useMemo(
+    () =>
+      ciLinks.filter((link) => visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target)),
+    [ciLinks, visibleNodeIds],
+  );
+  const compactLocationClusters =
+    selectedLocations.length > 0 && selectedLocations.length < locationOptions.length;
+  const nodeMap = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
 
-	useEffect(() => {
-		const currentNodeIds = new Set(nodes.map((node) => node.id));
-		for (const cachedNodeId of nodePositionCacheRef.current.keys()) {
-			if (!currentNodeIds.has(cachedNodeId)) {
-				nodePositionCacheRef.current.delete(cachedNodeId);
-			}
-		}
-	}, [nodes]);
+  useEffect(() => {
+    const currentNodeIds = new Set(nodes.map((node) => node.id));
+    for (const cachedNodeId of nodePositionCacheRef.current.keys()) {
+      if (!currentNodeIds.has(cachedNodeId)) {
+        nodePositionCacheRef.current.delete(cachedNodeId);
+      }
+    }
+  }, [nodes]);
 
-	const selectedCi = selectedCiId ? nodeMap.get(selectedCiId) : undefined;
-	const isEditingCi = Boolean(selectedCi);
+  const selectedCi = selectedCiId ? nodeMap.get(selectedCiId) : undefined;
+  const isEditingCi = Boolean(selectedCi);
 
-	useEffect(() => {
-		setSourceId((current) =>
-			current && !visibleNodeIds.has(current) ? "" : current,
-		);
-		setTargetId((current) =>
-			current && !visibleNodeIds.has(current) ? "" : current,
-		);
-	}, [visibleNodeIds]);
+  useEffect(() => {
+    setSourceId((current) => (current && !visibleNodeIds.has(current) ? "" : current));
+    setTargetId((current) => (current && !visibleNodeIds.has(current) ? "" : current));
+  }, [visibleNodeIds]);
 
-	const toggleLayer = (layer: string) => {
-		setSelectedLayers((current) =>
-			current.includes(layer)
-				? current.filter((item) => item !== layer)
-				: [...current, layer],
-		);
-	};
-	const selectAllLayers = () => {
-		setSelectedLayers(layerOptions.map((option) => option.label));
-	};
-	const clearAllLayers = () => {
-		setSelectedLayers([]);
-	};
-	const toggleLocation = (location: string) => {
-		setSelectedLocations((current) =>
-			current.includes(location)
-				? current.filter((item) => item !== location)
-				: [...current, location],
-		);
-	};
-	const selectAllLocations = () => {
-		setSelectedLocations(locationOptions.map((option) => option.label));
-	};
-	const clearAllLocations = () => {
-		setSelectedLocations([]);
-	};
-	const resetGraphView = () => {
-		setSelectedLayers(layerOptions.map((option) => option.label));
-		setSelectedLocations(locationOptions.map((option) => option.label));
-		setLocationSearch("");
-		setGraphSearch("");
-		nodePositionCacheRef.current.clear();
-		graphLayoutKeyRef.current = "";
-		zoomTransformRef.current = d3.zoomIdentity;
-		setViewResetNonce((current) => current + 1);
-	};
+  const toggleLayer = (layer: string) => {
+    setSelectedLayers((current) =>
+      current.includes(layer) ? current.filter((item) => item !== layer) : [...current, layer],
+    );
+  };
+  const selectAllLayers = () => {
+    setSelectedLayers(layerOptions.map((option) => option.label));
+  };
+  const clearAllLayers = () => {
+    setSelectedLayers([]);
+  };
+  const toggleLocation = (location: string) => {
+    setSelectedLocations((current) =>
+      current.includes(location)
+        ? current.filter((item) => item !== location)
+        : [...current, location],
+    );
+  };
+  const selectAllLocations = () => {
+    setSelectedLocations(locationOptions.map((option) => option.label));
+  };
+  const clearAllLocations = () => {
+    setSelectedLocations([]);
+  };
+  const resetGraphView = () => {
+    setSelectedLayers(layerOptions.map((option) => option.label));
+    setSelectedLocations(locationOptions.map((option) => option.label));
+    setLocationSearch("");
+    setGraphSearch("");
+    nodePositionCacheRef.current.clear();
+    graphLayoutKeyRef.current = "";
+    zoomTransformRef.current = d3.zoomIdentity;
+    setViewResetNonce((current) => current + 1);
+  };
 
-	const updateCiForm = (field: keyof CiFormState, value: string) => {
-		setCiForm((current) => ({ ...current, [field]: value }));
-	};
+  const updateCiForm = (field: keyof CiFormState, value: string) => {
+    setCiForm((current) => ({ ...current, [field]: value }));
+  };
 
-	const startNewCi = () => {
-		setSelectedCiId("");
-		setCiForm(EMPTY_CI_FORM);
-		setCiError("");
-	};
+  const startNewCi = () => {
+    setSelectedCiId("");
+    setCiForm(EMPTY_CI_FORM);
+    setCiError("");
+  };
 
-	const validateCiForm = () => {
-		if (!ciForm.id.trim()) return "CI ID is required.";
-		if (!ciForm.label.trim()) return "Label is required.";
-		if (!ciForm.type) return "Type is required.";
-		return "";
-	};
+  const validateCiForm = () => {
+    if (!ciForm.id.trim()) return "CI ID is required.";
+    if (!ciForm.label.trim()) return "Label is required.";
+    if (!ciForm.type) return "Type is required.";
+    return "";
+  };
 
-	const buildCiPayload = (): GraphNode => ({
-		...(selectedCi ?? {}),
-		id: ciForm.id.trim(),
-		label: ciForm.label.trim(),
-		type: ciForm.type as GraphNode["type"],
-		status: ciForm.status || "OK",
-		metadata: selectedCi?.metadata ?? {},
-		ip: ciForm.ip.trim() || undefined,
-		owner: ciForm.owner.trim() || undefined,
-		location_name: ciForm.location_name.trim() || undefined,
-	});
+  const buildCiPayload = (): GraphNode => ({
+    ...(selectedCi ?? {}),
+    id: ciForm.id.trim(),
+    label: ciForm.label.trim(),
+    type: ciForm.type as GraphNode["type"],
+    status: ciForm.status || "OK",
+    metadata: selectedCi?.metadata ?? {},
+    ip: ciForm.ip.trim() || undefined,
+    owner: ciForm.owner.trim() || undefined,
+    location_name: ciForm.location_name.trim() || undefined,
+  });
 
-	const handleSaveCi = async () => {
-		const validationError = validateCiForm();
-		if (validationError) {
-			setCiError(validationError);
-			return;
-		}
-		setCiSaving(true);
-		setCiError("");
-		try {
-			await api.post("/nodes", buildCiPayload());
-			await onMutated();
-		} catch (err) {
-			console.error(err);
-			setCiError("Could not save CI.");
-		} finally {
-			setCiSaving(false);
-		}
-	};
+  const handleSaveCi = async () => {
+    const validationError = validateCiForm();
+    if (validationError) {
+      setCiError(validationError);
+      return;
+    }
+    setCiSaving(true);
+    setCiError("");
+    try {
+      await api.post("/nodes", buildCiPayload());
+      await onMutated();
+    } catch (err) {
+      console.error(err);
+      setCiError("Could not save CI.");
+    } finally {
+      setCiSaving(false);
+    }
+  };
 
-	const handleDeleteCi = async () => {
-		if (!selectedCi) return;
-		if (!confirm(`Delete CI ${selectedCi.id}?`)) return;
-		setCiSaving(true);
-		setCiError("");
-		try {
-			await api.delete(`/nodes/${encodeURIComponent(selectedCi.id)}`);
-			setSelectedCiId("");
-			setCiForm(EMPTY_CI_FORM);
-			await onMutated();
-		} catch (err) {
-			console.error(err);
-			setCiError("Could not delete CI.");
-		} finally {
-			setCiSaving(false);
-		}
-	};
+  const handleDeleteCi = async () => {
+    if (!selectedCi) return;
+    if (!confirm(`Delete CI ${selectedCi.id}?`)) return;
+    setCiSaving(true);
+    setCiError("");
+    try {
+      await api.delete(`/nodes/${encodeURIComponent(selectedCi.id)}`);
+      setSelectedCiId("");
+      setCiForm(EMPTY_CI_FORM);
+      await onMutated();
+    } catch (err) {
+      console.error(err);
+      setCiError("Could not delete CI.");
+    } finally {
+      setCiSaving(false);
+    }
+  };
 
-	const selectNode = useCallback(
-		(id: string) => {
-			if (!visibleNodeIds.has(id)) return;
-			setError("");
-			setCiError("");
-			const node = nodeMap.get(id);
-			if (node) {
-				setSelectedCiId(id);
-				setCiForm(toCiForm(node));
-			}
-			if (!sourceId || (sourceId && targetId)) {
-				setSourceId(id);
-				setTargetId("");
-				return;
-			}
-			if (id === sourceId) {
-				setError("Source and target must be different CIs.");
-				return;
-			}
-			setTargetId(id);
-		},
-		[nodeMap, sourceId, targetId, visibleNodeIds],
-	);
+  const selectNode = useCallback(
+    (id: string) => {
+      if (!visibleNodeIds.has(id)) return;
+      setError("");
+      setCiError("");
+      const node = nodeMap.get(id);
+      if (node) {
+        setSelectedCiId(id);
+        setCiForm(toCiForm(node));
+      }
+      if (!sourceId || (sourceId && targetId)) {
+        setSourceId(id);
+        setTargetId("");
+        return;
+      }
+      if (id === sourceId) {
+        setError("Source and target must be different CIs.");
+        return;
+      }
+      setTargetId(id);
+    },
+    [nodeMap, sourceId, targetId, visibleNodeIds],
+  );
 
-	useEffect(() => {
-		const svgElement = graphSvgRef.current;
-		if (!svgElement) return;
+  useEffect(() => {
+    const svgElement = graphSvgRef.current;
+    if (!svgElement) return;
 
-		const viewportRect = svgElement.getBoundingClientRect();
-		const viewportWidth = viewportRect.width || svgElement.clientWidth || 1200;
-		const viewportHeight =
-			viewportRect.height || svgElement.clientHeight || 800;
-		const graphWidth = VISUAL_EDITOR_VIEWBOX_WIDTH;
-		const graphHeight = VISUAL_EDITOR_VIEWBOX_HEIGHT;
-		const graphLayoutKey = JSON.stringify({
-			version: "clustered-scaled-v3",
-			width: graphWidth,
-			height: graphHeight,
-			compactLocationClusters,
-			clusterPlacementMode,
-			viewResetNonce,
-			nodes: visibleNodes
-				.map((node) => {
-					const clusterName =
-						(node as typeof node & { cluster_name?: string }).cluster_name ??
-						"";
-					return `${node.id}:${clusterName}:${node.location_name ?? ""}:${node.owner ?? ""}:${node.location?.lat ?? ""}:${node.location?.long ?? ""}`;
-				})
-				.sort(),
-			links: visibleCiLinks
-				.map((link) => `${link.source}->${link.target}:${link.relationship}`)
-				.sort(),
-		});
-		const reuseCachedLayout = graphLayoutKeyRef.current === graphLayoutKey;
-		graphLayoutKeyRef.current = graphLayoutKey;
-		const graph = buildEditorForceGraphLayout(visibleNodes, visibleCiLinks, {
-			nodePositionCache: nodePositionCacheRef.current,
-			ticks: reuseCachedLayout ? 0 : undefined,
-			width: graphWidth,
-			height: graphHeight,
-			compactClusters: compactLocationClusters,
-			clusterPlacementMode,
-		});
-		const graphNodes = graph.nodes;
-		const graphLinks = graph.links;
-		const positionMap = new Map(graphNodes.map((node) => [node.id, node]));
-		const statusVisualMap = new Map(
-			graphNodes.map((node) => [node.id, getEditorStatusVisual(node.status)]),
-		);
+    const viewportRect = svgElement.getBoundingClientRect();
+    const viewportWidth = viewportRect.width || svgElement.clientWidth || 1200;
+    const viewportHeight = viewportRect.height || svgElement.clientHeight || 800;
+    const graphWidth = VISUAL_EDITOR_VIEWBOX_WIDTH;
+    const graphHeight = VISUAL_EDITOR_VIEWBOX_HEIGHT;
+    const graphLayoutKey = JSON.stringify({
+      version: "clustered-scaled-v3",
+      width: graphWidth,
+      height: graphHeight,
+      compactLocationClusters,
+      clusterPlacementMode,
+      viewResetNonce,
+      nodes: visibleNodes
+        .map((node) => {
+          const clusterName = (node as typeof node & { cluster_name?: string }).cluster_name ?? "";
+          return `${node.id}:${clusterName}:${node.location_name ?? ""}:${node.owner ?? ""}:${node.location?.lat ?? ""}:${node.location?.long ?? ""}`;
+        })
+        .sort(),
+      links: visibleCiLinks
+        .map((link) => `${link.source}->${link.target}:${link.relationship}`)
+        .sort(),
+    });
+    const reuseCachedLayout = graphLayoutKeyRef.current === graphLayoutKey;
+    graphLayoutKeyRef.current = graphLayoutKey;
+    const graph = buildEditorForceGraphLayout(visibleNodes, visibleCiLinks, {
+      nodePositionCache: nodePositionCacheRef.current,
+      ticks: reuseCachedLayout ? 0 : undefined,
+      width: graphWidth,
+      height: graphHeight,
+      compactClusters: compactLocationClusters,
+      clusterPlacementMode,
+    });
+    const graphNodes = graph.nodes;
+    const graphLinks = graph.links;
+    const positionMap = new Map(graphNodes.map((node) => [node.id, node]));
+    const statusVisualMap = new Map(
+      graphNodes.map((node) => [node.id, getEditorStatusVisual(node.status)]),
+    );
 
-		const svg = d3.select(svgElement);
-		svg.attr("width", viewportWidth).attr("height", viewportHeight);
-		svg.selectAll("*").remove();
+    const svg = d3.select(svgElement);
+    svg.attr("width", viewportWidth).attr("height", viewportHeight);
+    svg.selectAll("*").remove();
 
-		const container = svg.append("g").attr("class", "visual-editor-zoom-root");
-		const initialTransform =
-			zoomTransformRef.current === d3.zoomIdentity
-				? d3.zoomIdentity.translate(
-						(viewportWidth - graphWidth) / 2,
-						(viewportHeight - graphHeight) / 2,
-					)
-				: zoomTransformRef.current;
-		const zoom = d3
-			.zoom<SVGSVGElement, unknown>()
-			.extent([
-				[0, 0],
-				[viewportWidth, viewportHeight],
-			])
-			.scaleExtent([0.01, 12])
-			.on("zoom", (event) => {
-				zoomTransformRef.current = event.transform;
-				container.attr("transform", event.transform);
-			});
-		svg.call(zoom);
-		svg.call(zoom.transform, initialTransform);
+    const container = svg.append("g").attr("class", "visual-editor-zoom-root");
+    const initialTransform =
+      zoomTransformRef.current === d3.zoomIdentity
+        ? d3.zoomIdentity.translate(
+            (viewportWidth - graphWidth) / 2,
+            (viewportHeight - graphHeight) / 2,
+          )
+        : zoomTransformRef.current;
+    const zoom = d3
+      .zoom<SVGSVGElement, unknown>()
+      .extent([
+        [0, 0],
+        [viewportWidth, viewportHeight],
+      ])
+      .scaleExtent([0.01, 12])
+      .on("zoom", (event) => {
+        zoomTransformRef.current = event.transform;
+        container.attr("transform", event.transform);
+      });
+    svg.call(zoom);
+    svg.call(zoom.transform, initialTransform);
 
-		const linkEndpointIds = (link: (typeof graphLinks)[number]) => ({
-			sourceId: typeof link.source === "string" ? link.source : link.source.id,
-			targetId: typeof link.target === "string" ? link.target : link.target.id,
-		});
+    const linkEndpointIds = (link: (typeof graphLinks)[number]) => ({
+      sourceId: typeof link.source === "string" ? link.source : link.source.id,
+      targetId: typeof link.target === "string" ? link.target : link.target.id,
+    });
 
-		const clusterGroups = new Map<string, EditorGraphNodeDatum[]>();
-		graphNodes.forEach((node) => {
-			const clusterName = editorClusterName(node.sourceNode);
-			clusterGroups.set(clusterName, [
-				...(clusterGroups.get(clusterName) ?? []),
-				node,
-			]);
-		});
-		const clusterData = Array.from(clusterGroups.entries()).map(
-			([name, members]) => {
-				const x =
-					members.reduce((sum, node) => sum + node.x, 0) / members.length;
-				const y =
-					members.reduce((sum, node) => sum + node.y, 0) / members.length;
-				const memberRadius = Math.max(
-					...members.map((node) => {
-						const visual = statusVisualMap.get(node.id);
-						return Math.hypot(node.x - x, node.y - y) + (visual?.radius ?? 24);
-					}),
-				);
-				return {
-					name,
-					count: members.length,
-					x,
-					y,
-					radius: Math.max(92, memberRadius + 44),
-				};
-			},
-		);
-		const clusterByName = new Map(
-			clusterData.map((cluster) => [cluster.name, cluster]),
-		);
-		const constrainNodeToCluster = (
-			node: EditorGraphNodeDatum,
-			x: number,
-			y: number,
-		) => {
-			const cluster = clusterByName.get(editorClusterName(node.sourceNode));
-			if (!cluster) return { x, y };
-			const nodeRadius = statusVisualMap.get(node.id)?.radius ?? 24;
-			const maxDistance = Math.max(0, cluster.radius - nodeRadius - 14);
-			const dx = x - cluster.x;
-			const dy = y - cluster.y;
-			const distance = Math.hypot(dx, dy);
-			if (distance <= maxDistance || distance === 0) return { x, y };
-			const scale = maxDistance / distance;
-			return {
-				x: cluster.x + dx * scale,
-				y: cluster.y + dy * scale,
-			};
-		};
-		const matchingClusterNames = new Set(
-			clusterData
-				.filter((cluster) =>
-					graphNodes.some(
-						(node) =>
-							editorClusterName(node.sourceNode) === cluster.name &&
-							matchingNodeIds.has(node.id),
-					),
-				)
-				.map((cluster) => cluster.name),
-		);
-		const clusterSelection = container
-			.append("g")
-			.attr("class", "relationship-clusters")
-			.selectAll<SVGGElement, (typeof clusterData)[number]>("g")
-			.data(clusterData)
-			.join("g")
-			.attr("transform", (cluster) => `translate(${cluster.x},${cluster.y})`)
-			.attr("opacity", 0.72);
+    const clusterGroups = new Map<string, EditorGraphNodeDatum[]>();
+    graphNodes.forEach((node) => {
+      const clusterName = editorClusterName(node.sourceNode);
+      clusterGroups.set(clusterName, [...(clusterGroups.get(clusterName) ?? []), node]);
+    });
+    const clusterData = Array.from(clusterGroups.entries()).map(([name, members]) => {
+      const x = members.reduce((sum, node) => sum + node.x, 0) / members.length;
+      const y = members.reduce((sum, node) => sum + node.y, 0) / members.length;
+      const memberRadius = Math.max(
+        ...members.map((node) => {
+          const visual = statusVisualMap.get(node.id);
+          return Math.hypot(node.x - x, node.y - y) + (visual?.radius ?? 24);
+        }),
+      );
+      return {
+        name,
+        count: members.length,
+        x,
+        y,
+        radius: Math.max(92, memberRadius + 44),
+      };
+    });
+    const clusterByName = new Map(clusterData.map((cluster) => [cluster.name, cluster]));
+    const constrainNodeToCluster = (node: EditorGraphNodeDatum, x: number, y: number) => {
+      const cluster = clusterByName.get(editorClusterName(node.sourceNode));
+      if (!cluster) return { x, y };
+      const nodeRadius = statusVisualMap.get(node.id)?.radius ?? 24;
+      const maxDistance = Math.max(0, cluster.radius - nodeRadius - 14);
+      const dx = x - cluster.x;
+      const dy = y - cluster.y;
+      const distance = Math.hypot(dx, dy);
+      if (distance <= maxDistance || distance === 0) return { x, y };
+      const scale = maxDistance / distance;
+      return {
+        x: cluster.x + dx * scale,
+        y: cluster.y + dy * scale,
+      };
+    };
+    const matchingClusterNames = new Set(
+      clusterData
+        .filter((cluster) =>
+          graphNodes.some(
+            (node) =>
+              editorClusterName(node.sourceNode) === cluster.name && matchingNodeIds.has(node.id),
+          ),
+        )
+        .map((cluster) => cluster.name),
+    );
+    const clusterSelection = container
+      .append("g")
+      .attr("class", "relationship-clusters")
+      .selectAll<SVGGElement, (typeof clusterData)[number]>("g")
+      .data(clusterData)
+      .join("g")
+      .attr("transform", (cluster) => `translate(${cluster.x},${cluster.y})`)
+      .attr("opacity", 0.72);
 
-		clusterSelection
-			.append("circle")
-			.attr("r", (cluster) => cluster.radius)
-			.attr("fill", (cluster) =>
-				matchingClusterNames.has(cluster.name)
-					? "rgba(250, 204, 21, 0.12)"
-					: "rgba(15, 23, 42, 0.42)",
-			)
-			.attr("stroke", (cluster) =>
-				matchingClusterNames.has(cluster.name) ? "#facc15" : "#345bf2",
-			)
-			.attr("stroke-opacity", (cluster) =>
-				matchingClusterNames.has(cluster.name) ? 0.78 : 0.36,
-			)
-			.attr("stroke-width", (cluster) =>
-				matchingClusterNames.has(cluster.name) ? 3 : 1.5,
-			)
-			.attr("stroke-dasharray", "5, 8")
-			.style("pointer-events", "none");
+    clusterSelection
+      .append("circle")
+      .attr("r", (cluster) => cluster.radius)
+      .attr("fill", (cluster) =>
+        matchingClusterNames.has(cluster.name)
+          ? "rgba(250, 204, 21, 0.12)"
+          : "rgba(15, 23, 42, 0.42)",
+      )
+      .attr("stroke", (cluster) => (matchingClusterNames.has(cluster.name) ? "#facc15" : "#345bf2"))
+      .attr("stroke-opacity", (cluster) => (matchingClusterNames.has(cluster.name) ? 0.78 : 0.36))
+      .attr("stroke-width", (cluster) => (matchingClusterNames.has(cluster.name) ? 3 : 1.5))
+      .attr("stroke-dasharray", "5, 8")
+      .style("pointer-events", "none");
 
-		clusterSelection
-			.append("text")
-			.attr("y", (cluster) => -cluster.radius - 10)
-			.attr("text-anchor", "middle")
-			.attr("fill", "#e5e7eb")
-			.attr("font-size", 10)
-			.attr("font-weight", 900)
-			.attr("paint-order", "stroke")
-			.attr("stroke", "#020617")
-			.attr("stroke-width", 4)
-			.style("pointer-events", "none")
-			.text((cluster) => `${cluster.name} (${cluster.count})`);
+    clusterSelection
+      .append("text")
+      .attr("y", (cluster) => -cluster.radius - 10)
+      .attr("text-anchor", "middle")
+      .attr("fill", "#e5e7eb")
+      .attr("font-size", 10)
+      .attr("font-weight", 900)
+      .attr("paint-order", "stroke")
+      .attr("stroke", "#020617")
+      .attr("stroke-width", 4)
+      .style("pointer-events", "none")
+      .text((cluster) => `${cluster.name} (${cluster.count})`);
 
-		clusterSelection
-			.append("title")
-			.text((cluster) => `${cluster.name}: ${cluster.count} CIs`);
+    clusterSelection.append("title").text((cluster) => `${cluster.name}: ${cluster.count} CIs`);
 
-		const linkSelection = container
-			.append("g")
-			.attr("class", "relationship-links")
-			.selectAll<SVGGElement, (typeof graphLinks)[number]>("g")
-			.data(graphLinks)
-			.join("g")
-			.attr("data-link-source", (link) => linkEndpointIds(link).sourceId)
-			.attr("data-link-target", (link) => linkEndpointIds(link).targetId)
-			.each(function (link) {
-				const { sourceId, targetId } = linkEndpointIds(link);
-				const source = positionMap.get(sourceId);
-				const target = positionMap.get(targetId);
-				if (!source || !target) return;
+    const linkSelection = container
+      .append("g")
+      .attr("class", "relationship-links")
+      .selectAll<SVGGElement, (typeof graphLinks)[number]>("g")
+      .data(graphLinks)
+      .join("g")
+      .attr("data-link-source", (link) => linkEndpointIds(link).sourceId)
+      .attr("data-link-target", (link) => linkEndpointIds(link).targetId)
+      .each(function (link) {
+        const { sourceId, targetId } = linkEndpointIds(link);
+        const source = positionMap.get(sourceId);
+        const target = positionMap.get(targetId);
+        if (!source || !target) return;
 
-				const linkGroup = d3.select(this);
-				linkGroup
-					.append("line")
-					.attr("x1", source.x)
-					.attr("y1", source.y)
-					.attr("x2", target.x)
-					.attr("y2", target.y)
-					.attr("stroke", statusVisualMap.get(target.id)?.color ?? "#4b5563")
-					.attr("stroke-opacity", 0.55)
-					.attr("stroke-width", 2)
-					.attr(
-						"stroke-dasharray",
-						link.type === "DEPENDS_ON"
-							? "5, 8"
-							: link.type === "HOSTED_ON"
-								? "2, 2"
-								: "none",
-					);
+        const linkGroup = d3.select(this);
+        linkGroup
+          .append("line")
+          .attr("x1", source.x)
+          .attr("y1", source.y)
+          .attr("x2", target.x)
+          .attr("y2", target.y)
+          .attr("stroke", statusVisualMap.get(target.id)?.color ?? "#4b5563")
+          .attr("stroke-opacity", 0.55)
+          .attr("stroke-width", 2)
+          .attr(
+            "stroke-dasharray",
+            link.type === "DEPENDS_ON" ? "5, 8" : link.type === "HOSTED_ON" ? "2, 2" : "none",
+          );
 
-				if (graphLinks.length <= 24) {
-					linkGroup
-						.append("text")
-						.attr("x", (source.x + target.x) / 2)
-						.attr("y", (source.y + target.y) / 2)
-						.attr("fill", "#d4d4d4")
-						.attr("font-size", 10)
-						.attr("font-weight", 700)
-						.text(link.type);
-				}
-			});
+        if (graphLinks.length <= 24) {
+          linkGroup
+            .append("text")
+            .attr("x", (source.x + target.x) / 2)
+            .attr("y", (source.y + target.y) / 2)
+            .attr("fill", "#d4d4d4")
+            .attr("font-size", 10)
+            .attr("font-weight", 700)
+            .text(link.type);
+        }
+      });
 
-		const updateLinksForNode = (nodeId: string) => {
-			linkSelection.each(function (link) {
-				const { sourceId, targetId } = linkEndpointIds(link);
-				if (sourceId !== nodeId && targetId !== nodeId) return;
-				const source = positionMap.get(sourceId);
-				const target = positionMap.get(targetId);
-				if (!source || !target) return;
-				const linkGroup = d3.select(this);
-				linkGroup
-					.select<SVGLineElement>("line")
-					.attr("x1", source.x)
-					.attr("y1", source.y)
-					.attr("x2", target.x)
-					.attr("y2", target.y);
-				linkGroup
-					.select<SVGTextElement>("text")
-					.attr("x", (source.x + target.x) / 2)
-					.attr("y", (source.y + target.y) / 2);
-			});
-		};
-		const suppressedClickNodeIds = new Set<string>();
-		const nodeSelection = container
-			.append("g")
-			.attr("class", "relationship-nodes")
-			.selectAll<SVGGElement, EditorGraphNodeDatum>("g")
-			.data(graphNodes, (node) => node.id)
-			.join("g")
-			.attr("role", "button")
-			.attr("tabindex", 0)
-			.attr("aria-label", (node) => `CI node ${node.label}`)
-			.attr("title", (node) => `${node.label} · ${node.layer}`)
-			.attr("data-node-id", (node) => node.id)
-			.attr("transform", (node) => `translate(${node.x},${node.y})`)
-			.attr("class", "cursor-pointer")
-			.on("click", (_event, node) => {
-				if (suppressedClickNodeIds.delete(node.id)) return;
-				selectNode(node.id);
-			})
-			.on("keydown", (event, node) => {
-				if (event.key === "Enter" || event.key === " ") {
-					event.preventDefault();
-					selectNode(node.id);
-				}
-			});
+    const updateLinksForNode = (nodeId: string) => {
+      linkSelection.each(function (link) {
+        const { sourceId, targetId } = linkEndpointIds(link);
+        if (sourceId !== nodeId && targetId !== nodeId) return;
+        const source = positionMap.get(sourceId);
+        const target = positionMap.get(targetId);
+        if (!source || !target) return;
+        const linkGroup = d3.select(this);
+        linkGroup
+          .select<SVGLineElement>("line")
+          .attr("x1", source.x)
+          .attr("y1", source.y)
+          .attr("x2", target.x)
+          .attr("y2", target.y);
+        linkGroup
+          .select<SVGTextElement>("text")
+          .attr("x", (source.x + target.x) / 2)
+          .attr("y", (source.y + target.y) / 2);
+      });
+    };
+    const suppressedClickNodeIds = new Set<string>();
+    const nodeSelection = container
+      .append("g")
+      .attr("class", "relationship-nodes")
+      .selectAll<SVGGElement, EditorGraphNodeDatum>("g")
+      .data(graphNodes, (node) => node.id)
+      .join("g")
+      .attr("role", "button")
+      .attr("tabindex", 0)
+      .attr("aria-label", (node) => `CI node ${node.label}`)
+      .attr("title", (node) => `${node.label} · ${node.layer}`)
+      .attr("data-node-id", (node) => node.id)
+      .attr("transform", (node) => `translate(${node.x},${node.y})`)
+      .attr("class", "cursor-pointer")
+      .on("click", (_event, node) => {
+        if (suppressedClickNodeIds.delete(node.id)) return;
+        selectNode(node.id);
+      })
+      .on("keydown", (event, node) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          selectNode(node.id);
+        }
+      });
 
-		nodeSelection
-			.append("circle")
-			.attr("r", (node) => statusVisualMap.get(node.id)?.radius ?? 24)
-			.attr("fill", (node) =>
-				node.id === sourceId
-					? "#345bf2"
-					: node.id === targetId
-						? "#06b6d4"
-						: matchingNodeIds.has(node.id)
-							? "#3a2f08"
-							: "#1a1a1a",
-			)
-			.attr("stroke", (node) =>
-				matchingNodeIds.has(node.id)
-					? "#facc15"
-					: (statusVisualMap.get(node.id)?.color ?? "#4b5563"),
-			)
-			.attr("stroke-width", (node) =>
-				matchingNodeIds.has(node.id) ||
-				node.id === sourceId ||
-				node.id === targetId
-					? 5
-					: (statusVisualMap.get(node.id)?.strokeWidth ?? 2),
-			)
-			.attr("filter", (node) =>
-				matchingNodeIds.has(node.id) ? "drop-shadow(0 0 14px #facc15)" : null,
-			)
-			.attr("class", "node-circle transition-all duration-300");
+    nodeSelection
+      .append("circle")
+      .attr("r", (node) => statusVisualMap.get(node.id)?.radius ?? 24)
+      .attr("fill", (node) =>
+        node.id === sourceId
+          ? "#345bf2"
+          : node.id === targetId
+            ? "#06b6d4"
+            : matchingNodeIds.has(node.id)
+              ? "#3a2f08"
+              : "#1a1a1a",
+      )
+      .attr("stroke", (node) =>
+        matchingNodeIds.has(node.id)
+          ? "#facc15"
+          : (statusVisualMap.get(node.id)?.color ?? "#4b5563"),
+      )
+      .attr("stroke-width", (node) =>
+        matchingNodeIds.has(node.id) || node.id === sourceId || node.id === targetId
+          ? 5
+          : (statusVisualMap.get(node.id)?.strokeWidth ?? 2),
+      )
+      .attr("filter", (node) =>
+        matchingNodeIds.has(node.id) ? "drop-shadow(0 0 14px #facc15)" : null,
+      )
+      .attr("class", "node-circle transition-all duration-300");
 
-		nodeSelection
-			.append("foreignObject")
-			.attr("x", (node) => -((statusVisualMap.get(node.id)?.radius ?? 24) - 7))
-			.attr("y", (node) => -((statusVisualMap.get(node.id)?.radius ?? 24) - 7))
-			.attr(
-				"width",
-				(node) => ((statusVisualMap.get(node.id)?.radius ?? 24) - 7) * 2,
-			)
-			.attr(
-				"height",
-				(node) => ((statusVisualMap.get(node.id)?.radius ?? 24) - 7) * 2,
-			)
-			.attr("class", "pointer-events-none")
-			.each(function (node) {
-				this.innerHTML = `<div class="flex h-full w-full items-center justify-center">${renderToStaticMarkup(
-					<CategoryIcon
-						iconKey={node.sourceNode.category_icon_key}
-						categoryName={node.sourceNode.category ?? node.sourceNode.type}
-						className="text-[18px] leading-none text-white pointer-events-none select-none"
-					/>,
-				)}</div>`;
-			});
+    nodeSelection
+      .append("foreignObject")
+      .attr("x", (node) => -((statusVisualMap.get(node.id)?.radius ?? 24) - 7))
+      .attr("y", (node) => -((statusVisualMap.get(node.id)?.radius ?? 24) - 7))
+      .attr("width", (node) => ((statusVisualMap.get(node.id)?.radius ?? 24) - 7) * 2)
+      .attr("height", (node) => ((statusVisualMap.get(node.id)?.radius ?? 24) - 7) * 2)
+      .attr("class", "pointer-events-none")
+      .each(function (node) {
+        this.innerHTML = `<div class="flex h-full w-full items-center justify-center">${renderToStaticMarkup(
+          <CategoryIcon
+            iconKey={node.sourceNode.category_icon_key}
+            categoryName={node.sourceNode.category ?? node.sourceNode.type}
+            className="text-[18px] leading-none text-white pointer-events-none select-none"
+          />,
+        )}</div>`;
+      });
 
-		nodeSelection
-			.append("text")
-			.attr("dy", "-1.8em")
-			.attr("text-anchor", "middle")
-			.attr("fill", "#f5f5f5")
-			.attr("font-size", 9)
-			.attr("font-weight", 900)
-			.attr("pointer-events", "none")
-			.text((node) => node.label.slice(0, 2).toUpperCase());
+    nodeSelection
+      .append("text")
+      .attr("dy", "-1.8em")
+      .attr("text-anchor", "middle")
+      .attr("fill", "#f5f5f5")
+      .attr("font-size", 9)
+      .attr("font-weight", 900)
+      .attr("pointer-events", "none")
+      .text((node) => node.label.slice(0, 2).toUpperCase());
 
-		nodeSelection
-			.append("text")
-			.attr("dy", "3.5em")
-			.attr("text-anchor", "middle")
-			.attr("fill", "#a3a3a3")
-			.attr("font-size", 10)
-			.attr("font-weight", 700)
-			.attr("class", "node-label pointer-events-none")
-			.text((node) => truncateGraphLabel(node.label).displayLabel);
+    nodeSelection
+      .append("text")
+      .attr("dy", "3.5em")
+      .attr("text-anchor", "middle")
+      .attr("fill", "#a3a3a3")
+      .attr("font-size", 10)
+      .attr("font-weight", 700)
+      .attr("class", "node-label pointer-events-none")
+      .text((node) => truncateGraphLabel(node.label).displayLabel);
 
-		nodeSelection.call(
-			d3
-				.drag<SVGGElement, EditorGraphNodeDatum>()
-				.on("start", function (event, node) {
-					event.sourceEvent?.stopPropagation();
-					d3.select(this).raise().attr("data-dragging", "true");
-					node.vx = 0;
-					node.vy = 0;
-				})
-				.on("drag", function (event, node) {
-					event.sourceEvent?.stopPropagation();
-					const next = constrainNodeToCluster(node, event.x, event.y);
-					node.x = next.x;
-					node.y = next.y;
-					node.vx = 0;
-					node.vy = 0;
-					positionMap.set(node.id, node);
-					nodePositionCacheRef.current.set(node.id, {
-						x: next.x,
-						y: next.y,
-						vx: 0,
-						vy: 0,
-					});
-					suppressedClickNodeIds.add(node.id);
-					d3.select(this).attr("transform", `translate(${next.x},${next.y})`);
-					updateLinksForNode(node.id);
-				})
-				.on("end", function (event, node) {
-					event.sourceEvent?.stopPropagation();
-					d3.select(this).attr("data-dragging", null);
-					nodePositionCacheRef.current.set(node.id, {
-						x: node.x,
-						y: node.y,
-						vx: 0,
-						vy: 0,
-					});
-				}),
-		);
+    nodeSelection.call(
+      d3
+        .drag<SVGGElement, EditorGraphNodeDatum>()
+        .on("start", function (event, node) {
+          event.sourceEvent?.stopPropagation();
+          d3.select(this).raise().attr("data-dragging", "true");
+          node.vx = 0;
+          node.vy = 0;
+        })
+        .on("drag", function (event, node) {
+          event.sourceEvent?.stopPropagation();
+          const next = constrainNodeToCluster(node, event.x, event.y);
+          node.x = next.x;
+          node.y = next.y;
+          node.vx = 0;
+          node.vy = 0;
+          positionMap.set(node.id, node);
+          nodePositionCacheRef.current.set(node.id, {
+            x: next.x,
+            y: next.y,
+            vx: 0,
+            vy: 0,
+          });
+          suppressedClickNodeIds.add(node.id);
+          d3.select(this).attr("transform", `translate(${next.x},${next.y})`);
+          updateLinksForNode(node.id);
+        })
+        .on("end", function (event, node) {
+          event.sourceEvent?.stopPropagation();
+          d3.select(this).attr("data-dragging", null);
+          nodePositionCacheRef.current.set(node.id, {
+            x: node.x,
+            y: node.y,
+            vx: 0,
+            vy: 0,
+          });
+        }),
+    );
 
-		const selectedStrokeWidth = (node: EditorGraphNodeDatum) =>
-			node.id === sourceId || node.id === targetId
-				? 5
-				: (statusVisualMap.get(node.id)?.strokeWidth ?? 2);
-		const resetGraphFocus = () => {
-			nodeSelection.attr("opacity", 1);
-			nodeSelection
-				.select<SVGCircleElement>("circle.node-circle")
-				.attr("stroke-width", selectedStrokeWidth)
-				.attr("filter", null);
-			nodeSelection
-				.select<SVGTextElement>("text.node-label")
-				.attr("fill", "#a3a3a3")
-				.attr("font-weight", 700)
-				.text((node) => truncateGraphLabel(node.label).displayLabel);
-			linkSelection
-				.select<SVGLineElement>("line")
-				.attr("stroke-opacity", 0.55)
-				.attr("stroke-width", 2);
-			linkSelection.select<SVGTextElement>("text").attr("opacity", 1);
-		};
-		const applyGraphFocus = (activeNodeId: string) => {
-			const relatedNodeIds = new Set([activeNodeId]);
-			const relatedLinkIds = new Set<string>();
-			for (const link of graphLinks) {
-				const { sourceId: linkSourceId, targetId: linkTargetId } =
-					linkEndpointIds(link);
-				if (linkSourceId === activeNodeId || linkTargetId === activeNodeId) {
-					relatedNodeIds.add(linkSourceId);
-					relatedNodeIds.add(linkTargetId);
-					relatedLinkIds.add(link.id);
-				}
-			}
+    const selectedStrokeWidth = (node: EditorGraphNodeDatum) =>
+      node.id === sourceId || node.id === targetId
+        ? 5
+        : (statusVisualMap.get(node.id)?.strokeWidth ?? 2);
+    const resetGraphFocus = () => {
+      nodeSelection.attr("opacity", 1);
+      nodeSelection
+        .select<SVGCircleElement>("circle.node-circle")
+        .attr("stroke-width", selectedStrokeWidth)
+        .attr("filter", null);
+      nodeSelection
+        .select<SVGTextElement>("text.node-label")
+        .attr("fill", "#a3a3a3")
+        .attr("font-weight", 700)
+        .text((node) => truncateGraphLabel(node.label).displayLabel);
+      linkSelection
+        .select<SVGLineElement>("line")
+        .attr("stroke-opacity", 0.55)
+        .attr("stroke-width", 2);
+      linkSelection.select<SVGTextElement>("text").attr("opacity", 1);
+    };
+    const applyGraphFocus = (activeNodeId: string) => {
+      const relatedNodeIds = new Set([activeNodeId]);
+      const relatedLinkIds = new Set<string>();
+      for (const link of graphLinks) {
+        const { sourceId: linkSourceId, targetId: linkTargetId } = linkEndpointIds(link);
+        if (linkSourceId === activeNodeId || linkTargetId === activeNodeId) {
+          relatedNodeIds.add(linkSourceId);
+          relatedNodeIds.add(linkTargetId);
+          relatedLinkIds.add(link.id);
+        }
+      }
 
-			nodeSelection.attr("opacity", (node) => {
-				if (node.id === activeNodeId) return 1;
-				return relatedNodeIds.has(node.id) ? 0.9 : 0.18;
-			});
-			nodeSelection
-				.select<SVGCircleElement>("circle.node-circle")
-				.attr("stroke-width", (node) =>
-					node.id === activeNodeId ? 7 : selectedStrokeWidth(node),
-				)
-				.attr("filter", (node) =>
-					node.id === activeNodeId ? "drop-shadow(0 0 8px currentColor)" : null,
-				);
-			nodeSelection
-				.select<SVGTextElement>("text.node-label")
-				.attr("fill", (node) =>
-					node.id === activeNodeId ? "#ffffff" : "#a3a3a3",
-				)
-				.attr("font-weight", (node) => (node.id === activeNodeId ? 900 : 700))
-				.text((node) =>
-					node.id === activeNodeId
-						? truncateGraphLabel(node.label).fullLabel
-						: truncateGraphLabel(node.label).displayLabel,
-				);
-			linkSelection
-				.select<SVGLineElement>("line")
-				.attr("stroke-opacity", (link) =>
-					relatedLinkIds.has(link.id) ? 0.72 : 0.12,
-				)
-				.attr("stroke-width", (link) =>
-					relatedLinkIds.has(link.id) ? 3 : 1.5,
-				);
-			linkSelection
-				.select<SVGTextElement>("text")
-				.attr("opacity", (link) => (relatedLinkIds.has(link.id) ? 1 : 0.18));
-		};
-		nodeSelection
-			.on("mouseover", (_event, node) => applyGraphFocus(node.id))
-			.on("mouseout", resetGraphFocus)
-			.on("focus", (_event, node) => applyGraphFocus(node.id))
-			.on("blur", resetGraphFocus);
+      nodeSelection.attr("opacity", (node) => {
+        if (node.id === activeNodeId) return 1;
+        return relatedNodeIds.has(node.id) ? 0.9 : 0.18;
+      });
+      nodeSelection
+        .select<SVGCircleElement>("circle.node-circle")
+        .attr("stroke-width", (node) => (node.id === activeNodeId ? 7 : selectedStrokeWidth(node)))
+        .attr("filter", (node) =>
+          node.id === activeNodeId ? "drop-shadow(0 0 8px currentColor)" : null,
+        );
+      nodeSelection
+        .select<SVGTextElement>("text.node-label")
+        .attr("fill", (node) => (node.id === activeNodeId ? "#ffffff" : "#a3a3a3"))
+        .attr("font-weight", (node) => (node.id === activeNodeId ? 900 : 700))
+        .text((node) =>
+          node.id === activeNodeId
+            ? truncateGraphLabel(node.label).fullLabel
+            : truncateGraphLabel(node.label).displayLabel,
+        );
+      linkSelection
+        .select<SVGLineElement>("line")
+        .attr("stroke-opacity", (link) => (relatedLinkIds.has(link.id) ? 0.72 : 0.12))
+        .attr("stroke-width", (link) => (relatedLinkIds.has(link.id) ? 3 : 1.5));
+      linkSelection
+        .select<SVGTextElement>("text")
+        .attr("opacity", (link) => (relatedLinkIds.has(link.id) ? 1 : 0.18));
+    };
+    nodeSelection
+      .on("mouseover", (_event, node) => applyGraphFocus(node.id))
+      .on("mouseout", resetGraphFocus)
+      .on("focus", (_event, node) => applyGraphFocus(node.id))
+      .on("blur", resetGraphFocus);
 
-		return () => {
-			svg.on(".zoom", null);
-		};
-	}, [
-		visibleNodes,
-		visibleCiLinks,
-		selectNode,
-		sourceId,
-		targetId,
-		compactLocationClusters,
-		clusterPlacementMode,
-		viewResetNonce,
-	]);
+    return () => {
+      svg.on(".zoom", null);
+    };
+  }, [
+    visibleNodes,
+    visibleCiLinks,
+    selectNode,
+    sourceId,
+    targetId,
+    compactLocationClusters,
+    clusterPlacementMode,
+    viewResetNonce,
+    matchingNodeIds,
+  ]);
 
-	const handleCreate = async () => {
-		if (!sourceId || !targetId) {
-			setError("Select a source CI and a target CI.");
-			return;
-		}
-		if (sourceId === targetId) {
-			setError("Source and target must be different CIs.");
-			return;
-		}
-		if (!visibleNodeIds.has(sourceId) || !visibleNodeIds.has(targetId)) {
-			setError("Selected CIs must be visible.");
-			return;
-		}
-		setSaving(true);
-		setError("");
-		try {
-			await api.post("/links", {
-				source: sourceId,
-				target: targetId,
-				relationship,
-			});
-			setTargetId("");
-			await onMutated();
-		} catch (err) {
-			console.error(err);
-			setError("Could not create relationship.");
-		} finally {
-			setSaving(false);
-		}
-	};
+  const handleCreate = async () => {
+    if (!sourceId || !targetId) {
+      setError("Select a source CI and a target CI.");
+      return;
+    }
+    if (sourceId === targetId) {
+      setError("Source and target must be different CIs.");
+      return;
+    }
+    if (!visibleNodeIds.has(sourceId) || !visibleNodeIds.has(targetId)) {
+      setError("Selected CIs must be visible.");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      await api.post("/links", {
+        source: sourceId,
+        target: targetId,
+        relationship,
+        ...(tunnelMedium ? { medium: tunnelMedium } : {}),
+      });
+      setTargetId("");
+      await onMutated();
+    } catch (err) {
+      console.error(err);
+      setError("Could not create relationship.");
+    } finally {
+      setSaving(false);
+    }
+  };
 
-	const handleDelete = async (link: LinkData) => {
-		if (!canDeleteRelationship(link.relationship)) return;
+  const linkEditorKey = (link: LinkData) => `${link.source}-${link.target}-${link.relationship}`;
 
-		setSaving(true);
-		setError("");
-		try {
-			await api.delete("/links", link);
-			await onMutated();
-		} catch (err) {
-			console.error(err);
-			setError("Could not delete relationship.");
-		} finally {
-			setSaving(false);
-		}
-	};
+  const handleSaveMedium = async (link: LinkData) => {
+    if (!canDeleteRelationship(link.relationship)) return;
+    const medium = editedMediumByLink[linkEditorKey(link)] || link.medium;
+    if (!isTunnelMedium(medium)) return;
 
-	const isPageMode = mode === "page";
+    setSaving(true);
+    setError("");
+    try {
+      await api.post("/links", {
+        source: link.source,
+        target: link.target,
+        relationship: link.relationship,
+        medium,
+      });
+      await onMutated();
+    } catch (err) {
+      console.error(err);
+      setError("Could not update tunnel medium.");
+    } finally {
+      setSaving(false);
+    }
+  };
 
-	const editorContent = (
-		<div
-			className={`${isPageMode ? "flex h-full w-full flex-col bg-neutral-950" : "flex h-full w-full max-w-7xl flex-col rounded-2xl border border-white/10 bg-neutral-950 shadow-2xl"}`}
-		>
-			<div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
-				<div>
-					<h2 className="text-xl font-black uppercase text-white">
-						Visual Relationship Editor
-					</h2>
-					<p className="text-xs font-bold uppercase tracking-widest text-neutral-500">
-						Click source CI, click target CI, choose type, then create link
-					</p>
-				</div>
-				<button
-					onClick={onClose}
-					className="text-neutral-400 hover:text-white"
-					aria-label="Close visual relationship editor"
-				>
-					<span className="material-symbols-outlined text-3xl">close</span>
-				</button>
-			</div>
+  const handleDelete = async (link: LinkData) => {
+    if (!canDeleteRelationship(link.relationship)) return;
 
-			<div className="grid flex-1 min-h-0 grid-cols-[1fr_360px] gap-4 p-4">
-				<div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.12),rgba(0,0,0,0.18)_42%,rgba(0,0,0,0.62))]">
-					<div className="pointer-events-none absolute inset-0 opacity-35 [background-image:linear-gradient(rgba(255,255,255,0.06)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.06)_1px,transparent_1px)] [background-size:48px_48px]" />
-					<div className="absolute left-4 top-4 z-10 max-h-[calc(100%-2rem)] w-72 overflow-y-auto rounded-xl border border-white/10 bg-neutral-950/85 p-3 shadow-xl backdrop-blur custom-scrollbar">
-						<div className="mb-3 flex items-center justify-between gap-2">
-							<p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
-								View Controls
-							</p>
-							<button
-								type="button"
-								onClick={resetGraphView}
-								className="rounded-full border border-white/10 px-2 py-1 text-[10px] font-black uppercase text-neutral-300 hover:border-brand-400 hover:text-white"
-							>
-								Reset View
-							</button>
-						</div>
-						<div className="mb-3 rounded-lg border border-white/5 bg-black/20 p-2">
-							<p className="mb-2 text-[10px] font-black uppercase tracking-widest text-neutral-400">
-								CI Placement
-							</p>
-							<div className="grid grid-cols-2 gap-2 text-[10px] font-black uppercase">
-								<button
-									type="button"
-									onClick={() => setClusterPlacementMode("relationshipAware")}
-									className={`rounded-lg border px-2 py-1 ${clusterPlacementMode === "relationshipAware" ? "border-brand-400 bg-brand-500/20 text-white" : "border-white/10 text-neutral-400 hover:text-white"}`}
-								>
-									Auto Links
-								</button>
-								<button
-									type="button"
-									onClick={() => setClusterPlacementMode("radial")}
-									className={`rounded-lg border px-2 py-1 ${clusterPlacementMode === "radial" ? "border-brand-400 bg-brand-500/20 text-white" : "border-white/10 text-neutral-400 hover:text-white"}`}
-								>
-									Radial
-								</button>
-							</div>
-							<p className="mt-2 text-[10px] leading-snug text-neutral-500">
-								Drag CIs inside their cluster to fine-tune this session.
-							</p>
-						</div>
-						<label className="block">
-							<span className="mb-1 block text-[10px] font-black uppercase tracking-widest text-neutral-400">
-								Graph Search
-							</span>
-							<div className="relative">
-								<input
-									value={graphSearch}
-									onChange={(event) => setGraphSearch(event.target.value)}
-									placeholder="Search any CI field..."
-									className="w-full rounded-lg border border-yellow-500/20 bg-neutral-950 py-2 pl-8 pr-8 text-xs text-white outline-none transition-colors focus:border-yellow-400"
-								/>
-								<span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-yellow-400">
-									search
-								</span>
-								{graphSearch && (
-									<button
-										type="button"
-										onClick={() => setGraphSearch("")}
-										className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-yellow-300"
-									>
-										×
-									</button>
-								)}
-							</div>
-						</label>
+    setSaving(true);
+    setError("");
+    try {
+      await api.delete("/links", link);
+      await onMutated();
+    } catch (err) {
+      console.error(err);
+      setError("Could not delete relationship.");
+    } finally {
+      setSaving(false);
+    }
+  };
 
-						<div className="mt-4">
-							<div className="flex items-center justify-between gap-2">
-								<div>
-									<p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
-										Layers
-									</p>
-									<p className="text-[10px] text-neutral-500">
-										{visibleNodes.length}/{nodes.length} CIs
-									</p>
-								</div>
-								<div className="flex gap-2 text-[10px] font-black uppercase">
-									<button
-										type="button"
-										onClick={selectAllLayers}
-										className="text-brand-300 hover:text-brand-200"
-									>
-										All
-									</button>
-									<button
-										type="button"
-										onClick={clearAllLayers}
-										className="text-neutral-400 hover:text-white"
-									>
-										None
-									</button>
-								</div>
-							</div>
-							<div className="mt-3 max-h-36 space-y-2 overflow-y-auto pr-1 custom-scrollbar">
-								{layerOptions.map((option) => (
-									<label
-										key={option.label}
-										className="flex items-center justify-between gap-2 text-xs text-neutral-300"
-									>
-										<span className="flex items-center gap-2 truncate">
-											<input
-												type="checkbox"
-												checked={selectedLayers.includes(option.label)}
-												onChange={() => toggleLayer(option.label)}
-												aria-label={`${option.label} layer (${option.count} CIs)`}
-											/>
-											<span className="truncate">{option.label}</span>
-										</span>
-										<span className="rounded bg-white/10 px-2 py-0.5 font-mono text-[10px] text-neutral-400">
-											{option.count}
-										</span>
-									</label>
-								))}
-							</div>
-						</div>
+  const isPageMode = mode === "page";
 
-						<div className="mt-4 border-t border-white/10 pt-4">
-							<div className="flex items-center justify-between gap-2">
-								<div>
-									<p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
-										Locations
-									</p>
-									<p className="text-[10px] text-neutral-500">
-										{selectedLocations.length}/{locationOptions.length} selected
-									</p>
-								</div>
-								<div className="flex gap-2 text-[10px] font-black uppercase">
-									<button
-										type="button"
-										onClick={selectAllLocations}
-										aria-label="All locations"
-										className="text-brand-300 hover:text-brand-200"
-									>
-										All
-									</button>
-									<button
-										type="button"
-										onClick={clearAllLocations}
-										aria-label="No locations"
-										className="text-neutral-400 hover:text-white"
-									>
-										None
-									</button>
-								</div>
-							</div>
-							<div className="relative mt-2">
-								<input
-									value={locationSearch}
-									onChange={(event) => setLocationSearch(event.target.value)}
-									placeholder="Search locations..."
-									className="w-full rounded-lg border border-white/5 bg-neutral-950 py-2 pl-8 pr-3 text-xs text-white outline-none transition-colors focus:border-brand-500"
-								/>
-								<span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-neutral-600">
-									search
-								</span>
-							</div>
-							<div className="mt-3 max-h-44 space-y-2 overflow-y-auto pr-1 custom-scrollbar">
-								{filteredLocationOptions.map((option) => (
-									<label
-										key={option.label}
-										className="flex items-center justify-between gap-2 text-xs text-neutral-300"
-									>
-										<span className="flex items-center gap-2 truncate">
-											<input
-												type="checkbox"
-												checked={selectedLocations.includes(option.label)}
-												onChange={() => toggleLocation(option.label)}
-												aria-label={`${option.label} location (${option.count} CIs)`}
-											/>
-											<span className="truncate">{option.label}</span>
-										</span>
-										<span className="rounded bg-white/10 px-2 py-0.5 font-mono text-[10px] text-neutral-400">
-											{option.count}
-										</span>
-									</label>
-								))}
-							</div>
-						</div>
-					</div>
-					<svg
-						ref={graphSvgRef}
-						className="absolute inset-0 h-full w-full"
-						aria-label="Visual CI relationship map"
-					/>
-					{visibleNodes.length === 0 && (
-						<div className="absolute inset-0 flex items-center justify-center text-xs font-bold uppercase tracking-widest text-neutral-500">
-							No CIs match selected layers
-						</div>
-					)}
-				</div>
+  const editorContent = (
+    <div
+      className={`${isPageMode ? "flex h-full w-full flex-col bg-neutral-950" : "flex h-full w-full max-w-7xl flex-col rounded-2xl border border-white/10 bg-neutral-950 shadow-2xl"}`}
+    >
+      <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+        <div>
+          <h2 className="text-xl font-black uppercase text-white">Visual Relationship Editor</h2>
+          <p className="text-xs font-bold uppercase tracking-widest text-neutral-500">
+            Click source CI, click target CI, choose type, then create link
+          </p>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-neutral-400 hover:text-white"
+          aria-label="Close visual relationship editor"
+        >
+          <span className="material-symbols-outlined text-3xl">close</span>
+        </button>
+      </div>
 
-				<aside className="flex min-h-0 flex-col gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-					<div className="rounded-xl border border-white/10 bg-black/20 p-3">
-						<div className="flex items-center justify-between gap-2">
-							<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
-								CI details — {isEditingCi ? "editing" : "new"}
-							</p>
-							<button
-								type="button"
-								onClick={startNewCi}
-								className="text-[10px] font-black uppercase text-brand-300 hover:text-brand-200"
-							>
-								New CI
-							</button>
-						</div>
-						<div className="mt-3 grid grid-cols-2 gap-2 text-xs text-neutral-300">
-							<label className="col-span-2 space-y-1">
-								<span className="text-neutral-500">CI ID</span>
-								<input
-									aria-label="CI ID"
-									value={ciForm.id}
-									disabled={isEditingCi || ciSaving}
-									onChange={(event) => updateCiForm("id", event.target.value)}
-									className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white disabled:opacity-60"
-								/>
-							</label>
-							<label className="col-span-2 space-y-1">
-								<span className="text-neutral-500">Label</span>
-								<input
-									aria-label="CI label"
-									value={ciForm.label}
-									disabled={ciSaving}
-									onChange={(event) =>
-										updateCiForm("label", event.target.value)
-									}
-									className="w-full rounded-lg border border-white/10 bg-black/30 p-2 text-white"
-								/>
-							</label>
-							<label className="space-y-1">
-								<span className="text-neutral-500">Type</span>
-								<select
-									aria-label="CI type"
-									value={ciForm.type}
-									disabled={ciSaving}
-									onChange={(event) => updateCiForm("type", event.target.value)}
-									className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
-								>
-									<option value="">Select type</option>
-									{CI_TYPES.map((type) => (
-										<option key={type} value={type}>
-											{type}
-										</option>
-									))}
-								</select>
-							</label>
-							<label className="space-y-1">
-								<span className="text-neutral-500">Status</span>
-								<select
-									aria-label="CI status"
-									value={ciForm.status}
-									disabled={ciSaving}
-									onChange={(event) =>
-										updateCiForm("status", event.target.value)
-									}
-									className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
-								>
-									{CI_STATUSES.map((status) => (
-										<option key={status} value={status}>
-											{status}
-										</option>
-									))}
-								</select>
-							</label>
-							{ciError && (
-								<div className="col-span-2 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
-									{ciError}
-								</div>
-							)}
-							<button
-								type="button"
-								onClick={handleSaveCi}
-								disabled={ciSaving}
-								className="col-span-2 rounded-xl bg-cyan-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
-							>
-								{ciSaving
-									? "Saving CI..."
-									: isEditingCi
-										? "Save CI"
-										: "Create CI"}
-							</button>
-							<button
-								type="button"
-								onClick={handleDeleteCi}
-								disabled={!isEditingCi || ciSaving}
-								className="col-span-2 rounded-xl border border-red-500/30 py-2 text-xs font-black uppercase text-red-300 disabled:cursor-not-allowed disabled:opacity-40"
-							>
-								Delete CI
-							</button>
-						</div>
-					</div>
+      <div className="grid flex-1 min-h-0 grid-cols-[1fr_360px] gap-4 p-4">
+        <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-[radial-gradient(circle_at_center,rgba(59,130,246,0.12),rgba(0,0,0,0.18)_42%,rgba(0,0,0,0.62))]">
+          <div className="pointer-events-none absolute inset-0 opacity-35 [background-image:linear-gradient(rgba(255,255,255,0.06)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.06)_1px,transparent_1px)] [background-size:48px_48px]" />
+          <div className="absolute left-4 top-4 z-10 max-h-[calc(100%-2rem)] w-72 overflow-y-auto rounded-xl border border-white/10 bg-neutral-950/85 p-3 shadow-xl backdrop-blur custom-scrollbar">
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
+                View Controls
+              </p>
+              <button
+                type="button"
+                onClick={resetGraphView}
+                className="rounded-full border border-white/10 px-2 py-1 text-[10px] font-black uppercase text-neutral-300 hover:border-brand-400 hover:text-white"
+              >
+                Reset View
+              </button>
+            </div>
+            <div className="mb-3 rounded-lg border border-white/5 bg-black/20 p-2">
+              <p className="mb-2 text-[10px] font-black uppercase tracking-widest text-neutral-400">
+                CI Placement
+              </p>
+              <div className="grid grid-cols-2 gap-2 text-[10px] font-black uppercase">
+                <button
+                  type="button"
+                  onClick={() => setClusterPlacementMode("relationshipAware")}
+                  className={`rounded-lg border px-2 py-1 ${clusterPlacementMode === "relationshipAware" ? "border-brand-400 bg-brand-500/20 text-white" : "border-white/10 text-neutral-400 hover:text-white"}`}
+                >
+                  Auto Links
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setClusterPlacementMode("radial")}
+                  className={`rounded-lg border px-2 py-1 ${clusterPlacementMode === "radial" ? "border-brand-400 bg-brand-500/20 text-white" : "border-white/10 text-neutral-400 hover:text-white"}`}
+                >
+                  Radial
+                </button>
+              </div>
+              <p className="mt-2 text-[10px] leading-snug text-neutral-500">
+                Drag CIs inside their cluster to fine-tune this session.
+              </p>
+            </div>
+            <label className="block">
+              <span className="mb-1 block text-[10px] font-black uppercase tracking-widest text-neutral-400">
+                Graph Search
+              </span>
+              <div className="relative">
+                <input
+                  value={graphSearch}
+                  onChange={(event) => setGraphSearch(event.target.value)}
+                  placeholder="Search any CI field..."
+                  className="w-full rounded-lg border border-yellow-500/20 bg-neutral-950 py-2 pl-8 pr-8 text-xs text-white outline-none transition-colors focus:border-yellow-400"
+                />
+                <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-yellow-400">
+                  search
+                </span>
+                {graphSearch && (
+                  <button
+                    type="button"
+                    onClick={() => setGraphSearch("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500 hover:text-yellow-300"
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            </label>
 
-					<div className="rounded-xl border border-white/10 bg-black/20 p-3">
-						<p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
-							New relationship
-						</p>
-						<div className="mt-3 space-y-2 text-xs text-neutral-300">
-							<div>
-								<span className="text-neutral-500">Source:</span>{" "}
-								{nodeLabel(nodeMap.get(sourceId))}
-							</div>
-							<div>
-								<span className="text-neutral-500">Target:</span>{" "}
-								{targetId ? nodeLabel(nodeMap.get(targetId)) : "Select target"}
-							</div>
-							<select
-								value={relationship}
-								onChange={(event) =>
-									setRelationship(event.target.value as typeof relationship)
-								}
-								className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
-								aria-label="Relationship type"
-							>
-								{SUPPORTED_RELATIONSHIP_TYPES.map((type) => (
-									<option key={type} value={type}>
-										{type}
-									</option>
-								))}
-							</select>
-							{error && (
-								<div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
-									{error}
-								</div>
-							)}
-							<button
-								onClick={handleCreate}
-								disabled={
-									saving || !sourceId || !targetId || sourceId === targetId
-								}
-								className="w-full rounded-xl bg-brand-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
-							>
-								{saving ? "Saving..." : "Create relationship"}
-							</button>
-						</div>
-					</div>
+            <div className="mt-4">
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
+                    Layers
+                  </p>
+                  <p className="text-[10px] text-neutral-500">
+                    {visibleNodes.length}/{nodes.length} CIs
+                  </p>
+                </div>
+                <div className="flex gap-2 text-[10px] font-black uppercase">
+                  <button
+                    type="button"
+                    onClick={selectAllLayers}
+                    className="text-brand-300 hover:text-brand-200"
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={clearAllLayers}
+                    className="text-neutral-400 hover:text-white"
+                  >
+                    None
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 max-h-36 space-y-2 overflow-y-auto pr-1 custom-scrollbar">
+                {layerOptions.map((option) => (
+                  <label
+                    key={option.label}
+                    className="flex items-center justify-between gap-2 text-xs text-neutral-300"
+                  >
+                    <span className="flex items-center gap-2 truncate">
+                      <input
+                        type="checkbox"
+                        checked={selectedLayers.includes(option.label)}
+                        onChange={() => toggleLayer(option.label)}
+                        aria-label={`${option.label} layer (${option.count} CIs)`}
+                      />
+                      <span className="truncate">{option.label}</span>
+                    </span>
+                    <span className="rounded bg-white/10 px-2 py-0.5 font-mono text-[10px] text-neutral-400">
+                      {option.count}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
 
-					<div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-white/10 bg-black/20">
-						<div className="sticky top-0 bg-neutral-950/90 p-3 text-[10px] font-black uppercase tracking-widest text-neutral-500">
-							Existing links
-						</div>
-						{visibleCiLinks.map((link) => {
-							const readOnly = isReadOnlyRelationship(link.relationship);
+            <div className="mt-4 border-t border-white/10 pt-4">
+              <div className="flex items-center justify-between gap-2">
+                <div>
+                  <p className="text-[10px] font-black uppercase tracking-widest text-neutral-400">
+                    Locations
+                  </p>
+                  <p className="text-[10px] text-neutral-500">
+                    {selectedLocations.length}/{locationOptions.length} selected
+                  </p>
+                </div>
+                <div className="flex gap-2 text-[10px] font-black uppercase">
+                  <button
+                    type="button"
+                    onClick={selectAllLocations}
+                    aria-label="All locations"
+                    className="text-brand-300 hover:text-brand-200"
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    onClick={clearAllLocations}
+                    aria-label="No locations"
+                    className="text-neutral-400 hover:text-white"
+                  >
+                    None
+                  </button>
+                </div>
+              </div>
+              <div className="relative mt-2">
+                <input
+                  value={locationSearch}
+                  onChange={(event) => setLocationSearch(event.target.value)}
+                  placeholder="Search locations..."
+                  className="w-full rounded-lg border border-white/5 bg-neutral-950 py-2 pl-8 pr-3 text-xs text-white outline-none transition-colors focus:border-brand-500"
+                />
+                <span className="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-sm text-neutral-600">
+                  search
+                </span>
+              </div>
+              <div className="mt-3 max-h-44 space-y-2 overflow-y-auto pr-1 custom-scrollbar">
+                {filteredLocationOptions.map((option) => (
+                  <label
+                    key={option.label}
+                    className="flex items-center justify-between gap-2 text-xs text-neutral-300"
+                  >
+                    <span className="flex items-center gap-2 truncate">
+                      <input
+                        type="checkbox"
+                        checked={selectedLocations.includes(option.label)}
+                        onChange={() => toggleLocation(option.label)}
+                        aria-label={`${option.label} location (${option.count} CIs)`}
+                      />
+                      <span className="truncate">{option.label}</span>
+                    </span>
+                    <span className="rounded bg-white/10 px-2 py-0.5 font-mono text-[10px] text-neutral-400">
+                      {option.count}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+          <svg
+            ref={graphSvgRef}
+            className="absolute inset-0 h-full w-full"
+            aria-label="Visual CI relationship map"
+          />
+          {visibleNodes.length === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center text-xs font-bold uppercase tracking-widest text-neutral-500">
+              No CIs match selected layers
+            </div>
+          )}
+        </div>
 
-							return (
-								<div
-									key={`${link.source}-${link.target}-${link.relationship}`}
-									className="border-t border-white/5 p-3 text-xs text-neutral-300"
-								>
-									<div className="font-bold text-white">
-										{link.source_label || link.source} →{" "}
-										{link.target_label || link.target}
-									</div>
-									<div className="mt-1 flex items-center justify-between gap-2">
-										<span className="flex items-center gap-2">
-											<span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
-												{link.relationship}
-											</span>
-											{readOnly && (
-												<span className="rounded border border-amber-400/30 bg-amber-400/10 px-2 py-1 text-[10px] font-black uppercase text-amber-200">
-													Read-only
-												</span>
-											)}
-										</span>
-										{canDeleteRelationship(link.relationship) && (
-											<button
-												onClick={() => handleDelete(link)}
-												className="text-red-300 hover:text-red-200"
-												disabled={saving}
-											>
-												Delete
-											</button>
-										)}
-									</div>
-								</div>
-							);
-						})}
-						{visibleCiLinks.length === 0 && (
-							<div className="p-6 text-center text-xs text-neutral-500">
-								{ciLinks.length === 0
-									? "No CI links yet."
-									: "No visible CI links for selected layers."}
-							</div>
-						)}
-					</div>
-				</aside>
-			</div>
-		</div>
-	);
+        <aside className="flex min-h-0 flex-col gap-4 rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
+                CI details — {isEditingCi ? "editing" : "new"}
+              </p>
+              <button
+                type="button"
+                onClick={startNewCi}
+                className="text-[10px] font-black uppercase text-brand-300 hover:text-brand-200"
+              >
+                New CI
+              </button>
+            </div>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-neutral-300">
+              <label className="col-span-2 space-y-1">
+                <span className="text-neutral-500">CI ID</span>
+                <input
+                  aria-label="CI ID"
+                  value={ciForm.id}
+                  disabled={isEditingCi || ciSaving}
+                  onChange={(event) => updateCiForm("id", event.target.value)}
+                  className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white disabled:opacity-60"
+                />
+              </label>
+              <label className="col-span-2 space-y-1">
+                <span className="text-neutral-500">Label</span>
+                <input
+                  aria-label="CI label"
+                  value={ciForm.label}
+                  disabled={ciSaving}
+                  onChange={(event) => updateCiForm("label", event.target.value)}
+                  className="w-full rounded-lg border border-white/10 bg-black/30 p-2 text-white"
+                />
+              </label>
+              <label className="space-y-1">
+                <span className="text-neutral-500">Type</span>
+                <select
+                  aria-label="CI type"
+                  value={ciForm.type}
+                  disabled={ciSaving}
+                  onChange={(event) => updateCiForm("type", event.target.value)}
+                  className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+                >
+                  <option value="">Select type</option>
+                  {CI_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {type}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="space-y-1">
+                <span className="text-neutral-500">Status</span>
+                <select
+                  aria-label="CI status"
+                  value={ciForm.status}
+                  disabled={ciSaving}
+                  onChange={(event) => updateCiForm("status", event.target.value)}
+                  className="w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+                >
+                  {CI_STATUSES.map((status) => (
+                    <option key={status} value={status}>
+                      {status}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {ciError && (
+                <div className="col-span-2 rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
+                  {ciError}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={handleSaveCi}
+                disabled={ciSaving}
+                className="col-span-2 rounded-xl bg-cyan-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {ciSaving ? "Saving CI..." : isEditingCi ? "Save CI" : "Create CI"}
+              </button>
+              <button
+                type="button"
+                onClick={handleDeleteCi}
+                disabled={!isEditingCi || ciSaving}
+                className="col-span-2 rounded-xl border border-red-500/30 py-2 text-xs font-black uppercase text-red-300 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Delete CI
+              </button>
+            </div>
+          </div>
 
-	if (isPageMode) return editorContent;
+          <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+            <p className="text-[10px] font-black uppercase tracking-widest text-neutral-500">
+              New relationship
+            </p>
+            <div className="mt-3 space-y-2 text-xs text-neutral-300">
+              <div>
+                <span className="text-neutral-500">Source:</span> {nodeLabel(nodeMap.get(sourceId))}
+              </div>
+              <div>
+                <span className="text-neutral-500">Target:</span>{" "}
+                {targetId ? nodeLabel(nodeMap.get(targetId)) : "Select target"}
+              </div>
+              <select
+                value={relationship}
+                onChange={(event) => setRelationship(event.target.value as typeof relationship)}
+                className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+                aria-label="Relationship type"
+              >
+                {SUPPORTED_RELATIONSHIP_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={tunnelMedium}
+                onChange={(event) => setTunnelMedium(event.target.value as TunnelMedium | "")}
+                className="mt-2 w-full rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-white"
+                aria-label="Tunnel medium"
+              >
+                <option value="">No tunnel medium</option>
+                {TUNNEL_MEDIUM_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {error && (
+                <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-2 text-red-300">
+                  {error}
+                </div>
+              )}
+              <button
+                onClick={handleCreate}
+                disabled={saving || !sourceId || !targetId || sourceId === targetId}
+                className="w-full rounded-xl bg-brand-600 py-2 text-xs font-black uppercase text-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {saving ? "Saving..." : "Create relationship"}
+              </button>
+            </div>
+          </div>
 
-	return (
-		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-6 backdrop-blur-xl">
-			{editorContent}
-		</div>
-	);
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-white/10 bg-black/20">
+            <div className="sticky top-0 bg-neutral-950/90 p-3 text-[10px] font-black uppercase tracking-widest text-neutral-500">
+              Existing links
+            </div>
+            {visibleCiLinks.map((link) => {
+              const readOnly = isReadOnlyRelationship(link.relationship);
+              const visual = resolveTunnelVisual(
+                { medium: link.medium },
+                link.tunnel_health ?? undefined,
+              );
+              const editableMedium = editedMediumByLink[linkEditorKey(link)] || link.medium || "";
+
+              return (
+                <div
+                  key={`${link.source}-${link.target}-${link.relationship}`}
+                  className="border-t border-white/5 p-3 text-xs text-neutral-300"
+                >
+                  <div className="font-bold text-white">
+                    {link.source_label || link.source} → {link.target_label || link.target}
+                  </div>
+                  <div className="mt-1 flex items-center justify-between gap-2">
+                    <span className="flex items-center gap-2">
+                      <span className="rounded bg-white/10 px-2 py-1 font-mono text-[10px]">
+                        {link.relationship}
+                      </span>
+                      {visual.medium && (
+                        <span className="rounded border border-cyan-400/30 bg-cyan-400/10 px-2 py-1 text-[10px] font-black uppercase text-cyan-100">
+                          {visual.mediumLabel}
+                        </span>
+                      )}
+                      {readOnly && (
+                        <span className="rounded border border-amber-400/30 bg-amber-400/10 px-2 py-1 text-[10px] font-black uppercase text-amber-200">
+                          Read-only
+                        </span>
+                      )}
+                    </span>
+                    {canDeleteRelationship(link.relationship) && (
+                      <button
+                        onClick={() => handleDelete(link)}
+                        className="text-red-300 hover:text-red-200"
+                        disabled={saving}
+                      >
+                        Delete
+                      </button>
+                    )}
+                  </div>
+                  {visual.medium && (
+                    <div className="mt-2 space-y-2">
+                      <div className="flex flex-wrap gap-2 text-[10px] font-bold uppercase text-neutral-400">
+                        <span>Authority: {visual.authorityText}</span>
+                        {visual.tooltipRows
+                          .filter((row) => row.label === "ICMP")
+                          .map((row) => (
+                            <span key={`${row.label}-${row.value}`}>
+                              {row.label}: {row.value}
+                            </span>
+                          ))}
+                      </div>
+                      {canDeleteRelationship(link.relationship) && (
+                        <div className="flex gap-2">
+                          <select
+                            value={editableMedium}
+                            onChange={(event) =>
+                              setEditedMediumByLink((current) => ({
+                                ...current,
+                                [linkEditorKey(link)]: event.target.value as TunnelMedium,
+                              }))
+                            }
+                            aria-label={`Medium for ${link.source_label || link.source} to ${link.target_label || link.target}`}
+                            className="min-w-0 flex-1 rounded-lg border border-white/10 bg-black/30 p-2 font-mono text-[11px] text-white"
+                          >
+                            {TUNNEL_MEDIUM_OPTIONS.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            type="button"
+                            onClick={() => handleSaveMedium(link)}
+                            disabled={saving || !isTunnelMedium(editableMedium)}
+                            className="rounded-lg border border-cyan-400/30 px-2 text-[10px] font-black uppercase text-cyan-100 disabled:cursor-not-allowed disabled:opacity-40"
+                          >
+                            Save medium
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+            {visibleCiLinks.length === 0 && (
+              <div className="p-6 text-center text-xs text-neutral-500">
+                {ciLinks.length === 0
+                  ? "No CI links yet."
+                  : "No visible CI links for selected layers."}
+              </div>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+
+  if (isPageMode) return editorContent;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-6 backdrop-blur-xl">
+      {editorContent}
+    </div>
+  );
 };
 
 export default VisualRelationshipEditor;

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -42,6 +42,13 @@ export default [
       globals: {
         window: "readonly",
         document: "readonly",
+        alert: "readonly",
+        confirm: "readonly",
+        SVGSVGElement: "readonly",
+        SVGGElement: "readonly",
+        SVGLineElement: "readonly",
+        SVGTextElement: "readonly",
+        SVGCircleElement: "readonly",
         console: "readonly",
         navigator: "readonly",
         fetch: "readonly",

--- a/openspec/changes/feat-324-tunnel-visualization/apply-progress.md
+++ b/openspec/changes/feat-324-tunnel-visualization/apply-progress.md
@@ -110,3 +110,126 @@ PR1 only: shared helpers, query/bounds, and aggregate telemetry for the feature-
 - [ ] Re-run focused frontend Vitest once Corepack/pnpm is available and check off GREEN tasks if passing.
 - [ ] Re-run backend pytest once pytest dependencies are available and check off task 1.6 if passing.
 - [ ] Continue PR2/PR3 only after PR1 verification.
+
+---
+
+## PR2 Progress Update — 2026-07-05
+
+## Scope
+
+PR2 only: scoped `public_ip` projection after server-side scoped repository reads, plus VisualRelationshipEditor tunnel medium create/edit/display support through the shared tunnel visual model. PR3 topology surface integrations remain out of scope.
+
+## Completed Task Checkboxes
+
+- [x] 2.1 RED backend route tests for `/nodes` and `/graph/full` scoped `public_ip` projection, including CIDetailModal topology consumer contract coverage through `/graph/full`.
+- [ ] 2.2 GREEN backend projection implementation — implemented, but not marked complete because local Python execution is blocked by `xcode-select` before pytest or py_compile can run.
+- [x] 2.3 RED VisualRelationshipEditor tests for creating, editing, and displaying tunnel media and non-authoritative health context.
+- [ ] 2.4 GREEN VisualRelationshipEditor implementation — implemented, but not marked complete because local Corepack/pnpm execution is blocked in this environment.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 2.1 | `backend/tests/test_routers_nodes.py`; `backend/tests/test_routers_links.py` | API | ⚠️ Blocked before edits: `python3 -m pytest backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` failed at `xcode-select`; no test runner reached | ✅ Written first for admin, limited non-admin, and empty non-admin scope on `/nodes` and `/graph/full`; CIDetailModal topology consumer represented by `/graph/full` contract tests | ❌ Not executed: Python command resolution is blocked by missing Xcode command line tools | ✅ Non-empty scoped public IP, empty scoped result, and out-of-scope non-leak assertions | ➖ Awaiting runner |
+| 2.2 | `backend/tests/test_routers_nodes.py`; `backend/tests/test_routers_links.py` | API/service | ⚠️ Blocked: Python runner unavailable due `xcode-select` | ✅ Covered by 2.1 tests before implementation | ❌ Not claimed: pytest and py_compile both blocked by `xcode-select` | ✅ `/nodes` and `/graph/full` projections preserve `metadata.public_ip` and expose nullable top-level `public_ip` only on already-returned scoped rows | ➖ Awaiting runner |
+| 2.3 | `frontend/components/VisualRelationshipEditor.test.tsx` | Component | ⚠️ Blocked before edits: `corepack pnpm --dir frontend test:run components/VisualRelationshipEditor.test.tsx` failed with `operation not permitted: corepack` | ✅ Written first for create medium, edit medium, display medium, and non-authoritative `UP` + ICMP failed health context | ❌ Not executed: Corepack/pnpm unavailable | ✅ Covers `sd_wan` creation, `satellite` edit, `vpn` display, and no `DEGRADED` authority drift | ➖ Awaiting runner |
+| 2.4 | `frontend/components/VisualRelationshipEditor.test.tsx` | Component | ⚠️ Blocked: frontend runner unavailable | ✅ Covered by 2.3 tests before implementation | ❌ Not claimed: Corepack/pnpm unavailable | ✅ Create payload includes selected medium; existing links display shared visual medium/authority/ICMP rows; editable tunnel links can save a new medium through the link contract | ➖ Awaiting runner |
+
+## Test Commands and Results
+
+- `python3 -m pytest backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` before PR2 edits → blocked: `xcode-select: error: No developer tools were found...`.
+- `corepack pnpm --dir frontend test:run components/VisualRelationshipEditor.test.tsx` before PR2 edits → blocked: `zsh:1: operation not permitted: corepack`.
+- `python3 -m pytest backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` after PR2 edits → blocked: `xcode-select: error: No developer tools were found...`.
+- `corepack pnpm --dir frontend test:run components/VisualRelationshipEditor.test.tsx` after PR2 edits → blocked: `zsh:1: operation not permitted: corepack`.
+- `python3 -m py_compile backend/services/node_service.py backend/services/link_service.py backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` after PR2 edits → blocked: `xcode-select: error: No developer tools were found...`.
+- `git diff --check` after PR2 edits → blocked: `xcode-select: error: No developer tools were found...`.
+
+## Files Touched
+
+- `backend/tests/test_routers_nodes.py` — RED scoped `/nodes` public_ip projection tests for admin, limited non-admin, and empty non-admin scope.
+- `backend/tests/test_routers_links.py` — RED scoped `/graph/full` public_ip projection tests, including CIDetailModal topology consumer contract coverage through the same topology payload.
+- `backend/services/node_service.py` — projects top-level nullable `public_ip` after `topology_repo.get_nodes(...)` has already applied scope, while preserving `metadata.public_ip`.
+- `backend/services/link_service.py` — projects top-level nullable `public_ip` after `topology_repo.get_filtered_graph_data(...)` has already applied scope, while preserving `metadata.public_ip`.
+- `frontend/components/RelationshipManager.tsx` — extends `LinkData` with optional tunnel `medium` and `tunnel_health` so editor consumers can share the tunnel visual contract.
+- `frontend/components/VisualRelationshipEditor.test.tsx` — RED tests for create/edit/display tunnel medium and non-authoritative health context.
+- `frontend/components/VisualRelationshipEditor.tsx` — adds tunnel medium selection for creation, existing-link medium display/editing, and shared `resolveTunnelVisual` usage for medium/authority/ICMP display.
+- `openspec/changes/feat-324-tunnel-visualization/tasks.md` — marks completed RED tasks 2.1 and 2.3 only.
+- `openspec/changes/feat-324-tunnel-visualization/apply-progress.md` — appends this PR2 TDD evidence.
+
+## Deviations
+
+- GREEN tasks 2.2 and 2.4 are implemented but intentionally not checked off because local automated GREEN execution is blocked by environment/tooling, not by failing assertions.
+- No PR3 surface integrations were modified.
+- No backend tunnel-health normalization, ICMP authority, pollers, vendor telemetry, bulk health endpoints, or icon assets were changed.
+
+## Remaining Tasks
+
+- [ ] Run focused backend pytest once Python execution is not blocked by `xcode-select`; if passing, mark 2.2 complete.
+- [ ] Run focused frontend Vitest once Corepack/pnpm is available; if passing, mark 2.4 complete.
+- [ ] Run formatter/lint or `git diff --check` once Git/developer tools are available.
+
+---
+
+## PR2 Backend Scope-Safety Fix — 2026-07-05
+
+## Scope
+
+PR2 backend-only fix for the `/graph/full` empty non-admin scope leak found during fresh review. Frontend and PR3 surfaces remain out of scope.
+
+## Completed Task Checkboxes
+
+- [x] 2.1 RED strengthened: `/graph/full` limited-scope and empty-scope tests now include out-of-scope `public_ip` fixture data and assert no top-level public IP leak.
+- [ ] 2.2 GREEN backend projection/scope implementation — empty non-admin scope guard implemented in `backend/services/link_service.py`, but not marked complete because local Python execution is still blocked by missing Xcode command line tools.
+
+## TDD Cycle Evidence
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 2.1/2.2 scope fix | `backend/tests/test_routers_links.py` | API/service | ⚠️ Blocked before edits: `python3 -m pytest backend/tests/test_routers_links.py -k "full_graph_operator_empty_scope or full_graph_operator_limited_scope"` failed at `xcode-select` before pytest could start | ✅ Test strengthened first: empty non-admin scope now seeds out-of-scope `public_ip` data and asserts the repository is not called; limited scope seeds in-scope and out-of-scope public IP fixtures and asserts only scoped public IP is projected | ❌ Not claimed: focused pytest and py_compile both blocked by `xcode-select` | ✅ Covers empty scope, limited scope, repository non-invocation for empty scope, and no out-of-scope top-level `public_ip` in response text | ➖ Awaiting runner |
+
+## Test Commands and Results
+
+- `python3 -m pytest backend/tests/test_routers_links.py -k "full_graph_operator_empty_scope or full_graph_operator_limited_scope"` before implementation → blocked: `xcode-select: error: No developer tools were found...`.
+- `python3 -m pytest backend/tests/test_routers_links.py -k "full_graph_operator_empty_scope or full_graph_operator_limited_scope"` after implementation → blocked: `xcode-select: error: No developer tools were found...`.
+- `python3 -m py_compile backend/services/link_service.py backend/tests/test_routers_links.py` after implementation → blocked: `xcode-select: error: No developer tools were found...`.
+
+## Files Touched
+
+- `backend/tests/test_routers_links.py` — strengthened `/graph/full` empty-scope and limited-scope public IP leak coverage with out-of-scope fixtures.
+- `backend/services/link_service.py` — added an explicit empty non-admin `allowed_locations == []` guard before repository access.
+- `openspec/changes/feat-324-tunnel-visualization/apply-progress.md` — recorded TDD evidence and runner blockers for this backend scope-safety fix.
+
+## Deviations
+
+- Task 2.2 remains unchecked because no local GREEN execution was possible.
+- No frontend, PR3 surface, repository, or router implementation files were changed.
+
+## Remaining Tasks
+
+- [ ] Run focused backend pytest once Python execution is not blocked by `xcode-select`; if passing, task 2.2 can be considered for completion.
+- [ ] Run formatter/lint or `git diff --check` once Git/developer tools are available.
+
+---
+
+## PR2 Backend GREEN Validation — 2026-07-05
+
+## Completed Task Checkboxes
+
+- [x] 2.2 GREEN completed: backend scoped `public_ip` projection now has focused pytest coverage passing for `/nodes` and `/graph/full`.
+
+## TDD Cycle Evidence Update
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 2.2 | `backend/tests/test_routers_nodes.py`; `backend/tests/test_routers_links.py` | API/service | ✅ Temporary Python 3.11 venv created at `/private/tmp/next-gen-pr2-py311` because system `python3` is blocked by missing Xcode command line tools | ✅ Covered by prior 2.1 RED tests plus strengthened `/graph/full` empty/limited scope leak tests | ✅ `/private/tmp/next-gen-pr2-py311/bin/python -m pytest backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` passed: 64 passed, 18 warnings | ✅ Admin, limited non-admin, and empty non-admin scope behavior covered for `/nodes` and `/graph/full`; empty non-admin `/graph/full` avoids repository access | ✅ Critical empty-scope leak fix re-reviewed with no blockers; only CI/full-suite confirmation remains |
+
+## Test Commands and Results
+
+- `/Users/macbook/.local/bin/python3.11 -m venv /private/tmp/next-gen-pr2-py311 && /private/tmp/next-gen-pr2-py311/bin/python -m pip install -q --upgrade pip && /private/tmp/next-gen-pr2-py311/bin/python -m pip install -q -r backend/requirements.txt -r backend/requirements-dev.txt` → passed.
+- `/private/tmp/next-gen-pr2-py311/bin/python -m pytest backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` → passed: 64 passed, 18 warnings.
+- `OPENSSL_CONF=/dev/null /Applications/Codex.app/Contents/Resources/cua_node/bin/node node_modules/vitest/vitest.mjs run components/VisualRelationshipEditor.test.tsx` → blocked by macOS native Rollup/Node Team ID signing mismatch, so 2.4 remains unchecked pending CI-capable frontend test execution.
+
+## Remaining Tasks
+
+- [ ] Run focused frontend Vitest in CI-capable environment; if passing, mark 2.4 complete.
+- [ ] Run final changed-file lint/format and prepare PR2 commit/PR after frontend GREEN evidence.

--- a/openspec/changes/feat-324-tunnel-visualization/apply-progress.md
+++ b/openspec/changes/feat-324-tunnel-visualization/apply-progress.md
@@ -233,3 +233,37 @@ PR2 backend-only fix for the `/graph/full` empty non-admin scope leak found duri
 
 - [ ] Run focused frontend Vitest in CI-capable environment; if passing, mark 2.4 complete.
 - [ ] Run final changed-file lint/format and prepare PR2 commit/PR after frontend GREEN evidence.
+
+---
+
+## PR2 CI GREEN Validation — 2026-07-05
+
+## Completed Task Checkboxes
+
+- [x] 2.4 GREEN completed: CI validated frontend tests for the VisualRelationshipEditor medium create/edit/display work.
+
+## CI Evidence
+
+PR #367 head `d559b587a7d474836fa4f1b9dc8d15926cd01da7` completed successfully:
+
+- `frontend-tests` → success
+- `backend-tests` → success
+- `smoke` → success
+- `lint-backend` → success
+- `lint-frontend` → success
+- `lint-verify (PR1 gate)` → success
+- `ci-verify (PR2 gate)` → success
+- `ci-verify (PR3 gate)` → success
+- `shellcheck` → success
+- `yamllint` → success
+- `actionlint` → success
+
+## TDD Cycle Evidence Update
+
+| Task | Test File | Layer | Safety Net | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|------------|-----|-------|-------------|----------|
+| 2.4 | `frontend/components/VisualRelationshipEditor.test.tsx` | Component | ✅ CI `frontend-tests` validated the focused frontend work after local Vitest was blocked by macOS Rollup/Node signing | ✅ Covered by 2.3 RED tests for create, edit, display, and non-authoritative health context | ✅ PR #367 CI `frontend-tests` passed on head `d559b587a7d474836fa4f1b9dc8d15926cd01da7` | ✅ Medium create/edit/display behavior plus shared visual model context covered in PR2 scope | ✅ Changed-file `lint-frontend` and Prettier checks passed in CI |
+
+## Remaining Tasks
+
+- [ ] Merge PR2 after review, then continue PR3 topology surface integrations.

--- a/openspec/changes/feat-324-tunnel-visualization/tasks.md
+++ b/openspec/changes/feat-324-tunnel-visualization/tasks.md
@@ -41,9 +41,9 @@ Rollback: PR1 disables hook/telemetry imports; PR2 reverts projection/editor onl
 
 ## PR2: Scoped Projection and Editor Medium
 
-- [ ] 2.1 RED: Add backend tests in `backend/tests/test_routers_nodes.py` and `backend/tests/test_routers_links.py` for admin, non-admin limited scope, and non-admin empty scope on `/nodes`, `/graph/full`, and CIDetailModal topology consumers.
-- [ ] 2.2 GREEN: Update `backend/services/node_service.py` and `backend/services/link_service.py` to project top-level nullable `public_ip` only after scoped repository results, preserving `metadata.public_ip`.
-- [ ] 2.3 RED: Add `frontend/components/VisualRelationshipEditor.tsx` tests for creating, editing, and displaying `vpn`, `sd_wan`, and `satellite` medium plus non-authoritative health context.
+- [x] 2.1 RED: Add backend tests in `backend/tests/test_routers_nodes.py` and `backend/tests/test_routers_links.py` for admin, non-admin limited scope, and non-admin empty scope on `/nodes`, `/graph/full`, and CIDetailModal topology consumers.
+- [x] 2.2 GREEN: Update `backend/services/node_service.py` and `backend/services/link_service.py` to project top-level nullable `public_ip` only after scoped repository results, preserving `metadata.public_ip`.
+- [x] 2.3 RED: Add `frontend/components/VisualRelationshipEditor.tsx` tests for creating, editing, and displaying `vpn`, `sd_wan`, and `satellite` medium plus non-authoritative health context.
 - [ ] 2.4 GREEN: Wire VisualRelationshipEditor medium create/edit/display through the shared tunnel visual model.
 
 ## PR3: Topology Surface Integrations

--- a/openspec/changes/feat-324-tunnel-visualization/tasks.md
+++ b/openspec/changes/feat-324-tunnel-visualization/tasks.md
@@ -44,7 +44,7 @@ Rollback: PR1 disables hook/telemetry imports; PR2 reverts projection/editor onl
 - [x] 2.1 RED: Add backend tests in `backend/tests/test_routers_nodes.py` and `backend/tests/test_routers_links.py` for admin, non-admin limited scope, and non-admin empty scope on `/nodes`, `/graph/full`, and CIDetailModal topology consumers.
 - [x] 2.2 GREEN: Update `backend/services/node_service.py` and `backend/services/link_service.py` to project top-level nullable `public_ip` only after scoped repository results, preserving `metadata.public_ip`.
 - [x] 2.3 RED: Add `frontend/components/VisualRelationshipEditor.tsx` tests for creating, editing, and displaying `vpn`, `sd_wan`, and `satellite` medium plus non-authoritative health context.
-- [ ] 2.4 GREEN: Wire VisualRelationshipEditor medium create/edit/display through the shared tunnel visual model.
+- [x] 2.4 GREEN: Wire VisualRelationshipEditor medium create/edit/display through the shared tunnel visual model.
 
 ## PR3: Topology Surface Integrations
 


### PR DESCRIPTION
## Description

Closes #324

PR2 of Issue #324 Slice 3. Builds on PR1 (#360) and adds the scoped `public_ip` projection plus VisualRelationshipEditor tunnel medium create/edit/display support.

Summary:
- Projects top-level nullable `public_ip` only after scoped backend results are established, preserving `metadata.public_ip`.
- Adds explicit empty non-admin `/graph/full` guard to avoid repository access and prevent public IP leakage.
- Adds VisualRelationshipEditor tunnel medium create/edit/display support for `vpn`, `sd_wan`, and `satellite` through the shared tunnel visual model.
- Cleans changed-file frontend lint for PR2 editor files.

Chain context:
```text
main
└── tracker: feat/324-tunnel-visualization (#359)
    └── PR1: helpers/query/bounds/telemetry (#360 merged)
        └── 📍 PR2: public_ip projection + editor medium
            └── PR3: topology surface integrations
```

Current PR boundary:
- Start: tracker branch after PR1 merge.
- End: scoped public IP projection and editor medium create/edit/display.
- Follow-up: PR3 topology surface integrations only.
- Out of scope: NetworkVisualizer, MonitoringConsole, TopologyViewer, RelationshipManager/CIDetailModal surface rendering integrations beyond PR2 editor contract needs.

## Type of Change
- [x] Feat (New functionality)
- [ ] Fix (Bug fix)
- [ ] Docs (Documentation)
- [ ] Performance (Optimization)

## How was this tested?
- [x] Backend focused tests: `/private/tmp/next-gen-pr2-py311/bin/python -m pytest backend/tests/test_routers_nodes.py backend/tests/test_routers_links.py` → 64 passed, 18 warnings.
- [x] Fresh security re-review: empty non-admin `/graph/full` public IP leak blocker resolved; no blocking findings.
- [x] Frontend changed-file lint direct: `eslint --max-warnings=0` passed for PR2 editor files and `eslint.config.js`.
- [x] Frontend changed-file format check direct: Prettier check passed for PR2 editor files and `eslint.config.js`.
- [ ] Frontend Vitest pending in CI: local Vitest is blocked by macOS native Rollup/Node Team ID signing mismatch.

CI is the source of truth for final frontend GREEN on this PR.

## Security Checklist
- [x] Verified no secrets or API keys are included.
- [x] Public IP projection happens only after scoped backend results.
- [x] Empty non-admin `/graph/full` scope returns an empty graph before repository access.
- [x] Telemetry/IP guardrails from PR1 remain unchanged.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
