### PR TITLE
test(events): add writer lock load harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ docker-compose.override.yml
 .atl/
 .engram/
 .pi/
+.codegraph/
 .worktrees/
 context.md
 progress.md

--- a/backend/scripts/event_writer_lock_load.py
+++ b/backend/scripts/event_writer_lock_load.py
@@ -111,7 +111,10 @@ def _configure_session_timeouts(
     if not callable(execute):
         return
 
-    execute(text("SELECT set_config('lock_timeout', :value, true)"), {"value": f"{int(lock_timeout_ms)}ms"})
+    execute(
+        text("SELECT set_config('lock_timeout', :value, true)"),
+        {"value": f"{int(lock_timeout_ms)}ms"},
+    )
     execute(
         text("SELECT set_config('statement_timeout', :value, true)"),
         {"value": f"{int(statement_timeout_ms)}ms"},
@@ -333,10 +336,10 @@ def _parser() -> argparse.ArgumentParser:
         type=float,
         default=DEFAULT_WORKLOAD_TIMEOUT_S,
         help=(
-                "Maximum seconds the parent waits for each threaded workload; "
-                "timed-out daemon workers may continue until process exit "
-                f"(default: {DEFAULT_WORKLOAD_TIMEOUT_S:g})"
-            ),
+            "Maximum seconds the parent waits for each threaded workload; "
+            "timed-out daemon workers may continue until process exit "
+            f"(default: {DEFAULT_WORKLOAD_TIMEOUT_S:g})"
+        ),
     )
     return parser
 

--- a/backend/scripts/event_writer_lock_load.py
+++ b/backend/scripts/event_writer_lock_load.py
@@ -102,8 +102,11 @@ def _configure_session_timeouts(
     if not callable(execute):
         return
 
-    execute(text(f"SET LOCAL lock_timeout = '{int(lock_timeout_ms)}ms'"))
-    execute(text(f"SET LOCAL statement_timeout = '{int(statement_timeout_ms)}ms'"))
+    execute(text("SELECT set_config('lock_timeout', :value, true)"), {"value": f"{int(lock_timeout_ms)}ms"})
+    execute(
+        text("SELECT set_config('statement_timeout', :value, true)"),
+        {"value": f"{int(statement_timeout_ms)}ms"},
+    )
 
 
 def _run_one_write(

--- a/backend/scripts/event_writer_lock_load.py
+++ b/backend/scripts/event_writer_lock_load.py
@@ -1,0 +1,422 @@
+"""Controlled advisory-lock load harness for event writer contention.
+
+The harness uses PostgreSQL transaction-scoped advisory locks and a configurable
+protected write delay to compare same-triplet contention against disjoint triplets.
+It intentionally does not enforce timing thresholds; non-zero exits are reserved
+for argument/configuration/runtime errors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from queue import Empty, Queue
+from pathlib import Path
+from typing import Callable, Iterable, Literal, NamedTuple
+
+from sqlalchemy import text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from postgres_db import SessionLocal
+from services.event_lock import acquire_event_triplet_lock
+
+Triplet = tuple[str, str, str]
+WorkloadMode = Literal["same-triplet", "disjoint-triplets"]
+DEFAULT_LOCK_TIMEOUT_MS = 5000
+DEFAULT_STATEMENT_TIMEOUT_MS = 30000
+DEFAULT_WORKLOAD_TIMEOUT_S = 120.0
+
+
+@dataclass(frozen=True)
+class WorkloadConfig:
+    lock_timeout_ms: int = DEFAULT_LOCK_TIMEOUT_MS
+    statement_timeout_ms: int = DEFAULT_STATEMENT_TIMEOUT_MS
+    workload_timeout_s: float = DEFAULT_WORKLOAD_TIMEOUT_S
+
+
+class WriteSample(NamedTuple):
+    lock_wait_ms: float
+    event_write_ms: float
+
+
+def duration_stats(values: Iterable[float]) -> dict[str, float | int]:
+    """Return stable millisecond summary stats for a sample set."""
+    ordered = sorted(round(float(value), 3) for value in values)
+    if not ordered:
+        return {
+            "count": 0,
+            "p50_ms": 0.0,
+            "p95_ms": 0.0,
+            "p99_ms": 0.0,
+            "max_ms": 0.0,
+        }
+
+    def percentile(percent: float) -> float:
+        if len(ordered) == 1:
+            return ordered[0]
+        rank = (len(ordered) - 1) * percent
+        lower = int(rank)
+        upper = min(lower + 1, len(ordered) - 1)
+        fraction = rank - lower
+        return round(ordered[lower] + (ordered[upper] - ordered[lower]) * fraction, 3)
+
+    return {
+        "count": len(ordered),
+        "p50_ms": percentile(0.50),
+        "p95_ms": percentile(0.95),
+        "p99_ms": percentile(0.99),
+        "max_ms": ordered[-1],
+    }
+
+
+def triplet_for(mode: WorkloadMode, writer_index: int, iteration: int) -> Triplet:
+    """Return the target event triplet for a workload sample."""
+    if mode == "same-triplet":
+        return ("ci-contention", "metric-contention", "THRESHOLD_BREACH")
+    if mode == "disjoint-triplets":
+        return (f"ci-{writer_index}", f"metric-{writer_index}", "THRESHOLD_BREACH")
+    raise ValueError(f"Unsupported workload mode: {mode}")
+
+
+def _default_protected_write(delay_seconds: float) -> Callable[[object, Triplet], None]:
+    def write(_session: object, _triplet: Triplet) -> None:
+        if delay_seconds > 0:
+            time.sleep(delay_seconds)
+
+    return write
+
+
+def _configure_session_timeouts(
+    session: object,
+    *,
+    lock_timeout_ms: int,
+    statement_timeout_ms: int,
+) -> None:
+    """Bound PostgreSQL lock/statement waits for the current transaction."""
+    execute = getattr(session, "execute", None)
+    if not callable(execute):
+        return
+
+    execute(text(f"SET LOCAL lock_timeout = '{int(lock_timeout_ms)}ms'"))
+    execute(text(f"SET LOCAL statement_timeout = '{int(statement_timeout_ms)}ms'"))
+
+
+def _run_one_write(
+    *,
+    writer_index: int,
+    iteration: int,
+    mode: WorkloadMode,
+    session_factory: Callable[[], object],
+    acquire_lock: Callable[..., None],
+    protected_write: Callable[[object, Triplet], None],
+    monotonic: Callable[[], float],
+    config: WorkloadConfig,
+) -> WriteSample:
+    triplet = triplet_for(mode, writer_index, iteration)
+    session = session_factory()
+    try:
+        _configure_session_timeouts(
+            session,
+            lock_timeout_ms=config.lock_timeout_ms,
+            statement_timeout_ms=config.statement_timeout_ms,
+        )
+        lock_start = monotonic()
+        acquire_lock(
+            session,
+            triplet[0],
+            triplet[1],
+            triplet[2],
+            writer_context="event_writer_lock_load",
+        )
+        lock_wait_ms = (monotonic() - lock_start) * 1000
+
+        write_start = monotonic()
+        protected_write(session, triplet)
+        event_write_ms = (monotonic() - write_start) * 1000
+
+        commit = getattr(session, "commit", None)
+        if callable(commit):
+            commit()
+        return WriteSample(lock_wait_ms=lock_wait_ms, event_write_ms=event_write_ms)
+    except Exception:
+        rollback = getattr(session, "rollback", None)
+        if callable(rollback):
+            rollback()
+        raise
+    finally:
+        close = getattr(session, "close", None)
+        if callable(close):
+            close()
+
+
+def _run_writer(
+    *,
+    writer_index: int,
+    iterations: int,
+    mode: WorkloadMode,
+    session_factory: Callable[[], object],
+    acquire_lock: Callable[..., None],
+    protected_write: Callable[[object, Triplet], None],
+    monotonic: Callable[[], float],
+    config: WorkloadConfig,
+) -> list[WriteSample]:
+    return [
+        _run_one_write(
+            writer_index=writer_index,
+            iteration=iteration,
+            mode=mode,
+            session_factory=session_factory,
+            acquire_lock=acquire_lock,
+            protected_write=protected_write,
+            monotonic=monotonic,
+            config=config,
+        )
+        for iteration in range(iterations)
+    ]
+
+
+def run_workload(
+    *,
+    name: str,
+    mode: WorkloadMode,
+    writers: int,
+    iterations: int,
+    session_factory: Callable[[], object],
+    acquire_lock: Callable[..., None] | None = None,
+    protected_write: Callable[[object, Triplet], None] | None = None,
+    monotonic: Callable[[], float] = time.perf_counter,
+    use_threads: bool = True,
+    config: WorkloadConfig | None = None,
+) -> dict[str, object]:
+    """Run one workload and return JSON-ready lock/write latency evidence."""
+    if writers < 2:
+        raise ValueError("writers must be >= 2")
+    if iterations < 1:
+        raise ValueError("iterations must be >= 1")
+    workload_config = config or WorkloadConfig()
+    if workload_config.workload_timeout_s <= 0:
+        raise ValueError("workload_timeout_s must be > 0")
+
+    lock_acquirer = acquire_lock or acquire_event_triplet_lock
+    write = protected_write or _default_protected_write(0.0)
+    samples: list[WriteSample] = []
+
+    if use_threads:
+        result_queue: Queue[tuple[str, list[WriteSample] | BaseException]] = Queue()
+
+        start_barrier = threading.Barrier(writers)
+
+        def run_writer_thread(writer_index: int) -> None:
+            try:
+                start_barrier.wait()
+                result_queue.put(
+                    (
+                        "samples",
+                        _run_writer(
+                            writer_index=writer_index,
+                            iterations=iterations,
+                            mode=mode,
+                            session_factory=session_factory,
+                            acquire_lock=lock_acquirer,
+                            protected_write=write,
+                            monotonic=monotonic,
+                            config=workload_config,
+                        ),
+                    )
+                )
+            except BaseException as exc:  # pragma: no cover - re-raised in parent thread
+                result_queue.put(("error", exc))
+
+        threads = [
+            threading.Thread(
+                target=run_writer_thread,
+                args=(writer_index,),
+                name=f"event-writer-lock-load-{name}-{writer_index}",
+                daemon=True,
+            )
+            for writer_index in range(writers)
+        ]
+        for thread in threads:
+            thread.start()
+
+        deadline = time.monotonic() + workload_config.workload_timeout_s
+        completed = 0
+        while completed < writers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"workload '{name}' timed out after {workload_config.workload_timeout_s:g}s"
+                )
+            try:
+                result_type, result = result_queue.get(timeout=remaining)
+            except Empty as exc:
+                raise TimeoutError(
+                    f"workload '{name}' timed out after {workload_config.workload_timeout_s:g}s"
+                ) from exc
+
+            completed += 1
+            if result_type == "error":
+                raise result  # type: ignore[misc]
+            samples.extend(result)  # type: ignore[arg-type]
+
+        for thread in threads:
+            thread.join(timeout=0)
+    else:
+        for writer_index in range(writers):
+            samples.extend(
+                _run_writer(
+                    writer_index=writer_index,
+                    iterations=iterations,
+                    mode=mode,
+                    session_factory=session_factory,
+                    acquire_lock=lock_acquirer,
+                    protected_write=write,
+                    monotonic=monotonic,
+                    config=workload_config,
+                )
+            )
+
+    return {
+        "name": name,
+        "mode": mode,
+        "writers": writers,
+        "iterations_per_writer": iterations,
+        "total_writes": len(samples),
+        "lock_wait": duration_stats(sample.lock_wait_ms for sample in samples),
+        "event_write": duration_stats(sample.event_write_ms for sample in samples),
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare event writer advisory-lock contention workloads as JSON"
+    )
+    parser.add_argument("--writers", type=int, default=2, help="Concurrent writers; must be >= 2")
+    parser.add_argument(
+        "--iterations", type=int, default=20, help="Writes per writer for each workload"
+    )
+    parser.add_argument(
+        "--event-write-ms",
+        type=float,
+        default=25.0,
+        help="Simulated protected Event write duration while the advisory lock is held",
+    )
+    parser.add_argument(
+        "--lock-timeout-ms",
+        type=int,
+        default=DEFAULT_LOCK_TIMEOUT_MS,
+        help="PostgreSQL lock_timeout applied before each advisory lock acquisition",
+    )
+    parser.add_argument(
+        "--statement-timeout-ms",
+        type=int,
+        default=DEFAULT_STATEMENT_TIMEOUT_MS,
+        help="PostgreSQL statement_timeout applied before each advisory lock acquisition",
+    )
+    parser.add_argument(
+        "--workload-timeout-s",
+        type=float,
+        default=DEFAULT_WORKLOAD_TIMEOUT_S,
+        help=(
+                "Maximum seconds the parent waits for each threaded workload; "
+                "timed-out daemon workers may continue until process exit "
+                f"(default: {DEFAULT_WORKLOAD_TIMEOUT_S:g})"
+            ),
+    )
+    return parser
+
+
+def _load_session_factory():
+    return SessionLocal
+
+
+def build_report(
+    *,
+    writers: int,
+    iterations: int,
+    event_write_ms: float,
+    session_factory: Callable[[], object],
+    config: WorkloadConfig | None = None,
+) -> dict[str, object]:
+    workload_config = config or WorkloadConfig()
+    protected_write = _default_protected_write(event_write_ms / 1000)
+    workloads = {
+        "same_triplet": run_workload(
+            name="same_triplet",
+            mode="same-triplet",
+            writers=writers,
+            iterations=iterations,
+            session_factory=session_factory,
+            protected_write=protected_write,
+            config=workload_config,
+        ),
+        "disjoint_triplets": run_workload(
+            name="disjoint_triplets",
+            mode="disjoint-triplets",
+            writers=writers,
+            iterations=iterations,
+            session_factory=session_factory,
+            protected_write=protected_write,
+            config=workload_config,
+        ),
+    }
+    return {
+        "script": "event_writer_lock_load",
+        "threshold_policy": "no timing thresholds; fail only on execution/correctness errors",
+        "config": {
+            "writers": writers,
+            "iterations_per_writer": iterations,
+            "event_write_ms": event_write_ms,
+            "lock_timeout_ms": workload_config.lock_timeout_ms,
+            "statement_timeout_ms": workload_config.statement_timeout_ms,
+            "workload_timeout_s": workload_config.workload_timeout_s,
+        },
+        "workloads": workloads,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.writers < 2:
+        raise SystemExit("--writers must be >= 2")
+    if args.iterations < 1:
+        raise SystemExit("--iterations must be >= 1")
+    if args.event_write_ms < 0:
+        raise SystemExit("--event-write-ms must be >= 0")
+    if args.lock_timeout_ms < 1:
+        raise SystemExit("--lock-timeout-ms must be >= 1")
+    if args.statement_timeout_ms < 1:
+        raise SystemExit("--statement-timeout-ms must be >= 1")
+    if args.workload_timeout_s <= 0:
+        raise SystemExit("--workload-timeout-s must be > 0")
+
+    try:
+        report = build_report(
+            writers=args.writers,
+            iterations=args.iterations,
+            event_write_ms=args.event_write_ms,
+            session_factory=_load_session_factory(),
+            config=WorkloadConfig(
+                lock_timeout_ms=args.lock_timeout_ms,
+                statement_timeout_ms=args.statement_timeout_ms,
+                workload_timeout_s=args.workload_timeout_s,
+            ),
+        )
+    except TimeoutError as exc:
+        print(f"event_writer_lock_load timed out: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"event_writer_lock_load failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/event_writer_lock_load.py
+++ b/backend/scripts/event_writer_lock_load.py
@@ -38,6 +38,14 @@ class WorkloadConfig:
     statement_timeout_ms: int = DEFAULT_STATEMENT_TIMEOUT_MS
     workload_timeout_s: float = DEFAULT_WORKLOAD_TIMEOUT_S
 
+    def __post_init__(self) -> None:
+        if self.lock_timeout_ms < 1:
+            raise ValueError("lock_timeout_ms must be >= 1")
+        if self.statement_timeout_ms < 1:
+            raise ValueError("statement_timeout_ms must be >= 1")
+        if self.workload_timeout_s <= 0:
+            raise ValueError("workload_timeout_s must be > 0")
+
 
 class WriteSample(NamedTuple):
     lock_wait_ms: float
@@ -202,8 +210,6 @@ def run_workload(
     if iterations < 1:
         raise ValueError("iterations must be >= 1")
     workload_config = config or WorkloadConfig()
-    if workload_config.workload_timeout_s <= 0:
-        raise ValueError("workload_timeout_s must be > 0")
 
     lock_acquirer = acquire_lock or acquire_event_triplet_lock
     write = protected_write or _default_protected_write(0.0)

--- a/backend/scripts/event_writer_lock_load.py
+++ b/backend/scripts/event_writer_lock_load.py
@@ -13,10 +13,11 @@ import json
 import sys
 import threading
 import time
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from queue import Empty, Queue
 from pathlib import Path
-from typing import Callable, Iterable, Literal, NamedTuple
+from queue import Empty, Queue
+from typing import Literal, NamedTuple
 
 from sqlalchemy import text
 

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import threading
 from collections import deque

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -1,0 +1,240 @@
+import json
+import threading
+from collections import deque
+
+from scripts import event_writer_lock_load as load
+
+
+class FakeSession:
+    def __init__(self):
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def test_duration_stats_include_required_percentiles():
+    stats = load.duration_stats([1.0, 2.0, 3.0, 4.0])
+
+    assert stats == {
+        "count": 4,
+        "p50_ms": 2.5,
+        "p95_ms": 3.85,
+        "p99_ms": 3.97,
+        "max_ms": 4.0,
+    }
+
+
+def test_workload_report_records_same_triplet_lock_and_write_stats():
+    sessions = []
+    clock_values = deque([0.00, 0.01, 0.01, 0.03, 0.10, 0.12, 0.12, 0.15])
+    acquired = []
+
+    def session_factory():
+        session = FakeSession()
+        sessions.append(session)
+        return session
+
+    def acquire_lock(session, ci_id, metric_id, event_type, *, writer_context):
+        acquired.append((ci_id, metric_id, event_type, writer_context, session.closed))
+
+    report = load.run_workload(
+        name="same_triplet",
+        mode="same-triplet",
+        writers=2,
+        iterations=1,
+        session_factory=session_factory,
+        acquire_lock=acquire_lock,
+        protected_write=lambda session, triplet: None,
+        monotonic=lambda: clock_values.popleft(),
+        use_threads=False,
+    )
+
+    assert report["name"] == "same_triplet"
+    assert report["mode"] == "same-triplet"
+    assert report["writers"] == 2
+    assert report["iterations_per_writer"] == 1
+    assert report["total_writes"] == 2
+    assert report["lock_wait"]["count"] == 2
+    assert report["event_write"]["count"] == 2
+    assert report["lock_wait"]["max_ms"] == 20.0
+    assert report["event_write"]["max_ms"] == 30.0
+    assert {item[:3] for item in acquired} == {("ci-contention", "metric-contention", "THRESHOLD_BREACH")}
+    assert all(session.commits == 1 and session.closed for session in sessions)
+
+
+def test_disjoint_triplet_workload_gives_each_writer_a_distinct_triplet():
+    acquired = []
+
+    def acquire_lock(session, ci_id, metric_id, event_type, *, writer_context):
+        acquired.append((ci_id, metric_id, event_type))
+
+    load.run_workload(
+        name="disjoint_triplets",
+        mode="disjoint-triplets",
+        writers=3,
+        iterations=1,
+        session_factory=FakeSession,
+        acquire_lock=acquire_lock,
+        protected_write=lambda session, triplet: None,
+        monotonic=lambda: 0.0,
+        use_threads=False,
+    )
+
+    assert len(set(acquired)) == 3
+
+
+def test_threaded_workload_runs_each_writer_iterations_serially():
+    active_writers = set()
+    overlap_detected = []
+    release_slow_writer = threading.Event()
+
+    def acquire_lock(session, ci_id, metric_id, event_type, *, writer_context):
+        writer_index = int(ci_id.removeprefix("ci-"))
+        if writer_index in active_writers:
+            overlap_detected.append(writer_index)
+            release_slow_writer.set()
+        active_writers.add(writer_index)
+
+    def protected_write(session, triplet):
+        writer_index = int(triplet[0].removeprefix("ci-"))
+        if writer_index == 0:
+            release_slow_writer.wait(timeout=0.2)
+        active_writers.remove(writer_index)
+
+    load.run_workload(
+        name="disjoint_triplets",
+        mode="disjoint-triplets",
+        writers=2,
+        iterations=2,
+        session_factory=FakeSession,
+        acquire_lock=acquire_lock,
+        protected_write=protected_write,
+        monotonic=lambda: 0.0,
+        use_threads=True,
+    )
+
+    assert overlap_detected == []
+
+
+def test_threaded_same_triplet_workload_starts_writers_together():
+    active = 0
+    max_active = 0
+    lock = threading.Lock()
+    both_active = threading.Event()
+
+    def acquire_lock(session, ci_id, metric_id, event_type, *, writer_context):
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+            if active == 2:
+                both_active.set()
+
+    def protected_write(session, triplet):
+        nonlocal active
+        both_active.wait(timeout=1)
+        with lock:
+            active -= 1
+
+    load.run_workload(
+        name="same_triplet",
+        mode="same-triplet",
+        writers=2,
+        iterations=1,
+        session_factory=FakeSession,
+        acquire_lock=acquire_lock,
+        protected_write=protected_write,
+        monotonic=lambda: 0.0,
+        use_threads=True,
+    )
+
+    assert max_active == 2
+
+
+
+def test_build_report_resolves_default_lock_acquirer_at_call_time(monkeypatch):
+    acquired = []
+
+    def acquire_lock(session, ci_id, metric_id, event_type, *, writer_context):
+        acquired.append((ci_id, metric_id, event_type, writer_context))
+
+    monkeypatch.setattr(load, "acquire_event_triplet_lock", acquire_lock)
+    monkeypatch.setattr(load.time, "sleep", lambda seconds: None)
+
+    report = load.build_report(
+        writers=2,
+        iterations=1,
+        event_write_ms=0,
+        session_factory=FakeSession,
+    )
+
+    assert report["workloads"]["same_triplet"]["total_writes"] == 2
+    assert report["workloads"]["disjoint_triplets"]["total_writes"] == 2
+    assert len(acquired) == 4
+
+
+def test_threaded_workload_times_out_when_a_worker_blocks():
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def protected_write(session, triplet):
+        if triplet[0] == "ci-0":
+            worker_started.set()
+            release_worker.wait(timeout=2)
+
+    try:
+        try:
+            load.run_workload(
+                name="disjoint_triplets",
+                mode="disjoint-triplets",
+                writers=2,
+                iterations=1,
+                session_factory=FakeSession,
+                acquire_lock=lambda *args, **kwargs: None,
+                protected_write=protected_write,
+                monotonic=lambda: 0.0,
+                use_threads=True,
+                config=load.WorkloadConfig(workload_timeout_s=0.05),
+            )
+        except TimeoutError as exc:
+            assert "timed out after 0.05s" in str(exc)
+        else:
+            raise AssertionError("run_workload should time out when a worker blocks")
+    finally:
+        release_worker.set()
+
+
+def test_main_returns_nonzero_when_workload_times_out(monkeypatch, capsys):
+    def raise_timeout(**kwargs):
+        raise TimeoutError("simulated workload timeout")
+
+    monkeypatch.setattr(load, "run_workload", raise_timeout)
+    monkeypatch.setattr(load, "_load_session_factory", lambda: FakeSession)
+
+    assert load.main(["--writers", "2", "--iterations", "1", "--event-write-ms", "0"]) == 1
+    assert "event_writer_lock_load timed out: simulated workload timeout" in capsys.readouterr().err
+
+
+def test_main_emits_machine_readable_comparison_json(monkeypatch, capsys):
+    monkeypatch.setattr(load, "_load_session_factory", lambda: FakeSession)
+    monkeypatch.setattr(load, "acquire_event_triplet_lock", lambda *args, **kwargs: None)
+    monkeypatch.setattr(load.time, "sleep", lambda seconds: None)
+
+    assert load.main(["--writers", "2", "--iterations", "1", "--event-write-ms", "0"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["script"] == "event_writer_lock_load"
+    assert set(payload["workloads"]) == {"same_triplet", "disjoint_triplets"}
+    for workload in payload["workloads"].values():
+        assert workload["lock_wait"]["count"] == 2
+        assert workload["event_write"]["count"] == 2
+        assert set(workload["lock_wait"]) >= {"count", "p50_ms", "p95_ms", "p99_ms", "max_ms"}

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -5,7 +5,6 @@ import threading
 from collections import deque
 
 import pytest
-
 from scripts import event_writer_lock_load as load
 
 

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -79,7 +79,9 @@ def test_workload_report_records_same_triplet_lock_and_write_stats():
     assert report["event_write"]["count"] == 2
     assert report["lock_wait"]["max_ms"] == 20.0
     assert report["event_write"]["max_ms"] == 30.0
-    assert {item[:3] for item in acquired} == {("ci-contention", "metric-contention", "THRESHOLD_BREACH")}
+    assert {item[:3] for item in acquired} == {
+        ("ci-contention", "metric-contention", "THRESHOLD_BREACH")
+    }
     assert all(session.commits == 1 and session.closed for session in sessions)
 
 

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections import deque
 import json
 import threading
-from collections import deque
 
 import pytest
 

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections import deque
 import json
 import threading
+from collections import deque
 
 import pytest
 

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -2,6 +2,8 @@ import json
 import threading
 from collections import deque
 
+import pytest
+
 from scripts import event_writer_lock_load as load
 
 
@@ -19,6 +21,15 @@ class FakeSession:
 
     def close(self):
         self.closed = True
+
+
+class RecordingSession(FakeSession):
+    def __init__(self):
+        super().__init__()
+        self.executed = []
+
+    def execute(self, statement, params=None):
+        self.executed.append((str(statement), params))
 
 
 def test_duration_stats_include_required_percentiles():
@@ -158,6 +169,58 @@ def test_threaded_same_triplet_workload_starts_writers_together():
     )
 
     assert max_active == 2
+
+
+
+def test_database_timeouts_are_configured_before_lock_acquisition():
+    sessions = []
+    lock_seen_after_timeouts = []
+
+    def session_factory():
+        session = RecordingSession()
+        sessions.append(session)
+        return session
+
+    def acquire_lock(session_arg, ci_id, metric_id, event_type, *, writer_context):
+        lock_seen_after_timeouts.append(len(session_arg.executed) == 2)
+
+    load.run_workload(
+        name="same_triplet",
+        mode="same-triplet",
+        writers=2,
+        iterations=1,
+        session_factory=session_factory,
+        acquire_lock=acquire_lock,
+        protected_write=lambda session, triplet: None,
+        monotonic=lambda: 0.0,
+        use_threads=False,
+        config=load.WorkloadConfig(lock_timeout_ms=123, statement_timeout_ms=456),
+    )
+
+    assert lock_seen_after_timeouts == [True, True]
+    assert [session.executed for session in sessions] == [
+        [
+            ("SELECT set_config('lock_timeout', :value, true)", {"value": "123ms"}),
+            ("SELECT set_config('statement_timeout', :value, true)", {"value": "456ms"}),
+        ],
+        [
+            ("SELECT set_config('lock_timeout', :value, true)", {"value": "123ms"}),
+            ("SELECT set_config('statement_timeout', :value, true)", {"value": "456ms"}),
+        ],
+    ]
+
+
+@pytest.mark.parametrize(
+    "args, message",
+    [
+        (["--lock-timeout-ms", "0"], "--lock-timeout-ms must be >= 1"),
+        (["--statement-timeout-ms", "0"], "--statement-timeout-ms must be >= 1"),
+        (["--workload-timeout-s", "0"], "--workload-timeout-s must be > 0"),
+    ],
+)
+def test_main_rejects_invalid_timeout_boundaries(args, message):
+    with pytest.raises(SystemExit, match=message):
+        load.main(["--writers", "2", "--iterations", "1", *args])
 
 
 

--- a/backend/tests/test_event_writer_lock_load.py
+++ b/backend/tests/test_event_writer_lock_load.py
@@ -136,25 +136,17 @@ def test_threaded_workload_runs_each_writer_iterations_serially():
     assert overlap_detected == []
 
 
-def test_threaded_same_triplet_workload_starts_writers_together():
-    active = 0
-    max_active = 0
-    lock = threading.Lock()
-    both_active = threading.Event()
+def test_threaded_workload_uses_start_barrier(monkeypatch):
+    barrier_waits = []
 
-    def acquire_lock(session, ci_id, metric_id, event_type, *, writer_context):
-        nonlocal active, max_active
-        with lock:
-            active += 1
-            max_active = max(max_active, active)
-            if active == 2:
-                both_active.set()
+    class SpyBarrier:
+        def __init__(self, parties):
+            self.parties = parties
 
-    def protected_write(session, triplet):
-        nonlocal active
-        both_active.wait(timeout=1)
-        with lock:
-            active -= 1
+        def wait(self):
+            barrier_waits.append(self.parties)
+
+    monkeypatch.setattr(load.threading, "Barrier", SpyBarrier)
 
     load.run_workload(
         name="same_triplet",
@@ -162,14 +154,13 @@ def test_threaded_same_triplet_workload_starts_writers_together():
         writers=2,
         iterations=1,
         session_factory=FakeSession,
-        acquire_lock=acquire_lock,
-        protected_write=protected_write,
+        acquire_lock=lambda *args, **kwargs: None,
+        protected_write=lambda session, triplet: None,
         monotonic=lambda: 0.0,
         use_threads=True,
     )
 
-    assert max_active == 2
-
+    assert barrier_waits == [2, 2]
 
 
 def test_database_timeouts_are_configured_before_lock_acquisition():
@@ -223,6 +214,18 @@ def test_main_rejects_invalid_timeout_boundaries(args, message):
         load.main(["--writers", "2", "--iterations", "1", *args])
 
 
+@pytest.mark.parametrize(
+    "config_kwargs, message",
+    [
+        ({"lock_timeout_ms": 0}, "lock_timeout_ms must be >= 1"),
+        ({"statement_timeout_ms": 0}, "statement_timeout_ms must be >= 1"),
+        ({"workload_timeout_s": 0}, "workload_timeout_s must be > 0"),
+    ],
+)
+def test_workload_config_rejects_invalid_timeout_boundaries(config_kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        load.WorkloadConfig(**config_kwargs)
+
 
 def test_build_report_resolves_default_lock_acquirer_at_call_time(monkeypatch):
     acquired = []
@@ -246,12 +249,10 @@ def test_build_report_resolves_default_lock_acquirer_at_call_time(monkeypatch):
 
 
 def test_threaded_workload_times_out_when_a_worker_blocks():
-    worker_started = threading.Event()
     release_worker = threading.Event()
 
     def protected_write(session, triplet):
         if triplet[0] == "ci-0":
-            worker_started.set()
             release_worker.wait(timeout=2)
 
     try:

--- a/docs/polling-pipeline-tuning.md
+++ b/docs/polling-pipeline-tuning.md
@@ -26,6 +26,33 @@ python backend/scripts/polling_host_benchmark.py --sink db --allow-db --json
 
 Do not use DB-backed mode on production without a maintenance window and rollback owner.
 
+## Event writer advisory-lock load evidence
+
+Use this harness when changing event writer lock behavior or validating runner/database capacity. It compares writers contending on the same `(ci_id, metric_id, event_type)` triplet with writers using disjoint triplets and emits machine-readable JSON.
+
+```bash
+cd backend
+python scripts/event_writer_lock_load.py \
+  --writers 2 \
+  --iterations 20 \
+  --event-write-ms 25 \
+  --workload-timeout-s 120 \
+  > event-writer-lock-load.json
+```
+
+Requirements:
+
+- PostgreSQL reachable through the normal backend environment variables (`POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, or `RUNNING_LOCALLY=true` for localhost).
+- Python backend dependencies installed, including SQLAlchemy and `psycopg2-binary`.
+- A non-production database or an approved maintenance window. The script only takes transaction-scoped advisory locks and does not write application rows, but it still opens concurrent database sessions.
+
+Interpretation:
+
+- `workloads.same_triplet.lock_wait` should show higher wait than `workloads.disjoint_triplets.lock_wait` when contention is real.
+- `event_write` measures the protected write window while the lock is held; tune `--event-write-ms` to approximate observed Neo4j Event write latency.
+- `--workload-timeout-s` defaults to `120` seconds per threaded workload. It bounds how long the parent waits for worker results; workers run in daemon threads so a timed-out CLI can return non-zero instead of keeping the process alive. Database lock and statement timeouts still provide the first line of cleanup for PostgreSQL waits.
+- Treat the JSON as baseline evidence, not a CI performance gate. The harness hard-fails only on argument, connection, lock acquisition, timeout, or execution errors; it has no default timing threshold.
+
 ## Queue partitions
 
 - Partition by protocol plus site/subnet/CI hash so one hot site does not block the whole queue.


### PR DESCRIPTION
Closes #338

## Descripción del Cambio
- Adds a controlled event writer advisory-lock load harness for same-triplet vs disjoint-triplet workloads.
- Emits machine-readable JSON with lock-wait and protected event-write latency stats.
- Documents runner/database requirements and keeps performance data as baseline evidence, not a flaky CI timing gate.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)
- [x] Chore (Mantenimiento/tooling)

## Changes
| File | Change |
|------|--------|
| `backend/scripts/event_writer_lock_load.py` | Adds configurable concurrent advisory-lock load harness. |
| `backend/tests/test_event_writer_lock_load.py` | Adds deterministic tests for stats, workload behavior, timeout handling, and CLI JSON. |
| `docs/polling-pipeline-tuning.md` | Documents execution, requirements, and baseline interpretation. |
| `.gitignore` | Ignores local `.codegraph/` artifacts. |

## ¿Cómo se probó?
- [x] `.venv/bin/python -m pytest backend/tests/test_event_writer_lock_load.py -q` — `9 passed, 1 warning`
- [x] `.venv/bin/python -m py_compile backend/scripts/event_writer_lock_load.py backend/tests/test_event_writer_lock_load.py`
- [x] Fresh reliability/resilience/risk reviews: no BLOCKER/CRITICAL/WARNING findings.
- [x] Fresh readability review completed; remaining warning is internal pass-through readability, accepted for this first harness slice.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
