### PR TITLE
fix(ai): guard chat harness execution

### DIFF
--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -351,7 +351,11 @@ async def chat_with_ai(
                             target_type="ci",
                             target_id=target_id,
                             target_name=target_name,
-                            result="blocked" if denial.get("reason_code") != "escalation_required" else "escalated",
+                            result=(
+                                "blocked"
+                                if denial.get("reason_code") != "escalation_required"
+                                else "escalated"
+                            ),
                             blocked_reason=denial.get("reason_code"),
                         )
                         harness_result = denial
@@ -393,7 +397,11 @@ async def chat_with_ai(
                     target_type="event_query",
                     target_id=target_id,
                     target_name=target_name,
-                    result="blocked" if denial.get("reason_code") != "escalation_required" else "escalated",
+                    result=(
+                        "blocked"
+                        if denial.get("reason_code") != "escalation_required"
+                        else "escalated"
+                    ),
                     blocked_reason=denial.get("reason_code"),
                 )
                 harness_result = denial
@@ -438,7 +446,9 @@ async def chat_with_ai(
                     request_context=guard_context,
                 )
                 block_target_id = resolved_targets[0] if resolved_targets else ""
-                block_target_name = target_names.get(block_target_id, "unresolved availability target")
+                block_target_name = target_names.get(
+                    block_target_id, "unresolved availability target"
+                )
                 _record_chat_operation(
                     user=current_user,
                     intent=intent,
@@ -454,9 +464,15 @@ async def chat_with_ai(
                     run_intent = type(
                         "ResolvedAvailabilityBatchIntent",
                         (),
-                        {"type": "availability_check_batch", "ci_refs": normalized_refs, "_resolved_ci_targets": resolved_by_ref},
+                        {
+                            "type": "availability_check_batch",
+                            "ci_refs": normalized_refs,
+                            "_resolved_ci_targets": resolved_by_ref,
+                        },
                     )()
-                    harness_result = await asyncio.to_thread(maybe_run_harness, run_intent, neo4j_driver, current_user)
+                    harness_result = await asyncio.to_thread(
+                        maybe_run_harness, run_intent, neo4j_driver, current_user
+                    )
                 else:
                     denial = _evaluate_chat_guard(
                         user=current_user,
@@ -479,14 +495,22 @@ async def chat_with_ai(
 
                     if denial is not None:
                         denial_target_id = denial.get("target_ids", [])
-                        record_target_id = denial_target_id[0] if denial_target_id else (resolved_targets[0] if resolved_targets else "")
+                        record_target_id = (
+                            denial_target_id[0]
+                            if denial_target_id
+                            else (resolved_targets[0] if resolved_targets else "")
+                        )
                         _record_chat_operation(
                             user=current_user,
                             intent=intent,
                             target_type="ci",
                             target_id=record_target_id,
                             target_name=target_names.get(record_target_id, record_target_id),
-                            result="blocked" if denial.get("reason_code") != "escalation_required" else "escalated",
+                            result=(
+                                "blocked"
+                                if denial.get("reason_code") != "escalation_required"
+                                else "escalated"
+                            ),
                             blocked_reason=denial.get("reason_code"),
                         )
                         denial["target_ids"] = resolved_targets
@@ -495,9 +519,15 @@ async def chat_with_ai(
                         run_intent = type(
                             "ResolvedAvailabilityBatchIntent",
                             (),
-                            {"type": "availability_check_batch", "ci_refs": normalized_refs, "_resolved_ci_targets": resolved_by_ref},
+                            {
+                                "type": "availability_check_batch",
+                                "ci_refs": normalized_refs,
+                                "_resolved_ci_targets": resolved_by_ref,
+                            },
                         )()
-                        harness_result = await asyncio.to_thread(maybe_run_harness, run_intent, neo4j_driver, current_user)
+                        harness_result = await asyncio.to_thread(
+                            maybe_run_harness, run_intent, neo4j_driver, current_user
+                        )
                         for canonical_id in resolved_targets:
                             _record_chat_operation(
                                 user=current_user,
@@ -508,10 +538,14 @@ async def chat_with_ai(
                                 result="success",
                             )
         else:
-            harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
+            harness_result = await asyncio.to_thread(
+                maybe_run_harness, intent, neo4j_driver, current_user
+            )
 
         if harness_result is None:
-            harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
+            harness_result = await asyncio.to_thread(
+                maybe_run_harness, intent, neo4j_driver, current_user
+            )
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -11,16 +11,19 @@ from config import get_lm_studio_settings
 from database import get_db
 from postgres_db import get_pg_db
 from models.user import AIPermission, User, UserPermission
+from services import ai_chat_service
 from services.auth_service import check_permission, get_current_active_user
 from services.ai_chat_service import (
     LMStudioError,
     LMStudioTimeoutError,
+    build_guard_denial_harness_result,
     complete_chat,
     latest_event_list_ci_refs,
     load_chat_history,
     maybe_run_harness,
     save_chat_exchange,
 )
+from services.ai_guard_service import check_all_guards, record_operation
 
 
 router = APIRouter(prefix="/ai", tags=["AI Chat"])
@@ -157,6 +160,134 @@ def infer_followup_intent(query: str, db, username: str) -> AIChatIntent | None:
     return AvailabilityBatchIntent(type="availability_check_batch", ci_refs=ci_refs)
 
 
+def _normalize_availability_ci_ref(ci_ref: str) -> str:
+    return str(ci_ref).strip()
+
+
+def _safe_get_ci_field(ci: Any, field: str) -> Any:
+    if isinstance(ci, dict):
+        return ci.get(field)
+    getter = getattr(ci, "get", None)
+    if callable(getter):
+        try:
+            return getter(field)
+        except TypeError:
+            return None
+    return getattr(ci, field, None)
+
+
+def _canonical_ci_target_id(ci: Any) -> str | None:
+    ci_id = _safe_get_ci_field(ci, "id")
+    if ci_id is None:
+        return None
+    canonical = str(ci_id)
+    if not canonical.strip():
+        return None
+    return f"ci:{canonical}"
+
+
+def _build_availability_not_found_result(ci_ref: str) -> dict[str, Any]:
+    return {"type": "availability_check", "ci_ref": ci_ref, "status": "ci_not_found"}
+
+
+def _resolve_ci_for_harness(neo4j_driver, ci_ref: str) -> dict[str, Any] | None:
+    return ai_chat_service.resolve_ci_for_harness(neo4j_driver, ci_ref)
+
+
+def _event_query_target_id(intent: EventListIntent) -> str:
+    status = str(getattr(intent, "status", "ACTIVE") or "ACTIVE").upper()
+    severity = str(getattr(intent, "severity", "any") or "any").lower()
+    return f"event_query:{status}:{severity}"
+
+
+def _build_guard_request_context(intent: AIChatIntent) -> dict[str, Any]:
+    context = {
+        "source": "ai_chat",
+        "intent_type": intent.type,
+    }
+    if isinstance(intent, AvailabilityIntent):
+        context["ci_ref"] = intent.ci_ref
+        context["ci_refs_count"] = 1
+    elif isinstance(intent, AvailabilityBatchIntent):
+        context["ci_refs_count"] = len(intent.ci_refs)
+    else:
+        context["status"] = intent.status
+        context["severity"] = intent.severity
+        context["limit"] = intent.limit
+    return context
+
+
+def _evaluate_chat_guard(
+    *,
+    user: User,
+    target_type: str,
+    target_ids: list[str],
+    reason_context: dict[str, Any],
+    intent_type: str,
+) -> dict[str, Any] | None:
+    try:
+        guard_result = check_all_guards(user.username, "diagnose", target_ids)
+    except Exception:
+        return build_guard_denial_harness_result(
+            intent_type=intent_type,
+            target_type=target_type,
+            target_ids=target_ids,
+            reason="AI guardrail system could not verify this request was safe.",
+            reason_code="guard_unavailable",
+            request_context=reason_context,
+        )
+
+    if guard_result.escalation_required:
+        return build_guard_denial_harness_result(
+            intent_type=intent_type,
+            target_type=target_type,
+            target_ids=target_ids,
+            reason=guard_result.reason,
+            escalation_required=True,
+            escalation_id=guard_result.escalation_id,
+            request_context=reason_context,
+        )
+
+    if not guard_result.allowed:
+        return build_guard_denial_harness_result(
+            intent_type=intent_type,
+            target_type=target_type,
+            target_ids=target_ids,
+            reason=guard_result.reason,
+            cooldown_remaining_seconds=guard_result.cooldown_remaining_seconds,
+            request_context=reason_context,
+        )
+    return None
+
+
+def _record_chat_operation(
+    *,
+    user: User,
+    intent: AIChatIntent,
+    target_type: str,
+    target_id: str,
+    target_name: str,
+    result: str,
+    blocked_reason: str | None = None,
+) -> None:
+    request_context = _build_guard_request_context(intent)
+    request_context["event_category"] = "chat_harness"
+    try:
+        record_operation(
+            ai_persona=str(user.role),
+            ai_agent_id=user.username,
+            operation="diagnose",
+            target_type=target_type,
+            target_id=target_id,
+            target_name=target_name,
+            result=result,
+            blocked_reason=blocked_reason,
+            request_context=request_context,
+        )
+    except Exception:
+        return
+
+
 @router.post("/chat", response_model=AIChatResponse)
 async def chat_with_ai(
     body: AIChatRequest,
@@ -186,8 +317,190 @@ async def chat_with_ai(
         )
         raise HTTPException(status_code=403, detail=detail)
 
+    harness_result: dict[str, Any] | None = None
+
     try:
-        harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
+        if intent is None:
+            pass
+        elif intent.type == "availability_check":
+            ci_ref = _normalize_availability_ci_ref(intent.ci_ref)
+            ci = _resolve_ci_for_harness(neo4j_driver, ci_ref)
+            if ci is None:
+                harness_result = _build_availability_not_found_result(ci_ref)
+            else:
+                target_id = _canonical_ci_target_id(ci)
+                if target_id is None:
+                    harness_result = _build_availability_not_found_result(ci_ref)
+                else:
+                    target_name = str(_safe_get_ci_field(ci, "name") or ci_ref)
+                    guard_context = _build_guard_request_context(intent)
+                    denial = _evaluate_chat_guard(
+                        user=current_user,
+                        target_type="ci",
+                        target_ids=[target_id],
+                        reason_context=guard_context,
+                        intent_type="availability_check",
+                    )
+                    if denial is not None:
+                        _record_chat_operation(
+                            user=current_user,
+                            intent=intent,
+                            target_type="ci",
+                            target_id=target_id,
+                            target_name=target_name,
+                            result="blocked" if denial.get("reason_code") != "escalation_required" else "escalated",
+                            blocked_reason=denial.get("reason_code"),
+                        )
+                        harness_result = denial
+                    else:
+                        run_intent = type("ResolvedAvailabilityIntent", (), {"type": "availability_check", "ci_ref": ci_ref})()
+                        setattr(run_intent, "_resolved_ci", ci)
+                        harness_result = await asyncio.to_thread(maybe_run_harness, run_intent, neo4j_driver, current_user)
+                        _record_chat_operation(
+                            user=current_user,
+                            intent=intent,
+                            target_type="ci",
+                            target_id=target_id,
+                            target_name=target_name,
+                            result="success",
+                        )
+        elif intent.type in {"event_list", "active_events"}:
+            target_id = _event_query_target_id(intent)
+            target_name = f"event query {target_id}"
+            guard_context = _build_guard_request_context(intent)
+            denial = _evaluate_chat_guard(
+                user=current_user,
+                target_type="event_query",
+                target_ids=[target_id],
+                reason_context=guard_context,
+                intent_type="event_list",
+            )
+            if denial is not None:
+                _record_chat_operation(
+                    user=current_user,
+                    intent=intent,
+                    target_type="event_query",
+                    target_id=target_id,
+                    target_name=target_name,
+                    result="blocked" if denial.get("reason_code") != "escalation_required" else "escalated",
+                    blocked_reason=denial.get("reason_code"),
+                )
+                harness_result = denial
+            else:
+                harness_result = await asyncio.to_thread(
+                    maybe_run_harness,
+                    intent,
+                    neo4j_driver,
+                    current_user,
+                )
+        elif intent.type == "availability_check_batch":
+            target_names: dict[str, str] = {}
+            resolved_targets: list[str] = []
+            resolved_by_ref: dict[str, Any | None] = {}
+            normalized_refs: list[str] = []
+            non_executable_ci_refs: list[str] = []
+            for ci_ref in intent.ci_refs:
+                ref = _normalize_availability_ci_ref(ci_ref)
+                normalized_refs.append(ref)
+                ci = _resolve_ci_for_harness(neo4j_driver, ref)
+                if ci is None:
+                    resolved_by_ref[ref] = None
+                    continue
+
+                canonical_id = _canonical_ci_target_id(ci)
+                if canonical_id is None:
+                    non_executable_ci_refs.append(ref)
+                    continue
+
+                resolved_by_ref[ref] = ci
+                resolved_targets.append(canonical_id)
+                target_names[canonical_id] = str(_safe_get_ci_field(ci, "name") or ref)
+
+            guard_context = _build_guard_request_context(intent)
+            if non_executable_ci_refs:
+                denial = build_guard_denial_harness_result(
+                    intent_type="availability_check_batch",
+                    target_type="ci",
+                    target_ids=resolved_targets,
+                    reason="Could not verify one or more availability targets for guard-safe execution.",
+                    reason_code="guard_unavailable",
+                    request_context=guard_context,
+                )
+                block_target_id = resolved_targets[0] if resolved_targets else ""
+                block_target_name = target_names.get(block_target_id, "unresolved availability target")
+                _record_chat_operation(
+                    user=current_user,
+                    intent=intent,
+                    target_type="ci",
+                    target_id=block_target_id,
+                    target_name=block_target_name,
+                    result="blocked",
+                    blocked_reason=denial.get("reason_code"),
+                )
+                harness_result = denial
+            else:
+                if not resolved_targets:
+                    run_intent = type(
+                        "ResolvedAvailabilityBatchIntent",
+                        (),
+                        {"type": "availability_check_batch", "ci_refs": normalized_refs, "_resolved_ci_targets": resolved_by_ref},
+                    )()
+                    harness_result = await asyncio.to_thread(maybe_run_harness, run_intent, neo4j_driver, current_user)
+                else:
+                    denial = _evaluate_chat_guard(
+                        user=current_user,
+                        target_type="ci",
+                        target_ids=resolved_targets,
+                        reason_context=guard_context,
+                        intent_type="availability_check_batch",
+                    )
+                    if denial is None:
+                        for canonical_id in resolved_targets:
+                            denial = _evaluate_chat_guard(
+                                user=current_user,
+                                target_type="ci",
+                                target_ids=[canonical_id],
+                                reason_context=guard_context,
+                                intent_type="availability_check_batch",
+                            )
+                            if denial is not None:
+                                break
+
+                    if denial is not None:
+                        denial_target_id = denial.get("target_ids", [])
+                        record_target_id = denial_target_id[0] if denial_target_id else (resolved_targets[0] if resolved_targets else "")
+                        _record_chat_operation(
+                            user=current_user,
+                            intent=intent,
+                            target_type="ci",
+                            target_id=record_target_id,
+                            target_name=target_names.get(record_target_id, record_target_id),
+                            result="blocked" if denial.get("reason_code") != "escalation_required" else "escalated",
+                            blocked_reason=denial.get("reason_code"),
+                        )
+                        denial["target_ids"] = resolved_targets
+                        harness_result = denial
+                    else:
+                        run_intent = type(
+                            "ResolvedAvailabilityBatchIntent",
+                            (),
+                            {"type": "availability_check_batch", "ci_refs": normalized_refs, "_resolved_ci_targets": resolved_by_ref},
+                        )()
+                        harness_result = await asyncio.to_thread(maybe_run_harness, run_intent, neo4j_driver, current_user)
+                        for canonical_id in resolved_targets:
+                            _record_chat_operation(
+                                user=current_user,
+                                intent=intent,
+                                target_type="ci",
+                                target_id=canonical_id,
+                                target_name=target_names.get(canonical_id, canonical_id),
+                                result="success",
+                            )
+        else:
+            harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
+
+        if harness_result is None:
+            harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/backend/routers/ai.py
+++ b/backend/routers/ai.py
@@ -4,15 +4,13 @@ import asyncio
 import re
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field, field_validator
-
 from config import get_lm_studio_settings
 from database import get_db
-from postgres_db import get_pg_db
+from fastapi import APIRouter, Depends, HTTPException, status
 from models.user import AIPermission, User, UserPermission
+from postgres_db import get_pg_db
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from services import ai_chat_service
-from services.auth_service import check_permission, get_current_active_user
 from services.ai_chat_service import (
     LMStudioError,
     LMStudioTimeoutError,
@@ -24,6 +22,11 @@ from services.ai_chat_service import (
     save_chat_exchange,
 )
 from services.ai_guard_service import check_all_guards, record_operation
+from services.auth_service import check_permission, get_current_active_user
+
+CurrentUserDep = Depends(get_current_active_user)
+PgDbDep = Depends(get_pg_db)
+Neo4jDriverDep = Depends(get_db)
 
 
 router = APIRouter(prefix="/ai", tags=["AI Chat"])
@@ -291,9 +294,9 @@ def _record_chat_operation(
 @router.post("/chat", response_model=AIChatResponse)
 async def chat_with_ai(
     body: AIChatRequest,
-    current_user: User = Depends(get_current_active_user),
-    db=Depends(get_pg_db),
-    neo4j_driver=Depends(get_db),
+    current_user: User = CurrentUserDep,
+    db=PgDbDep,
+    neo4j_driver=Neo4jDriverDep,
 ) -> AIChatResponse:
     if not get_lm_studio_settings().enabled:
         raise HTTPException(
@@ -353,9 +356,17 @@ async def chat_with_ai(
                         )
                         harness_result = denial
                     else:
-                        run_intent = type("ResolvedAvailabilityIntent", (), {"type": "availability_check", "ci_ref": ci_ref})()
-                        setattr(run_intent, "_resolved_ci", ci)
-                        harness_result = await asyncio.to_thread(maybe_run_harness, run_intent, neo4j_driver, current_user)
+                        run_intent = type(
+                            "ResolvedAvailabilityIntent",
+                            (),
+                            {"type": "availability_check", "ci_ref": ci_ref, "_resolved_ci": ci},
+                        )()
+                        harness_result = await asyncio.to_thread(
+                            maybe_run_harness,
+                            run_intent,
+                            neo4j_driver,
+                            current_user,
+                        )
                         _record_chat_operation(
                             user=current_user,
                             intent=intent,
@@ -501,11 +512,11 @@ async def chat_with_ai(
 
         if harness_result is None:
             harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
-    except Exception:
+    except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Operational harness is unavailable; no diagnostic or event result was executed.",
-        )
+        ) from exc
 
     history = await asyncio.to_thread(load_chat_history, db, current_user.username)
     try:
@@ -516,16 +527,16 @@ async def chat_with_ai(
             harness_result,
             history,
         )
-    except LMStudioTimeoutError:
+    except LMStudioTimeoutError as exc:
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
             detail="LM Studio request timed out",
-        )
-    except LMStudioError:
+        ) from exc
+    except LMStudioError as exc:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="LM Studio is unavailable",
-        )
+        ) from exc
 
     row = await asyncio.to_thread(
         save_chat_exchange,

--- a/backend/services/ai_chat_service.py
+++ b/backend/services/ai_chat_service.py
@@ -10,12 +10,12 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from config import LMStudioSettings, get_ai_prompts_settings, get_lm_studio_settings
 from models.ai_chat import AIChatMessage
-from services import event_service
 from models.user import AIPermission, User
+from services import event_service
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ AI_DIR = Path(__file__).resolve().parents[1] / "ai"
 # User override root. ``None`` means "feature off" -> loaders read AI_DIR in
 # place (legacy behavior). Tests monkeypatch this directly; production resolves
 # it lazily from AI_PROMPTS_DIR via _user_dir().
-AI_USER_DIR: Optional[Path] = None
+AI_USER_DIR: Path | None = None
 REQUIRED_PROMPT_SOURCE_FILES = (
     "identity/Soul.md",
     "identity/scope.md",
@@ -63,7 +63,7 @@ class LMStudioTimeoutError(LMStudioError):
     """LM Studio did not answer within the configured timeout."""
 
 
-def _user_dir() -> Optional[Path]:
+def _user_dir() -> Path | None:
     """Resolve the user override root, caching the env lookup in AI_USER_DIR."""
     global AI_USER_DIR
     if AI_USER_DIR is None:
@@ -307,11 +307,27 @@ def _safe_ci_field(ci: Any, field: str) -> Any:
     return getattr(ci, field, None)
 
 
+_PRIVATE_INTENT_MISSING = object()
+
+
+def _private_intent_value(intent: Any, key: str) -> Any:
+    try:
+        intent_vars = vars(intent)
+        if key in intent_vars:
+            return intent_vars[key]
+    except TypeError:
+        return _PRIVATE_INTENT_MISSING
+    try:
+        class_vars = vars(type(intent))
+    except TypeError:
+        return _PRIVATE_INTENT_MISSING
+    return class_vars.get(key, _PRIVATE_INTENT_MISSING)
+
+
 def _run_availability_harness(intent: Any, neo4j_driver) -> dict[str, Any]:
     ci_ref = str(getattr(intent, "ci_ref", "")).strip()
-    if hasattr(intent, "_resolved_ci"):
-        ci = getattr(intent, "_resolved_ci")
-    else:
+    ci = _private_intent_value(intent, "_resolved_ci")
+    if ci is _PRIVATE_INTENT_MISSING:
         ci = resolve_ci_for_harness(neo4j_driver, ci_ref)
     if ci is None:
         return {"type": "availability_check", "ci_ref": ci_ref, "status": "ci_not_found"}
@@ -433,13 +449,19 @@ def _run_event_list_harness(intent: Any, neo4j_driver, user: User | None = None)
 
 def _run_availability_batch_harness(intent: Any, neo4j_driver) -> dict[str, Any]:
     ci_refs = list(getattr(intent, "ci_refs", []) or [])[:MAX_BATCH_AVAILABILITY_CHECKS]
-    resolved_by_ref = getattr(intent, "_resolved_ci_targets", None)
+    resolved_by_ref = _private_intent_value(intent, "_resolved_ci_targets")
     results = []
     for ci_ref in ci_refs:
         normalized_ref = str(ci_ref).strip()
-        child_intent = type("AvailabilityIntent", (), {"ci_ref": normalized_ref})()
+        child_ci = resolved_by_ref.get(normalized_ref) if isinstance(resolved_by_ref, dict) else None
         if isinstance(resolved_by_ref, dict) and normalized_ref in resolved_by_ref:
-            setattr(child_intent, "_resolved_ci", resolved_by_ref.get(normalized_ref))
+            child_intent = type(
+                "AvailabilityIntent",
+                (),
+                {"ci_ref": normalized_ref, "_resolved_ci": child_ci},
+            )()
+        else:
+            child_intent = type("AvailabilityIntent", (), {"ci_ref": normalized_ref})()
         results.append(_run_availability_harness(child_intent, neo4j_driver))
     return {
         "type": "availability_check_batch",

--- a/backend/services/ai_chat_service.py
+++ b/backend/services/ai_chat_service.py
@@ -295,9 +295,24 @@ def run_bounded_ping(target: str) -> PingResult:
     return PingResult(status=status, target=target, latency_ms=latency_ms, detail=detail)
 
 
+def _safe_ci_field(ci: Any, field: str) -> Any:
+    if isinstance(ci, dict):
+        return ci.get(field)
+    getter = getattr(ci, "get", None)
+    if callable(getter):
+        try:
+            return getter(field)
+        except TypeError:
+            return None
+    return getattr(ci, field, None)
+
+
 def _run_availability_harness(intent: Any, neo4j_driver) -> dict[str, Any]:
     ci_ref = str(getattr(intent, "ci_ref", "")).strip()
-    ci = resolve_ci_for_harness(neo4j_driver, ci_ref)
+    if hasattr(intent, "_resolved_ci"):
+        ci = getattr(intent, "_resolved_ci")
+    else:
+        ci = resolve_ci_for_harness(neo4j_driver, ci_ref)
     if ci is None:
         return {"type": "availability_check", "ci_ref": ci_ref, "status": "ci_not_found"}
 
@@ -307,8 +322,8 @@ def _run_availability_harness(intent: Any, neo4j_driver) -> dict[str, Any]:
     except ValueError as exc:
         return {
             "type": "availability_check",
-            "ci_id": ci.get("id"),
-            "ci_name": ci.get("name"),
+            "ci_id": _safe_ci_field(ci, "id"),
+            "ci_name": _safe_ci_field(ci, "name"),
             "status": "invalid_target",
             "detail": str(exc),
         }
@@ -418,9 +433,13 @@ def _run_event_list_harness(intent: Any, neo4j_driver, user: User | None = None)
 
 def _run_availability_batch_harness(intent: Any, neo4j_driver) -> dict[str, Any]:
     ci_refs = list(getattr(intent, "ci_refs", []) or [])[:MAX_BATCH_AVAILABILITY_CHECKS]
+    resolved_by_ref = getattr(intent, "_resolved_ci_targets", None)
     results = []
     for ci_ref in ci_refs:
-        child_intent = type("AvailabilityIntent", (), {"ci_ref": str(ci_ref)})()
+        normalized_ref = str(ci_ref).strip()
+        child_intent = type("AvailabilityIntent", (), {"ci_ref": normalized_ref})()
+        if isinstance(resolved_by_ref, dict) and normalized_ref in resolved_by_ref:
+            setattr(child_intent, "_resolved_ci", resolved_by_ref.get(normalized_ref))
         results.append(_run_availability_harness(child_intent, neo4j_driver))
     return {
         "type": "availability_check_batch",
@@ -735,6 +754,8 @@ def _render_availability_batch_response(query: str, harness_result: dict[str, An
 def render_harness_response(query: str, harness_result: dict[str, Any] | None) -> str | None:
     if not harness_result:
         return None
+    if harness_result.get("status") == "denied":
+        return _render_harness_denial_response(query, harness_result)
     harness_type = harness_result.get("type")
     if harness_type == "event_list":
         load_ai_markdown_contract("templates", "event_list.md")
@@ -808,11 +829,91 @@ def _fallback_availability_batch_response(harness_result: dict[str, Any], spanis
     return "\n".join(lines)
 
 
+def _infer_guard_denial_reason_code(
+    reason: str | None,
+    escalation_required: bool,
+) -> str:
+    if escalation_required:
+        return "escalation_required"
+    reason_text = (reason or "").lower()
+    if "cooldown" in reason_text:
+        return "cooldown_active"
+    if "bulk" in reason_text:
+        return "bulk_operation_too_large"
+    if "behavior" in reason_text or "flood" in reason_text:
+        return "behavioral_guard_denied"
+    return "guard_denied"
+
+
+def build_guard_denial_harness_result(
+    *,
+    intent_type: str,
+    reason: str | None,
+    target_type: str,
+    target_ids: list[str],
+    request_context: dict[str, Any] | None = None,
+    escalation_required: bool = False,
+    escalation_id: str | None = None,
+    cooldown_remaining_seconds: int | None = None,
+    reason_code: str | None = None,
+) -> dict[str, Any]:
+    normalized_reason = reason or "AI guardrail denied execution for safety"
+    normalized_code = reason_code or _infer_guard_denial_reason_code(
+        normalized_reason,
+        escalation_required=escalation_required,
+    )
+    return {
+        "type": intent_type,
+        "status": "denied",
+        "denied": True,
+        "reason": normalized_reason,
+        "reason_code": normalized_code,
+        "cooldown_remaining_seconds": cooldown_remaining_seconds,
+        "escalation_required": escalation_required,
+        "escalation_id": escalation_id,
+        "operation": "diagnose",
+        "target_type": target_type,
+        "target_ids": list(target_ids),
+        "request_context": request_context or {},
+        "source": "ai_guard_service",
+    }
+
+
+def _render_harness_denial_response(query: str, harness_result: dict[str, Any]) -> str:
+    spanish = _prefers_spanish(query)
+    reason = str(harness_result.get("reason") or "").strip()
+    reason_code = harness_result.get("reason_code")
+    if reason_code == "guard_unavailable":
+        if spanish:
+            return (
+                "No puedo ejecutar esta verificación operativa ahora porque el sistema de guardrails de IA "
+                "no pudo verificar que fuera seguro. No se ejecutó ningún diagnóstico ni consulta de eventos."
+            )
+        return (
+            "I cannot run that operational check right now because the AI guardrail system "
+            "could not verify it was safe. No diagnostic or event lookup was executed."
+        )
+
+    if not reason:
+        reason = "an AI guardrail check blocked this harness execution"
+    if spanish:
+        return (
+            f"No puedo ejecutar esa verificación operativa ahora: {reason}. "
+            "No se ejecutó ningún diagnóstico ni consulta de eventos."
+        )
+    return (
+        f"I cannot run that operational check right now because a guardrail blocked it: {reason}. "
+        "No diagnostic or event lookup was executed."
+    )
+
+
 def synthesize_harness_fallback_response(query: str, harness_result: dict[str, Any] | None) -> str | None:
     """Return deterministic text when the model produces no assistant content."""
     if not harness_result:
         return None
     spanish = _prefers_spanish(query)
+    if harness_result.get("status") == "denied":
+        return _render_harness_denial_response(query, harness_result)
     harness_type = harness_result.get("type")
     if harness_type in DETERMINISTIC_HARNESS_TYPES:
         return render_harness_response(query, harness_result)
@@ -835,7 +936,7 @@ def complete_chat(
     settings = get_lm_studio_settings()
     if not settings.enabled:
         raise LMStudioError("LM Studio chat is disabled")
-    if harness_result and harness_result.get("type") in DETERMINISTIC_HARNESS_TYPES:
+    if harness_result and (harness_result.get("status") == "denied" or harness_result.get("type") in DETERMINISTIC_HARNESS_TYPES):
         deterministic_response = render_harness_response(query, harness_result)
         if deterministic_response:
             return {"content": deterministic_response, "model": DETERMINISTIC_MODEL_LABEL}

--- a/backend/services/ai_chat_service.py
+++ b/backend/services/ai_chat_service.py
@@ -194,7 +194,9 @@ def build_lm_studio_payload(
     }
 
 
-def _post_lm_studio_chat_completion(payload: dict[str, Any], settings: LMStudioSettings) -> dict[str, str]:
+def _post_lm_studio_chat_completion(
+    payload: dict[str, Any], settings: LMStudioSettings
+) -> dict[str, str]:
     url = f"{settings.base_url}/chat/completions"
     body = json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(
@@ -453,7 +455,9 @@ def _run_availability_batch_harness(intent: Any, neo4j_driver) -> dict[str, Any]
     results = []
     for ci_ref in ci_refs:
         normalized_ref = str(ci_ref).strip()
-        child_ci = resolved_by_ref.get(normalized_ref) if isinstance(resolved_by_ref, dict) else None
+        child_ci = (
+            resolved_by_ref.get(normalized_ref) if isinstance(resolved_by_ref, dict) else None
+        )
         if isinstance(resolved_by_ref, dict) and normalized_ref in resolved_by_ref:
             child_intent = type(
                 "AvailabilityIntent",
@@ -526,10 +530,15 @@ def _normalized_terms(text: str) -> list[str]:
 def _event_matches_query(event: dict[str, Any], query_terms: list[str]) -> bool:
     if not query_terms:
         return True
-    haystack = " ".join(
-        str(event.get(field) or "")
-        for field in ("ci_name", "ci_id", "ci_hostname", "ci_location_name", "message")
-    ).lower().replace("_", " ").replace("-", " ")
+    haystack = (
+        " ".join(
+            str(event.get(field) or "")
+            for field in ("ci_name", "ci_id", "ci_hostname", "ci_location_name", "message")
+        )
+        .lower()
+        .replace("_", " ")
+        .replace("-", " ")
+    )
     return all(term in haystack for term in query_terms)
 
 
@@ -640,7 +649,9 @@ def _fmt_latency(value: Any) -> str:
 
 
 def _event_symptom(event: dict[str, Any], spanish: bool) -> str:
-    text = " ".join(str(event.get(key) or "") for key in ("message", "metric_name", "metric_id", "event_type")).lower()
+    text = " ".join(
+        str(event.get(key) or "") for key in ("message", "metric_name", "metric_id", "event_type")
+    ).lower()
     ci = event.get("ci_name") or event.get("ci_id") or "CI desconocido"
     severity = event.get("severity") or "UNKNOWN"
     if any(marker in text for marker in ("latency", "threshold", "umbral", "icmp_latency")):
@@ -674,7 +685,11 @@ def _render_event_list_response(query: str, harness_result: dict[str, Any]) -> s
         return f"There are no events for {filter_text}.\n\nLimitations:\n- No event facts are available for diagnosis."
 
     lines = [
-        f"Hay {len(events)} eventos para {filter_text}." if spanish else f"There are {len(events)} events for {filter_text}.",
+        (
+            f"Hay {len(events)} eventos para {filter_text}."
+            if spanish
+            else f"There are {len(events)} events for {filter_text}."
+        ),
         "",
         "Eventos observados:" if spanish else "Observed events:",
     ]
@@ -682,32 +697,44 @@ def _render_event_list_response(query: str, harness_result: dict[str, Any]) -> s
         ci = event.get("ci_name") or event.get("ci_id") or "CI desconocido"
         message = event.get("message") or event.get("metric_name") or "sin detalle"
         last_seen = f"; last_seen={event.get('last_seen')}" if event.get("last_seen") else ""
-        lines.append(f"- [{event.get('severity') or 'UNKNOWN'} / {event.get('status') or status}] {ci}: {message}{last_seen}")
-    lines.extend([
-        "",
-        "Diagnóstico observado:" if spanish else "Observed diagnosis:",
-        *[_event_symptom(event, spanish) for event in events],
-        "",
-        "Límites:" if spanish else "Limitations:",
-    ])
+        lines.append(
+            f"- [{event.get('severity') or 'UNKNOWN'} / {event.get('status') or status}] {ci}: {message}{last_seen}"
+        )
+    lines.extend(
+        [
+            "",
+            "Diagnóstico observado:" if spanish else "Observed diagnosis:",
+            *[_event_symptom(event, spanish) for event in events],
+            "",
+            "Límites:" if spanish else "Limitations:",
+        ]
+    )
     if spanish:
-        lines.extend([
-            "- No confirma causa raíz ni cierre del evento.",
-            "- No confirma congestión, energía, cableado, firewall, salud completa del servicio ni estado estable/óptimo.",
-            "",
-            "Siguiente chequeo sugerido:",
-            "- Ejecutar availability_check para CIs con síntomas de disponibilidad y revisar métricas históricas para latencia.",
-        ])
+        lines.extend(
+            [
+                "- No confirma causa raíz ni cierre del evento.",
+                "- No confirma congestión, energía, cableado, firewall, salud completa del servicio ni estado estable/óptimo.",
+                "",
+                "Siguiente chequeo sugerido:",
+                "- Ejecutar availability_check para CIs con síntomas de disponibilidad y revisar métricas históricas para latencia.",
+            ]
+        )
     else:
-        lines.extend([
-            "- Does not confirm root cause or event closure.",
-            "- Does not confirm congestion, power, cabling, firewall, complete service health, or stable/optimal state.",
-            "",
-            "Suggested next checks:",
-            "- Run availability_check for CIs with availability symptoms and review historical metrics for latency.",
-        ])
+        lines.extend(
+            [
+                "- Does not confirm root cause or event closure.",
+                "- Does not confirm congestion, power, cabling, firewall, complete service health, or stable/optimal state.",
+                "",
+                "Suggested next checks:",
+                "- Run availability_check for CIs with availability symptoms and review historical metrics for latency.",
+            ]
+        )
     if harness_result.get("truncated"):
-        lines.append("- Resultado truncado por seguridad; pedí más detalle si necesitás ampliar." if spanish else "- Result truncated for safety; ask for more detail if needed.")
+        lines.append(
+            "- Resultado truncado por seguridad; pedí más detalle si necesitás ampliar."
+            if spanish
+            else "- Result truncated for safety; ask for more detail if needed."
+        )
     return "\n".join(lines)
 
 
@@ -715,7 +742,11 @@ def _render_availability_check_response(query: str, result: dict[str, Any]) -> s
     spanish = _prefers_spanish(query)
     ci = result.get("ci_name") or result.get("ci_ref") or result.get("ci_id") or "CI desconocido"
     lines = [
-        (f"Resultado de disponibilidad para {ci}:" if spanish else f"Availability result for {ci}:"),
+        (
+            f"Resultado de disponibilidad para {ci}:"
+            if spanish
+            else f"Availability result for {ci}:"
+        ),
         f"- status: {_fmt(result.get('status'))}",
         f"- target: {_fmt(result.get('target'))}",
         f"- latency: {_fmt_latency(result.get('latency_ms'))}",
@@ -723,21 +754,25 @@ def _render_availability_check_response(query: str, result: dict[str, Any]) -> s
         "",
     ]
     if spanish:
-        lines.extend([
-            "Interpretación permitida:",
-            "- Este resultado describe solo un ping acotado actual ejecutado por el backend.",
-            "",
-            "Límites:",
-            "- No confirma salud completa del servicio, causa raíz ni cierre automático de eventos.",
-        ])
+        lines.extend(
+            [
+                "Interpretación permitida:",
+                "- Este resultado describe solo un ping acotado actual ejecutado por el backend.",
+                "",
+                "Límites:",
+                "- No confirma salud completa del servicio, causa raíz ni cierre automático de eventos.",
+            ]
+        )
     else:
-        lines.extend([
-            "Interpretation:",
-            "- This result describes only a current bounded ping executed by the backend.",
-            "",
-            "Limitations:",
-            "- It does not confirm complete service health, root cause, or automatic event closure.",
-        ])
+        lines.extend(
+            [
+                "Interpretation:",
+                "- This result describes only a current bounded ping executed by the backend.",
+                "",
+                "Limitations:",
+                "- It does not confirm complete service health, root cause, or automatic event closure.",
+            ]
+        )
     return "\n".join(lines)
 
 
@@ -745,31 +780,41 @@ def _render_availability_batch_response(query: str, harness_result: dict[str, An
     spanish = _prefers_spanish(query)
     results = list(harness_result.get("results", []) or [])[:MAX_BATCH_AVAILABILITY_CHECKS]
     lines = [
-        f"Chequeo de disponibilidad ejecutado sobre {len(results)} CIs:" if spanish else f"Availability check executed for {len(results)} CIs:",
+        (
+            f"Chequeo de disponibilidad ejecutado sobre {len(results)} CIs:"
+            if spanish
+            else f"Availability check executed for {len(results)} CIs:"
+        ),
     ]
     for result in results:
-        ci = result.get("ci_name") or result.get("ci_ref") or result.get("ci_id") or "CI desconocido"
+        ci = (
+            result.get("ci_name") or result.get("ci_ref") or result.get("ci_id") or "CI desconocido"
+        )
         lines.append(
             f"- {ci}: {result.get('status') or 'unknown'}, target={_fmt(result.get('target'))}, "
             f"latency={_fmt_latency(result.get('latency_ms'))}, detail={_fmt(result.get('detail'))}"
         )
     lines.append("")
     if spanish:
-        lines.extend([
-            "Interpretación permitida:",
-            "- Los resultados describen ping acotado actual; máximo 5 CIs por lote.",
-            "",
-            "Límites:",
-            "- La respuesta a ping no confirma salud completa del servicio, causa raíz ni cierre automático de eventos.",
-        ])
+        lines.extend(
+            [
+                "Interpretación permitida:",
+                "- Los resultados describen ping acotado actual; máximo 5 CIs por lote.",
+                "",
+                "Límites:",
+                "- La respuesta a ping no confirma salud completa del servicio, causa raíz ni cierre automático de eventos.",
+            ]
+        )
     else:
-        lines.extend([
-            "Interpretation:",
-            "- Results describe current bounded ping checks only; maximum 5 CIs per batch.",
-            "",
-            "Limitations:",
-            "- Ping reachability does not confirm complete service health, root cause, or automatic event closure.",
-        ])
+        lines.extend(
+            [
+                "Interpretation:",
+                "- Results describe current bounded ping checks only; maximum 5 CIs per batch.",
+                "",
+                "Limitations:",
+                "- Ping reachability does not confirm complete service health, root cause, or automatic event closure.",
+            ]
+        )
     return "\n".join(lines)
 
 
@@ -821,7 +866,12 @@ def _fallback_event_list_response(harness_result: dict[str, Any], spanish: bool)
         return f"There are no{qualifier} events with status {status} right now."
 
     severity_order = {"CRITICAL": 0, "WARNING": 1, "INFO": 2}
-    events.sort(key=lambda event: (severity_order.get(str(event.get("severity")), 9), str(event.get("ci_name") or "")))
+    events.sort(
+        key=lambda event: (
+            severity_order.get(str(event.get("severity")), 9),
+            str(event.get("ci_name") or ""),
+        )
+    )
     lines = []
     if spanish:
         lines.append(f"Hay {len(events)} eventos abiertos en este momento:")
@@ -834,17 +884,27 @@ def _fallback_event_list_response(harness_result: dict[str, Any], spanish: bool)
         message = event.get("message") or event.get("metric_name") or "sin detalle"
         lines.append(f"- [{event_severity} / {event_status}] {ci_name}: {message}")
     if harness_result.get("truncated"):
-        lines.append("- Resultado truncado por seguridad; pedí más detalle si necesitás ampliar." if spanish else "- Result truncated for safety; ask for more detail if needed.")
+        lines.append(
+            "- Resultado truncado por seguridad; pedí más detalle si necesitás ampliar."
+            if spanish
+            else "- Result truncated for safety; ask for more detail if needed."
+        )
     return "\n".join(lines)
 
 
 def _fallback_availability_batch_response(harness_result: dict[str, Any], spanish: bool) -> str:
     results = list(harness_result.get("results", []) or [])
     if not results:
-        return "No se ejecutaron verificaciones de disponibilidad." if spanish else "No availability checks were executed."
+        return (
+            "No se ejecutaron verificaciones de disponibilidad."
+            if spanish
+            else "No availability checks were executed."
+        )
     lines = ["Resultado de disponibilidad:" if spanish else "Availability results:"]
     for result in results[:MAX_BATCH_AVAILABILITY_CHECKS]:
-        ci_name = result.get("ci_name") or result.get("ci_ref") or result.get("ci_id") or "CI desconocido"
+        ci_name = (
+            result.get("ci_name") or result.get("ci_ref") or result.get("ci_id") or "CI desconocido"
+        )
         status = result.get("status") or "unknown"
         detail = result.get("detail") or ""
         lines.append(f"- {ci_name}: {status}{f' ({detail})' if detail else ''}")
@@ -929,7 +989,9 @@ def _render_harness_denial_response(query: str, harness_result: dict[str, Any]) 
     )
 
 
-def synthesize_harness_fallback_response(query: str, harness_result: dict[str, Any] | None) -> str | None:
+def synthesize_harness_fallback_response(
+    query: str, harness_result: dict[str, Any] | None
+) -> str | None:
     """Return deterministic text when the model produces no assistant content."""
     if not harness_result:
         return None
@@ -940,7 +1002,12 @@ def synthesize_harness_fallback_response(query: str, harness_result: dict[str, A
     if harness_type in DETERMINISTIC_HARNESS_TYPES:
         return render_harness_response(query, harness_result)
     if harness_type == "availability_check":
-        ci_name = harness_result.get("ci_name") or harness_result.get("ci_ref") or harness_result.get("ci_id") or "CI desconocido"
+        ci_name = (
+            harness_result.get("ci_name")
+            or harness_result.get("ci_ref")
+            or harness_result.get("ci_id")
+            or "CI desconocido"
+        )
         status = harness_result.get("status") or "unknown"
         detail = harness_result.get("detail") or ""
         if spanish:
@@ -958,7 +1025,10 @@ def complete_chat(
     settings = get_lm_studio_settings()
     if not settings.enabled:
         raise LMStudioError("LM Studio chat is disabled")
-    if harness_result and (harness_result.get("status") == "denied" or harness_result.get("type") in DETERMINISTIC_HARNESS_TYPES):
+    if harness_result and (
+        harness_result.get("status") == "denied"
+        or harness_result.get("type") in DETERMINISTIC_HARNESS_TYPES
+    ):
         deterministic_response = render_harness_response(query, harness_result)
         if deterministic_response:
             return {"content": deterministic_response, "model": DETERMINISTIC_MODEL_LABEL}

--- a/backend/tests/test_ai_chat_service.py
+++ b/backend/tests/test_ai_chat_service.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from models.user import User
+from models.ai_guard_models import GuardResult
 
 
 def _operator_user() -> User:
@@ -103,6 +104,12 @@ class _FakeHistoryDb(_FakeDb):
 
     def query(self, *_args, **_kwargs):
         return _FakeQuery(self.rows)
+
+
+@pytest.fixture(autouse=True)
+def _default_ai_chat_guard(monkeypatch):
+    monkeypatch.setattr("routers.ai.check_all_guards", lambda *args, **kwargs: GuardResult(allowed=True))
+    monkeypatch.setattr("routers.ai.record_operation", lambda *args, **kwargs: None)
 
 
 def _make_client(db=None, user=None):
@@ -1259,6 +1266,512 @@ def test_availability_check_requires_ai_view_all_before_ci_resolution(monkeypatc
     resolve_ci.assert_not_called()
     run_ping.assert_not_called()
     complete.assert_not_called()
+
+
+def test_non_harness_chat_does_not_run_ai_guard_checks(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client()
+
+    with patch("routers.ai.check_all_guards") as check_all_guards, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        complete.return_value = {"content": "Hello there", "model": "local-model"}
+        response = client.post("/api/ai/chat", json={"query": "hello"})
+
+    assert response.status_code == 200
+    assert response.json()["answer"] == "Hello there"
+    check_all_guards.assert_not_called()
+
+
+def test_event_list_repeatability_no_success_cooldown_record(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_event_view_user())
+
+    event_list_result = {
+        "type": "event_list",
+        "status": "ACTIVE",
+        "limit": 10,
+        "severity": None,
+        "count": 0,
+        "truncated": False,
+        "events": [],
+    }
+
+    state = {"success_logged": False}
+
+    def fake_guard(*_args, **_kwargs):
+        if state["success_logged"]:
+            return GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=12)
+        return GuardResult(allowed=True)
+
+    def fake_record_operation(*_args, **_kwargs):
+        if _kwargs.get("result") == "success":
+            state["success_logged"] = True
+
+    with patch("routers.ai.check_all_guards", side_effect=fake_guard) as check_all_guards, \
+         patch("routers.ai.record_operation", side_effect=fake_record_operation) as record_operation, \
+         patch("routers.ai.maybe_run_harness", return_value=event_list_result) as maybe_run_harness:
+        first_response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "List active events",
+                "intent": {"type": "event_list", "status": "ACTIVE", "severity": None, "limit": 10},
+            },
+        )
+        second_response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "List active events",
+                "intent": {"type": "event_list", "status": "ACTIVE", "severity": None, "limit": 10},
+            },
+        )
+
+    assert first_response.status_code == 200
+    assert second_response.status_code == 200
+    assert first_response.json()["harness_result"] == event_list_result
+    assert second_response.json()["harness_result"] == event_list_result
+    assert check_all_guards.call_count == 2
+    assert maybe_run_harness.call_count == 2
+    assert not any(call.kwargs.get("result") == "success" for call in record_operation.call_args_list)
+    assert state["success_logged"] is False
+
+
+
+def test_event_list_guard_uses_event_query_target(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_event_view_user())
+
+    with patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active")) as check_all, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete, \
+         patch("routers.ai.record_operation") as record_operation:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "List active events",
+                "intent": {"type": "event_list", "status": "ACTIVE", "severity": None, "limit": 10},
+            },
+        )
+
+    assert response.status_code == 200
+    assert maybe_run.call_count == 0
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert response.json()["harness_result"]["target_ids"] == ["event_query:ACTIVE:any"]
+    assert response.json()["harness_result"]["reason_code"] == "cooldown_active"
+    assert response.json()["harness_result"]["operation"] == "diagnose"
+    assert "No diagnostic or event lookup was executed." in response.json()["answer"]
+    check_all.assert_called_once()
+    assert not any(call.kwargs.get("result") == "success" for call in record_operation.call_args_list)
+
+
+def test_availability_check_denied_blocks_execution_and_records_denied_result(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, db = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    ci = {"id": "ci-1", "name": "Router-01", "ip": "192.168.1.10"}
+    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci, \
+         patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=42)) as check_all, \
+         patch("routers.ai.record_operation") as record_operation, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion"):
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-01 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-01"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert response.json()["harness_result"]["target_ids"] == ["ci:ci-1"]
+    assert response.json()["harness_result"]["reason_code"] == "cooldown_active"
+    assert db.added[0].harness_result == response.json()["harness_result"]
+    maybe_run.assert_not_called()
+    resolve_ci.assert_called_once()
+    record_operation.assert_called_once()
+    assert any(call.kwargs.get("result") == "blocked" for call in record_operation.call_args_list)
+
+
+def test_availability_check_canonicalizes_ci_ref_and_evaluates_guard_before_ping(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    ci = {"id": "CI-ABC", "name": "Router-01", "ip": "192.168.1.10"}
+    calls = []
+
+    def fake_ping(*_args, **_kwargs):
+        calls.append("ping")
+        from services.ai_chat_service import PingResult
+        return PingResult(status="reachable", target="192.168.1.10", latency_ms=10.2, detail="1 packet received")
+
+    def fake_resolve(_driver, ci_ref):
+        calls.append(f"resolve:{ci_ref}")
+        return ci
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=fake_resolve) as resolve_ci, \
+         patch("services.ai_chat_service.run_bounded_ping", side_effect=fake_ping) as run_ping, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete, \
+         patch("routers.ai.check_all_guards") as check_all:
+        complete.return_value = {"content": "Ready", "model": "local-model"}
+        check_all.side_effect = lambda *_args, **_kwargs: GuardResult(allowed=True)
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router alias-001 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Alias-001"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["answer"].startswith("Availability result for Router-01")
+    assert "status: reachable" in response.json()["answer"]
+    assert response.json()["harness_result"]["type"] == "availability_check"
+    assert response.json()["harness_result"]["status"] == "reachable"
+    assert check_all.call_args.args[2] == ["ci:CI-ABC"]
+    assert calls[0].startswith("resolve:")
+    assert calls[1] == "ping"
+    resolve_ci.assert_called_once()
+    run_ping.assert_called_once()
+
+
+
+def test_availability_check_resolve_failure_returns_ci_not_found_without_second_resolution_or_ping(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=[None]) as resolve_ci, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        complete.return_value = {"content": "No host alias", "model": "local-model"}
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Alias-404 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Alias-404"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "ci_not_found"
+    assert response.json()["harness_result"]["ci_ref"] == "Alias-404"
+    assert resolve_ci.call_count == 1
+    maybe_run.assert_not_called()
+    run_ping.assert_not_called()
+
+
+def test_availability_check_with_blank_canonical_ci_id_is_non_executable(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    ci = {"id": "   ", "name": "Broken CI", "ip": "192.168.1.8"}
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci, \
+         patch("routers.ai.check_all_guards") as check_all, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        complete.return_value = {"content": "No valid target", "model": "local-model"}
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Alias-blank availability",
+                "intent": {"type": "availability_check", "ci_ref": "Alias-blank"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "ci_not_found"
+    assert response.json()["harness_result"]["ci_ref"] == "Alias-blank"
+    assert resolve_ci.call_count == 1
+    assert check_all.call_count == 0
+    maybe_run.assert_not_called()
+    run_ping.assert_not_called()
+
+
+def test_availability_check_batch_with_canonical_id_missing_no_ping_or_maybe_run_harness(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    def resolve_side_effect(_driver, ci_ref):
+        if ci_ref == "alias-no-id":
+            return {"id": None, "name": "Broken CI", "ip": "192.168.1.8"}
+        if ci_ref == "alias-whitespace":
+            return {"id": "   ", "name": "Broken CI", "ip": "192.168.1.9"}
+        if ci_ref == "alias-ok":
+            return {"id": "ci-ok", "name": "Alias OK", "ip": "192.168.1.10"}
+        return {"id": "ci-missing", "name": "Missing", "ip": "192.168.1.11"}
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
+         patch("routers.ai.check_all_guards") as check_all, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("routers.ai.record_operation") as record_operation, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        complete.return_value = {"content": "Unavailable", "model": "local-model"}
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Batch check",
+                "intent": {"type": "availability_check_batch", "ci_refs": ["alias-no-id", "alias-whitespace", "alias-ok"]},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert response.json()["harness_result"]["reason_code"] == "guard_unavailable"
+    maybe_run.assert_not_called()
+    check_all.assert_not_called()
+    run_ping.assert_not_called()
+    assert resolve_ci.call_count == 3
+    assert any(call.kwargs.get("result") == "blocked" for call in record_operation.call_args_list)
+
+
+def test_availability_check_escalation_required_denied(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    ci = {"id": "ci-2", "name": "Router-02", "ip": "10.0.0.1"}
+    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci), \
+         patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=True, escalation_required=True, escalation_id="esc-1", reason="Need approval")) as check_all, \
+         patch("routers.ai.record_operation") as record_operation, \
+         patch("routers.ai.maybe_run_harness") as maybe_run:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-02 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-02"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert response.json()["harness_result"]["reason_code"] == "escalation_required"
+    assert response.json()["harness_result"]["escalation_required"] is True
+    assert response.json()["harness_result"]["escalation_id"] == "esc-1"
+    maybe_run.assert_not_called()
+    check_all.assert_called_once()
+    assert any(call.kwargs.get("result") == "escalated" for call in record_operation.call_args_list)
+
+
+def test_availability_batch_denied_if_any_target_fails_harness_targeting(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    def resolve_side_effect(_driver, ci_ref):
+        return {"id": f"id-{ci_ref}", "name": ci_ref, "ip": "192.168.1.10"}
+
+    guard_calls = 0
+
+    def guard_side_effect(_username, _operation, target_ids):
+        nonlocal guard_calls
+        guard_calls += 1
+        if guard_calls == 1:
+            return GuardResult(allowed=True)
+        if target_ids[0].endswith("alias2"):
+            return GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=11)
+        return GuardResult(allowed=True)
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
+         patch("routers.ai.check_all_guards", side_effect=guard_side_effect) as check_all, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("routers.ai.record_operation") as record_operation:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Batch check",
+                "intent": {"type": "availability_check_batch", "ci_refs": ["alias1", "alias2"]},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert set(response.json()["harness_result"]["target_ids"]) == {"ci:id-alias1", "ci:id-alias2"}
+    maybe_run.assert_not_called()
+    assert check_all.call_count >= 2
+    assert any(call.kwargs.get("result") == "blocked" for call in record_operation.call_args_list)
+    assert resolve_ci.call_count == 2
+
+
+def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_denied_without_ping(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    def resolve_side_effect(_driver, ci_ref):
+        if ci_ref == "alias1":
+            return {"id": "ci-alias1", "name": "Alias 1", "ip": "192.168.1.10"}
+        if ci_ref == "alias3":
+            return {"id": "ci-alias3", "name": "Alias 3", "ip": "192.168.1.11"}
+        return None
+
+    def guard_side_effect(_username, _operation, target_ids):
+        if target_ids == ["ci:ci-alias1", "ci:ci-alias3"]:
+            return GuardResult(allowed=True)
+        if target_ids == ["ci:ci-alias3"]:
+            return GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=11)
+        return GuardResult(allowed=True)
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
+         patch("routers.ai.check_all_guards", side_effect=guard_side_effect) as check_all, \
+         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("routers.ai.record_operation") as record_operation:
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Batch check",
+                "intent": {"type": "availability_check_batch", "ci_refs": ["alias1", "missing", "alias3"]},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert response.json()["harness_result"]["reason_code"] == "cooldown_active"
+    assert set(response.json()["harness_result"]["target_ids"]) == {"ci:ci-alias1", "ci:ci-alias3"}
+    for call in check_all.call_args_list:
+        resolved_ids = call.args[2]
+        assert all(target_id in {"ci:ci-alias1", "ci:ci-alias3"} for target_id in resolved_ids)
+    maybe_run.assert_not_called()
+    run_ping.assert_not_called()
+    assert resolve_ci.call_count == 3
+    assert check_all.call_count >= 2
+    assert any(call.kwargs.get("result") == "blocked" for call in record_operation.call_args_list)
+
+
+
+def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_returns_ci_not_found(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    def resolve_side_effect(_driver, ci_ref):
+        if ci_ref == "alias-ok":
+            return {"id": "ci-ok", "name": "Alias OK", "ip": "192.168.1.10"}
+        if ci_ref == "alias-ok-2":
+            return {"id": "ci-ok-2", "name": "Alias OK2", "ip": "192.168.1.11"}
+        return None
+
+    def fake_ping(*_args, **_kwargs):
+        from services.ai_chat_service import PingResult
+
+        return PingResult(status="reachable", target="192.168.1.10", latency_ms=5.5, detail="1 packet received")
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
+             patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=True)) as check_all, \
+             patch("services.ai_chat_service.run_bounded_ping", side_effect=fake_ping) as run_ping, \
+             patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        complete.return_value = {"content": "ready", "model": "local-model"}
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Batch",
+                "intent": {"type": "availability_check_batch", "ci_refs": ["alias-ok", "missing", "alias-ok-2"]},
+            },
+        )
+
+    assert response.status_code == 200
+    batch_results = response.json()["harness_result"]["results"]
+    assert response.json()["harness_result"]["type"] == "availability_check_batch"
+    assert any(item.get("status") == "ci_not_found" and item.get("ci_ref") == "missing" for item in batch_results)
+    assert len(batch_results) == 3
+    for call in check_all.call_args_list:
+        assert all(target_id in {"ci:ci-ok", "ci:ci-ok-2"} for target_id in call.args[2])
+    assert run_ping.call_count == 2
+    assert resolve_ci.call_count == 3
+    assert check_all.call_count >= 2
+
+
+
+def test_availability_check_batch_guard_unavailable_does_not_execute_harness(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, db = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
+         patch("routers.ai.check_all_guards", side_effect=RuntimeError("guard db offline")) as check_all, \
+         patch("routers.ai.maybe_run_harness") as maybe_run, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+        resolve_ci.side_effect = [
+            {"id": "ci-a", "name": "A", "ip": "192.168.1.1"},
+            {"id": "ci-b", "name": "B", "ip": "192.168.1.2"},
+        ]
+        complete.return_value = {"content": "unused", "model": "local-model"}
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Batch",
+                "intent": {"type": "availability_check_batch", "ci_refs": ["alias-a", "alias-b"]},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "denied"
+    assert response.json()["harness_result"]["reason_code"] == "guard_unavailable"
+    assert "could not verify it was safe" in response.json()["answer"]
+    maybe_run.assert_not_called()
+    assert db.added[0].harness_result["status"] == "denied"
+    assert check_all.call_count >= 1
+    assert resolve_ci.call_count == 2
+
+
+def test_availability_check_allowed_records_success_result(monkeypatch):
+    monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
+    monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
+    monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
+    client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
+
+    ci = {"id": "ci-77", "name": "Router-77", "ip": "192.168.1.77"}
+    harness = {
+        "type": "availability_check",
+        "ci_id": "ci-77",
+        "ci_name": "Router-77",
+        "status": "reachable",
+        "target": "192.168.1.77",
+        "latency_ms": 4.1,
+        "detail": "1 packet received",
+    }
+
+    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci), \
+         patch("routers.ai.record_operation") as record_operation, \
+         patch("routers.ai.maybe_run_harness", return_value=harness):
+        response = client.post(
+            "/api/ai/chat",
+            json={
+                "query": "Check Router-77 availability",
+                "intent": {"type": "availability_check", "ci_ref": "Router-77"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["harness_result"]["status"] == "reachable"
+    assert response.json()["harness_result"]["ci_id"] == "ci-77"
+    assert response.json()["harness_result"].get("denied", False) is False
+    assert any(call.kwargs.get("result") == "success" for call in record_operation.call_args_list)
+    assert any(call.kwargs.get("target_id") == "ci:ci-77" for call in record_operation.call_args_list)
 
 
 def test_disabled_lm_studio_blocks_harness_side_effects(monkeypatch):

--- a/backend/tests/test_ai_chat_service.py
+++ b/backend/tests/test_ai_chat_service.py
@@ -109,7 +109,9 @@ class _FakeHistoryDb(_FakeDb):
 
 @pytest.fixture(autouse=True)
 def _default_ai_chat_guard(monkeypatch):
-    monkeypatch.setattr("routers.ai.check_all_guards", lambda *args, **kwargs: GuardResult(allowed=True))
+    monkeypatch.setattr(
+        "routers.ai.check_all_guards", lambda *args, **kwargs: GuardResult(allowed=True)
+    )
     monkeypatch.setattr("routers.ai.record_operation", lambda *args, **kwargs: None)
 
 
@@ -150,7 +152,9 @@ def test_ai_chat_success_uses_server_config_and_persists_history(monkeypatch):
         captured_payloads.append(payload)
         return {"content": "Use the incident timeline first.", "model": settings.model}
 
-    with patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=fake_completion):
+    with patch(
+        "services.ai_chat_service._post_lm_studio_chat_completion", side_effect=fake_completion
+    ):
         response = client.post(
             "/api/ai/chat",
             json={"query": "What should I check?", "context": "Two Redis alerts"},
@@ -174,9 +178,13 @@ def test_payload_system_prompt_uses_backend_identity_sources(tmp_path, monkeypat
 
     identity_dir = tmp_path / "identity"
     identity_dir.mkdir()
-    (identity_dir / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    (identity_dir / "Soul.md").write_text(
+        "# Custom identity\n\nUnique runtime identity.", encoding="utf-8"
+    )
     (identity_dir / "scope.md").write_text("# Scope\n\nRead-only diagnostics.", encoding="utf-8")
-    (identity_dir / "context-policy.md").write_text("# Context\n\nUse compact context.", encoding="utf-8")
+    (identity_dir / "context-policy.md").write_text(
+        "# Context\n\nUse compact context.", encoding="utf-8"
+    )
     # User override folder is the parent of identity/; resolver reads identity/<file>.
     monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", tmp_path)
 
@@ -201,12 +209,22 @@ def test_payload_system_prompt_loads_optional_tool_catalog(tmp_path, monkeypatch
     tools_dir = tmp_path / "tools"
     identity_dir.mkdir()
     tools_dir.mkdir()
-    (identity_dir / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    (identity_dir / "Soul.md").write_text(
+        "# Custom identity\n\nUnique runtime identity.", encoding="utf-8"
+    )
     (identity_dir / "scope.md").write_text("# Scope\n\nRead-only diagnostics.", encoding="utf-8")
-    (identity_dir / "context-policy.md").write_text("# Context\n\nUse compact context.", encoding="utf-8")
-    (tools_dir / "README.md").write_text("# AI tool system\n\nBackend-owned tool catalog.", encoding="utf-8")
-    (tools_dir / "event-list.md").write_text("# Event list\n\nProvider-neutral event listing.", encoding="utf-8")
-    (tools_dir / "network-basic.md").write_text("# Network basic tools\n\n`availability_check` and planned traceroute.", encoding="utf-8")
+    (identity_dir / "context-policy.md").write_text(
+        "# Context\n\nUse compact context.", encoding="utf-8"
+    )
+    (tools_dir / "README.md").write_text(
+        "# AI tool system\n\nBackend-owned tool catalog.", encoding="utf-8"
+    )
+    (tools_dir / "event-list.md").write_text(
+        "# Event list\n\nProvider-neutral event listing.", encoding="utf-8"
+    )
+    (tools_dir / "network-basic.md").write_text(
+        "# Network basic tools\n\n`availability_check` and planned traceroute.", encoding="utf-8"
+    )
     monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", tmp_path)
 
     payload = ai_chat_service.build_lm_studio_payload(
@@ -260,8 +278,18 @@ def test_complete_chat_falls_back_when_model_returns_empty_event_list(monkeypatc
         "count": 2,
         "truncated": False,
         "events": [
-            {"ci_name": "Router A", "severity": "CRITICAL", "status": "OPEN", "message": "Service down"},
-            {"ci_name": "Switch B", "severity": "INFO", "status": "OPEN", "message": "Ping warning"},
+            {
+                "ci_name": "Router A",
+                "severity": "CRITICAL",
+                "status": "OPEN",
+                "message": "Service down",
+            },
+            {
+                "ci_name": "Switch B",
+                "severity": "INFO",
+                "status": "OPEN",
+                "message": "Ping warning",
+            },
         ],
     }
 
@@ -410,7 +438,9 @@ def test_system_prompt_user_override_wins(tmp_path, monkeypatch):
     (user_dir / "identity").mkdir(parents=True)
     (user_dir / "identity" / "Soul.md").write_text("CUSTOM-SOUL-MARKER", encoding="utf-8")
     (user_dir / "identity" / "scope.md").write_text("Read-only diagnostics.", encoding="utf-8")
-    (user_dir / "identity" / "context-policy.md").write_text("Use compact context.", encoding="utf-8")
+    (user_dir / "identity" / "context-policy.md").write_text(
+        "Use compact context.", encoding="utf-8"
+    )
     monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
 
     payload = ai_chat_service.build_lm_studio_payload(
@@ -541,7 +571,9 @@ def test_render_event_list_response_uses_facts_and_safe_observed_diagnosis():
         ],
     }
 
-    response = render_harness_response("que eventos tenemos abiertos y cual es el diagnostico?", harness_result)
+    response = render_harness_response(
+        "que eventos tenemos abiertos y cual es el diagnostico?", harness_result
+    )
 
     assert response is not None
     assert "Hay 2 eventos" in response
@@ -555,7 +587,13 @@ def test_render_event_list_response_uses_facts_and_safe_observed_diagnosis():
     assert "disponibilidad" in response.lower()
     assert "Resultado truncado" in response
     assert "No confirma causa raíz" in response
-    for unsafe in ("congestión severa", "falla eléctrica", "firewall bloqueando", "estado óptimo", "resuelto"):
+    for unsafe in (
+        "congestión severa",
+        "falla eléctrica",
+        "firewall bloqueando",
+        "estado óptimo",
+        "resuelto",
+    ):
         assert unsafe not in response.lower()
 
 
@@ -711,8 +749,12 @@ def test_payload_system_prompt_falls_back_when_identity_source_missing(tmp_path,
     bundled_dir = tmp_path / "bundled"
     (user_dir / "identity").mkdir(parents=True)
     (bundled_dir / "identity").mkdir(parents=True)
-    (user_dir / "identity" / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
-    (bundled_dir / "identity" / "Soul.md").write_text("# Custom identity\n\nUnique runtime identity.", encoding="utf-8")
+    (user_dir / "identity" / "Soul.md").write_text(
+        "# Custom identity\n\nUnique runtime identity.", encoding="utf-8"
+    )
+    (bundled_dir / "identity" / "Soul.md").write_text(
+        "# Custom identity\n\nUnique runtime identity.", encoding="utf-8"
+    )
     monkeypatch.setattr(ai_chat_service, "AI_USER_DIR", user_dir)
     monkeypatch.setattr(ai_chat_service, "AI_DIR", bundled_dir)
 
@@ -753,7 +795,10 @@ def test_ai_chat_maps_lm_studio_timeout(monkeypatch):
 
     from services.ai_chat_service import LMStudioTimeoutError
 
-    with patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=LMStudioTimeoutError("timeout")):
+    with patch(
+        "services.ai_chat_service._post_lm_studio_chat_completion",
+        side_effect=LMStudioTimeoutError("timeout"),
+    ):
         response = client.post("/api/ai/chat", json={"query": "hello"})
 
     assert response.status_code == 504
@@ -768,7 +813,10 @@ def test_ai_chat_maps_lm_studio_error_without_traceback(monkeypatch):
 
     from services.ai_chat_service import LMStudioError
 
-    with patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=LMStudioError("Connection refused: stack")):
+    with patch(
+        "services.ai_chat_service._post_lm_studio_chat_completion",
+        side_effect=LMStudioError("Connection refused: stack"),
+    ):
         response = client.post("/api/ai/chat", json={"query": "hello"})
 
     assert response.status_code == 502
@@ -791,9 +839,14 @@ def test_availability_check_resolves_ci_and_persists_ping_metadata(monkeypatch):
         detail="1 packet received",
     )
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci), \
-         patch("services.ai_chat_service.run_bounded_ping", return_value=ping_result), \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion", return_value={"content": "Router-01 is reachable.", "model": "local-model"}):
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci),
+        patch("services.ai_chat_service.run_bounded_ping", return_value=ping_result),
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "Router-01 is reachable.", "model": "local-model"},
+        ),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -843,13 +896,16 @@ def test_event_list_query_applies_user_scope():
     session = Session()
     driver = type("Driver", (), {"session": lambda _self: session})()
 
-    assert ai_chat_service.list_events_for_harness(
-        driver,
-        "OPEN",
-        10,
-        None,
-        user=_scoped_event_view_user(),
-    ) == []
+    assert (
+        ai_chat_service.list_events_for_harness(
+            driver,
+            "OPEN",
+            10,
+            None,
+            user=_scoped_event_view_user(),
+        )
+        == []
+    )
 
     assert session.params["is_unscoped"] is False
     assert session.params["allowed_locations"] == ["Site A"]
@@ -859,14 +915,21 @@ def test_event_list_query_applies_user_scope():
 def test_event_list_query_returns_no_rows_without_scope():
     from services import ai_chat_service
 
-    driver = type("Driver", (), {"session": lambda _self: (_ for _ in ()).throw(AssertionError("should not query"))})()
+    driver = type(
+        "Driver",
+        (),
+        {"session": lambda _self: (_ for _ in ()).throw(AssertionError("should not query"))},
+    )()
 
-    assert ai_chat_service.list_events_for_harness(
-        driver,
-        "OPEN",
-        10,
-        user=_event_view_user(),
-    ) == []
+    assert (
+        ai_chat_service.list_events_for_harness(
+            driver,
+            "OPEN",
+            10,
+            user=_event_view_user(),
+        )
+        == []
+    )
 
 
 def test_ai_chat_route_uses_async_offload_for_blocking_work():
@@ -909,8 +972,14 @@ def test_event_list_harness_persists_bounded_event_metadata(monkeypatch):
         captured_payloads.append(payload)
         return {"content": "There are 2 active events.", "model": settings.model}
 
-    with patch("services.ai_chat_service.list_events_for_harness", return_value=events) as list_events, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion", side_effect=fake_completion):
+    with (
+        patch(
+            "services.ai_chat_service.list_events_for_harness", return_value=events
+        ) as list_events,
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion", side_effect=fake_completion
+        ),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -939,8 +1008,13 @@ def test_event_list_harness_infers_open_critical_filters(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_event_view_user())
 
-    with patch("services.ai_chat_service.list_events_for_harness", return_value=[]) as list_events, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion", return_value={"content": "No critical open events.", "model": "local-model"}):
+    with (
+        patch("services.ai_chat_service.list_events_for_harness", return_value=[]) as list_events,
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "No critical open events.", "model": "local-model"},
+        ),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={"query": "lista todos los eventos abiertos criticos"},
@@ -958,8 +1032,13 @@ def test_event_list_harness_accepts_active_events_alias(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
 
-    with patch("services.ai_chat_service.list_events_for_harness", return_value=[]), \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion", return_value={"content": "No active events.", "model": "local-model"}):
+    with (
+        patch("services.ai_chat_service.list_events_for_harness", return_value=[]),
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "No active events.", "model": "local-model"},
+        ),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -978,8 +1057,13 @@ def test_event_list_harness_infers_unrecovered_events_from_query(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_event_view_user())
 
-    with patch("services.ai_chat_service.list_events_for_harness", return_value=[]) as list_events, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion", return_value={"content": "No unrecovered events.", "model": "local-model"}):
+    with (
+        patch("services.ai_chat_service.list_events_for_harness", return_value=[]) as list_events,
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "No unrecovered events.", "model": "local-model"},
+        ),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={"query": "que eventos no se han recuperado?"},
@@ -1018,9 +1102,17 @@ def test_followup_availability_batch_uses_latest_event_list_context(monkeypatch)
     def resolve_ci(_driver, ci_ref):
         return {"id": ci_ref.lower().replace(" ", "-"), "name": ci_ref, "ip": "192.168.1.10"}
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_ci), \
-         patch("services.ai_chat_service.run_bounded_ping", return_value=PingResult("reachable", "192.168.1.10", 1.2, "1 packet received")), \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion", return_value={"content": "Both switches are reachable.", "model": "local-model"}):
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_ci),
+        patch(
+            "services.ai_chat_service.run_bounded_ping",
+            return_value=PingResult("reachable", "192.168.1.10", 1.2, "1 packet received"),
+        ),
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "Both switches are reachable.", "model": "local-model"},
+        ),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={"query": "verifica si están funcionando"},
@@ -1059,15 +1151,25 @@ def test_followup_status_filters_latest_event_list_by_named_area(monkeypatch):
 
     from services.ai_chat_service import PingResult
 
-    with patch(
-        "services.ai_chat_service.resolve_ci_for_harness",
-        side_effect=lambda _driver, ci_ref: {"id": ci_ref, "name": ci_ref, "ip": "192.168.1.10"},
-    ), patch(
-        "services.ai_chat_service.run_bounded_ping",
-        return_value=PingResult("unreachable", "192.168.1.10", None, "no response to one bounded ping"),
-    ), patch(
-        "services.ai_chat_service._post_lm_studio_chat_completion",
-        return_value={"content": "Availability checked.", "model": "local-model"},
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness",
+            side_effect=lambda _driver, ci_ref: {
+                "id": ci_ref,
+                "name": ci_ref,
+                "ip": "192.168.1.10",
+            },
+        ),
+        patch(
+            "services.ai_chat_service.run_bounded_ping",
+            return_value=PingResult(
+                "unreachable", "192.168.1.10", None, "no response to one bounded ping"
+            ),
+        ),
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "Availability checked.", "model": "local-model"},
+        ),
     ):
         response = client.post(
             "/api/ai/chat",
@@ -1094,22 +1196,33 @@ def test_admin_can_run_followup_availability_without_ai_view_all(monkeypatch):
             "username": "admin-operator",
             "user_message": "eventos abiertos",
             "assistant_response": "Open events listed.",
-            "harness_result": {"type": "event_list", "events": [{"ci_name": "AP01-ISLAS_AGRARIAS-BAJA01"}]},
+            "harness_result": {
+                "type": "event_list",
+                "events": [{"ci_name": "AP01-ISLAS_AGRARIAS-BAJA01"}],
+            },
         },
     )()
     client, _db = _make_client(db=_FakeHistoryDb([previous_row]), user=_admin_user())
 
     from services.ai_chat_service import PingResult
 
-    with patch(
-        "services.ai_chat_service.resolve_ci_for_harness",
-        return_value={"id": "ci-ap01", "name": "AP01-ISLAS_AGRARIAS-BAJA01", "ip": "192.168.1.10"},
-    ), patch(
-        "services.ai_chat_service.run_bounded_ping",
-        return_value=PingResult("reachable", "192.168.1.10", 1.0, "1 packet received"),
-    ), patch(
-        "services.ai_chat_service._post_lm_studio_chat_completion",
-        return_value={"content": "Done.", "model": "local-model"},
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness",
+            return_value={
+                "id": "ci-ap01",
+                "name": "AP01-ISLAS_AGRARIAS-BAJA01",
+                "ip": "192.168.1.10",
+            },
+        ),
+        patch(
+            "services.ai_chat_service.run_bounded_ping",
+            return_value=PingResult("reachable", "192.168.1.10", 1.0, "1 packet received"),
+        ),
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "Done.", "model": "local-model"},
+        ),
     ):
         response = client.post(
             "/api/ai/chat",
@@ -1144,15 +1257,23 @@ def test_followup_confirmation_runs_availability_batch_from_recent_event_list(mo
 
     from services.ai_chat_service import PingResult
 
-    with patch(
-        "services.ai_chat_service.resolve_ci_for_harness",
-        side_effect=lambda _driver, ci_ref: {"id": ci_ref, "name": ci_ref, "ip": "192.168.1.10"},
-    ), patch(
-        "services.ai_chat_service.run_bounded_ping",
-        return_value=PingResult("reachable", "192.168.1.10", 1.0, "1 packet received"),
-    ), patch(
-        "services.ai_chat_service._post_lm_studio_chat_completion",
-        return_value={"content": "Done.", "model": "local-model"},
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness",
+            side_effect=lambda _driver, ci_ref: {
+                "id": ci_ref,
+                "name": ci_ref,
+                "ip": "192.168.1.10",
+            },
+        ),
+        patch(
+            "services.ai_chat_service.run_bounded_ping",
+            return_value=PingResult("reachable", "192.168.1.10", 1.0, "1 packet received"),
+        ),
+        patch(
+            "services.ai_chat_service._post_lm_studio_chat_completion",
+            return_value={"content": "Done.", "model": "local-model"},
+        ),
     ):
         response = client.post(
             "/api/ai/chat",
@@ -1182,14 +1303,19 @@ def test_harness_failure_returns_operational_unavailable(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
     client, _ = _make_client(user=_event_view_user())
 
-    with patch("services.ai_chat_service.list_events_for_harness", side_effect=RuntimeError("neo4j down")):
+    with patch(
+        "services.ai_chat_service.list_events_for_harness", side_effect=RuntimeError("neo4j down")
+    ):
         response = client.post(
             "/api/ai/chat",
             json={"query": "dime que eventos hay abiertos"},
         )
 
     assert response.status_code == 503
-    assert response.json()["detail"] == "Operational harness is unavailable; no diagnostic or event result was executed."
+    assert (
+        response.json()["detail"]
+        == "Operational harness is unavailable; no diagnostic or event result was executed."
+    )
 
 
 def test_event_list_harness_requires_event_permission(monkeypatch):
@@ -1198,8 +1324,10 @@ def test_event_list_harness_requires_event_permission(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client()
 
-    with patch("services.ai_chat_service.list_events_for_harness") as list_events, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.list_events_for_harness") as list_events,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1220,9 +1348,11 @@ def test_availability_check_requires_diagnostic_permission(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client()
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1244,9 +1374,11 @@ def test_availability_check_requires_ai_view_all_before_ci_resolution(monkeypatc
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_diagnostic_user())
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1268,8 +1400,10 @@ def test_non_harness_chat_does_not_run_ai_guard_checks(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client()
 
-    with patch("routers.ai.check_all_guards") as check_all_guards, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("routers.ai.check_all_guards") as check_all_guards,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         complete.return_value = {"content": "Hello there", "model": "local-model"}
         response = client.post("/api/ai/chat", json={"query": "hello"})
 
@@ -1298,16 +1432,20 @@ def test_event_list_repeatability_no_success_cooldown_record(monkeypatch):
 
     def fake_guard(*_args, **_kwargs):
         if state["success_logged"]:
-            return GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=12)
+            return GuardResult(
+                allowed=False, reason="Cooldown active", cooldown_remaining_seconds=12
+            )
         return GuardResult(allowed=True)
 
     def fake_record_operation(*_args, **_kwargs):
         if _kwargs.get("result") == "success":
             state["success_logged"] = True
 
-    with patch("routers.ai.check_all_guards", side_effect=fake_guard) as check_all_guards, \
-         patch("routers.ai.record_operation", side_effect=fake_record_operation) as record_operation, \
-         patch("routers.ai.maybe_run_harness", return_value=event_list_result) as maybe_run_harness:
+    with (
+        patch("routers.ai.check_all_guards", side_effect=fake_guard) as check_all_guards,
+        patch("routers.ai.record_operation", side_effect=fake_record_operation) as record_operation,
+        patch("routers.ai.maybe_run_harness", return_value=event_list_result) as maybe_run_harness,
+    ):
         first_response = client.post(
             "/api/ai/chat",
             json={
@@ -1329,9 +1467,10 @@ def test_event_list_repeatability_no_success_cooldown_record(monkeypatch):
     assert second_response.json()["harness_result"] == event_list_result
     assert check_all_guards.call_count == 2
     assert maybe_run_harness.call_count == 2
-    assert not any(call.kwargs.get("result") == "success" for call in record_operation.call_args_list)
+    assert not any(
+        call.kwargs.get("result") == "success" for call in record_operation.call_args_list
+    )
     assert state["success_logged"] is False
-
 
 
 def test_event_list_guard_uses_event_query_target(monkeypatch):
@@ -1340,10 +1479,15 @@ def test_event_list_guard_uses_event_query_target(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_event_view_user())
 
-    with patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active")) as check_all, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion"), \
-         patch("routers.ai.record_operation") as record_operation:
+    with (
+        patch(
+            "routers.ai.check_all_guards",
+            return_value=GuardResult(allowed=False, reason="Cooldown active"),
+        ) as check_all,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion"),
+        patch("routers.ai.record_operation") as record_operation,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1360,7 +1504,9 @@ def test_event_list_guard_uses_event_query_target(monkeypatch):
     assert response.json()["harness_result"]["operation"] == "diagnose"
     assert "No diagnostic or event lookup was executed." in response.json()["answer"]
     check_all.assert_called_once()
-    assert not any(call.kwargs.get("result") == "success" for call in record_operation.call_args_list)
+    assert not any(
+        call.kwargs.get("result") == "success" for call in record_operation.call_args_list
+    )
 
 
 def test_availability_check_denied_blocks_execution_and_records_denied_result(monkeypatch):
@@ -1370,11 +1516,18 @@ def test_availability_check_denied_blocks_execution_and_records_denied_result(mo
     client, db = _make_client(user=_ai_cmdb_diagnostic_user())
 
     ci = {"id": "ci-1", "name": "Router-01", "ip": "192.168.1.10"}
-    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci, \
-         patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=42)), \
-         patch("routers.ai.record_operation") as record_operation, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion"):
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci,
+        patch(
+            "routers.ai.check_all_guards",
+            return_value=GuardResult(
+                allowed=False, reason="Cooldown active", cooldown_remaining_seconds=42
+            ),
+        ),
+        patch("routers.ai.record_operation") as record_operation,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion"),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1406,16 +1559,23 @@ def test_availability_check_canonicalizes_ci_ref_and_evaluates_guard_before_ping
     def fake_ping(*_args, **_kwargs):
         calls.append("ping")
         from services.ai_chat_service import PingResult
-        return PingResult(status="reachable", target="192.168.1.10", latency_ms=10.2, detail="1 packet received")
+
+        return PingResult(
+            status="reachable", target="192.168.1.10", latency_ms=10.2, detail="1 packet received"
+        )
 
     def fake_resolve(_driver, ci_ref):
         calls.append(f"resolve:{ci_ref}")
         return ci
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=fake_resolve) as resolve_ci, \
-         patch("services.ai_chat_service.run_bounded_ping", side_effect=fake_ping) as run_ping, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete, \
-         patch("routers.ai.check_all_guards") as check_all:
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness", side_effect=fake_resolve
+        ) as resolve_ci,
+        patch("services.ai_chat_service.run_bounded_ping", side_effect=fake_ping) as run_ping,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+        patch("routers.ai.check_all_guards") as check_all,
+    ):
         complete.return_value = {"content": "Ready", "model": "local-model"}
         check_all.side_effect = lambda *_args, **_kwargs: GuardResult(allowed=True)
         response = client.post(
@@ -1438,17 +1598,20 @@ def test_availability_check_canonicalizes_ci_ref_and_evaluates_guard_before_ping
     run_ping.assert_called_once()
 
 
-
-def test_availability_check_resolve_failure_returns_ci_not_found_without_second_resolution_or_ping(monkeypatch):
+def test_availability_check_resolve_failure_returns_ci_not_found_without_second_resolution_or_ping(
+    monkeypatch,
+):
     monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
     monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=[None]) as resolve_ci, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=[None]) as resolve_ci,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         complete.return_value = {"content": "No host alias", "model": "local-model"}
         response = client.post(
             "/api/ai/chat",
@@ -1474,11 +1637,13 @@ def test_availability_check_with_blank_canonical_ci_id_is_non_executable(monkeyp
 
     ci = {"id": "   ", "name": "Broken CI", "ip": "192.168.1.8"}
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci, \
-         patch("routers.ai.check_all_guards") as check_all, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci,
+        patch("routers.ai.check_all_guards") as check_all,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         complete.return_value = {"content": "No valid target", "model": "local-model"}
         response = client.post(
             "/api/ai/chat",
@@ -1497,7 +1662,9 @@ def test_availability_check_with_blank_canonical_ci_id_is_non_executable(monkeyp
     run_ping.assert_not_called()
 
 
-def test_availability_check_batch_with_canonical_id_missing_no_ping_or_maybe_run_harness(monkeypatch):
+def test_availability_check_batch_with_canonical_id_missing_no_ping_or_maybe_run_harness(
+    monkeypatch,
+):
     monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
     monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
@@ -1512,18 +1679,25 @@ def test_availability_check_batch_with_canonical_id_missing_no_ping_or_maybe_run
             return {"id": "ci-ok", "name": "Alias OK", "ip": "192.168.1.10"}
         return {"id": "ci-missing", "name": "Missing", "ip": "192.168.1.11"}
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
-         patch("routers.ai.check_all_guards") as check_all, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("routers.ai.record_operation") as record_operation, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect
+        ) as resolve_ci,
+        patch("routers.ai.check_all_guards") as check_all,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("routers.ai.record_operation") as record_operation,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         complete.return_value = {"content": "Unavailable", "model": "local-model"}
         response = client.post(
             "/api/ai/chat",
             json={
                 "query": "Batch check",
-                "intent": {"type": "availability_check_batch", "ci_refs": ["alias-no-id", "alias-whitespace", "alias-ok"]},
+                "intent": {
+                    "type": "availability_check_batch",
+                    "ci_refs": ["alias-no-id", "alias-whitespace", "alias-ok"],
+                },
             },
         )
 
@@ -1544,10 +1718,20 @@ def test_availability_check_escalation_required_denied(monkeypatch):
     client, _ = _make_client(user=_ai_cmdb_diagnostic_user())
 
     ci = {"id": "ci-2", "name": "Router-02", "ip": "10.0.0.1"}
-    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci), \
-         patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=True, escalation_required=True, escalation_id="esc-1", reason="Need approval")) as check_all, \
-         patch("routers.ai.record_operation") as record_operation, \
-         patch("routers.ai.maybe_run_harness") as maybe_run:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci),
+        patch(
+            "routers.ai.check_all_guards",
+            return_value=GuardResult(
+                allowed=True,
+                escalation_required=True,
+                escalation_id="esc-1",
+                reason="Need approval",
+            ),
+        ) as check_all,
+        patch("routers.ai.record_operation") as record_operation,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1583,13 +1767,19 @@ def test_availability_batch_denied_if_any_target_fails_harness_targeting(monkeyp
         if guard_calls == 1:
             return GuardResult(allowed=True)
         if target_ids[0].endswith("alias2"):
-            return GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=11)
+            return GuardResult(
+                allowed=False, reason="Cooldown active", cooldown_remaining_seconds=11
+            )
         return GuardResult(allowed=True)
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
-         patch("routers.ai.check_all_guards", side_effect=guard_side_effect) as check_all, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("routers.ai.record_operation") as record_operation:
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect
+        ) as resolve_ci,
+        patch("routers.ai.check_all_guards", side_effect=guard_side_effect) as check_all,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("routers.ai.record_operation") as record_operation,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1607,7 +1797,9 @@ def test_availability_batch_denied_if_any_target_fails_harness_targeting(monkeyp
     assert resolve_ci.call_count == 2
 
 
-def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_denied_without_ping(monkeypatch):
+def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_denied_without_ping(
+    monkeypatch,
+):
     monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
     monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
@@ -1624,19 +1816,28 @@ def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_denied
         if target_ids == ["ci:ci-alias1", "ci:ci-alias3"]:
             return GuardResult(allowed=True)
         if target_ids == ["ci:ci-alias3"]:
-            return GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=11)
+            return GuardResult(
+                allowed=False, reason="Cooldown active", cooldown_remaining_seconds=11
+            )
         return GuardResult(allowed=True)
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
-         patch("routers.ai.check_all_guards", side_effect=guard_side_effect) as check_all, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("routers.ai.record_operation") as record_operation:
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect
+        ) as resolve_ci,
+        patch("routers.ai.check_all_guards", side_effect=guard_side_effect) as check_all,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("routers.ai.record_operation") as record_operation,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
                 "query": "Batch check",
-                "intent": {"type": "availability_check_batch", "ci_refs": ["alias1", "missing", "alias3"]},
+                "intent": {
+                    "type": "availability_check_batch",
+                    "ci_refs": ["alias1", "missing", "alias3"],
+                },
             },
         )
 
@@ -1654,8 +1855,9 @@ def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_denied
     assert any(call.kwargs.get("result") == "blocked" for call in record_operation.call_args_list)
 
 
-
-def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_returns_ci_not_found(monkeypatch):
+def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_returns_ci_not_found(
+    monkeypatch,
+):
     monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
     monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
@@ -1671,25 +1873,37 @@ def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_return
     def fake_ping(*_args, **_kwargs):
         from services.ai_chat_service import PingResult
 
-        return PingResult(status="reachable", target="192.168.1.10", latency_ms=5.5, detail="1 packet received")
+        return PingResult(
+            status="reachable", target="192.168.1.10", latency_ms=5.5, detail="1 packet received"
+        )
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect) as resolve_ci, \
-             patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=True)) as check_all, \
-             patch("services.ai_chat_service.run_bounded_ping", side_effect=fake_ping) as run_ping, \
-             patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch(
+            "services.ai_chat_service.resolve_ci_for_harness", side_effect=resolve_side_effect
+        ) as resolve_ci,
+        patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=True)) as check_all,
+        patch("services.ai_chat_service.run_bounded_ping", side_effect=fake_ping) as run_ping,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         complete.return_value = {"content": "ready", "model": "local-model"}
         response = client.post(
             "/api/ai/chat",
             json={
                 "query": "Batch",
-                "intent": {"type": "availability_check_batch", "ci_refs": ["alias-ok", "missing", "alias-ok-2"]},
+                "intent": {
+                    "type": "availability_check_batch",
+                    "ci_refs": ["alias-ok", "missing", "alias-ok-2"],
+                },
             },
         )
 
     assert response.status_code == 200
     batch_results = response.json()["harness_result"]["results"]
     assert response.json()["harness_result"]["type"] == "availability_check_batch"
-    assert any(item.get("status") == "ci_not_found" and item.get("ci_ref") == "missing" for item in batch_results)
+    assert any(
+        item.get("status") == "ci_not_found" and item.get("ci_ref") == "missing"
+        for item in batch_results
+    )
     assert len(batch_results) == 3
     for call in check_all.call_args_list:
         assert all(target_id in {"ci:ci-ok", "ci:ci-ok-2"} for target_id in call.args[2])
@@ -1698,17 +1912,20 @@ def test_availability_check_batch_with_mixed_resolved_and_unresolved_refs_return
     assert check_all.call_count >= 2
 
 
-
 def test_availability_check_batch_guard_unavailable_does_not_execute_harness(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_ENABLED", "true")
     monkeypatch.setenv("LM_STUDIO_BASE_URL", "http://lmstudio.local:1234/v1")
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, db = _make_client(user=_ai_cmdb_diagnostic_user())
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
-         patch("routers.ai.check_all_guards", side_effect=RuntimeError("guard db offline")) as check_all, \
-         patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci,
+        patch(
+            "routers.ai.check_all_guards", side_effect=RuntimeError("guard db offline")
+        ) as check_all,
+        patch("routers.ai.maybe_run_harness") as maybe_run,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         resolve_ci.side_effect = [
             {"id": "ci-a", "name": "A", "ip": "192.168.1.1"},
             {"id": "ci-b", "name": "B", "ip": "192.168.1.2"},
@@ -1749,9 +1966,11 @@ def test_availability_check_allowed_records_success_result(monkeypatch):
         "detail": "1 packet received",
     }
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci), \
-         patch("routers.ai.record_operation") as record_operation, \
-         patch("routers.ai.maybe_run_harness", return_value=harness):
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci),
+        patch("routers.ai.record_operation") as record_operation,
+        patch("routers.ai.maybe_run_harness", return_value=harness),
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1765,7 +1984,9 @@ def test_availability_check_allowed_records_success_result(monkeypatch):
     assert response.json()["harness_result"]["ci_id"] == "ci-77"
     assert response.json()["harness_result"].get("denied", False) is False
     assert any(call.kwargs.get("result") == "success" for call in record_operation.call_args_list)
-    assert any(call.kwargs.get("target_id") == "ci:ci-77" for call in record_operation.call_args_list)
+    assert any(
+        call.kwargs.get("target_id") == "ci:ci-77" for call in record_operation.call_args_list
+    )
 
 
 def test_disabled_lm_studio_blocks_harness_side_effects(monkeypatch):
@@ -1774,9 +1995,11 @@ def test_disabled_lm_studio_blocks_harness_side_effects(monkeypatch):
     monkeypatch.setenv("LM_STUDIO_MODEL", "local-model")
     client, _ = _make_client(user=_diagnostic_user())
 
-    with patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci, \
-         patch("services.ai_chat_service.run_bounded_ping") as run_ping, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete:
+    with (
+        patch("services.ai_chat_service.resolve_ci_for_harness") as resolve_ci,
+        patch("services.ai_chat_service.run_bounded_ping") as run_ping,
+        patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete,
+    ):
         response = client.post(
             "/api/ai/chat",
             json={
@@ -1802,7 +2025,10 @@ def test_ping_harness_rejects_invalid_stored_target():
 def test_bounded_ping_maps_command_timeout():
     from services.ai_chat_service import run_bounded_ping
 
-    with patch("services.ai_chat_service.subprocess.run", side_effect=subprocess.TimeoutExpired(["ping"], 3)):
+    with patch(
+        "services.ai_chat_service.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(["ping"], 3),
+    ):
         result = run_bounded_ping("192.168.1.10")
 
     assert result.status == "error"
@@ -1870,7 +2096,9 @@ def test_bounded_ping_maps_missing_command():
 def test_bounded_ping_maps_execution_failure_without_exception_details():
     from services.ai_chat_service import run_bounded_ping
 
-    with patch("services.ai_chat_service.subprocess.run", side_effect=PermissionError("secret path")):
+    with patch(
+        "services.ai_chat_service.subprocess.run", side_effect=PermissionError("secret path")
+    ):
         result = run_bounded_ping("192.168.1.10")
 
     assert result.status == "error"
@@ -1883,7 +2111,10 @@ def test_bounded_ping_maps_execution_failure_without_exception_details():
 def test_bounded_ping_maps_subprocess_failure_without_exception_details():
     from services.ai_chat_service import run_bounded_ping
 
-    with patch("services.ai_chat_service.subprocess.run", side_effect=subprocess.SubprocessError("secret detail")):
+    with patch(
+        "services.ai_chat_service.subprocess.run",
+        side_effect=subprocess.SubprocessError("secret detail"),
+    ):
         result = run_bounded_ping("192.168.1.10")
 
     assert result.status == "error"
@@ -1897,10 +2128,14 @@ def test_post_lm_studio_logs_timeout_exception(caplog):
     from config import LMStudioSettings
     from services.ai_chat_service import LMStudioTimeoutError, _post_lm_studio_chat_completion
 
-    settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
+    settings = LMStudioSettings(
+        enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1"
+    )
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
     with (
-        patch("services.ai_chat_service.urllib.request.urlopen", side_effect=TimeoutError("timed out")),
+        patch(
+            "services.ai_chat_service.urllib.request.urlopen", side_effect=TimeoutError("timed out")
+        ),
         caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
         pytest.raises(LMStudioTimeoutError),
     ):
@@ -1913,10 +2148,15 @@ def test_post_lm_studio_logs_url_error(caplog):
     from config import LMStudioSettings
     from services.ai_chat_service import LMStudioError, _post_lm_studio_chat_completion
 
-    settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
+    settings = LMStudioSettings(
+        enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1"
+    )
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
     with (
-        patch("services.ai_chat_service.urllib.request.urlopen", side_effect=urllib.error.URLError("Connection refused")),
+        patch(
+            "services.ai_chat_service.urllib.request.urlopen",
+            side_effect=urllib.error.URLError("Connection refused"),
+        ),
         caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
         pytest.raises(LMStudioError, match="unavailable"),
     ):
@@ -1929,10 +2169,14 @@ def test_post_lm_studio_logs_parse_error(caplog):
     from config import LMStudioSettings
     from services.ai_chat_service import LMStudioError, _post_lm_studio_chat_completion
 
-    settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
+    settings = LMStudioSettings(
+        enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1"
+    )
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
     with (
-        patch("services.ai_chat_service.urllib.request.urlopen", side_effect=ValueError("bad data")),
+        patch(
+            "services.ai_chat_service.urllib.request.urlopen", side_effect=ValueError("bad data")
+        ),
         caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
         pytest.raises(LMStudioError, match="could not be parsed"),
     ):
@@ -1945,7 +2189,9 @@ def test_post_lm_studio_logs_missing_message(caplog):
     from config import LMStudioSettings
     from services.ai_chat_service import LMStudioError, _post_lm_studio_chat_completion
 
-    settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
+    settings = LMStudioSettings(
+        enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1"
+    )
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
     response_body = json.dumps({"choices": []}).encode("utf-8")
     mock_response = MagicMock()

--- a/backend/tests/test_ai_chat_service.py
+++ b/backend/tests/test_ai_chat_service.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 import subprocess
@@ -8,9 +9,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
-from models.user import User
 from models.ai_guard_models import GuardResult
+from models.user import User
+from routers.ai import chat_with_ai, get_current_active_user, get_db, get_pg_db, router
 
 
 def _operator_user() -> User:
@@ -113,8 +114,6 @@ def _default_ai_chat_guard(monkeypatch):
 
 
 def _make_client(db=None, user=None):
-    from routers.ai import router, get_pg_db, get_current_active_user, get_db
-
     app = FastAPI()
     app.include_router(router, prefix="/api")
     fake_db = db or _FakeDb()
@@ -129,8 +128,6 @@ def _make_client(db=None, user=None):
 
 
 def test_ai_chat_requires_authentication():
-    from routers.ai import router
-
     app = FastAPI()
     app.include_router(router, prefix="/api")
     client = TestClient(app)
@@ -873,9 +870,6 @@ def test_event_list_query_returns_no_rows_without_scope():
 
 
 def test_ai_chat_route_uses_async_offload_for_blocking_work():
-    import inspect
-    from routers.ai import chat_with_ai
-
     assert inspect.iscoroutinefunction(chat_with_ai)
 
 
@@ -1348,7 +1342,7 @@ def test_event_list_guard_uses_event_query_target(monkeypatch):
 
     with patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active")) as check_all, \
          patch("routers.ai.maybe_run_harness") as maybe_run, \
-         patch("services.ai_chat_service._post_lm_studio_chat_completion") as complete, \
+         patch("services.ai_chat_service._post_lm_studio_chat_completion"), \
          patch("routers.ai.record_operation") as record_operation:
         response = client.post(
             "/api/ai/chat",
@@ -1377,7 +1371,7 @@ def test_availability_check_denied_blocks_execution_and_records_denied_result(mo
 
     ci = {"id": "ci-1", "name": "Router-01", "ip": "192.168.1.10"}
     with patch("services.ai_chat_service.resolve_ci_for_harness", return_value=ci) as resolve_ci, \
-         patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=42)) as check_all, \
+         patch("routers.ai.check_all_guards", return_value=GuardResult(allowed=False, reason="Cooldown active", cooldown_remaining_seconds=42)), \
          patch("routers.ai.record_operation") as record_operation, \
          patch("routers.ai.maybe_run_harness") as maybe_run, \
          patch("services.ai_chat_service._post_lm_studio_chat_completion"):
@@ -1905,10 +1899,12 @@ def test_post_lm_studio_logs_timeout_exception(caplog):
 
     settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
-    with patch("services.ai_chat_service.urllib.request.urlopen", side_effect=TimeoutError("timed out")):
-        with caplog.at_level(logging.ERROR, logger="services.ai_chat_service"):
-            with pytest.raises(LMStudioTimeoutError):
-                _post_lm_studio_chat_completion(payload, settings)
+    with (
+        patch("services.ai_chat_service.urllib.request.urlopen", side_effect=TimeoutError("timed out")),
+        caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
+        pytest.raises(LMStudioTimeoutError),
+    ):
+        _post_lm_studio_chat_completion(payload, settings)
     assert "LM Studio request timed out" in caplog.text
     assert "lmstudio.local" in caplog.text
 
@@ -1919,10 +1915,12 @@ def test_post_lm_studio_logs_url_error(caplog):
 
     settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
-    with patch("services.ai_chat_service.urllib.request.urlopen", side_effect=urllib.error.URLError("Connection refused")):
-        with caplog.at_level(logging.ERROR, logger="services.ai_chat_service"):
-            with pytest.raises(LMStudioError, match="unavailable"):
-                _post_lm_studio_chat_completion(payload, settings)
+    with (
+        patch("services.ai_chat_service.urllib.request.urlopen", side_effect=urllib.error.URLError("Connection refused")),
+        caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
+        pytest.raises(LMStudioError, match="unavailable"),
+    ):
+        _post_lm_studio_chat_completion(payload, settings)
     assert "LM Studio unavailable" in caplog.text
     assert "lmstudio.local" in caplog.text
 
@@ -1933,16 +1931,17 @@ def test_post_lm_studio_logs_parse_error(caplog):
 
     settings = LMStudioSettings(enabled=True, model="local-model", base_url="http://lmstudio.local:1234/v1")
     payload = {"model": "local-model", "messages": [{"role": "user", "content": "test"}]}
-    with patch("services.ai_chat_service.urllib.request.urlopen", side_effect=ValueError("bad data")):
-        with caplog.at_level(logging.ERROR, logger="services.ai_chat_service"):
-            with pytest.raises(LMStudioError, match="could not be parsed"):
-                _post_lm_studio_chat_completion(payload, settings)
+    with (
+        patch("services.ai_chat_service.urllib.request.urlopen", side_effect=ValueError("bad data")),
+        caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
+        pytest.raises(LMStudioError, match="could not be parsed"),
+    ):
+        _post_lm_studio_chat_completion(payload, settings)
     assert "LM Studio response parse error" in caplog.text
     assert "lmstudio.local" in caplog.text
 
 
 def test_post_lm_studio_logs_missing_message(caplog):
-    import io
     from config import LMStudioSettings
     from services.ai_chat_service import LMStudioError, _post_lm_studio_chat_completion
 
@@ -1953,9 +1952,11 @@ def test_post_lm_studio_logs_missing_message(caplog):
     mock_response.read.return_value = response_body
     mock_response.__enter__ = MagicMock(return_value=mock_response)
     mock_response.__exit__ = MagicMock(return_value=False)
-    with patch("services.ai_chat_service.urllib.request.urlopen", return_value=mock_response):
-        with caplog.at_level(logging.ERROR, logger="services.ai_chat_service"):
-            with pytest.raises(LMStudioError, match="did not contain a chat message"):
-                _post_lm_studio_chat_completion(payload, settings)
+    with (
+        patch("services.ai_chat_service.urllib.request.urlopen", return_value=mock_response),
+        caplog.at_level(logging.ERROR, logger="services.ai_chat_service"),
+        pytest.raises(LMStudioError, match="did not contain a chat message"),
+    ):
+        _post_lm_studio_chat_completion(payload, settings)
     assert "LM Studio response missing chat message" in caplog.text
     assert "lmstudio.local" in caplog.text

--- a/openspec/changes/issue-375-ai-chat-guardrails/apply-progress.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/apply-progress.md
@@ -1,0 +1,55 @@
+# Apply Progress: issue-375-ai-chat-guardrails
+
+- status: success
+- started_slice: PR 1 (single-slice slice as requested by maintainer exception)
+- next_recommended: verify
+- started_at: 2026-07-07
+
+## Completed implementation
+
+- [x] Fixed single and batch availability CI resolution/guard flow in `backend/routers/ai.py` to evaluate guards before harness execution and to avoid repeated DB resolution.
+- [x] Canonicalized guard targets to `ci:<ci.id>` and event-list targets to `event_query:<status>:<severity-or-any>`.
+- [x] Added resolved-CI pre-handoff to service harness executor via `_resolved_ci` so `maybe_run_harness(...)` continues to own harness execution semantics while avoiding duplicate `resolve_ci_for_harness(...)` calls.
+- [x] Preserved existing allowed-path behavior for operational responses (`availability`, `availability_check_batch`, and `event_list`) and guard-denial short-circuit handling.
+- [x] Updated `backend/services/ai_chat_service.py` to accept explicit resolved CI hints and use them in `_run_availability_harness`/batch execution.
+- [x] Ensured unresolved batch refs remain represented as `ci_not_found` and are not re-resolved at harness execution time.
+- [x] Updated `backend/tests/test_ai_chat_service.py` assertions to reflect canonicalization/ordering behavior and confirmed all required edge cases pass.
+- [x] Added regression coverage for two critical 4R cases: single availability `ci_ref` not found and batch availability with canonical-id-missing CI.
+- [x] Verified both regression tests execute and enforce fail-closed behavior (no `maybe_run_harness`, no ping) when CI is unresolved or non-executable.
+- [x] Fixed `_canonical_ci_target_id` to reject `None`, empty, and whitespace-only CI IDs, and aligned single availability behavior to return `ci_not_found` instead of attempting diagnostics.
+- [x] Added regression coverage for single availability and batch availability with whitespace/empty canonical IDs to ensure no guard target `ci:` is emitted and no side effects occur.
+
+## Files changed
+
+- `backend/routers/ai.py`
+- `backend/services/ai_chat_service.py`
+- `backend/tests/test_ai_chat_service.py`
+- `openspec/changes/issue-375-ai-chat-guardrails/tasks.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/apply-progress.md`
+
+## Test commands run
+
+- `/tmp/next-gen-issue375-py311/bin/python -m pytest backend/tests/test_ai_chat_service.py`
+- `/tmp/next-gen-issue375-py311/bin/python -m py_compile backend/routers/ai.py backend/tests/test_ai_chat_service.py`
+
+## TDD Cycle Evidence
+
+| Task | RED | GREEN | TRIANGULATE | REFACTOR |
+| --- | --- | --- | --- | --- |
+| Work unit 1.10+ | ✅ (assertions for order/canonicalization and mixed batch handling were present/failing) | ✅ (`74 passed`) | ✅ `resolve_ci`/`run_ping`/blank-id call-order and guard target assertions exercised | ✅ small shim-path refactor (`_resolved_ci` injection) |
+| Work unit 1.11 (canonical-id-missing hardening) | ✅ `test_availability_check_with_blank_canonical_ci_id_is_non_executable` and batch invalid-id regression added first | ✅ (`74 passed`) | ✅ whitespace and blank ID variants with no side effects and no `ci:` target usage | ✅ no structural refactor needed |
+
+## Deviations / notes
+
+- No scope creep beyond `backend/routers/ai.py`, `backend/services/ai_chat_service.py`, and `backend/tests/test_ai_chat_service.py`.
+- Behavior remains deterministic for operational harness types in `complete_chat`, so some tests assert rendered availability text rather than raw patched LLM output.
+
+## Remaining / follow-up tasks
+
+- [ ] [Potential follow-up] Run `strict-TDD`-aligned broader suite and any additional cross-module regressions requested by reviewers.
+
+## Workload / PR boundary
+
+- Slice boundary completed: PR 1 / single-slice exception (guard ordering, canonicalization, batch resilience).
+- Remaining risk: none in this targeted scope.
+- Next boundary remains: **verify**.

--- a/openspec/changes/issue-375-ai-chat-guardrails/archive-report.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/archive-report.md
@@ -1,0 +1,100 @@
+# Archive Report — issue-375-ai-chat-guardrails
+
+## Status
+
+**Archive status:** PASS
+
+## Issue reference
+
+- Issue: `#375`
+- Change: `issue-375-ai-chat-guardrails`
+
+## Structured status and actionContext findings
+
+- Artifact store: `openspec`
+- Change root: `openspec/changes/issue-375-ai-chat-guardrails`
+- Action mode: repo-local workspace
+- Workspace root: `/Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/ai-chat-guardrails-orchestration`
+- Allowed edit roots: workspace root only
+- No workspace-planning restriction applied
+- Native status / sync context: `synced`, `openspec` canonical spec already created
+
+## Artifacts read
+
+- `openspec/changes/issue-375-ai-chat-guardrails/explore.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/proposal.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/spec.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/specs/ai-chat-harness-guardrails/spec.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/design.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/tasks.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/apply-progress.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/verify-report.md`
+- `openspec/changes/issue-375-ai-chat-guardrails/sync-report.md`
+- `openspec/config.yaml`
+
+## Implementation files
+
+- `backend/routers/ai.py`
+- `backend/services/ai_chat_service.py`
+- `backend/tests/test_ai_chat_service.py`
+
+## Test / verification evidence
+
+- `py_compile` PASS for `backend/routers/ai.py backend/services/ai_chat_service.py backend/tests/test_ai_chat_service.py`
+- `pytest backend/tests/test_ai_chat_service.py` PASS: `74 passed, 2 warnings`
+- Verify report status: PASS
+- No CRITICAL findings in verify report
+
+## Review evidence / critical 4R findings fixed
+
+- Review-ready evidence recorded in `apply-progress.md` and confirmed by `verify-report.md`
+- Critical 4R cases addressed:
+  - single availability `ci_ref` not found returns fail-closed / no harness execution
+  - batch availability with canonical-id-missing CI is non-executable
+  - blank / whitespace-only canonical CI IDs do not produce `ci:` guard targets
+- Verify report found no remaining CRITICAL / WARNING findings
+
+## Sync / canonical spec status
+
+- Sync status: `synced`
+- Canonical spec created: `openspec/specs/ai-chat-harness-guardrails/spec.md`
+- Domain synced: `ai-chat-harness-guardrails`
+- Requirement deltas synced as ADDED requirements only; no MODIFIED or REMOVED requirements
+
+## Size exception note
+
+- Maintainer-approved single-slice exception was used
+- Review workload forecast in `tasks.md` marked high risk and recommended chained PRs, but the approved slice completed as one boundary
+- Actual implementation exceeded the 400-line budget, but this was explicitly covered by the recorded exception and verified as reviewable
+
+## Task completion / reconciliation
+
+- Persisted tasks artifact re-read before archive
+- Exact unchecked implementation task lines: none
+- `tasks.md` contains one unchecked follow-up item only: broader suite / strict-TDD-aligned follow-up, which is non-blocking and not an implementation task
+- `apply-progress.md` and `verify-report.md` agree the implementation checklist is complete
+
+## Remaining non-blocking follow-ups
+
+- Broader strict-TDD-aligned suite run can be executed later if requested
+- No archive blockers remain
+
+## PR-prep readiness
+
+- Ready for PR prep / merge review
+- Canonical spec is synced
+- Verification is green
+- No destructive canonical merge actions were needed
+- No same-domain collision was detected
+
+## Archived path
+
+- Source retained in place: `openspec/changes/issue-375-ai-chat-guardrails/`
+- Archive report persisted at: `openspec/changes/issue-375-ai-chat-guardrails/archive-report.md`
+- No folder move performed during archive
+
+## Findings
+
+- PASS: archive completed with synced canonical spec and passing verification
+- PASS: no unresolved implementation checklist items
+- PASS: no CRITICAL verification blockers remain

--- a/openspec/changes/issue-375-ai-chat-guardrails/design.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/design.md
@@ -1,0 +1,335 @@
+# Design: Harden `/api/ai/chat` harness execution with existing guardrails
+
+This slice adds a permission-first guardrail gate to the backend-owned `/api/ai/chat` harness path. Allowed harnesses keep the current execution and response behavior; guardrail-denied or escalation-required harnesses do not execute and instead return/persist an explicit conversational denial in `harness_result` with HTTP 200.
+
+## Quick path
+
+1. Resolve or infer `intent` exactly as today.
+2. Keep the existing `_can_run_intent_harness(...)` permission gate; permission failures remain HTTP 403.
+3. Build guard metadata before harness execution. For availability intents, this may include **read-only CI resolution to canonical CI IDs**; it must not include ping, diagnostics, event lookup execution, or operation recording.
+4. Before `maybe_run_harness(...)`, evaluate chat-harness guardrails through `ai_guard_service`.
+5. If denied, escalation-required, or guard evaluation cannot safely complete, skip `maybe_run_harness(...)`, build a denial `harness_result`, render a deterministic denial answer, and persist it through `save_chat_exchange(...)`.
+6. If allowed, execute the harness as today and record successful guard-tracked operation(s) only where doing so does not introduce unstable cooldown UX.
+
+## CodeGraph note
+
+The workspace does not contain a `.codegraph/` index and no CodeGraph tool is available in this executor environment, so design inspection used the explicit evidence files from the proposal/spec plus targeted reads of the affected files instead of broad repository exploration.
+
+## Current integration seam
+
+`backend/routers/ai.py::chat_with_ai` is the exact integration point.
+
+Current flow:
+
+```python
+intent = body.intent or infer_chat_intent(body.query)
+# maybe infer_followup_intent(...)
+if intent is not None and not _can_run_intent_harness(intent, current_user):
+    raise HTTPException(status_code=403, detail=detail)
+
+harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
+```
+
+New flow:
+
+```python
+intent = body.intent or infer_chat_intent(body.query)
+# maybe infer_followup_intent(...)
+if intent is not None and not _can_run_intent_harness(intent, current_user):
+    raise HTTPException(status_code=403, detail=detail)
+
+guard_context = await asyncio.to_thread(build_chat_harness_guard_context, intent, neo4j_driver)
+if guard_context.non_diagnostic_result is not None:
+    harness_result = guard_context.non_diagnostic_result
+else:
+    guard_decision = await asyncio.to_thread(evaluate_chat_harness_guard, guard_context, current_user)
+    if guard_decision.denied or guard_decision.escalation_required:
+        harness_result = build_denied_harness_result(intent, guard_context, guard_decision)
+    else:
+        harness_result = await asyncio.to_thread(maybe_run_harness, intent, neo4j_driver, current_user)
+        await asyncio.to_thread(record_chat_harness_success, guard_context, current_user, harness_result)
+```
+
+`complete_chat(...)` should deterministically render denied harness results before normal deterministic harness rendering. This avoids an LM Studio call to explain a denial and prevents fabricated diagnostics.
+
+## Guard target canonicalization
+
+Availability guard target identity must be canonical. Do **not** guard availability diagnostics using unresolved strings such as `ci_ref:<normalized ci_ref>` when the harness accepts user-facing references.
+
+### Availability canonical target strategy
+
+Before guard evaluation, perform a read-only CMDB lookup with the same safe resolution semantics used by the current harness seam (`resolve_ci_for_harness(...)`) or its extracted equivalent:
+
+- The lookup is allowed before the guard because it is read-only target resolution.
+- The lookup must not run ping, network diagnostics, event queries, operation logging, cooldown mutation, or any other harness side effect.
+- If the CI resolves, guard and record against the canonical target ID: `ci:<ci.id>`.
+- Preserve the original user-entered value only in `request_context` and user-facing result fields.
+- If the CI does not resolve, do not execute the availability harness. Return the existing non-diagnostic `ci_not_found`-style result deterministically and do not record a successful diagnostic operation. This keeps the no-diagnostic-before-guard invariant without inventing an unstable guard target.
+
+For `availability_check_batch`, resolve every requested CI reference read-only before guard evaluation:
+
+- If one or more refs resolve, build one canonical target ID per resolved CI: `ci:<ci.id>`.
+- If any requested ref is unresolved, return a batch result containing `ci_not_found` entries for those refs and no ping work for them.
+- If the batch contains any resolved target, all resolved targets must pass guard evaluation before any ping executes.
+- If any resolved target is denied or escalation-required, deny the whole batch and execute no partial ping work.
+
+This keeps batch in the first slice and avoids both unresolved guard identities and partial guarded execution.
+
+## Guard operation mapping
+
+Use existing `ai_guard_service` operation semantics; do not add a new Raven/tool runtime and do not call `set_cooldown(...)` directly.
+
+| Chat intent | Guard operation | Target type | Target IDs before harness execution | Recording after success | Notes |
+|---|---:|---|---|---|---|
+| `availability_check` | `diagnose` | `ci` | `ci:<canonical ci.id>` after read-only CI resolution | `result="success"` for resolved CI | No ping/diagnostic side effect occurs before guard. |
+| `availability_check_batch` | `diagnose` | `ci` | one `ci:<canonical ci.id>` per resolved CI, max existing batch size | `result="success"` per resolved CI | Batch is fully guarded in this first slice. |
+| `event_list` | `diagnose` for guard check only | `event_query` | `event_query:<status>:<severity-or-any>` | Do **not** record cooldown-producing success in this slice | Guard bulk/behavioral safety where practical, but avoid event-list cooldown UX instability. |
+| `active_events` | `diagnose` for guard check only | `event_query` | `event_query:ACTIVE:<severity-or-any>` | Do **not** record cooldown-producing success in this slice | Treat as event-list alias. |
+
+Rationale: `diagnose` is the existing read/diagnostic operation in `ai_guard_service.COOLDOWNS`. For availability diagnostics, the cooldown maps well to real ping execution. For event listing, mapping to `diagnose` is useful for safety checks, but recording `success` would set a diagnose cooldown on a broad query target and could make repeat event-list UX unstable. Therefore, event-list success recording is excluded from cooldown-producing operation recording in this first slice. Denied or guard-unavailable event-list attempts may still be logged as `result="blocked"` best-effort because blocked records do not set cooldown.
+
+Target normalization:
+
+- Trim whitespace.
+- Lowercase event filters.
+- Use canonical `ci.id` for availability target IDs after read-only resolution; do not lowercase or rewrite the canonical ID beyond the existing stored identifier.
+- Replace empty severity with `any`.
+- Preserve original user-facing values only in `request_context`, not in canonical target IDs.
+
+## Guard decision handling
+
+Treat a `GuardResult` as blocking when either:
+
+- `allowed is False`, or
+- `escalation_required is True`.
+
+For this first slice, escalation is surfaced as a structured guardrail denial/escalation-required response with HTTP 200 and no harness execution. Do not attempt human-approval workflow creation in this change.
+
+Escalation denial payload rules:
+
+- `status`: `"denied"`
+- `denied`: `true`
+- `reason_code`: `"escalation_required"`
+- `escalation_required`: `true`
+- `escalation_id`: include when provided by `GuardResult`
+- `reason`: use the guard reason, falling back to `"AI guardrail requires human approval before this harness can run."`
+
+Best-effort operation logging may use `result="escalated"` when the operation log is written, but logging failure must not cause harness execution.
+
+## Event-list vs availability-check vs batch behavior
+
+### Event-list intents
+
+- Guard once using the event query target ID before running `_run_event_list_harness(...)`.
+- The guard check is for bulk/behavioral safety and guard-unavailable fail-closed behavior.
+- If allowed, run `maybe_run_harness(...)` unchanged; scoped event filtering remains inside `_run_event_list_harness(...)`.
+- Do not prefetch event IDs only for guardrails; that would move event-list harness behavior before the guard.
+- Do not record `result="success"` for event-list in this slice, because current `record_operation(...)` sets cooldown on every success and the existing service has no no-cooldown success operation. This prevents repeat event-list requests from being blocked solely by a diagnose cooldown produced by the previous list query.
+
+### Availability-check intent
+
+- Resolve the requested CI reference to a canonical CI ID using a read-only lookup before guard evaluation.
+- If unresolved, return a non-diagnostic `ci_not_found` result without invoking `maybe_run_harness(...)`, without pinging, and without recording diagnostic success.
+- If resolved, guard `ci:<ci.id>` before any ping.
+- If allowed, run the existing harness path unchanged for that CI and record success after the harness returns.
+- If the harness result is `invalid_target`, success may still be recorded because the diagnostic harness was executed against the resolved CI and should enter cooldown/tracking.
+
+### Availability-check-batch intent
+
+- Keep batch guarded in the first slice.
+- Resolve all requested CI refs read-only to canonical CI IDs before any guard decision or ping.
+- Evaluate all resolved targets before executing any ping.
+- Recommended helper behavior:
+  - call `check_all_guards(current_user.username, "diagnose", canonical_target_ids)` once to preserve bulk detection,
+  - additionally ensure per-target cooldown coverage by checking each canonical target with `check_all_guards(current_user.username, "diagnose", [target_id])` until a denial or escalation-required result is found.
+- If any target is denied or escalation-required, deny the whole batch and execute no partial harness work.
+- If all resolved targets are allowed, run the existing batch harness for resolved CIs and include non-diagnostic `ci_not_found` entries for unresolved refs.
+- Record success for each resolved target ID after execution so `record_operation(..., result="success")` sets cooldown for every resolved CI.
+
+## Denial result contract
+
+Returned and persisted `harness_result` for guardrail denial must be stable and explicit:
+
+```json
+{
+  "type": "availability_check",
+  "status": "denied",
+  "denied": true,
+  "reason": "Cooldown active",
+  "reason_code": "cooldown_active",
+  "cooldown_remaining_seconds": 123,
+  "operation": "diagnose",
+  "target_type": "ci",
+  "target_ids": ["ci:router-1-id"],
+  "source": "ai_guard_service"
+}
+```
+
+Field rules:
+
+- `type`: original intent type when present; otherwise omit/`None` is not required because no harness exists.
+- `status`: always `"denied"` for guardrail-denied and escalation-required outcomes.
+- `denied`: always `true`.
+- `reason`: human-readable guard reason; fallback to `"AI guardrail denied this harness execution."`.
+- `reason_code`: normalized stable code where possible. Minimum codes: `cooldown_active`, `bulk_operation_too_large`, `behavioral_guard_denied`, `escalation_required`, `guard_unavailable`, `guard_denied`.
+- `cooldown_remaining_seconds`: include only when the guard result provides it.
+- `escalation_required` and `escalation_id`: include when escalation is required/provided.
+- `operation`, `target_type`, `target_ids`: audit/debug fields from the mapping above.
+- `source`: always `"ai_guard_service"` for this slice.
+
+For `reason_code="guard_unavailable"`, wording must say the guardrail system could not verify safety. It must not say a policy or cooldown explicitly blocked the request.
+
+Example deterministic answer:
+
+> I cannot run that operational check right now because the AI guardrail system could not verify it was safe to proceed. No diagnostic or event lookup was executed.
+
+For explicit denials, the answer may mention the guard reason:
+
+> I cannot run that operational check right now because an AI guardrail blocked it: Cooldown active. No diagnostic or event lookup was executed.
+
+This denial answer should be generated by a small renderer in `ai_chat_service` (or router-local helper if kept tiny), not by LM Studio.
+
+## Recording and cooldown tracking
+
+Use `record_operation(...)`; do not call `set_cooldown(...)` directly from the chat path.
+
+| Outcome | `record_operation` call | Cooldown behavior |
+|---|---|---|
+| Guard denied | Best-effort `result="blocked"`, `blocked_reason=<reason>` | No cooldown is set by current service semantics. |
+| Guard escalation required | Best-effort `result="escalated"`, `blocked_reason=<reason>` | No cooldown is set. |
+| Guard unavailable before execution | Best-effort `result="blocked"`, `blocked_reason="guard_unavailable"`; no harness execution | No cooldown is set. |
+| Availability harness allowed and executed | `result="success"` after harness returns | Existing `record_operation` sets cooldown for canonical CI target. |
+| Batch availability allowed and executed | `result="success"` per resolved canonical CI after harness returns | Existing `record_operation` sets cooldown for each canonical CI target. |
+| Event-list harness allowed and executed | No success record in this first slice | Avoids repeat event-list cooldown instability. |
+| Harness execution raises | Preserve existing HTTP 503 behavior; optional best-effort `result="failed"` if target metadata is available | No cooldown is set unless service semantics change later. |
+
+Suggested `record_operation(...)` parameters:
+
+- `ai_persona`: `str(current_user.role)`.
+- `ai_agent_id`: `current_user.username`.
+- `operation`: mapped operation, currently `diagnose`.
+- `target_type`: mapped target type (`ci` or `event_query`).
+- `target_id`: each target ID for batch/success, or primary target ID for single/event-list.
+- `target_name`: canonical CI name/original ref for availability, event query description for event-list.
+- `request_context`: include `{"source": "ai_chat", "intent_type": intent.type}` plus safe intent fields (`status`, `severity`, `limit`, original `ci_ref`/`ci_refs` counts, not prompt text).
+
+Implementation guardrail: wrap `record_operation(...)` calls so a denial response can still be returned if blocked-operation logging fails. For allowed successful execution, prefer not to fail the already-completed chat response solely because post-execution audit logging failed; log internally if a logger is available. The critical safety invariant is that guard evaluation must happen successfully before harness execution.
+
+## Backward compatibility and failure handling
+
+- Permission failures stay exactly as today: HTTP 403 from `_can_run_intent_harness(...)`.
+- Non-harness chat (`intent is None`) bypasses guard evaluation and behaves as today.
+- Allowed harness responses remain unchanged; do not add denial fields to successful harness results.
+- Existing deterministic rendering for `event_list`, `availability_check`, and `availability_check_batch` remains unchanged when allowed.
+- Guard-denied and escalation-required harnesses return HTTP 200 and persist the denial in `AIChatMessage.harness_result` through the existing `save_chat_exchange(...)` path.
+- Guard evaluation exceptions fail closed: no harness execution, deterministic denial payload with `reason_code="guard_unavailable"`, wording that the guardrail system could not verify safety, and HTTP 200. This preserves the no-untracked-execution safety requirement.
+- Existing `maybe_run_harness(...)` exceptions continue to return HTTP 503.
+- No database schema changes are required.
+
+## RED tests to write first
+
+Strict TDD should add failing tests before implementation, likely in `backend/tests/test_ai_chat_service.py` because existing `/api/ai/chat` router tests already live there.
+
+1. **Permission failure remains 403**
+   - Given an availability intent and a user without diagnostic permission.
+   - Assert response is HTTP 403.
+   - Assert `check_all_guards` and `maybe_run_harness` are not called.
+
+2. **Canonical CI identity is used before availability guard**
+   - Given a permitted availability user and `ci_ref` supplied as a display name/alias accepted by the resolver.
+   - Mock read-only CI resolution to return `{"id": "ci-123", "name": "Router A"}`.
+   - Assert `check_all_guards` receives target ID `ci:ci-123`, not `ci_ref:<normalized input>`.
+   - Assert no ping or harness executor runs before the guard decision.
+
+3. **Guard denial returns HTTP 200 and does not execute harness**
+   - Given a permitted availability user and `check_all_guards.allowed=False` with reason/cooldown.
+   - Assert response HTTP 200.
+   - Assert `harness_result.denied is True`, `status == "denied"`, reason fields exist.
+   - Assert `maybe_run_harness` is not called.
+   - Assert persisted fake DB row has the same `harness_result`.
+
+4. **Escalation-required guard result denies execution in first slice**
+   - Given `check_all_guards` returns `allowed=True` and `escalation_required=True`.
+   - Assert response HTTP 200 with `harness_result.denied is True`, `reason_code == "escalation_required"`, and `escalation_required is True`.
+   - Assert `maybe_run_harness` is not called.
+   - Assert best-effort logging uses an escalated/blocked non-success result and sets no cooldown.
+
+5. **Denied event-list uses event-query target without cooldown-producing success**
+   - Given permitted event-view user and explicit `event_list` intent.
+   - Assert `check_all_guards` called with operation `diagnose` and target like `event_query:active:any`.
+   - Assert no event harness execution when denied.
+
+6. **Repeat event-list behavior remains stable when allowed**
+   - Given two consecutive permitted `event_list` requests with the same query target.
+   - Mock guard allow for both.
+   - Assert both can execute and the first success does not create a diagnose cooldown that blocks the second.
+   - Assert no `record_operation(..., result="success")` call is made for event-list in this slice.
+
+7. **Allowed availability path preserves current behavior**
+   - Given permitted diagnostic user, canonical CI resolution, and `check_all_guards.allowed=True`.
+   - Mock `maybe_run_harness` to return an availability result.
+   - Assert response harness result equals the harness result and no denial fields are injected.
+   - Assert `record_operation(..., result="success", target_id="ci:<canonical id>")` is called.
+
+8. **Batch is fully guarded before execution**
+   - Given `availability_check_batch` with two resolvable CI refs.
+   - Mock canonical resolution to two CI IDs.
+   - Mock second per-target guard check denied.
+   - Assert HTTP 200 denial and `maybe_run_harness` not called.
+   - Assert target IDs include both canonical CI IDs and no partial ping work occurs.
+
+9. **Batch handles unresolved refs without unguarded diagnostics**
+   - Given `availability_check_batch` with one resolvable and one unresolved CI ref.
+   - Assert the resolved CI is guarded by canonical ID before any ping.
+   - Assert unresolved ref produces `ci_not_found` content and is not represented by an unresolved guard target.
+   - Assert no ping executes if any resolved target is denied.
+
+10. **Guard failure fails closed with accurate wording**
+    - Mock `check_all_guards` to raise.
+    - Assert HTTP 200 with `harness_result.reason_code == "guard_unavailable"`.
+    - Assert answer says the guardrail system could not verify safety.
+    - Assert answer does not claim a policy/cooldown explicitly blocked the request.
+    - Assert no harness execution and denial is persisted.
+
+11. **Non-harness chat stays untouched**
+    - Given ordinary chat with no inferred intent.
+    - Assert guard service is not called and existing LM Studio completion path remains active.
+
+## File-change plan
+
+Expected application changes for the next phase:
+
+| File | Purpose | Estimate |
+|---|---|---:|
+| `backend/routers/ai.py` | Add guard context build/evaluation before `maybe_run_harness`, canonical availability targets, recording hooks, denial branch | ~110-165 lines |
+| `backend/services/ai_chat_service.py` | Extract/reuse read-only CI resolution, add deterministic denial renderer / denial-aware `complete_chat` branch if not router-local | ~35-65 lines |
+| `backend/tests/test_ai_chat_service.py` | RED tests for canonical identity, denial, escalation, repeat event-list, batch, failure, compatibility | ~160-230 lines |
+
+Estimated changed lines: **305-460**. The canonical target and batch requirements may push the final diff over the 400-line review budget. Do not defer batch hardening while it remains in scope; if the implementation cannot stay reviewable, split only after a task-level PR boundary that still keeps batch guarded within the planned chain.
+
+PR slicing risk: **medium**. The slice remains localized, but canonical resolution plus batch and denial persistence tests increase review load. If chained PRs are needed, keep the first implementation PR internally coherent: guard context/denial renderer/availability single target first, then batch/event-list follow-up before closing the spec.
+
+## Out of scope
+
+- No Raven runtime adapter, Raven write path, Raven read bridge, or Raven-backed guard decisions.
+- No provider-native tool calling, OpenAI function-calling loop, model-selected tools, or model-executed tools.
+- No new harness families.
+- No permission model redesign.
+- No `ai_guard_service` schema migration or cooldown model redesign.
+- No human-approval workflow implementation for escalations in this slice.
+- No UI redesign.
+
+## Review checklist
+
+- [ ] Guard evaluation happens after permission approval and before `maybe_run_harness(...)`.
+- [ ] Availability guard target IDs are canonical `ci:<ci.id>` values resolved read-only before guard evaluation.
+- [ ] No ping, event lookup execution, operation recording, or diagnostic side effect occurs before guard approval.
+- [ ] Permission failures still return HTTP 403.
+- [ ] Guard denials and escalation-required results return HTTP 200 with persisted `harness_result.denied == true`.
+- [ ] `guard_unavailable` wording says safety could not be verified, not that policy/cooldown blocked it.
+- [ ] Denied paths do not execute ping, event lookup, or any harness executor.
+- [ ] Batch availability is fully guarded; no partial ping work occurs after any denied/escalated target.
+- [ ] Repeat event-list requests are not destabilized by diagnose cooldown from prior successful event-list calls.
+- [ ] Allowed harness result shape remains unchanged.
+- [ ] `record_operation(...)` is used for blocked/escalated/availability-success tracking; no direct cooldown writes from chat.
+- [ ] Raven and provider-native tool calling remain absent.

--- a/openspec/changes/issue-375-ai-chat-guardrails/explore.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/explore.md
@@ -1,0 +1,109 @@
+# Exploration: issue-375-ai-chat-guardrails
+
+## 1) Current orchestration model
+
+The flow is **backend-owned deterministic harness orchestration**. It is not provider-native or model-native tool calling.
+
+- `/api/ai/chat` handles intent selection and execution in backend code.
+- Supported backend harnesses are executed through `maybe_run_harness` in `backend/services/ai_chat_service.py`.
+- Deterministic harness types such as `event_list`, `availability_check`, and `availability_check_batch` can be rendered locally without calling LM Studio.
+- LM Studio is used for non-deterministic chat content after bounded context and harness output are assembled.
+
+## 2) Current flow
+
+```mermaid
+flowchart TD
+  U[Client POST /api/ai/chat] --> R[chat_with_ai]
+  R --> I{body.intent provided?}
+  I -->|no| F[infer_chat_intent / infer_followup_intent]
+  I -->|yes| S[Use provided intent]
+  F --> A{can run intent harness?}
+  S --> A
+  A -->|deny| E403[HTTP 403]
+  A -->|allow| H[maybe_run_harness]
+  H --> EH[event_list / active_events]
+  H --> AC[availability_check / availability_check_batch]
+  H --> NN[no harness]
+  EH --> L[list events with user scope]
+  AC --> PING[resolve CI and run bounded ping]
+  L --> HIST[load bounded chat history]
+  PING --> HIST
+  NN --> HIST
+  HIST --> CP[complete_chat]
+  CP -->|deterministic harness| D[render_harness_response]
+  CP -->|other content| M[LM Studio chat completion]
+  D --> SAVE[save_chat_exchange]
+  M --> SAVE
+  SAVE --> OUT[AIChatResponse with answer, model, message_id, harness_result]
+
+  subgraph Guarded operational AI paths
+    EV[events / node AI actions] --> GUARD[ai_guard_service check_all_guards + record_operation]
+  end
+```
+
+## 3) Raven usage / boundary
+
+Raven is currently a documented boundary/future integration point, not a runtime integration in the chat orchestration flow.
+
+- Current docs indicate backend-owned tool catalog and backend-owned execution.
+- Policy boundaries forbid the model from directly writing Raven or other operational stores.
+- If Raven becomes part of diagnostics/attention, it needs an explicit backend bridge/adapter contract rather than prompt-only policy.
+
+## 4) Tool execution and authorization flow
+
+1. Intent detection:
+   - Uses structured request intent when present.
+   - Otherwise uses backend inference (`infer_chat_intent`, follow-up inference from history/context).
+2. Authorization:
+   - Chat router checks permissions per intent family.
+   - Availability diagnostics require diagnostic permission or AI diagnostic permission with the expected view scope.
+   - Event-list harness requires event-view or AI view permissions.
+3. Execution:
+   - `maybe_run_harness` dispatches through fixed backend executors.
+   - Event listing applies user scope constraints.
+   - Availability resolves CI and executes bounded ping semantics.
+4. Response:
+   - Harness results are included in the model payload or rendered deterministically.
+   - Chat exchange persists answer and `harness_result`.
+5. Existing operational AI guards:
+   - Event/node operational AI paths use `ai_guard_service` for cooldowns, behavioral guards, bulk detection, operation recording, and denial logic.
+   - The chat harness path appears separate from this guardrail plane.
+
+## 5) Initial context / history / prompt handling
+
+- Chat history is loaded from persisted `AIChatMessage` rows with turn and character bounds.
+- User-provided context is injected into the prompt with size limits.
+- System prompt is assembled from identity/tool/policy markdown with fallback and capped reads.
+- Prompt instructions explicitly block claims of executed diagnostics when no backend harness result is present.
+- Follow-up availability can be inferred from previously persisted event-list harness metadata.
+
+## 6) Recoverable pieces
+
+- `HARNESS_EXECUTORS` and deterministic rendering are good seams for a shared execution contract.
+- Existing permission checks should remain and become the first gate before guardrails.
+- `ai_guard_service` already centralizes important safety behavior and should be reused rather than duplicated.
+- Tool catalog markdown under `backend/ai/tools/*` is useful as human/model-facing documentation.
+- Persisted `harness_result` gives a recovery point for auditability and follow-up context.
+
+## 7) Critical gaps / risks / planning constraints
+
+- The system does not currently have true model-native tool calling or an explicit function-call schema loop.
+- The chat harness path appears to use permissions but not the same `ai_guard_service` guardrails as operational AI endpoints.
+- Raven is not implemented as a runtime adapter, so any design must explicitly define whether Raven is read-only context, write target, or out of scope.
+- Regex/heuristic intent inference can misroute ambiguous follow-ups.
+- Availability diagnostics depend on host-level bounded `ping` behavior.
+- Existing cooldowns may be in-memory while operation logs are persistent, so guard design must account for restart/replay behavior.
+
+## 8) Evidence paths
+
+- `backend/routers/ai.py`
+- `backend/services/ai_chat_service.py`
+- `backend/services/ai_guard_service.py`
+- `backend/routers/events.py`
+- `backend/models/ai_chat.py`
+- `backend/ai/tools/README.md`
+- `backend/ai/tools/event-list.md`
+- `backend/ai/tools/availability_check.md`
+- `backend/ai/policies/response-boundaries.md`
+- `backend/tests/test_ai_chat_service.py`
+- `backend/tests/test_routers_events.py`

--- a/openspec/changes/issue-375-ai-chat-guardrails/proposal.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/proposal.md
@@ -1,0 +1,77 @@
+# Proposal: Issue #375 — Guardrails for `/api/ai/chat` harness execution
+
+## Problem statement
+The `/api/ai/chat` harness execution path currently uses existing permission checks but does not consistently apply the same control-plane safety contract used by operational AI endpoints (`ai_guard_service`). This creates a control-plane gap: harness actions can be executed without the same cooldown/behavioral guard semantics and denial recording that other AI operations already enforce.
+
+## Decision and intent
+Unify chat harness execution in this slice with explicit, permission-first guardrails while preserving the current client-facing behavior. Specifically:
+- keep existing `/api/ai/chat` behavior and UX stable,
+- reuse `ai_guard_service` guard patterns where they already exist,
+- require explicit denial outcomes to be surfaced and persisted when a harness action is blocked.
+
+## Scope (first slice)
+**In scope (this change):**
+1. Chat harness hardening around backend execution.
+2. Permission checks remain as the first gate (no changes to permission model today).
+3. Add `ai_guard_service`-based check-and-track for harness execution path.
+4. Persist and return clear denial reasons when execution is blocked.
+5. Ensure denial paths do not fabricate diagnostics and remain reviewable.
+
+**Out of scope (first slice, documented boundaries):**
+- Raven bridge runtime behavior.
+- Model-native/tool-native calling loop implementation.
+- New tool families or expansion of tool catalog.
+- Major UI/workflow redesign.
+
+## Affected areas
+- Backend API entry for chat: `backend/routers/ai.py` (where `/api/ai/chat` is handled).
+- Chat orchestration service: `backend/services/ai_chat_service.py` and harness execution flow.
+- Guardrails service: `backend/services/ai_guard_service.py` integration points.
+- Persistence/observability around `AIChatMessage.harness_result` and related denial records.
+- Backend test coverage for denied/allowed chat harness flows.
+
+## Proposed behavior
+- On chat requests that resolve to a harness execution path, preserve existing permission checks.
+- Before harness execution, run guardrail evaluation via existing `ai_guard_service` contract.
+- If guardrails deny:
+  - block harness run,
+  - emit a concrete, non-fabricated reason in response and persisted chat record,
+  - keep response shape stable and explicit about denial.
+- If allowed: continue current deterministic/LLM flow and preserve existing successful behavior.
+- Minimal compatibility-preserving changes only (no behavior shift to model-native execution).
+
+## Risks and tradeoffs
+| Risk | Impact | Tradeoff |
+|---|---|---|
+| Minimal hardening now | Leaves model-native tool calling unaddressed in this slice | Faster delivery and lower migration risk, but requires a later design for richer tool-call contract |
+| Different guard lifecycle semantics | Potential mismatch in timeout/replay/rollback states | Keep guard contract explicit and auditable; defer broader framework convergence |
+| Additional denial reasons in responses | Possible downstream assumptions on legacy harness outputs | Contract should define exact, stable denial payload fields |
+| Persisting denials | Small runtime/storage overhead | Gains traceability and operational supportability |
+
+## Rollback plan
+Revert proposal-scope changes in chat harness path only; keep this localized so existing permission logic and chat responses can be restored immediately by disabling the new guardrail gate and denial persistence in chat harness handler.
+
+## Success criteria
+- **No harness execution occurs when guardrails deny.**
+- **Existing permission checks remain intact** and continue to be the primary entitlement gate.
+- **Denial reason is observable** in chat response and persisted record.
+- **Tests cover denied and allowed harness paths** (including payload shape and persistence expectations).
+- **No fabricated diagnostics** are returned.
+- Target remains reviewable under **400 changed lines**, if possible.
+
+## Next phase
+Proceed to **spec**.
+
+## Proposal question round (interactive)
+To reduce ambiguity before specs, please confirm these assumptions:
+1. **Denial surface area:** Should a denied harness always return a 200 response with structured denial content, or should HTTP status change in specific denial categories?
+2. **Reason fidelity:** Are free-text reasons acceptable, or must denial reasons always map to a fixed enum/code set for analytics and client handling?
+3. **Persistence scope:** Should denials always be persisted as `harness_result` on the chat message, or only for denied harness executions with explicit intent?
+4. **Permission model boundary:** Should the scope of permissions considered unchanged for this slice, or can we formalize one narrow additive condition in parallel (e.g., diagnostic-role-only for availability checks)?
+
+### Assumptions for now
+- Keep permission model unchanged in this slice.
+- Keep response contract backward-compatible unless denied by guardrail, with minimal required new fields for explicit denial reason.
+- Keep user-facing behavior stable except for explicit, truthful denial explanation.
+
+Reply if any assumption should change, or request a second question round if needed.

--- a/openspec/changes/issue-375-ai-chat-guardrails/spec.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/spec.md
@@ -1,0 +1,98 @@
+# /api/ai/chat Harness Guardrail Specification
+
+## Purpose
+The chat API MUST enforce a clear, two-layer decision model for harness execution requests: keep entitlement checks as the first gate, then run chat-harness guardrails before execution, while preserving existing behavior for allowed/unauthorized flows.
+
+## Requirements
+
+### Requirement: Permission failures and guardrail denials use distinct HTTP semantics
+The system MUST return **HTTP 403** when `/api/ai/chat` request fails permission/entitlement checks.
+
+The system MUST return **HTTP 200** when a request passes permissions but is denied by `ai_guard_service` during harness guardrail evaluation.
+
+#### Scenario: Permission failure remains forbidden
+- GIVEN a chat request requires a restricted intent permission
+- WHEN the caller lacks the required permission
+- THEN the response MUST be HTTP 403
+- AND the response body MUST NOT be treated as a guardrail denial payload.
+
+#### Scenario: Guardrail denial is conversationally stable
+- GIVEN a caller has required permissions for a harness intent
+- AND `ai_guard_service` denies execution for that request
+- WHEN the request is processed
+- THEN the response MUST be HTTP 200
+- AND the response MUST preserve chat response shape while explicitly reporting denial status.
+
+### Requirement: Guardrail evaluation occurs before chat harness execution
+The system MUST evaluate guardrails for harness-backed intent requests **before** `maybe_run_harness` execution begins.
+
+#### Scenario: Guardrails are checked prior to harness execution
+- GIVEN a request resolves to a harness-capable intent
+- WHEN processing reaches execution phase
+- THEN the guardrail service MUST be consulted prior to any external command, ping, event lookup, or other harness side effects.
+- AND execution decisions MUST be based on that guard decision result.
+
+### Requirement: No harness execution when guardrails deny
+The system MUST NOT execute harness actions when guardrails deny an execution attempt.
+
+#### Scenario: Denied harness is not executed
+- GIVEN a guardrail decision of `deny`
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND no backend side effects from that harness intent SHALL occur.
+
+### Requirement: Denied harness result is explicit, structured, persisted, and returned
+The system MUST return and persist a structured `harness_result` containing at minimum:
+- `denied: true`
+- `status: "denied"`
+- human-readable reason text
+- where available, a reason code
+
+The system MUST NOT fabricate diagnostic content when producing denial output.
+
+#### Scenario: Denial payload is explicit and persisted
+- GIVEN a harness request is blocked by guardrails
+- WHEN the API response is built
+- THEN `harness_result.denied` MUST be `true`
+- AND `harness_result.status` MUST be `"denied"`
+- AND a reason MUST be present (`reason` and/or `reason_code`)
+- AND the persisted chat message record MUST include this `harness_result` object.
+
+### Requirement: Allowed path remains backward-compatible in this slice
+When guardrails allow execution, the system MUST preserve existing successful chat behavior, including harness invocation flow and response shape, except for the new denial metadata field definitions in denied cases only.
+
+#### Scenario: Allowed path behavior is unchanged
+- GIVEN a request with sufficient permission and guardrail allow
+- WHEN the harness executes
+- THEN current harness behavior, prompt assembly, and persisted chat record semantics MUST match existing behavior for this path.
+- AND no new denial fields are required in `harness_result`.
+
+### Requirement: No Raven runtime integration and no provider-native tool calling in this slice
+The system MUST NOT introduce Raven runtime integration in the `/api/ai/chat` harness execution path in this slice.
+
+The system MUST NOT introduce provider-native/tool-call execution loops for this slice.
+
+#### Scenario: Safety slice boundary is respected
+- GIVEN any chat harness request in this first slice
+- WHEN request handling is implemented
+- THEN only backend-owned harness execution and existing LLM completion path are used.
+- AND no additional Raven/runtime adapters are used for chat execution decisions.
+
+### Requirement: Test expectations for denied and allowed paths
+The system MUST be covered by tests that assert both denied and allowed harness outcomes, including status and persistence behavior.
+
+#### Scenario: Denied harness path test
+- GIVEN harness-eligible input with permission present
+- AND mocked guardrails return deny
+- WHEN API is invoked
+- THEN tests MUST assert HTTP 200, `harness_result.denied === true`, `harness_result.status === "denied"`, and that harness execution methods are not called.
+
+#### Scenario: Allowed harness path test
+- GIVEN harness-eligible input with permission present
+- AND mocked guardrails return allow
+- WHEN API is invoked
+- THEN tests MUST assert harness execution occurs and persisted chat output still includes harness result content consistent with existing success behavior.
+
+## Notes
+- Proposal had no explicit Capabilities section; this change is treated as a first-slice new AI-chat guardrail slice with acceptance constraints scoped to this issue.
+- This spec applies to `/api/ai/chat` backend harness execution only in this slice.

--- a/openspec/changes/issue-375-ai-chat-guardrails/specs/ai-chat-harness-guardrails/spec.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/specs/ai-chat-harness-guardrails/spec.md
@@ -1,0 +1,194 @@
+# AI Chat Harness Guardrails — Delta Specification
+
+## Purpose
+
+The chat API MUST enforce a clear, two-layer decision model for backend-owned harness execution: entitlement checks remain the first gate, then operational guardrails run before any harness side effect. Guardrail denials remain conversationally stable while preventing diagnostics, event lookups, and other harness work from executing.
+
+## ADDED Requirements
+
+### Requirement: Permission failures and guardrail denials use distinct HTTP semantics
+
+The system MUST return **HTTP 403** when a `/api/ai/chat` request fails permission or entitlement checks.
+
+The system MUST return **HTTP 200** when a request passes permissions but is denied by `ai_guard_service` during harness guardrail evaluation.
+
+#### Scenario: Permission failure remains forbidden
+
+- GIVEN a chat request requires a restricted intent permission
+- WHEN the caller lacks the required permission
+- THEN the response MUST be HTTP 403
+- AND the response body MUST NOT be treated as a guardrail denial payload.
+
+#### Scenario: Guardrail denial is conversationally stable
+
+- GIVEN a caller has required permissions for a harness intent
+- AND `ai_guard_service` denies execution for that request
+- WHEN the request is processed
+- THEN the response MUST be HTTP 200
+- AND the response MUST preserve chat response shape while explicitly reporting denial status.
+
+### Requirement: Guardrail evaluation occurs before chat harness execution
+
+The system MUST evaluate guardrails for harness-backed intent requests **before** `maybe_run_harness` execution begins.
+
+#### Scenario: Guardrails are checked prior to harness execution
+
+- GIVEN a request resolves to a harness-capable intent
+- WHEN processing reaches execution phase
+- THEN the guardrail service MUST be consulted prior to any external command, ping, event lookup, or other harness side effects
+- AND execution decisions MUST be based on that guard decision result.
+
+### Requirement: No harness execution when guardrails deny, escalate, or fail closed
+
+The system MUST NOT execute harness actions when guardrails deny an execution attempt, require escalation, or cannot verify safety.
+
+#### Scenario: Denied harness is not executed
+
+- GIVEN a guardrail decision of deny
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND no backend side effects from that harness intent SHALL occur.
+
+#### Scenario: Escalation-required harness is not executed
+
+- GIVEN a guardrail result with `escalation_required=true`
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND the response SHALL report a structured denied/escalation result.
+
+#### Scenario: Guard unavailable fails closed
+
+- GIVEN guard evaluation cannot safely complete
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND the response SHALL explain that safety could not be verified.
+
+### Requirement: Denied harness result is explicit, structured, persisted, and returned
+
+The system MUST return and persist a structured `harness_result` containing at minimum:
+
+- `denied: true`
+- `status: "denied"`
+- human-readable reason text
+- where available, a stable reason code
+
+The system MUST NOT fabricate diagnostic content when producing denial output.
+
+#### Scenario: Denial payload is explicit and persisted
+
+- GIVEN a harness request is blocked by guardrails
+- WHEN the API response is built
+- THEN `harness_result.denied` MUST be `true`
+- AND `harness_result.status` MUST be `"denied"`
+- AND a reason MUST be present through `reason` and/or `reason_code`
+- AND the persisted chat message record MUST include this `harness_result` object.
+
+### Requirement: Availability guard targets use canonical CI identity
+
+Availability-check guard targets MUST use canonical CI identity before any ping or diagnostic side effect. Missing, empty, or whitespace-only CI IDs MUST be treated as non-executable.
+
+#### Scenario: Single availability uses canonical CI target
+
+- GIVEN a user requests an availability check for a CI reference
+- WHEN the backend resolves that reference read-only before guard evaluation
+- THEN guard evaluation MUST use target ID `ci:<ci.id>`
+- AND no ping or harness side effect SHALL occur before guard evaluation.
+
+#### Scenario: Unresolved CI does not re-enter harness execution
+
+- GIVEN the read-only CI resolution returns no CI
+- WHEN the request is processed
+- THEN the response SHALL return a deterministic `ci_not_found`-style result
+- AND the system SHALL NOT call `maybe_run_harness`
+- AND the system SHALL NOT perform a second resolution that could ping unguarded.
+
+#### Scenario: Non-canonical CI ID is non-executable
+
+- GIVEN read-only CI resolution returns a CI with missing, empty, or whitespace-only `id`
+- WHEN the request is processed
+- THEN no `ci:` blank target SHALL be produced
+- AND no ping or harness execution SHALL occur.
+
+### Requirement: Batch availability is fully guarded before any ping
+
+Batch availability checks MUST resolve candidate CIs read-only, reject unguardable targets, evaluate guardrails for all executable canonical targets, and only then execute bounded pings.
+
+#### Scenario: Batch denial blocks the whole batch
+
+- GIVEN a batch availability request with multiple resolvable CIs
+- AND any target is denied, escalated, or fails closed during guard evaluation
+- WHEN the request is processed
+- THEN no ping SHALL execute for any target
+- AND no partial harness work SHALL occur.
+
+#### Scenario: Batch unresolved refs are not guard targets
+
+- GIVEN a batch availability request includes unresolved CI refs
+- WHEN the request is processed
+- THEN unresolved refs SHALL be represented as deterministic `ci_not_found` entries
+- AND unresolved refs SHALL NOT be passed to guardrails as synthetic target IDs.
+
+#### Scenario: Batch non-canonical CI IDs do not execute
+
+- GIVEN a batch availability request resolves a CI with missing, empty, or whitespace-only `id`
+- WHEN the request is processed
+- THEN no blank `ci:` target SHALL be produced
+- AND no ping or harness execution SHALL occur for that item.
+
+### Requirement: Event-list guardrails do not create cooldown-producing success records
+
+Event-list and active-event harnesses MUST use event-query guard targets for blocked-path safety, but allowed event-list success MUST NOT emit cooldown-producing diagnostic success records in this slice.
+
+#### Scenario: Event-list uses event-query target
+
+- GIVEN a user requests an event-list harness
+- WHEN guardrails are evaluated
+- THEN the guard target SHALL be `event_query:<status>:<severity-or-any>`.
+
+#### Scenario: Repeat event-list remains stable
+
+- GIVEN two allowed event-list requests use the same query target
+- WHEN both requests are processed
+- THEN the first allowed event-list request SHALL NOT create a diagnose success cooldown that blocks the second request.
+
+### Requirement: Allowed path remains backward-compatible in this slice
+
+When guardrails allow execution, the system MUST preserve existing successful chat behavior, including harness invocation flow and response shape, except for denial-only metadata in denied cases.
+
+#### Scenario: Allowed path behavior is unchanged
+
+- GIVEN a request with sufficient permission and guardrail allow
+- WHEN the harness executes
+- THEN current harness behavior, prompt assembly, and persisted chat record semantics MUST match existing behavior for this path
+- AND no new denial fields are required in successful `harness_result` values.
+
+### Requirement: No Raven runtime integration and no provider-native tool calling in this slice
+
+The system MUST NOT introduce Raven runtime integration in the `/api/ai/chat` harness execution path in this slice.
+
+The system MUST NOT introduce provider-native/tool-call execution loops for this slice.
+
+#### Scenario: Safety slice boundary is respected
+
+- GIVEN any chat harness request in this first slice
+- WHEN request handling is implemented
+- THEN only backend-owned harness execution and existing LLM completion path are used
+- AND no additional Raven/runtime adapters are used for chat execution decisions.
+
+### Requirement: Regression tests cover denied and allowed paths
+
+The system MUST be covered by tests that assert denied and allowed harness outcomes, including status, persistence, target identity, no-side-effect ordering, and allowed-path compatibility.
+
+#### Scenario: Denied harness path test
+
+- GIVEN harness-eligible input with permission present
+- AND mocked guardrails return deny
+- WHEN API is invoked
+- THEN tests MUST assert HTTP 200, `harness_result.denied === true`, `harness_result.status === "denied"`, and that harness execution methods are not called.
+
+#### Scenario: Allowed harness path test
+
+- GIVEN harness-eligible input with permission present
+- AND mocked guardrails return allow
+- WHEN API is invoked
+- THEN tests MUST assert harness execution occurs and persisted chat output still includes harness result content consistent with existing success behavior.

--- a/openspec/changes/issue-375-ai-chat-guardrails/sync-report.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/sync-report.md
@@ -1,0 +1,70 @@
+# Sync Report — issue-375-ai-chat-guardrails
+
+status: synced
+
+## Structured status and action context
+
+- artifactStore: `openspec`
+- change root: `openspec/changes/issue-375-ai-chat-guardrails`
+- action mode: repo-local workspace
+- action context: workspace root and edits are under `/Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/ai-chat-guardrails-orchestration`
+- verify-report status: PASS
+- verification evidence: `74 passed, 2 warnings`
+- py_compile evidence: PASS
+- strict TDD evidence: `TDD Cycle Evidence` present in `apply-progress.md`
+
+## Domain sync results
+
+- resolved domain specs in change artifact:
+  - `openspec/changes/issue-375-ai-chat-guardrails/specs/ai-chat-harness-guardrails/spec.md`
+
+### Domains synced
+
+- `ai-chat-harness-guardrails`
+
+### Canonical files updated
+
+- created: `openspec/specs/ai-chat-harness-guardrails/spec.md`
+- this was a first-write sync (canonical file did not exist)
+
+### Requirement delta reconciliation
+
+- **ADDED**: Permission failures and guardrail denials use distinct HTTP semantics
+- **ADDED**: Guardrail evaluation occurs before chat harness execution
+- **ADDED**: No harness execution when guardrails deny, escalate, or fail closed
+- **ADDED**: Denied harness result is explicit, structured, persisted, and returned
+- **ADDED**: Availability guard targets use canonical CI identity
+- **ADDED**: Batch availability is fully guarded before ping
+- **ADDED**: Batch unresolved references are handled deterministically and are not passed as guard targets
+- **ADDED**: Event-list guard targets use `event_query:*` and must not create cooldown-producing success records
+- **ADDED**: Allowed-path behavior remains backward-compatible in this slice
+- **ADDED**: No Raven runtime integration and no provider-native tool calling
+- **ADDED**: Regression tests cover denied and allowed harness paths
+- **MODIFIED**: none
+- **REMOVED**: none
+
+## Sync guardrails and blockers
+
+- active same-domain collisions: none detected
+- destructive deltas requiring explicit approval: none
+- renames present: none
+- legacy flat spec layout conflict: resolved by syncing from `specs/ai-chat-harness-guardrails/spec.md`
+- no blocking sync conditions remain
+
+## Validation/commands checked
+
+- `cat openspec/changes/issue-375-ai-chat-guardrails/verify-report.md`
+- `cp openspec/changes/issue-375-ai-chat-guardrails/specs/ai-chat-harness-guardrails/spec.md openspec/specs/ai-chat-harness-guardrails/spec.md`
+- `diff -u openspec/specs/ai-chat-harness-guardrails/spec.md openspec/changes/issue-375-ai-chat-guardrails/specs/ai-chat-harness-guardrails/spec.md`
+- verification evidence recorded in:
+  - `openspec/changes/issue-375-ai-chat-guardrails/verify-report.md`
+  - `openspec/changes/issue-375-ai-chat-guardrails/apply-progress.md`
+
+## Archive/sync readiness
+
+- native filesystem canonical sync is now representable and complete for this change.
+- if any follow-up deltas are introduced later (new `MODIFIED`/`REMOVED` blocks or additional requirement changes), they should be synced in a subsequent sync run; current state is clean.
+
+## Next recommended
+
+- `sdd-archive`

--- a/openspec/changes/issue-375-ai-chat-guardrails/tasks.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: issue-375-ai-chat-guardrails
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 420-560 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → PR 2 |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+
+## Acceptance checklist (Spec + Design mapping)
+
+- [x] Spec: Permission failures remain HTTP 403 in `/api/ai/chat`.
+- [x] Spec: Guardrail denials return HTTP 200 with stable `harness_result.denied=true`, `status="denied"`, and reason data.
+- [x] Spec: Guardrail decision is evaluated before `maybe_run_harness(...)` for harness-backed intents.
+- [x] Spec: No harness execution occurs when guardrail denies/escalates/fails closed.
+- [x] Spec: Guard-denied and escalation paths return persisted denial payload and do not fabricate diagnostics.
+- [x] Spec: Allowed harness path behavior remains unchanged, except for denial-only metadata when relevant.
+- [x] Design: Availability guard uses canonical target IDs `ci:<ci.id>` via read-only resolution.
+- [x] Design: `availability_check_batch` is fully guarded before any ping execution.
+- [x] Design: `event_list`/`active_events` guard target is event query (`event_query:<status>:<severity-or-any>`) and does not emit cooldown-producing success.
+- [x] Design: `record_operation(...)` is used; no `set_cooldown(...)` direct writes from chat path.
+- [x] Design: No Raven runtime integration and no provider-native tool-calling added.
+- [x] Canonical CI targets reject `id` values that are `None`, empty, or whitespace-only before guard and execution.
+
+## Work-unit boundaries and rollback notes
+
+- **PR 1 boundary**: Permission + guard decision + single-target deny/allow behavior.
+  - Start: Current harness flow in `backend/routers/ai.py` and `backend/services/ai_chat_service.py`.
+  - Finish: Guarded single intent path, structured denial payload, deterministic no-side-effect refusal.
+  - Verify: New RED tests (Unit 1) pass and no chat test harness side effects on deny/escalation.
+  - Rollback: revert `backend/routers/ai.py` and affected helper/test blocks.
+
+- **PR 2 boundary**: Batch + event-list constraints + operation logging semantics.
+  - Start: PR1 merged and test green.
+  - Finish: Batch guard logic + canonical IDs + batch deny/recording behavior complete.
+  - Verify: Batch and event-list GREEN tests pass and existing harness success semantics stay intact.
+  - Rollback: revert PR2-only changes in `backend/routers/ai.py` and `backend/services/ai_chat_service.py`.
+
+## Work Unit 1 — RED (tests first)
+
+### 1.1 Permission and routing baseline
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add a new test to assert when intent capability is denied, response status is `403`, and guard/service mocks (`check_all_guards`, `maybe_run_harness`) are not called.
+
+### 1.2 No-guard for non-harness chat
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test for non-harness chat (`intent is None`) that asserts `check_all_guards(...)` and deterministic harness guard helpers are not called, while normal LM response path is used.
+
+### 1.3 Canonical CI target before guard
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add a failing test that sends availability intent with alias/display `ci_ref` and asserts:
+  - guard check receives `ci:<resolved_ci.id>` (no `ci_ref:` prefix),
+  - no ping/external availability executor is called before guard decision.
+
+### 1.4 Guarded deny path (single availability)
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test with `check_all_guards(allowed=False, reason_code, cooldown)` + permission present:
+  - HTTP `200`,
+  - `harness_result.denied is True`, `status == "denied"`, has `reason`/`reason_code`,
+  - persisted chat row stores same `harness_result`,
+  - `maybe_run_harness(...)` not called.
+
+### 1.5 Escalation-required first-slice behavior
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test with `escalation_required=True` and mock decision details:
+  - HTTP `200`,
+  - `harness_result.status == "denied"`, `denied=True`, `reason_code == "escalation_required"`, `escalation_required=True`,
+  - no harness execution.
+
+### 1.6 Fail-closed guard unavailable
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test where guard evaluation raises:
+  - response is `200`,
+  - `harness_result.reason_code == "guard_unavailable"`,
+  - answer text says safety could not be verified,
+  - does not claim policy/cooldown blocked the request,
+  - no harness execution.
+
+### 1.7 Event-list deny and no cooldown success
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test for `event_list` denied by guard:
+  - guard target = `event_query:<status>:<severity-or-any>`,
+  - `status == "denied"`, no harness side effects,
+  - no `record_operation(..., result="success")` for event list success in this slice.
+
+### 1.8 Event-list repeatability
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test with two back-to-back allowed `event_list` calls:
+  - both requests execute,
+  - second request is not blocked by prior diagnose success cooldown because no success record is written for allowed event-list.
+
+### 1.9 Allowed availability success contract
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test asserting guard allow for availability keeps existing successful payload:
+  - returned `harness_result` matches existing success shape,
+  - no denial fields injected,
+  - `record_operation(..., result="success", target_id="ci:<canonical-id>")` called.
+
+### 1.10 Batch fully guarded before execution
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test for `availability_check_batch` with two resolvable refs where one guard check denies:
+  - HTTP `200` denied payload,
+  - `maybe_run_harness(...)` never called,
+  - resolved target ids are canonicalized and both considered in guard path,
+  - no partial ping.
+
+### 1.11 Batch unresolved ref handling
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add test with mixed resolved/unresolved CI refs:
+  - unresolved refs return deterministic `ci_not_found` entries,
+  - unresolved refs are not passed as guard targets,
+  - if any resolved target is denied, no ping occurs for any resolved target.
+
+## Work Unit 2 — GREEN (implementation)
+
+### 2.1 Add pre-harness guard gate in route
+- **Target file:** `backend/routers/ai.py`
+- Replace the current direct call flow for harnessed intents with:
+  - permission gate first,
+  - build guard context,
+  - guard evaluation before `maybe_run_harness(...)`,
+  - denial branch that returns deterministic harness result and persists via existing exchange-saving path.
+
+### 2.2 Canonicalize availability CI before guard
+- **Target files:** `backend/routers/ai.py`, `backend/services/ai_chat_service.py`
+- Ensure availability and batch availability resolve CI via read-only lookup first, then pass `ci:<ci.id>` to guard and recording.
+
+### 2.3 Implement guarded decision handler (deny/escalate/fail-closed)
+- **Target files:** `backend/routers/ai.py`, `backend/services/ai_chat_service.py`
+- Add deterministic builder for denial payload including required fields: `denied`, `status`, `reason`, `reason_code`, and optional `cooldown_remaining_seconds`, `escalation_required`, `escalation_id`, `source="ai_guard_service"`.
+
+### 2.4 Implement event-list/all event-like intents guard mapping
+- **Target file:** `backend/routers/ai.py`
+- Add target normalization for status/severity (`any` default), `event_query:*` target_id mapping, and one-to-one denied path with no pre-harness event lookups.
+
+### 2.5 Implement full-batch guard precondition
+- **Target file:** `backend/routers/ai.py`
+- Add guard sequence for `availability_check_batch` that resolves all refs read-only, evaluates all relevant canonical targets before any ping, and fails the whole batch on any denied/escalated target.
+
+### 2.6 Integrate `record_operation(...)` calls for slice behavior
+- **Target file:** `backend/routers/ai.py`
+- Add/adjust operation logging calls:
+  - `result="blocked"` on denied,
+  - `result="escalated"` where provided,
+  - `result="success"` for allowed availability and per-target availability-batch success,
+  - no cooldown-producing `success` writes for event-list/active-events in this slice.
+
+### 2.7 Keep non-harness behavior unchanged
+- **Target file:** `backend/routers/ai.py`
+- Add regression guard to preserve existing LM Studio completion flow and payload shape when `intent` is absent or not a harness intent.
+
+## Work Unit 3 — TRIANGULATE / REFACTOR
+
+### 3.1 Triangulation and ordering checks
+- **Target file:** `backend/tests/test_ai_chat_service.py`
+- Add/adjust tests to verify the order boundary: `check_all_guards(...)` occurs before any harness executor / ping function call for denied and fail-closed paths.
+
+### 3.2 Refactor for reviewability
+- **Target files:** `backend/routers/ai.py`, `backend/services/ai_chat_service.py`
+- Extract guard context/type helpers and assertion-friendly small functions if Unit 2 grows beyond single-screen blocks.
+- Keep interfaces narrow and test each helper independently with failing/allowed/denied states.
+
+## Scope-control notes
+
+- Keep PR scope confined to `backend/routers/ai.py`, `backend/services/ai_chat_service.py`, and `backend/tests/test_ai_chat_service.py`.
+- No schema changes.
+- No Raven runtime integration and no model/provider-native tool-calling path introduction.
+- No changes to frontend/response UI contracts outside `AIChatResponse`/`harness_result` fields required by this slice.
+- If scope starts creeping into other files, pause and split into an additional PR with explicit exception notes and updated forecast.

--- a/openspec/changes/issue-375-ai-chat-guardrails/verify-report.md
+++ b/openspec/changes/issue-375-ai-chat-guardrails/verify-report.md
@@ -1,0 +1,101 @@
+# Verify Report: issue-375-ai-chat-guardrails
+
+## Status
+
+PASS
+
+Verified change `issue-375-ai-chat-guardrails` against the explicit SDD artifacts and acceptance criteria supplied for Issue #375. No CRITICAL findings were found.
+
+## Structured status and actionContext findings
+
+- Artifact store: `openspec`
+- Change root: `openspec/changes/issue-375-ai-chat-guardrails`
+- Explicit required artifacts read:
+  - `openspec/changes/issue-375-ai-chat-guardrails/spec.md`
+  - `openspec/changes/issue-375-ai-chat-guardrails/design.md`
+  - `openspec/changes/issue-375-ai-chat-guardrails/tasks.md`
+  - `openspec/changes/issue-375-ai-chat-guardrails/apply-progress.md`
+- Native status command run: `gentle-ai sdd-status issue-375-ai-chat-guardrails --cwd . --json --instructions`
+  - Native status reported `artifactStore: openspec`, `mode: repo-local`, and `allowedEditRoots` containing the workspace root.
+  - Native status reported `nextRecommended: spec` and blocker `specs/**/spec.md is missing or partial` because it expects a nested `specs/**/spec.md` layout. The verify phase proceeded using the explicit required `spec.md` artifact provided in this change root.
+- Action context: repo-local workspace root is `/Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/ai-chat-guardrails-orchestration`; implementation files are inside the authoritative workspace.
+
+## Spec coverage
+
+All required spec/design areas were covered by code inspection and tests:
+
+1. Permission-first HTTP semantics.
+2. Guard denial HTTP 200 conversational response semantics.
+3. Guard-before-harness ordering.
+4. No harness execution for deny/escalate/fail-closed.
+5. Denial persistence and deterministic non-diagnostic rendering.
+6. Allowed-path compatibility.
+7. Canonical CI target IDs with rejection of missing/blank/whitespace IDs.
+8. Fully guarded batch availability before ping.
+9. Event-list `event_query` guard target without cooldown-producing success recording.
+10. No Raven runtime or provider-native tool calling in the changed backend path.
+
+## Task completion status
+
+- `tasks.md` implementation checklist: all listed checklist items are checked.
+- Exact unchecked implementation task lines in `tasks.md`: none.
+- `apply-progress.md` contains one unchecked potential follow-up line for broader suite execution; it is not an unchecked implementation task in `tasks.md` and is not an archive blocker for this targeted verification.
+
+## Acceptance result
+
+| # | Acceptance criterion | Result |
+|---|---|---|
+| 1 | Permission failures remain HTTP 403. | PASS |
+| 2 | Guardrail denials return HTTP 200 with stable structured denied `harness_result`. | PASS |
+| 3 | Guard evaluation occurs before harness execution. | PASS |
+| 4 | No harness execution when guard denies/escalates/fail-closed. | PASS |
+| 5 | Denied/escalated/fail-closed paths persist denial and do not fabricate diagnostics. | PASS |
+| 6 | Allowed path remains backward-compatible. | PASS |
+| 7 | Availability guard target IDs are canonical and reject missing/blank/whitespace IDs. | PASS |
+| 8 | Batch availability fully guarded before ping; no partial ping on denial/escalation/fail-closed/noncanonical target. | PASS |
+| 9 | Event-list uses event_query target and does not create cooldown-producing success. | PASS |
+| 10 | No Raven runtime integration or provider-native tool-calling introduced. | PASS |
+
+## Validation commands
+
+- `/tmp/next-gen-issue375-py311/bin/python -m py_compile backend/routers/ai.py backend/services/ai_chat_service.py backend/tests/test_ai_chat_service.py`
+  - Result: PASS
+- `/tmp/next-gen-issue375-py311/bin/python -m pytest backend/tests/test_ai_chat_service.py`
+  - Result: PASS — `74 passed, 2 warnings in 2.06s`
+
+## Strict TDD compliance
+
+- Strict TDD mode: active via `openspec/config.yaml` and parent prompt.
+- `apply-progress.md` includes a `TDD Cycle Evidence` table.
+- Reported test file exists and was executed: `backend/tests/test_ai_chat_service.py`.
+- Relevant tests are GREEN: `74 passed`.
+- Assertion quality audit: PASS. Changed tests assert observable behavior, ordering, persistence, target IDs, no-call safety invariants, and response fields. No tautological, type-only, ghost-loop, smoke-only, or CSS implementation-detail assertions were found in the changed test area.
+
+## Review workload / PR boundary findings
+
+- `tasks.md` forecast: chained PRs recommended, high 400-line budget risk, chain strategy pending.
+- `apply-progress.md` records a maintainer-requested single-slice exception.
+- Actual diff scope from `git diff --stat`: `backend/routers/ai.py`, `backend/services/ai_chat_service.py`, and `backend/tests/test_ai_chat_service.py` only, matching the planned scope.
+- Actual changed lines: 933 insertions, 6 deletions across those three implementation/test files. This exceeds the 400-line budget but is covered by the recorded single-slice exception and prior 4R/focused risk reviews supplied in context.
+
+## Findings
+
+### CRITICAL
+
+None.
+
+### WARNING
+
+None.
+
+### SUGGESTION
+
+- Consider reconciling OpenSpec layout expectations: native status expects `specs/**/spec.md`, while this change stores the explicit verify input at `openspec/changes/issue-375-ai-chat-guardrails/spec.md`.
+
+## Blockers
+
+None.
+
+## Next recommended
+
+sync

--- a/openspec/specs/ai-chat-harness-guardrails/spec.md
+++ b/openspec/specs/ai-chat-harness-guardrails/spec.md
@@ -1,0 +1,194 @@
+# AI Chat Harness Guardrails — Delta Specification
+
+## Purpose
+
+The chat API MUST enforce a clear, two-layer decision model for backend-owned harness execution: entitlement checks remain the first gate, then operational guardrails run before any harness side effect. Guardrail denials remain conversationally stable while preventing diagnostics, event lookups, and other harness work from executing.
+
+## ADDED Requirements
+
+### Requirement: Permission failures and guardrail denials use distinct HTTP semantics
+
+The system MUST return **HTTP 403** when a `/api/ai/chat` request fails permission or entitlement checks.
+
+The system MUST return **HTTP 200** when a request passes permissions but is denied by `ai_guard_service` during harness guardrail evaluation.
+
+#### Scenario: Permission failure remains forbidden
+
+- GIVEN a chat request requires a restricted intent permission
+- WHEN the caller lacks the required permission
+- THEN the response MUST be HTTP 403
+- AND the response body MUST NOT be treated as a guardrail denial payload.
+
+#### Scenario: Guardrail denial is conversationally stable
+
+- GIVEN a caller has required permissions for a harness intent
+- AND `ai_guard_service` denies execution for that request
+- WHEN the request is processed
+- THEN the response MUST be HTTP 200
+- AND the response MUST preserve chat response shape while explicitly reporting denial status.
+
+### Requirement: Guardrail evaluation occurs before chat harness execution
+
+The system MUST evaluate guardrails for harness-backed intent requests **before** `maybe_run_harness` execution begins.
+
+#### Scenario: Guardrails are checked prior to harness execution
+
+- GIVEN a request resolves to a harness-capable intent
+- WHEN processing reaches execution phase
+- THEN the guardrail service MUST be consulted prior to any external command, ping, event lookup, or other harness side effects
+- AND execution decisions MUST be based on that guard decision result.
+
+### Requirement: No harness execution when guardrails deny, escalate, or fail closed
+
+The system MUST NOT execute harness actions when guardrails deny an execution attempt, require escalation, or cannot verify safety.
+
+#### Scenario: Denied harness is not executed
+
+- GIVEN a guardrail decision of deny
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND no backend side effects from that harness intent SHALL occur.
+
+#### Scenario: Escalation-required harness is not executed
+
+- GIVEN a guardrail result with `escalation_required=true`
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND the response SHALL report a structured denied/escalation result.
+
+#### Scenario: Guard unavailable fails closed
+
+- GIVEN guard evaluation cannot safely complete
+- WHEN a harness intent is requested
+- THEN no harness executor SHALL run
+- AND the response SHALL explain that safety could not be verified.
+
+### Requirement: Denied harness result is explicit, structured, persisted, and returned
+
+The system MUST return and persist a structured `harness_result` containing at minimum:
+
+- `denied: true`
+- `status: "denied"`
+- human-readable reason text
+- where available, a stable reason code
+
+The system MUST NOT fabricate diagnostic content when producing denial output.
+
+#### Scenario: Denial payload is explicit and persisted
+
+- GIVEN a harness request is blocked by guardrails
+- WHEN the API response is built
+- THEN `harness_result.denied` MUST be `true`
+- AND `harness_result.status` MUST be `"denied"`
+- AND a reason MUST be present through `reason` and/or `reason_code`
+- AND the persisted chat message record MUST include this `harness_result` object.
+
+### Requirement: Availability guard targets use canonical CI identity
+
+Availability-check guard targets MUST use canonical CI identity before any ping or diagnostic side effect. Missing, empty, or whitespace-only CI IDs MUST be treated as non-executable.
+
+#### Scenario: Single availability uses canonical CI target
+
+- GIVEN a user requests an availability check for a CI reference
+- WHEN the backend resolves that reference read-only before guard evaluation
+- THEN guard evaluation MUST use target ID `ci:<ci.id>`
+- AND no ping or harness side effect SHALL occur before guard evaluation.
+
+#### Scenario: Unresolved CI does not re-enter harness execution
+
+- GIVEN the read-only CI resolution returns no CI
+- WHEN the request is processed
+- THEN the response SHALL return a deterministic `ci_not_found`-style result
+- AND the system SHALL NOT call `maybe_run_harness`
+- AND the system SHALL NOT perform a second resolution that could ping unguarded.
+
+#### Scenario: Non-canonical CI ID is non-executable
+
+- GIVEN read-only CI resolution returns a CI with missing, empty, or whitespace-only `id`
+- WHEN the request is processed
+- THEN no `ci:` blank target SHALL be produced
+- AND no ping or harness execution SHALL occur.
+
+### Requirement: Batch availability is fully guarded before any ping
+
+Batch availability checks MUST resolve candidate CIs read-only, reject unguardable targets, evaluate guardrails for all executable canonical targets, and only then execute bounded pings.
+
+#### Scenario: Batch denial blocks the whole batch
+
+- GIVEN a batch availability request with multiple resolvable CIs
+- AND any target is denied, escalated, or fails closed during guard evaluation
+- WHEN the request is processed
+- THEN no ping SHALL execute for any target
+- AND no partial harness work SHALL occur.
+
+#### Scenario: Batch unresolved refs are not guard targets
+
+- GIVEN a batch availability request includes unresolved CI refs
+- WHEN the request is processed
+- THEN unresolved refs SHALL be represented as deterministic `ci_not_found` entries
+- AND unresolved refs SHALL NOT be passed to guardrails as synthetic target IDs.
+
+#### Scenario: Batch non-canonical CI IDs do not execute
+
+- GIVEN a batch availability request resolves a CI with missing, empty, or whitespace-only `id`
+- WHEN the request is processed
+- THEN no blank `ci:` target SHALL be produced
+- AND no ping or harness execution SHALL occur for that item.
+
+### Requirement: Event-list guardrails do not create cooldown-producing success records
+
+Event-list and active-event harnesses MUST use event-query guard targets for blocked-path safety, but allowed event-list success MUST NOT emit cooldown-producing diagnostic success records in this slice.
+
+#### Scenario: Event-list uses event-query target
+
+- GIVEN a user requests an event-list harness
+- WHEN guardrails are evaluated
+- THEN the guard target SHALL be `event_query:<status>:<severity-or-any>`.
+
+#### Scenario: Repeat event-list remains stable
+
+- GIVEN two allowed event-list requests use the same query target
+- WHEN both requests are processed
+- THEN the first allowed event-list request SHALL NOT create a diagnose success cooldown that blocks the second request.
+
+### Requirement: Allowed path remains backward-compatible in this slice
+
+When guardrails allow execution, the system MUST preserve existing successful chat behavior, including harness invocation flow and response shape, except for denial-only metadata in denied cases.
+
+#### Scenario: Allowed path behavior is unchanged
+
+- GIVEN a request with sufficient permission and guardrail allow
+- WHEN the harness executes
+- THEN current harness behavior, prompt assembly, and persisted chat record semantics MUST match existing behavior for this path
+- AND no new denial fields are required in successful `harness_result` values.
+
+### Requirement: No Raven runtime integration and no provider-native tool calling in this slice
+
+The system MUST NOT introduce Raven runtime integration in the `/api/ai/chat` harness execution path in this slice.
+
+The system MUST NOT introduce provider-native/tool-call execution loops for this slice.
+
+#### Scenario: Safety slice boundary is respected
+
+- GIVEN any chat harness request in this first slice
+- WHEN request handling is implemented
+- THEN only backend-owned harness execution and existing LLM completion path are used
+- AND no additional Raven/runtime adapters are used for chat execution decisions.
+
+### Requirement: Regression tests cover denied and allowed paths
+
+The system MUST be covered by tests that assert denied and allowed harness outcomes, including status, persistence, target identity, no-side-effect ordering, and allowed-path compatibility.
+
+#### Scenario: Denied harness path test
+
+- GIVEN harness-eligible input with permission present
+- AND mocked guardrails return deny
+- WHEN API is invoked
+- THEN tests MUST assert HTTP 200, `harness_result.denied === true`, `harness_result.status === "denied"`, and that harness execution methods are not called.
+
+#### Scenario: Allowed harness path test
+
+- GIVEN harness-eligible input with permission present
+- AND mocked guardrails return allow
+- WHEN API is invoked
+- THEN tests MUST assert harness execution occurs and persisted chat output still includes harness result content consistent with existing success behavior.


### PR DESCRIPTION
## Descripción del Cambio

Closes #375

Este PR endurece la ejecución de harnesses desde `/api/ai/chat` para que el backend aplique guardrails operacionales antes de ejecutar diagnósticos o listados operativos.

### Resumen

- Agrega un gate de `ai_guard_service` antes de `maybe_run_harness(...)` para intents operacionales.
- Mantiene permisos como primer gate: permiso insuficiente sigue devolviendo HTTP 403.
- Devuelve HTTP 200 conversacional con `harness_result.denied=true` cuando guardrails deniegan, requieren escalación o no pueden verificar seguridad.
- Canonicaliza availability targets como `ci:<ci.id>` y bloquea IDs faltantes, vacíos o whitespace-only sin ping ni re-resolve.
- Guarda `event_list` con target `event_query:*` sin emitir success cooldown para no romper repeatability.
- Agrega artefactos SDD/OpenSpec, verify, sync y archive para auditar el cambio.

## Tipo de Cambio

- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios principales

| Archivo | Cambio |
|---|---|
| `backend/routers/ai.py` | Integra guardrails antes de harness execution, canonicaliza targets, bloquea deny/escalation/fail-closed y registra operaciones según corresponda. |
| `backend/services/ai_chat_service.py` | Agrega render determinístico para denials y soporte para CI ya resuelto sin duplicar resolución. |
| `backend/tests/test_ai_chat_service.py` | Cubre permisos, deny/escalation/fail-closed, canonicalización, batch, event-list repeatability y no-side-effects. |
| `openspec/changes/issue-375-ai-chat-guardrails/*` | Artefactos SDD completos: explore, proposal, spec, design, tasks, apply, verify, sync, archive. |
| `openspec/specs/ai-chat-harness-guardrails/spec.md` | Spec canónica sincronizada para guardrails de AI chat harness. |

## ¿Cómo se probó?

- [x] `/tmp/next-gen-issue375-py311/bin/python -m pytest backend/tests/test_ai_chat_service.py` → `74 passed, 2 warnings`
- [x] `/tmp/next-gen-issue375-py311/bin/python -m py_compile backend/routers/ai.py backend/services/ai_chat_service.py backend/tests/test_ai_chat_service.py`
- [x] SDD verify: PASS
- [x] SDD sync: synced
- [x] SDD archive: PASS
- [x] 4R review aplicado por tamaño/riesgo; findings críticos corregidos y re-review de riesgo sin findings.

## Excepción de tamaño

Este PR supera el presupuesto de 400 líneas. La excepción fue aprobada explícitamente durante la planificación SDD porque el cambio necesitaba mantener juntos código, tests y artefactos de seguridad para revisar el guardrail end-to-end.

## Checklist de Seguridad

- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor checklist

- [x] Issue aprobado y enlazado: Closes #375
- [x] Exactly one `type:*` label planned: `type:bug`
- [x] Conventional commit: `fix(ai): guard chat harness execution`
- [x] No `Co-Authored-By` trailers
- [x] Size exception documented

---
*Generado por Alex*
