### PR TITLE
feat(mqtt): add mapping permissions

### DIFF
--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -45,6 +45,10 @@ class UserPermission(str, Enum):
     # Visualization
     METRICS_VIEW = "METRICS_VIEW"
 
+    # MQTT integration
+    MQTT_READ = "MQTT_READ"
+    MQTT_MAPPING_MANAGE = "MQTT_MAPPING_MANAGE"
+
 
 class Role(BaseModel):
     name: str
@@ -126,3 +130,5 @@ class PasswordChangeRequest(BaseModel):
 
 class UserResetRequest(BaseModel):
     new_password: str
+
+

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,16 +1,17 @@
-from pydantic import BaseModel, Field
-from typing import List, Literal, Optional
 from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel
 
 
-class UserRole(str, Enum):
+class UserRole(str, Enum):  # noqa: UP042
     ADMIN = "ADMIN"
     OPERATOR = "OPERATOR"
     VIEWER = "VIEWER"
     CUSTOM = "CUSTOM"
 
 
-class AIPermission(str, Enum):
+class AIPermission(str, Enum):  # noqa: UP042
     """Permissions exclusive to AI agents."""
 
     AI_RUN_DIAGNOSTIC = "AI_RUN_DIAGNOSTIC"
@@ -22,7 +23,7 @@ class AIPermission(str, Enum):
     AI_DICTIONARY_PREVIEW = "AI_DICTIONARY_PREVIEW"
 
 
-class UserPermission(str, Enum):
+class UserPermission(str, Enum):  # noqa: UP042
     # Event Management
     EVENT_VIEW = "EVENT_VIEW"
     EVENT_ACK = "EVENT_ACK"
@@ -52,30 +53,30 @@ class UserPermission(str, Enum):
 
 class Role(BaseModel):
     name: str
-    description: Optional[str] = None
-    permissions: List[str] = []  # Store as strings; UserPermission or AIPermission string values
+    description: str | None = None
+    permissions: list[str] = []  # Store as strings; UserPermission or AIPermission string values
     is_system: bool = False  # If True, cannot be deleted (e.g. ADMIN)
 
 
 class RoleCreate(BaseModel):
     name: str
-    description: Optional[str] = None
-    permissions: List[str] = []  # Store as strings
+    description: str | None = None
+    permissions: list[str] = []  # Store as strings
 
 
 class RoleUpdate(BaseModel):
-    description: Optional[str] = None
-    permissions: Optional[List[str]] = None
+    description: str | None = None
+    permissions: list[str] | None = None
 
 
 class UserBase(BaseModel):
     username: str
     role: str = UserRole.VIEWER.value
-    permissions: List[str] = []  # Store as strings; validated at service layer
-    allowed_locations: List[str] = []  # List of Location Names
-    allowed_ci_types: Optional[List[str]] = None
-    phone: Optional[str] = None
-    email: Optional[str] = None
+    permissions: list[str] = []  # Store as strings; validated at service layer
+    allowed_locations: list[str] = []  # List of Location Names
+    allowed_ci_types: list[str] | None = None
+    phone: str | None = None
+    email: str | None = None
     tier: Literal["T1", "T2", "T3"] = "T1"
 
 
@@ -84,17 +85,17 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
-    password: Optional[str] = None
-    role: Optional[str] = None
-    tier: Optional[Literal["T1", "T2", "T3"]] = None
-    permissions: Optional[List[str]] = None
-    allowed_locations: Optional[List[str]] = None
-    allowed_ci_types: Optional[List[str]] = None
+    password: str | None = None
+    role: str | None = None
+    tier: Literal["T1", "T2", "T3"] | None = None
+    permissions: list[str] | None = None
+    allowed_locations: list[str] | None = None
+    allowed_ci_types: list[str] | None = None
 
 
 class User(UserBase):
-    disabled: Optional[bool] = False
-    force_password_change: Optional[bool] = False
+    disabled: bool | None = False
+    force_password_change: bool | None = False
 
 
 class CurrentUserSessionPolicy(BaseModel):
@@ -120,7 +121,7 @@ class Token(BaseModel):
 
 
 class TokenData(BaseModel):
-    username: Optional[str] = None
+    username: str | None = None
 
 
 class PasswordChangeRequest(BaseModel):

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -131,5 +131,3 @@ class PasswordChangeRequest(BaseModel):
 
 class UserResetRequest(BaseModel):
     new_password: str
-
-

--- a/backend/seed_roles.py
+++ b/backend/seed_roles.py
@@ -1,8 +1,7 @@
 import asyncio
 
-from database import get_db, close_db
-from models.user import UserPermission, AIPermission
-
+from database import close_db, get_db
+from models.user import AIPermission, UserPermission
 
 SYSTEM_ROLE_PERMISSION_UPGRADES = {
     "ADMIN": [

--- a/backend/seed_roles.py
+++ b/backend/seed_roles.py
@@ -1,6 +1,19 @@
 import asyncio
+
 from database import get_db, close_db
 from models.user import UserPermission, AIPermission
+
+
+SYSTEM_ROLE_PERMISSION_UPGRADES = {
+    "ADMIN": [
+        UserPermission.MQTT_READ.value,
+        UserPermission.MQTT_MAPPING_MANAGE.value,
+    ],
+    "OPERATOR": [
+        UserPermission.MQTT_READ.value,
+        UserPermission.MQTT_MAPPING_MANAGE.value,
+    ],
+}
 
 
 async def seed_roles():
@@ -25,6 +38,8 @@ async def seed_roles():
                 UserPermission.CI_EDIT.value,
                 UserPermission.RUN_DIAGNOSTICS.value,
                 UserPermission.METRICS_VIEW.value,
+                UserPermission.MQTT_READ.value,
+                UserPermission.MQTT_MAPPING_MANAGE.value,
             ],
             "is_system": True,
         },
@@ -78,25 +93,48 @@ async def seed_roles():
                         permissions: $perms,
                         is_system: $sys
                     })
-                """,
+                    """,
                     name=name,
                     desc=data["description"],
                     perms=data["permissions"],
                     sys=data["is_system"],
                 )
             else:
-                # System roles are protected from overwrite once created
-                # If is_system is None (key absent or null), treat as non-system and allow update
-                existing_is_system = existing.get("r", {}).get("is_system")
+                # System roles are protected from destructive overwrite once created.
+                # They may still receive additive permission upgrades required by the
+                # current seed definition so existing deployments pick up new grants.
+                # If is_system is None (key absent or null), treat as non-system and allow update.
+                existing_role = existing.get("r", {})
+                existing_is_system = existing_role.get("is_system")
                 if existing_is_system is True:
-                    print(f"Skipping system role {name} — already exists, not overwriting")
+                    current_permissions = list(existing_role.get("permissions") or [])
+                    permitted_upgrades = SYSTEM_ROLE_PERMISSION_UPGRADES.get(name, [])
+                    missing_permissions = [
+                        permission
+                        for permission in permitted_upgrades
+                        if permission in data["permissions"]
+                        and permission not in current_permissions
+                    ]
+
+                    if missing_permissions:
+                        print(f"Upgrading system role {name} with explicit permissions")
+                        session.run(
+                            """
+                            MATCH (r:Role {name: $name})
+                            SET r.permissions = $perms
+                            """,
+                            name=name,
+                            perms=current_permissions + missing_permissions,
+                        )
+                    else:
+                        print(f"Skipping system role {name} — already up to date")
                 else:
                     print(f"Updating non-system role: {name}")
                     session.run(
                         """
                         MATCH (r:Role {name: $name})
                         SET r.permissions = $perms, r.is_system = false
-                    """,
+                        """,
                         name=name,
                         perms=data["permissions"],
                     )

--- a/backend/services/mqtt_mapping_service.py
+++ b/backend/services/mqtt_mapping_service.py
@@ -1,0 +1,90 @@
+"""Centralized MQTT authorization helpers for mapping and read operations.
+
+This module owns all permission checks introduced by the MQTT authorization slice
+(PR2). Route-level code should call :func:`require_mqtt_permission` instead of
+repeating permission logic.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from models.user import User, UserPermission, UserRole
+
+# Public permission kind strings. Kept as plain strings to keep dependency
+# surfaces explicit for route code and future migration of source-of-truth.
+MQTT_READ_PERMISSION_KIND = "MQTT_READ"
+MQTT_MAPPING_MANAGE_PERMISSION_KIND = "MQTT_MAPPING_MANAGE"
+
+# Backward-compatibility fallback when enum extension cannot be used in the
+# deployment/runtime environment. Must remain centralized in a single constant.
+MQTT_PERMISSION_COMPATIBILITY_MAP: dict[str, list[str]] = {
+    MQTT_READ_PERMISSION_KIND: [UserPermission.CI_VIEW.value],
+    MQTT_MAPPING_MANAGE_PERMISSION_KIND: [UserPermission.CI_EDIT.value],
+}
+
+# Explicitly supported permission kinds for this helper.
+_SUPPORTED_MQTT_PERMISSION_KINDS = set(MQTT_PERMISSION_COMPATIBILITY_MAP)
+
+
+def _supports_explicit_mqtt_permissions() -> bool:
+    """Return True when the permission enum includes native MQTT permission values."""
+    return (
+        isinstance(getattr(UserPermission, MQTT_READ_PERMISSION_KIND, None), UserPermission)
+        and isinstance(
+            getattr(UserPermission, MQTT_MAPPING_MANAGE_PERMISSION_KIND, None),
+            UserPermission,
+        )
+    )
+
+
+def _required_permissions_for_kind(kind: str) -> list[str]:
+    """Return the required permission values for ``kind``.
+
+    If native enum values are unavailable, resolves a single centralized
+    compatibility fallback mapping.
+    """
+    if kind not in _SUPPORTED_MQTT_PERMISSION_KINDS:
+        raise ValueError(f"Unknown MQTT permission kind: {kind}")
+
+    if _supports_explicit_mqtt_permissions():
+        if kind == MQTT_READ_PERMISSION_KIND:
+            return [getattr(UserPermission, MQTT_READ_PERMISSION_KIND).value]
+        if kind == MQTT_MAPPING_MANAGE_PERMISSION_KIND:
+            return [getattr(UserPermission, MQTT_MAPPING_MANAGE_PERMISSION_KIND).value]
+
+    return MQTT_PERMISSION_COMPATIBILITY_MAP[kind]
+
+
+def _is_admin(role: str | UserRole) -> bool:
+    return (
+        role == UserRole.ADMIN.value
+        or role == UserRole.ADMIN
+        or str(role).upper() == UserRole.ADMIN.value
+    )
+
+
+def _user_has_permission(current_user: User, permission: str) -> bool:
+    """Match permissions stored in role/user records against required values."""
+    if _is_admin(current_user.role):
+        return True
+
+    user_permissions = current_user.permissions or []
+    return permission in user_permissions
+
+
+def require_mqtt_permission(kind: str, current_user: User) -> None:
+    """Assert that ``current_user`` has the required MQTT permission for ``kind``.
+
+    Raises:
+        HTTPException: with 403 when permission is missing.
+    """
+    required_permissions = _required_permissions_for_kind(kind)
+
+    if any(_user_has_permission(current_user, permission) for permission in required_permissions):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Permission denied: {kind} required",
+    )

--- a/backend/services/mqtt_mapping_service.py
+++ b/backend/services/mqtt_mapping_service.py
@@ -8,7 +8,6 @@ repeating permission logic.
 from __future__ import annotations
 
 from fastapi import HTTPException, status
-
 from models.user import User, UserPermission, UserRole
 
 # Public permission kind strings. Kept as plain strings to keep dependency

--- a/backend/services/mqtt_mapping_service.py
+++ b/backend/services/mqtt_mapping_service.py
@@ -28,12 +28,11 @@ _SUPPORTED_MQTT_PERMISSION_KINDS = set(MQTT_PERMISSION_COMPATIBILITY_MAP)
 
 def _supports_explicit_mqtt_permissions() -> bool:
     """Return True when the permission enum includes native MQTT permission values."""
-    return (
-        isinstance(getattr(UserPermission, MQTT_READ_PERMISSION_KIND, None), UserPermission)
-        and isinstance(
-            getattr(UserPermission, MQTT_MAPPING_MANAGE_PERMISSION_KIND, None),
-            UserPermission,
-        )
+    return isinstance(
+        getattr(UserPermission, MQTT_READ_PERMISSION_KIND, None), UserPermission
+    ) and isinstance(
+        getattr(UserPermission, MQTT_MAPPING_MANAGE_PERMISSION_KIND, None),
+        UserPermission,
     )
 
 

--- a/backend/tests/test_auth_extended.py
+++ b/backend/tests/test_auth_extended.py
@@ -615,6 +615,8 @@ class TestPermissionSecurity:
             UserPermission.ROLE_MANAGE,
             UserPermission.AUDIT_VIEW,
             UserPermission.METRICS_VIEW,
+            UserPermission.MQTT_READ,
+            UserPermission.MQTT_MAPPING_MANAGE,
         }
 
         defined_permissions = set(UserPermission)

--- a/backend/tests/test_mqtt_permissions.py
+++ b/backend/tests/test_mqtt_permissions.py
@@ -68,8 +68,9 @@ def test_require_mqtt_read_falls_back_to_compatibility_map_on_explicit_missing(m
     mqtt_mapping_service.require_mqtt_permission("MQTT_READ", user)
 
 
-
-def test_require_mqtt_mapping_manage_falls_back_to_compatibility_map_on_explicit_missing(monkeypatch):
+def test_require_mqtt_mapping_manage_falls_back_to_compatibility_map_on_explicit_missing(
+    monkeypatch,
+):
     """Fallback must enforce mapping-manage boundary through central constants."""
 
     monkeypatch.setattr(
@@ -151,7 +152,9 @@ class _SeedRoleDriver:
 
 
 @pytest.mark.asyncio
-async def test_reseed_existing_system_operator_adds_mqtt_permissions_without_clobbering_unrelated_permissions(monkeypatch):
+async def test_reseed_existing_system_operator_adds_mqtt_permissions_without_clobbering_unrelated_permissions(
+    monkeypatch,
+):
     """Reseeding must upgrade protected OPERATOR roles additively for PR2 MQTT permissions."""
 
     existing_operator_permissions = [
@@ -185,7 +188,9 @@ async def test_reseed_existing_system_operator_adds_mqtt_permissions_without_clo
 
 
 @pytest.mark.asyncio
-async def test_reseed_existing_system_operator_only_adds_explicit_mqtt_upgrade_permissions(monkeypatch):
+async def test_reseed_existing_system_operator_only_adds_explicit_mqtt_upgrade_permissions(
+    monkeypatch,
+):
     """Protected OPERATOR reseeds must not backfill unrelated missing seeded permissions."""
 
     session = _SeedRoleSession(
@@ -217,7 +222,9 @@ async def test_reseed_existing_system_operator_only_adds_explicit_mqtt_upgrade_p
 
 
 @pytest.mark.asyncio
-async def test_reseed_existing_system_admin_adds_mqtt_permissions_without_clobbering_unrelated_permissions(monkeypatch):
+async def test_reseed_existing_system_admin_adds_mqtt_permissions_without_clobbering_unrelated_permissions(
+    monkeypatch,
+):
     """Reseeding must upgrade protected ADMIN roles additively for PR2 MQTT permissions."""
 
     existing_admin_permissions = [
@@ -239,9 +246,7 @@ async def test_reseed_existing_system_admin_adds_mqtt_permissions_without_clobbe
 
     await seed_roles.seed_roles()
 
-    admin_updates = [
-        update for update in session.permission_updates if update["name"] == "ADMIN"
-    ]
+    admin_updates = [update for update in session.permission_updates if update["name"] == "ADMIN"]
     assert len(admin_updates) == 1
     updated_permissions = admin_updates[0]["permissions"]
     assert UserPermission.MQTT_READ.value in updated_permissions
@@ -251,7 +256,9 @@ async def test_reseed_existing_system_admin_adds_mqtt_permissions_without_clobbe
 
 
 @pytest.mark.asyncio
-async def test_reseed_existing_system_admin_only_adds_explicit_mqtt_upgrade_permissions(monkeypatch):
+async def test_reseed_existing_system_admin_only_adds_explicit_mqtt_upgrade_permissions(
+    monkeypatch,
+):
     """Protected ADMIN reseeds must not backfill all missing admin permissions."""
 
     session = _SeedRoleSession(
@@ -283,7 +290,9 @@ async def test_reseed_existing_system_admin_only_adds_explicit_mqtt_upgrade_perm
 
 
 @pytest.mark.asyncio
-async def test_reseed_existing_system_operator_does_not_overwrite_protected_role_metadata(monkeypatch):
+async def test_reseed_existing_system_operator_does_not_overwrite_protected_role_metadata(
+    monkeypatch,
+):
     """System-role upgrades may add permissions but must not rewrite protected role metadata."""
 
     session = _SeedRoleSession(

--- a/backend/tests/test_mqtt_permissions.py
+++ b/backend/tests/test_mqtt_permissions.py
@@ -1,0 +1,308 @@
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.testclient import TestClient
+import pytest
+
+import seed_roles
+from models.user import User, UserPermission
+from services import mqtt_mapping_service
+
+
+
+def _make_user(username: str = "operator", role: str = "OPERATOR", permissions=None):
+    return User(
+        username=username,
+        role=role,
+        permissions=[p.value if isinstance(p, UserPermission) else p for p in (permissions or [])],
+        allowed_locations=[],
+    )
+
+
+def test_require_mqtt_read_denies_without_permission():
+    """MQTT read endpoints must fail for users lacking read permission."""
+
+    user = _make_user(permissions=[UserPermission.EVENT_VIEW])
+
+    with pytest.raises(HTTPException) as exc:
+        mqtt_mapping_service.require_mqtt_permission("MQTT_READ", user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Permission denied: MQTT_READ required"
+
+
+def test_require_mqtt_read_accepts_explicit_mqtt_permission():
+    """Explicit enum-backed permission should pass when available."""
+
+    user = _make_user(permissions=[UserPermission.MQTT_READ])
+
+    mqtt_mapping_service.require_mqtt_permission("MQTT_READ", user)
+
+
+def test_require_mqtt_mapping_manage_denies_without_mapping_permission():
+    """MQTT mapping operations must fail for users lacking mapping permission."""
+
+    user = _make_user(permissions=[UserPermission.MQTT_READ])
+
+    with pytest.raises(HTTPException) as exc:
+        mqtt_mapping_service.require_mqtt_permission("MQTT_MAPPING_MANAGE", user)
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Permission denied: MQTT_MAPPING_MANAGE required"
+
+
+def test_require_mqtt_mapping_manage_allows_explicit_permission():
+    """Mapping-management operations should pass when permission exists."""
+
+    user = _make_user(permissions=[UserPermission.MQTT_MAPPING_MANAGE])
+
+    mqtt_mapping_service.require_mqtt_permission("MQTT_MAPPING_MANAGE", user)
+
+
+def test_require_mqtt_read_falls_back_to_compatibility_map_on_explicit_missing(monkeypatch):
+    """Compatibility mapping is centralized in one fallback map."""
+
+    monkeypatch.setattr(
+        mqtt_mapping_service,
+        "_supports_explicit_mqtt_permissions",
+        lambda: False,
+    )
+
+    user = _make_user(permissions=[UserPermission.CI_VIEW])
+    mqtt_mapping_service.require_mqtt_permission("MQTT_READ", user)
+
+
+
+def test_require_mqtt_mapping_manage_falls_back_to_compatibility_map_on_explicit_missing(monkeypatch):
+    """Fallback must enforce mapping-manage boundary through central constants."""
+
+    monkeypatch.setattr(
+        mqtt_mapping_service,
+        "_supports_explicit_mqtt_permissions",
+        lambda: False,
+    )
+
+    user = _make_user(permissions=[UserPermission.CI_EDIT])
+    mqtt_mapping_service.require_mqtt_permission("MQTT_MAPPING_MANAGE", user)
+
+
+def test_require_mqtt_permission_router_negative_path_is_403():
+    """Route-style call path returns 403 when boundary is unmet."""
+
+    app = FastAPI()
+
+    def _forbidden_user() -> User:
+        return _make_user(permissions=[UserPermission.EVENT_VIEW])
+
+    @app.get("/mqtt/read")
+    def protected_endpoint(current_user: User = Depends(_forbidden_user)):
+        mqtt_mapping_service.require_mqtt_permission("MQTT_READ", current_user)
+        return {"ok": True}
+
+    response = TestClient(app).get("/mqtt/read")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Permission denied: MQTT_READ required"
+
+
+class _FakeResult:
+    def __init__(self, record):
+        self._record = record
+
+    def single(self):
+        return self._record
+
+
+class _SeedRoleSession:
+    def __init__(self, existing_roles):
+        self.existing_roles = existing_roles
+        self.permission_updates = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def run(self, query, **params):
+        normalized = " ".join(query.split()).lower()
+        role_name = params["name"]
+
+        if normalized.startswith("match (r:role {name: $name}) return r"):
+            role = self.existing_roles.get(role_name)
+            return _FakeResult({"r": role} if role is not None else None)
+
+        if "set r.permissions" in normalized:
+            self.permission_updates.append(
+                {
+                    "name": role_name,
+                    "permissions": params["perms"],
+                    "query": normalized,
+                }
+            )
+
+        return _FakeResult(None)
+
+
+class _SeedRoleDriver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self):
+        return self._session
+
+
+@pytest.mark.asyncio
+async def test_reseed_existing_system_operator_adds_mqtt_permissions_without_clobbering_unrelated_permissions(monkeypatch):
+    """Reseeding must upgrade protected OPERATOR roles additively for PR2 MQTT permissions."""
+
+    existing_operator_permissions = [
+        UserPermission.EVENT_VIEW.value,
+        "CUSTOM_KEEP",
+    ]
+    session = _SeedRoleSession(
+        {
+            "OPERATOR": {
+                "name": "OPERATOR",
+                "description": "Existing protected operator role",
+                "permissions": existing_operator_permissions,
+                "is_system": True,
+            }
+        }
+    )
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    operator_updates = [
+        update for update in session.permission_updates if update["name"] == "OPERATOR"
+    ]
+    assert len(operator_updates) == 1
+    updated_permissions = operator_updates[0]["permissions"]
+    assert UserPermission.MQTT_READ.value in updated_permissions
+    assert UserPermission.MQTT_MAPPING_MANAGE.value in updated_permissions
+    assert "CUSTOM_KEEP" in updated_permissions
+    assert UserPermission.EVENT_VIEW.value in updated_permissions
+
+
+@pytest.mark.asyncio
+async def test_reseed_existing_system_operator_only_adds_explicit_mqtt_upgrade_permissions(monkeypatch):
+    """Protected OPERATOR reseeds must not backfill unrelated missing seeded permissions."""
+
+    session = _SeedRoleSession(
+        {
+            "OPERATOR": {
+                "name": "OPERATOR",
+                "description": "Existing protected operator role",
+                "permissions": [UserPermission.EVENT_VIEW.value],
+                "is_system": True,
+            }
+        }
+    )
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    operator_update = next(
+        update for update in session.permission_updates if update["name"] == "OPERATOR"
+    )
+    updated_permissions = operator_update["permissions"]
+
+    assert UserPermission.MQTT_READ.value in updated_permissions
+    assert UserPermission.MQTT_MAPPING_MANAGE.value in updated_permissions
+    assert UserPermission.EVENT_ACK.value not in updated_permissions
+    assert UserPermission.CI_EDIT.value not in updated_permissions
+    assert UserPermission.RUN_DIAGNOSTICS.value not in updated_permissions
+    assert UserPermission.METRICS_VIEW.value not in updated_permissions
+
+
+@pytest.mark.asyncio
+async def test_reseed_existing_system_admin_adds_mqtt_permissions_without_clobbering_unrelated_permissions(monkeypatch):
+    """Reseeding must upgrade protected ADMIN roles additively for PR2 MQTT permissions."""
+
+    existing_admin_permissions = [
+        UserPermission.EVENT_VIEW.value,
+        "CUSTOM_ADMIN_KEEP",
+    ]
+    session = _SeedRoleSession(
+        {
+            "ADMIN": {
+                "name": "ADMIN",
+                "description": "Existing protected admin role",
+                "permissions": existing_admin_permissions,
+                "is_system": True,
+            }
+        }
+    )
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    admin_updates = [
+        update for update in session.permission_updates if update["name"] == "ADMIN"
+    ]
+    assert len(admin_updates) == 1
+    updated_permissions = admin_updates[0]["permissions"]
+    assert UserPermission.MQTT_READ.value in updated_permissions
+    assert UserPermission.MQTT_MAPPING_MANAGE.value in updated_permissions
+    assert "CUSTOM_ADMIN_KEEP" in updated_permissions
+    assert UserPermission.EVENT_VIEW.value in updated_permissions
+
+
+@pytest.mark.asyncio
+async def test_reseed_existing_system_admin_only_adds_explicit_mqtt_upgrade_permissions(monkeypatch):
+    """Protected ADMIN reseeds must not backfill all missing admin permissions."""
+
+    session = _SeedRoleSession(
+        {
+            "ADMIN": {
+                "name": "ADMIN",
+                "description": "Existing protected admin role",
+                "permissions": [UserPermission.EVENT_VIEW.value],
+                "is_system": True,
+            }
+        }
+    )
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    admin_update = next(
+        update for update in session.permission_updates if update["name"] == "ADMIN"
+    )
+    updated_permissions = admin_update["permissions"]
+
+    assert UserPermission.MQTT_READ.value in updated_permissions
+    assert UserPermission.MQTT_MAPPING_MANAGE.value in updated_permissions
+    assert UserPermission.USER_MANAGE.value not in updated_permissions
+    assert UserPermission.ROLE_MANAGE.value not in updated_permissions
+    assert UserPermission.AUDIT_VIEW.value not in updated_permissions
+    assert UserPermission.CI_DELETE.value not in updated_permissions
+
+
+@pytest.mark.asyncio
+async def test_reseed_existing_system_operator_does_not_overwrite_protected_role_metadata(monkeypatch):
+    """System-role upgrades may add permissions but must not rewrite protected role metadata."""
+
+    session = _SeedRoleSession(
+        {
+            "OPERATOR": {
+                "name": "OPERATOR",
+                "description": "Existing protected operator role",
+                "permissions": [UserPermission.EVENT_VIEW.value],
+                "is_system": True,
+            }
+        }
+    )
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    operator_update = next(
+        update for update in session.permission_updates if update["name"] == "OPERATOR"
+    )
+    assert "description" not in operator_update["query"]
+    assert "is_system" not in operator_update["query"]

--- a/backend/tests/test_mqtt_permissions.py
+++ b/backend/tests/test_mqtt_permissions.py
@@ -1,11 +1,9 @@
-from fastapi import FastAPI, Depends, HTTPException
-from fastapi.testclient import TestClient
 import pytest
-
 import seed_roles
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
 from models.user import User, UserPermission
 from services import mqtt_mapping_service
-
 
 
 def _make_user(username: str = "operator", role: str = "OPERATOR", permissions=None):
@@ -92,8 +90,10 @@ def test_require_mqtt_permission_router_negative_path_is_403():
     def _forbidden_user() -> User:
         return _make_user(permissions=[UserPermission.EVENT_VIEW])
 
+    forbidden_user_dependency = Depends(_forbidden_user)
+
     @app.get("/mqtt/read")
-    def protected_endpoint(current_user: User = Depends(_forbidden_user)):
+    def protected_endpoint(current_user: User = forbidden_user_dependency):
         mqtt_mapping_service.require_mqtt_permission("MQTT_READ", current_user)
         return {"ok": True}
 


### PR DESCRIPTION
Closes #321

## Descripción del Cambio
PR2 de la cadena #321. Agrega permisos explícitos y un helper centralizado para proteger futuros endpoints MQTT.

Incluye:
- permisos `MQTT_READ` y `MQTT_MAPPING_MANAGE`;
- helper centralizado `require_mqtt_permission(...)`;
- actualización segura de seed roles con allowlist de upgrades MQTT;
- cobertura de enum completeness, permisos, route-style 403 y reseed sin overgrant.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Chain Context

```text
main
└─ tracker: feat/issue-321-mqtt-monitoring
   └─ PR1: feat/issue-321-mqtt-monitoring-pr1-foundations
      └─ 📍 PR2: feat/issue-321-mqtt-monitoring-pr2-permissions
```

Base: `feat/issue-321-mqtt-monitoring-pr1-foundations`.

Out of scope:
- MQTT API/router endpoints (PR3)
- Timescale/event bridge (PR4)
- subscriber runtime/compose wiring (PR5)

## ¿Cómo se probó?
- [x] `cd backend && . .venv/bin/activate && python -m pytest tests/test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness tests/test_mqtt_permissions.py tests/test_mqtt_mapping_repo.py tests/test_mqtt_runtime_status_repo.py tests/test_mqtt_runtime_status_service.py -q`
- [x] Result: `30 passed, 2 warnings`

Known full-suite status:
- Full backend suite previously had unrelated/environmental failures: 2 auth cookie-domain tests and 4 Docker/testcontainers advisory-lock tests.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

---
*Generado por Alex*
