### PR TITLE
docs(events): add legacy backfill smoke validation evidence

### DIFF
--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md
@@ -4,11 +4,11 @@
 
 - Delivery strategy: ask-on-risk
 - Chain strategy: stacked-to-main
-- Current slice: PR 2 / Work Unit 2 only
-- Base: `origin/main` after PR #365 (`fe99822`)
-- Branch: `feat/issue-155-smoke-fixtures-pr2`
-- Boundary: extend the PR1 local-only seed/cleanup harness with read-only audit JSON execution bound to the same validated local Neo4j target, sanitized smoke-scoped audit evidence, direct classifier validation for smoke-only fixtures, and explicit aggregate recommendation gap evidence.
-- Explicitly not implemented: Phase 3 evidence/wiring tasks and Phase 4 verification/cleanup tasks remain pending.
+- Current slice: PR 3 / Work Unit 3 final evidence and verification
+- Base: `origin/main` after PR #366 (`dbd4aad`)
+- Branch: `feat/issue-155-smoke-fixtures-pr3`
+- Boundary: final OpenSpec evidence docs and verification only; no production code changes, no Docker/new environment, no migration/backfill run, and no `--apply`.
+- Explicitly not implemented: none for this slice; PR3 completes remaining Phase 3 and Phase 4 evidence tasks.
 
 ## Completed Tasks
 
@@ -53,14 +53,35 @@
 - Cleanup proof: `cleanup_verified=true`, `remaining_count=0`
 - Scope statement: local shared Neo4j only; no production mutation, no production conclusion, no `--apply`, no migration path, and no new Docker/test environment.
 
+## PR3 Final Evidence / Verification
+
+- Completed 3.1 with final Markdown evidence `evidence/pr3-final-evidence-issue155-smoke-pr3-20260705T211426Z.md`, validation manifest `evidence/pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json`, sanitized audit evidence `evidence/pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json`, and failure-safe JSON `evidence/pr3-failure-safe-verification-issue155-smoke-pr3-20260705T211426Z.json`.
+- Completed 3.2 with cleanup proof in `evidence/pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json`: `cleanup_verified=true`, `deleted_count=3`, `remaining_count=0`.
+- Completed 3.3 with local-only/no-production/no-apply scope statements in the final Markdown and failure-safe JSON evidence.
+- Completed 4.1 with focused failure-path unit evidence: audit/report error and classifier/validation error tests prove cleanup and post-cleanup verification execute after failures.
+- Completed 4.2 by tying PR3 runtime evidence artifacts to run id `issue155-smoke-pr3-20260705T211426Z` and confirming they are readable JSON/Markdown files.
+- Completed 4.3 without production code changes, Docker changes, new test environment files, migration/backfill execution, or `--apply` usage.
+
+### PR3 Runtime Evidence
+
+- Command: `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py --run-id issue155-smoke-pr3-20260705T211426Z --output pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json --audit-json-output pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json`
+- Environment source: approved root checkout `config/test-env/worktree-host.sample`; no denied `.env` file was read.
+- Status: `validation_complete_cleanup_verified`
+- Seeded count: 3 marker-scoped `Event` nodes
+- Classification result: safe=1, ambiguous=1, no-touch=1, mismatches=[]
+- Sanitized audit findings persisted: 6 smoke-scoped findings only
+- Cleanup proof: `cleanup_verified=true`, `deleted_count=3`, `remaining_count=0`
+
+### PR3 Verification Commands
+
+- `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` → 24 tests passed.
+- `python3 -m py_compile openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py` → passed.
+- `git diff --check` → passed.
+- Leak grep over PR3 JSON/Markdown evidence for configured absolute-path and credential-token patterns → passed, no matches.
+
 ## Remaining Tasks
 
-- [ ] 3.1 Persist Markdown and JSON evidence under `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` for seeded plan, report output, and classification comparison.
-- [ ] 3.2 Capture cleanup evidence showing deleted marker-scoped records and zero remaining marked nodes.
-- [ ] 3.3 Ensure the run summary states local-only validation, no production mutation, and no `--apply`/migration path.
-- [ ] 4.1 Re-run the helper in failure-safe mode to verify `finally`/trap cleanup still executes after a report or validation error.
-- [ ] 4.2 Confirm evidence artifacts are complete, readable, and tied to one unique run id.
-- [ ] 4.3 Keep the tasks scoped to local/shared Neo4j only; do not add Docker, new test env, or production-write paths.
+- None for PR3.
 
 ## Deviations
 
@@ -74,7 +95,7 @@
 
 ## Final PR2 Review Fixes
 
-- Bound the read-only audit subprocess to the same validated local `NEO4J_URI` used by seed/cleanup by passing explicit subprocess environment overrides for `NEO4J_URI`, `NEO4J_USER`, and `NEO4J_PASSWORD`.
+- Bound the read-only audit subprocess to the same validated local `NEO4J_URI` used by seed/cleanup by passing explicit subprocess environment overrides for the local URI, user, and password values without persisting credentials.
 - Kept credentials out of persisted evidence metadata; evidence records only sanitized command/output metadata.
 - Removed `raw_total_findings` and broad non-smoke aggregate counts from persisted sanitized audit evidence.
 - Updated task/help/progress wording to consistently describe sanitized smoke-scoped audit JSON evidence.

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-failure-safe-verification-issue155-smoke-pr3-20260705T211426Z.json
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-failure-safe-verification-issue155-smoke-pr3-20260705T211426Z.json
@@ -1,0 +1,42 @@
+{
+  "artifact_completeness": {
+    "all_pr3_runtime_artifacts_share_run_id": true,
+    "json_files": [
+      "pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json",
+      "pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json",
+      "pr3-failure-safe-verification-issue155-smoke-pr3-20260705T211426Z.json"
+    ],
+    "markdown_summary": "pr3-final-evidence-issue155-smoke-pr3-20260705T211426Z.md"
+  },
+  "failure_safe_unit_evidence": {
+    "assertion": "Focused failure-path tests prove cleanup query and post-cleanup verification still execute after audit/report and classifier/validation errors.",
+    "command": "python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py",
+    "exit_code": 0,
+    "failure_path_cases": [
+      "test_run_seed_cleanup_executes_cleanup_after_audit_generation_failure",
+      "test_run_seed_cleanup_executes_cleanup_after_classifier_failure",
+      "test_run_seed_cleanup_reports_cleanup_failure_after_prior_error",
+      "test_run_seed_cleanup_reports_cleanup_verification_failure_after_audit_error",
+      "test_run_seed_cleanup_reports_cleanup_verification_failure_after_classifier_error"
+    ],
+    "result": "Ran 24 tests in 0.169s; OK"
+  },
+  "run_id": "issue155-smoke-pr3-20260705T211426Z",
+  "runtime_evidence": {
+    "cleanup_deleted_count": 3,
+    "cleanup_verified": true,
+    "remaining_marked_count": 0,
+    "seeded_count": 3,
+    "smoke_audit_evidence": "pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json",
+    "status": "validation_complete_cleanup_verified",
+    "validation_manifest": "pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json"
+  },
+  "schema": "issue155_pr3_failure_safe_verification_v1",
+  "scope": {
+    "apply_or_migration_path": false,
+    "docker_or_new_test_environment_added": false,
+    "env_source": "approved root checkout test-env sample; no .env file read",
+    "neo4j_target": "shared local Neo4j only",
+    "production_mutation": false
+  }
+}

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-final-evidence-issue155-smoke-pr3-20260705T211426Z.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-final-evidence-issue155-smoke-pr3-20260705T211426Z.md
@@ -1,0 +1,62 @@
+# PR3 Final Evidence: Issue #155 Smoke Fixtures
+
+## Scope
+
+- Run id: `issue155-smoke-pr3-20260705T211426Z`
+- Scope: shared local Neo4j only.
+- Production mutation: none.
+- Backfill/migration apply path: not used; no `--apply` command was run.
+- Environment: approved root checkout test-env sample was sourced; no denied `.env` file was read.
+- No Docker or new test environment was added.
+
+## Runtime Artifacts
+
+- Validation manifest: `pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json`
+- Sanitized smoke-scoped audit evidence: `pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json`
+- Failure-safe verification evidence: `pr3-failure-safe-verification-issue155-smoke-pr3-20260705T211426Z.json`
+
+## Seeded Fixture Plan
+
+- Seeded marker-scoped `Event` nodes: 3
+- Marker: `issue155_smoke=true`
+- Run id field: `issue155_smoke_run_id=issue155-smoke-pr3-20260705T211426Z`
+
+| Event id | Expected bucket | Actual bucket |
+| --- | --- | --- |
+| `issue155-smoke-pr3-20260705T211426Z-safe` | `safe_candidates` | `safe_candidates` |
+| `issue155-smoke-pr3-20260705T211426Z-ambiguous` | `ambiguous_records` | `ambiguous_records` |
+| `issue155-smoke-pr3-20260705T211426Z-no-touch` | `no_touch_records` | `no_touch_records` |
+
+## Sanitized Audit Output
+
+- Persisted schema: `issue155_smoke_scoped_audit_v1`
+- Persisted scope: smoke fixture findings only; non-smoke finding details omitted.
+- Smoke findings persisted: 6
+- Smoke event ids with findings: `issue155-smoke-pr3-20260705T211426Z-ambiguous`, `issue155-smoke-pr3-20260705T211426Z-no-touch`
+- Safe fixture has no audit finding by design and is validated through direct classifier reuse.
+
+## Classification Comparison
+
+- Expected counts: `{'ambiguous_records': 1, 'no_touch_records': 1, 'safe_candidates': 1}`
+- Actual counts: `{'ambiguous_records': 1, 'no_touch_records': 1, 'safe_candidates': 1}`
+- Mismatches: `[]`
+- Valid for planning: `True`
+- Aggregate recommendation gap: `gap_recorded` — aggregate recommendation JSON does not expose per-record smoke fixture ids, so smoke-only validation uses sanitized audit JSON for ambiguous/no-touch records and direct classifier reuse for the safe record.
+
+## Cleanup Proof
+
+- Cleanup verified: `True`
+- Deleted marker-scoped records: `3`
+- Remaining marked records for this run id: `0`
+- Cleanup query remained marker/run-id scoped and verified zero remaining marked nodes after deletion.
+
+## Failure-Safe Verification
+
+- Focused unit command: `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py`
+- Result: `Ran 24 tests in 0.169s; OK`
+- Covered failure paths: audit/report error, classifier/validation error, cleanup failure after prior error, and cleanup verification failure after prior audit/classifier errors.
+- Evidence: `pr3-failure-safe-verification-issue155-smoke-pr3-20260705T211426Z.json`
+
+## Final Status
+
+PR3 evidence is complete and tied to run id `issue155-smoke-pr3-20260705T211426Z`. The evidence is local-only and does not support any production-scale conclusion beyond the smoke-fixture validation slice.

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json
@@ -1,0 +1,66 @@
+{
+  "findings": [
+    {
+      "code": "ambiguous_collection_failure_boundary",
+      "event_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "field": null,
+      "finding_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous:ambiguous_collection_failure_boundary",
+      "recommended_value": null,
+      "severity": "ambiguous"
+    },
+    {
+      "code": "ambiguous_threshold_or_availability",
+      "event_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "field": null,
+      "finding_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous:ambiguous_threshold_or_availability",
+      "recommended_value": null,
+      "severity": "ambiguous"
+    },
+    {
+      "code": "missing_event_type",
+      "event_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "field": "event_type",
+      "finding_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous:missing_event_type",
+      "recommended_value": null,
+      "severity": "missing"
+    },
+    {
+      "code": "missing_failure_family",
+      "event_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "field": "failure_family",
+      "finding_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous:missing_failure_family",
+      "recommended_value": null,
+      "severity": "missing"
+    },
+    {
+      "code": "missing_source_protocol",
+      "event_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "field": "source_protocol",
+      "finding_id": "issue155-smoke-pr3-20260705T211426Z-ambiguous:missing_source_protocol",
+      "recommended_value": null,
+      "severity": "missing"
+    },
+    {
+      "code": "missing_failure_family",
+      "event_id": "issue155-smoke-pr3-20260705T211426Z-no-touch",
+      "field": "failure_family",
+      "finding_id": "issue155-smoke-pr3-20260705T211426Z-no-touch:missing_failure_family",
+      "recommended_value": null,
+      "severity": "missing"
+    }
+  ],
+  "schema": "issue155_smoke_scoped_audit_v1",
+  "scope": "smoke fixture findings only; non-smoke finding details omitted",
+  "summary": {
+    "smoke_event_ids": [
+      "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "issue155-smoke-pr3-20260705T211426Z-no-touch",
+      "issue155-smoke-pr3-20260705T211426Z-safe"
+    ],
+    "smoke_event_ids_with_findings": [
+      "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "issue155-smoke-pr3-20260705T211426Z-no-touch"
+    ],
+    "smoke_findings_count": 6
+  }
+}

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-validation-smoke-issue155-smoke-pr3-20260705T211426Z.json
@@ -1,0 +1,138 @@
+{
+  "audit_json_report": {
+    "command": [
+      "python3",
+      "backend/scripts/audit_legacy_event_discriminators.py",
+      "--report",
+      "audit",
+      "--format",
+      "json",
+      "--output",
+      "<temporary-broad-audit-json>"
+    ],
+    "format": "json",
+    "output": "pr3-smoke-audit-issue155-smoke-pr3-20260705T211426Z.json",
+    "output_path_kind": "evidence-relative",
+    "persisted_schema": "issue155_smoke_scoped_audit_v1",
+    "persisted_scope": "smoke fixture findings only",
+    "report": "audit",
+    "smoke_findings_count": 6,
+    "stderr_captured": false,
+    "stdout_captured": true
+  },
+  "cleanup": {
+    "cleanup_verified": true,
+    "deleted_count": 3,
+    "query": "MATCH (e:Event {issue155_smoke:true, issue155_smoke_run_id:$run_id})\nRETURN count(e)=0 AS cleanup_verified, count(e) AS remaining_count",
+    "remaining_count": 0
+  },
+  "fixture_plan": [
+    {
+      "availability_source": "snmp",
+      "ci_id": "issue155-smoke-pr3-20260705T211426Z-ci-safe",
+      "created_at": "2026-07-05T21:14:27.232274+00:00",
+      "event_type": "AVAILABILITY",
+      "expected_bucket": "safe_candidates",
+      "failure_family": "COLLECTION",
+      "id": "issue155-smoke-pr3-20260705T211426Z-safe",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-pr3-20260705T211426Z",
+      "last_seen": "2026-07-05T21:14:27.232274+00:00",
+      "message": "SNMP availability event with complete discriminator fields.",
+      "metric_id": "availability.safe",
+      "metric_name": "Availability Safe Fixture",
+      "severity": "warning",
+      "source_protocol": "SNMP",
+      "status": "ACTIVE"
+    },
+    {
+      "availability_source": null,
+      "ci_id": "issue155-smoke-pr3-20260705T211426Z-ci-ambiguous",
+      "created_at": "2026-07-05T21:14:27.232274+00:00",
+      "event_type": null,
+      "expected_bucket": "ambiguous_records",
+      "failure_family": null,
+      "id": "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-pr3-20260705T211426Z",
+      "last_seen": "2026-07-05T21:14:27.232274+00:00",
+      "message": "PING availability timeout; host down boundary needs reviewer decision.",
+      "metric_id": "availability.ping.timeout",
+      "metric_name": "PING Timeout Fixture",
+      "severity": "warning",
+      "source_protocol": null,
+      "status": "ACTIVE"
+    },
+    {
+      "availability_source": "snmp",
+      "ci_id": "issue155-smoke-pr3-20260705T211426Z-ci-no-touch",
+      "created_at": "2026-07-05T21:14:27.232274+00:00",
+      "event_type": "THRESHOLD",
+      "expected_bucket": "no_touch_records",
+      "failure_family": null,
+      "id": "issue155-smoke-pr3-20260705T211426Z-no-touch",
+      "issue155_smoke": true,
+      "issue155_smoke_run_id": "issue155-smoke-pr3-20260705T211426Z",
+      "last_seen": "2026-07-05T21:14:27.232274+00:00",
+      "message": "Threshold signal with one missing discriminator and no ambiguity hint.",
+      "metric_id": "threshold.partial",
+      "metric_name": "Threshold Partial Fixture",
+      "severity": "warning",
+      "source_protocol": "SNMP",
+      "status": "ACTIVE"
+    }
+  ],
+  "run_id": "issue155-smoke-pr3-20260705T211426Z",
+  "scope": "local shared Neo4j only; no production mutation",
+  "seeded_count": 3,
+  "status": "validation_complete_cleanup_verified",
+  "validation_summary": {
+    "actual_buckets": {
+      "issue155-smoke-pr3-20260705T211426Z-ambiguous": "ambiguous_records",
+      "issue155-smoke-pr3-20260705T211426Z-no-touch": "no_touch_records",
+      "issue155-smoke-pr3-20260705T211426Z-safe": "safe_candidates"
+    },
+    "actual_counts": {
+      "ambiguous_records": 1,
+      "no_touch_records": 1,
+      "safe_candidates": 1
+    },
+    "audit_evidence": {
+      "event_ids_with_findings": [
+        "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+        "issue155-smoke-pr3-20260705T211426Z-no-touch"
+      ],
+      "expected_finding_event_ids": [
+        "issue155-smoke-pr3-20260705T211426Z-ambiguous",
+        "issue155-smoke-pr3-20260705T211426Z-no-touch"
+      ],
+      "missing_expected_finding_event_ids": [],
+      "schema": "issue155_smoke_scoped_audit_v1",
+      "status": "inspected"
+    },
+    "classification_source": "direct classifier reuse for smoke-only fixture rows",
+    "expected_buckets": {
+      "issue155-smoke-pr3-20260705T211426Z-ambiguous": "ambiguous_records",
+      "issue155-smoke-pr3-20260705T211426Z-no-touch": "no_touch_records",
+      "issue155-smoke-pr3-20260705T211426Z-safe": "safe_candidates"
+    },
+    "expected_counts": {
+      "ambiguous_records": 1,
+      "no_touch_records": 1,
+      "safe_candidates": 1
+    },
+    "mismatches": [],
+    "recommendation_gap": {
+      "description": "The existing aggregate recommendation JSON does not expose per-record smoke fixture IDs; smoke-only expected-vs-actual validation therefore parses sanitized audit JSON for ambiguous/no-touch findings and reuses the read-only classifier directly for safe fixtures, which have no finding by design.",
+      "status": "gap_recorded"
+    },
+    "safe_fixture_validation": {
+      "event_ids": [
+        "issue155-smoke-pr3-20260705T211426Z-safe"
+      ],
+      "source": "direct classifier reuse; safe fixtures have no audit finding by design"
+    },
+    "scope": "local shared Neo4j only; no production mutation or production-scale conclusion",
+    "valid_for_planning": true
+  }
+}

--- a/openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md
+++ b/openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md
@@ -38,12 +38,12 @@ Chain strategy: stacked-to-main
 
 ## Phase 3: Evidence / Wiring
 
-- [ ] 3.1 Persist Markdown and JSON evidence under `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` for seeded plan, report output, and classification comparison.
-- [ ] 3.2 Capture cleanup evidence showing deleted marker-scoped records and zero remaining marked nodes.
-- [ ] 3.3 Ensure the run summary states local-only validation, no production mutation, and no `--apply`/migration path.
+- [x] 3.1 Persist Markdown and JSON evidence under `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/` for seeded plan, report output, and classification comparison.
+- [x] 3.2 Capture cleanup evidence showing deleted marker-scoped records and zero remaining marked nodes.
+- [x] 3.3 Ensure the run summary states local-only validation, no production mutation, and no `--apply`/migration path.
 
 ## Phase 4: Verification / Cleanup
 
-- [ ] 4.1 Re-run the helper in failure-safe mode to verify `finally`/trap cleanup still executes after a report or validation error.
-- [ ] 4.2 Confirm evidence artifacts are complete, readable, and tied to one unique run id.
-- [ ] 4.3 Keep the tasks scoped to local/shared Neo4j only; do not add Docker, new test env, or production-write paths.
+- [x] 4.1 Re-run the helper in failure-safe mode to verify `finally`/trap cleanup still executes after a report or validation error.
+- [x] 4.2 Confirm evidence artifacts are complete, readable, and tied to one unique run id.
+- [x] 4.3 Keep the tasks scoped to local/shared Neo4j only; do not add Docker, new test env, or production-write paths.


### PR DESCRIPTION
Refs #155

## Summary
- Adds final PR3 Markdown/JSON evidence for issue #155 smoke fixture validation.
- Records cleanup proof with zero remaining marker-scoped records for the PR3 run id.
- Documents failure-safe verification coverage and confirms local-only scope with no production mutation, migration, or `--apply` path.

## Changes
| File | Change |
|------|--------|
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-final-evidence-*.md` | Final human-readable evidence summary for PR3. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-validation-smoke-*.json` | Runtime validation manifest for the PR3 run id. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-smoke-audit-*.json` | Sanitized smoke-scoped audit evidence for PR3. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/pr3-failure-safe-verification-*.json` | Failure-safe verification evidence. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/tasks.md` | Marks remaining Phase 3 and Phase 4 tasks complete. |
| `openspec/changes/validate-legacy-backfill-smoke-fixtures/apply-progress.md` | Records PR3 evidence boundary and verification results. |

## Test Plan
- [x] `python3 openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py`
- [x] `python3 -m py_compile openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/validate_smoke_fixtures.py openspec/changes/validate-legacy-backfill-smoke-fixtures/evidence/test_validate_smoke_fixtures.py`
- [x] `git diff --check`
- [x] PR3 evidence checked for local path/password leaks.
- [x] Fresh risk/reliability review completed; stale base metadata warning fixed before commit.

## Notes
- No production mutation, no migration, and no `--apply` path were used.
- This is OpenSpec/evidence documentation and is not counted as productive code-line growth for PR splitting.
