### PR TITLE
feat(mqtt): add raw readings and mapping api

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -155,6 +155,7 @@ from routers import (  # noqa: E402
     events,
     links,
     metrics,
+    mqtt,
     nodes,
     permissions,
     roles,
@@ -275,6 +276,7 @@ app.include_router(users.router, prefix="/api")
 app.include_router(roles.router, prefix="/api")
 app.include_router(nodes.router, prefix="/api")
 app.include_router(metrics.router, prefix="/api")
+app.include_router(mqtt.router, prefix="/api")
 app.include_router(catalog.router, prefix="/api")
 app.include_router(links.router, prefix="/api")
 app.include_router(tunnels.router, prefix="/api")

--- a/backend/models/mqtt.py
+++ b/backend/models/mqtt.py
@@ -1,0 +1,99 @@
+"""API models for MQTT raw telemetry and monitoring mappings."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+MQTT_RAW_CLASSIFICATION = "RAW_MQTT_NON_KPI"
+MAPPING_STATUSES = {"UNMAPPED", "DRAFT", "APPROVED", "REVOKED"}
+MAPPING_LIFECYCLE_STATUSES = {"DRAFT", "APPROVED", "REVOKED"}
+THRESHOLD_OPERATORS = {">", ">=", "<", "<=", "==", "!="}
+
+
+class MqttRawDeviceResponse(BaseModel):
+    device_id: str
+    name: str | None = None
+    location_id: str | None = None
+    source_topic: str | None = None
+    parser_name: str | None = None
+    last_seen: str | None = None
+    classification: str = MQTT_RAW_CLASSIFICATION
+    kpi_eligible: bool = False
+    mapped_metrics_count: int = 0
+    unmapped_metrics_count: int = 0
+
+
+class MqttRawMetricResponse(BaseModel):
+    device_id: str
+    metric_id: str
+    name: str | None = None
+    last_value: float | int | str | bool | None = None
+    unit: str | None = None
+    last_ts: str | None = None
+    classification: str = MQTT_RAW_CLASSIFICATION
+    kpi_eligible: bool = False
+    mapping_status: str = "UNMAPPED"
+
+    @field_validator("mapping_status")
+    @classmethod
+    def validate_mapping_status(cls, value: str) -> str:
+        if value not in MAPPING_STATUSES:
+            raise ValueError(f"Unsupported MQTT mapping status: {value}")
+        return value
+
+
+class MqttMappingThresholds(BaseModel):
+    operator: str | None = Field(default=None)
+    warning: float | None = None
+    critical: float | None = None
+
+    @field_validator("operator")
+    @classmethod
+    def validate_operator(cls, value: str | None) -> str | None:
+        if value is not None and value not in THRESHOLD_OPERATORS:
+            raise ValueError(f"Unsupported threshold operator: {value}")
+        return value
+
+
+class MqttMappingCreateRequest(BaseModel):
+    source_device_id: str
+    source_metric_id: str
+    source_metric_name: str
+    target_ci_id: str
+    target_metric_def_id: str
+    thresholds: MqttMappingThresholds | None = None
+
+
+class MqttMappingUpdateRequest(BaseModel):
+    source_metric_name: str | None = None
+    target_ci_id: str | None = None
+    target_metric_def_id: str | None = None
+    thresholds: MqttMappingThresholds | None = None
+
+
+class MqttMappingResponse(BaseModel):
+    id: str
+    source_device_id: str | None = None
+    source_metric_id: str | None = None
+    source_metric_name: str | None = None
+    target_ci_id: str | None = None
+    target_metric_def_id: str | None = None
+    status: str
+    version: int | None = None
+    warning: float | None = None
+    critical: float | None = None
+    operator: str | None = None
+    created_by: str | None = None
+    approved_by: str | None = None
+    revoked_by: str | None = None
+    created_at: str | None = None
+    approved_at: str | None = None
+    revoked_at: str | None = None
+    updated_at: str | None = None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, value: str) -> str:
+        if value not in MAPPING_LIFECYCLE_STATUSES:
+            raise ValueError(f"Unsupported MQTT mapping lifecycle status: {value}")
+        return value

--- a/backend/repositories/device_metric_repo.py
+++ b/backend/repositories/device_metric_repo.py
@@ -108,6 +108,72 @@ RETURN m.id AS id,
 ORDER BY m.name
 """
 
+_LIST_DEVICES_CYPHER = """
+MATCH (d:Device)
+WHERE d.source_topic IS NOT NULL
+OPTIONAL MATCH (d)-[:HAS_METRIC]->(m:Metric)
+OPTIONAL MATCH (m)-[:HAS_MQTT_MAPPING]->(mapping:MqttMetricMapping)
+WITH d,
+     count(DISTINCT m) AS metric_count,
+     count(DISTINCT CASE WHEN mapping.status = 'APPROVED' THEN m END) AS mapped_metrics_count
+RETURN d.id AS id,
+       d.name AS name,
+       d.location_id AS location_id,
+       d.source_topic AS source_topic,
+       d.parser_name AS parser_name,
+       d.first_seen AS first_seen,
+       d.last_seen AS last_seen,
+       d.extra AS extra,
+       metric_count AS metric_count,
+       mapped_metrics_count AS mapped_metrics_count
+ORDER BY d.id
+"""
+
+_LIST_DEVICE_METRICS_WITH_MAPPING_STATUS_CYPHER = """
+MATCH (d:Device {id: $device_id})-[:HAS_METRIC]->(m:Metric)
+WHERE d.source_topic IS NOT NULL
+OPTIONAL MATCH (m)-[:HAS_MQTT_MAPPING]->(mapping:MqttMetricMapping)
+WITH m,
+     CASE
+        WHEN count(mapping) = 0 THEN 'UNMAPPED'
+        WHEN any(status IN collect(mapping.status) WHERE status = 'APPROVED') THEN 'APPROVED'
+        WHEN any(status IN collect(mapping.status) WHERE status = 'DRAFT') THEN 'DRAFT'
+        ELSE 'REVOKED'
+     END AS mapping_status
+RETURN m.id AS id,
+       m.device_id AS device_id,
+       m.name AS name,
+       m.last_value AS last_value,
+       m.unit AS unit,
+       m.last_ts AS last_ts,
+       m.tags AS tags,
+       mapping_status AS mapping_status
+ORDER BY m.name
+"""
+
+_LIST_LATEST_READINGS_CYPHER = """
+MATCH (d:Device)-[:HAS_METRIC]->(m:Metric)
+WHERE d.source_topic IS NOT NULL
+OPTIONAL MATCH (m)-[:HAS_MQTT_MAPPING]->(mapping:MqttMetricMapping)
+WITH d, m,
+     CASE
+        WHEN count(mapping) = 0 THEN 'UNMAPPED'
+        WHEN any(status IN collect(mapping.status) WHERE status = 'APPROVED') THEN 'APPROVED'
+        WHEN any(status IN collect(mapping.status) WHERE status = 'DRAFT') THEN 'DRAFT'
+        ELSE 'REVOKED'
+     END AS mapping_status
+RETURN m.id AS id,
+       m.device_id AS device_id,
+       m.name AS name,
+       m.last_value AS last_value,
+       m.unit AS unit,
+       m.last_ts AS last_ts,
+       m.tags AS tags,
+       mapping_status AS mapping_status
+ORDER BY d.id, m.name
+LIMIT $limit
+"""
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -341,6 +407,60 @@ class DeviceMetricRepo:
         except Exception as exc:
             logger.exception("list_metrics failed for %s", device_id)
             raise RuntimeError(f"list_metrics failed for {device_id!r}: {exc}") from exc
+
+    def list_devices(self) -> list[dict[str, Any]]:
+        """Return raw MQTT devices with mapping counts for API visibility."""
+        try:
+            with self._driver.session() as session:
+                result = session.run(_LIST_DEVICES_CYPHER)
+                devices = []
+                for record in list(result):
+                    device = _record_to_device(record)
+                    metric_count = int(_get(record, "metric_count") or 0)
+                    mapped_count = int(_get(record, "mapped_metrics_count") or 0)
+                    device["metric_count"] = metric_count
+                    device["mapped_metrics_count"] = mapped_count
+                    device["unmapped_metrics_count"] = max(metric_count - mapped_count, 0)
+                    devices.append(device)
+                return devices
+        except Exception as exc:
+            logger.exception("list_devices failed")
+            raise RuntimeError(f"list_devices failed: {exc}") from exc
+
+    def list_metrics_with_mapping_status(self, device_id: str) -> list[dict[str, Any]]:
+        """Return latest device metrics annotated with mapping lifecycle status."""
+        try:
+            with self._driver.session() as session:
+                result = session.run(
+                    _LIST_DEVICE_METRICS_WITH_MAPPING_STATUS_CYPHER,
+                    device_id=device_id,
+                )
+                metrics = []
+                for record in list(result):
+                    metric = _record_to_metric(record)
+                    metric["mapping_status"] = _get(record, "mapping_status") or "UNMAPPED"
+                    metrics.append(metric)
+                return metrics
+        except Exception as exc:
+            logger.exception("list_metrics_with_mapping_status failed for %s", device_id)
+            raise RuntimeError(
+                f"list_metrics_with_mapping_status failed for {device_id!r}: {exc}"
+            ) from exc
+
+    def list_latest_readings(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Return latest raw MQTT metric snapshots across devices."""
+        try:
+            with self._driver.session() as session:
+                result = session.run(_LIST_LATEST_READINGS_CYPHER, limit=limit)
+                readings = []
+                for record in list(result):
+                    metric = _record_to_metric(record)
+                    metric["mapping_status"] = _get(record, "mapping_status") or "UNMAPPED"
+                    readings.append(metric)
+                return readings
+        except Exception as exc:
+            logger.exception("list_latest_readings failed")
+            raise RuntimeError(f"list_latest_readings failed: {exc}") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/backend/repositories/mqtt_mapping_repo.py
+++ b/backend/repositories/mqtt_mapping_repo.py
@@ -101,6 +101,24 @@ class MqttMappingRepo:
         if int(count or 0) == 0:
             raise MappingNotFoundError(f"MetricDef not found: {target_metric_def_id}")
 
+    def _require_source_metric_exists(
+        self, tx: Any, source_device_id: str, source_metric_id: str
+    ) -> None:
+        query = """
+        MATCH (d:Device {id: $source_device_id})-[:HAS_METRIC]->(m:Metric {id: $source_metric_id})
+        WHERE d.source_topic IS NOT NULL
+        WITH count(m) AS c
+        RETURN c
+        """
+        row = tx.run(
+            query,
+            source_device_id=source_device_id,
+            source_metric_id=source_metric_id,
+        ).single()
+        count = row["c"] if row else 0
+        if int(count or 0) == 0:
+            raise MappingNotFoundError(f"Source metric not found: {source_metric_id}")
+
     def _get(self, tx: Any, mapping_id: str) -> dict[str, Any] | None:
         query = """
         MATCH (m:MqttMetricMapping) WHERE m.id = $mapping_id
@@ -170,6 +188,7 @@ class MqttMappingRepo:
                 raise MappingConflictError(f"Mapping id already exists: {mapping_id}")
 
             self._require_device_exists(tx, source_device_id)
+            self._require_source_metric_exists(tx, source_device_id, source_metric_id)
             self._require_metric_target_exists(tx, target_ci_id)
             self._require_metric_def_exists(tx, target_metric_def_id)
 
@@ -421,6 +440,179 @@ class MqttMappingRepo:
             close = getattr(session, "close", None)
             if callable(close):
                 close()
+
+    def get_mapping(self, mapping_id: str) -> dict[str, Any] | None:
+        with self._session() as tx:
+            return self._get(tx, mapping_id)
+
+    def list_mappings(self, status: str | None = None) -> list[dict[str, Any]]:
+        with self._session() as tx:
+            query = """
+            MATCH (m:MqttMetricMapping)
+            WHERE $status IS NULL OR m.status = $status
+            RETURN
+                m.id AS id,
+                m.source_device_id AS source_device_id,
+                m.source_metric_id AS source_metric_id,
+                m.source_metric_name AS source_metric_name,
+                m.target_ci_id AS target_ci_id,
+                m.target_metric_def_id AS target_metric_def_id,
+                m.status AS status,
+                m.version AS version,
+                m.warning AS warning,
+                m.critical AS critical,
+                m.operator AS operator,
+                m.created_by AS created_by,
+                m.approved_by AS approved_by,
+                m.revoked_by AS revoked_by,
+                m.created_at AS created_at,
+                m.approved_at AS approved_at,
+                m.revoked_at AS revoked_at,
+                m.updated_at AS updated_at
+            ORDER BY m.created_at DESC, m.id
+            """
+            return [
+                self._record(
+                    row,
+                    (
+                        "id",
+                        "source_device_id",
+                        "source_metric_id",
+                        "source_metric_name",
+                        "target_ci_id",
+                        "target_metric_def_id",
+                        "status",
+                        "version",
+                        "warning",
+                        "critical",
+                        "operator",
+                        "created_by",
+                        "approved_by",
+                        "revoked_by",
+                        "created_at",
+                        "approved_at",
+                        "revoked_at",
+                        "updated_at",
+                    ),
+                )
+                for row in list(tx.run(query, status=status))
+            ]
+
+    def update_draft(
+        self,
+        mapping_id: str,
+        source_metric_name: str | None = None,
+        target_ci_id: str | None = None,
+        target_metric_def_id: str | None = None,
+        warning: float | None = None,
+        critical: float | None = None,
+        operator: str | None = None,
+    ) -> dict[str, Any]:
+        with self._session() as tx:
+            mapping = self._get(tx, mapping_id)
+            if not mapping:
+                raise MappingNotFoundError(f"Mapping not found: {mapping_id}")
+            if mapping["status"] != MAPPING_STATUS_DRAFT:
+                raise MappingConflictError("Only DRAFT mappings can be updated")
+
+            resolved_target_ci_id = target_ci_id or mapping.get("target_ci_id")
+            resolved_metric_def_id = target_metric_def_id or mapping.get("target_metric_def_id")
+            self._require_metric_target_exists(tx, resolved_target_ci_id)
+            self._require_metric_def_exists(tx, resolved_metric_def_id)
+
+            now = self._to_iso(self._now())
+            query = """
+            MATCH (m:MqttMetricMapping {id: $mapping_id})
+            SET m.source_metric_name = coalesce($source_metric_name, m.source_metric_name),
+                m.target_ci_id = $target_ci_id,
+                m.target_metric_def_id = $target_metric_def_id,
+                m.warning = $warning,
+                m.critical = $critical,
+                m.operator = $operator,
+                m.updated_at = datetime($updated_at),
+                m.version = toInteger(coalesce(m.version, 0)) + 1
+            RETURN
+                m.id AS id,
+                m.source_device_id AS source_device_id,
+                m.source_metric_id AS source_metric_id,
+                m.source_metric_name AS source_metric_name,
+                m.target_ci_id AS target_ci_id,
+                m.target_metric_def_id AS target_metric_def_id,
+                m.status AS status,
+                m.version AS version,
+                m.warning AS warning,
+                m.critical AS critical,
+                m.operator AS operator
+            """
+            row = tx.run(
+                query,
+                mapping_id=mapping_id,
+                source_metric_name=source_metric_name,
+                target_ci_id=resolved_target_ci_id,
+                target_metric_def_id=resolved_metric_def_id,
+                warning=warning,
+                critical=critical,
+                operator=operator,
+                updated_at=now,
+            ).single()
+            if row is None:
+                raise RuntimeError("Failed to update mapping")
+            return self._record(
+                row,
+                (
+                    "id",
+                    "source_device_id",
+                    "source_metric_id",
+                    "source_metric_name",
+                    "target_ci_id",
+                    "target_metric_def_id",
+                    "status",
+                    "version",
+                    "warning",
+                    "critical",
+                    "operator",
+                ),
+            )
+
+    def update_thresholds(
+        self,
+        mapping_id: str,
+        warning: float | None,
+        critical: float | None,
+        operator: str | None,
+    ) -> dict[str, Any]:
+        with self._session() as tx:
+            mapping = self._get(tx, mapping_id)
+            if not mapping:
+                raise MappingNotFoundError(f"Mapping not found: {mapping_id}")
+
+            now = self._to_iso(self._now())
+            query = """
+            MATCH (m:MqttMetricMapping {id: $mapping_id})
+            SET m.warning = $warning,
+                m.critical = $critical,
+                m.operator = $operator,
+                m.updated_at = datetime($updated_at),
+                m.version = toInteger(coalesce(m.version, 0)) + 1
+            RETURN
+                m.id AS id,
+                m.status AS status,
+                m.version AS version,
+                m.warning AS warning,
+                m.critical AS critical,
+                m.operator AS operator
+            """
+            row = tx.run(
+                query,
+                mapping_id=mapping_id,
+                warning=warning,
+                critical=critical,
+                operator=operator,
+                updated_at=now,
+            ).single()
+            if row is None:
+                raise RuntimeError("Failed to update mapping thresholds")
+            return self._record(row, ("id", "status", "version", "warning", "critical", "operator"))
 
     def revoke(self, mapping_id: str, revoked_by: str | None = None) -> dict[str, Any]:
         with self._session() as tx:

--- a/backend/routers/mqtt.py
+++ b/backend/routers/mqtt.py
@@ -1,0 +1,139 @@
+"""MQTT raw telemetry and mapping API."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from models.mqtt import (
+    MqttMappingCreateRequest,
+    MqttMappingResponse,
+    MqttMappingThresholds,
+    MqttMappingUpdateRequest,
+    MqttRawDeviceResponse,
+    MqttRawMetricResponse,
+)
+from models.user import User
+from services.auth_service import get_current_active_user
+from services.mqtt_mapping_service import (
+    MQTT_READ_PERMISSION_KIND,
+    MqttMappingService,
+    get_mqtt_mapping_service,
+    require_mqtt_permission,
+)
+from services.mqtt_raw_reading_service import MqttRawReadingService, get_mqtt_raw_reading_service
+
+router = APIRouter(
+    prefix="/mqtt",
+    tags=["MQTT"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+def _current_user(user: User = Depends(get_current_active_user)) -> User:  # noqa: B008
+    return user
+
+
+def _raw_service() -> MqttRawReadingService:
+    return get_mqtt_raw_reading_service()
+
+
+def _mapping_service() -> MqttMappingService:
+    return get_mqtt_mapping_service()
+
+
+CurrentUserDep = Depends(_current_user)
+RawServiceDep = Depends(_raw_service)
+MappingServiceDep = Depends(_mapping_service)
+
+
+@router.get("/devices", response_model=list[MqttRawDeviceResponse])
+def list_mqtt_devices(
+    current_user: User = CurrentUserDep,
+    service: MqttRawReadingService = RawServiceDep,
+):
+    require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
+    return service.list_devices()
+
+
+@router.get("/devices/{device_id}/metrics", response_model=list[MqttRawMetricResponse])
+def list_mqtt_device_metrics(
+    device_id: str,
+    current_user: User = CurrentUserDep,
+    service: MqttRawReadingService = RawServiceDep,
+):
+    require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
+    return service.list_device_metrics(device_id)
+
+
+@router.get("/readings", response_model=list[MqttRawMetricResponse])
+def list_mqtt_latest_readings(
+    limit: int = Query(100, ge=1, le=500),
+    current_user: User = CurrentUserDep,
+    service: MqttRawReadingService = RawServiceDep,
+):
+    require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
+    return service.list_latest_readings(limit=limit)
+
+
+@router.get("/mappings", response_model=list[MqttMappingResponse])
+def list_mqtt_mappings(
+    status: str | None = None,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.list_mappings(current_user=current_user, status_filter=status)
+
+
+@router.post("/mappings", response_model=MqttMappingResponse)
+def create_mqtt_mapping(
+    payload: MqttMappingCreateRequest,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.create_mapping(payload, current_user=current_user)
+
+
+@router.put("/mappings/{mapping_id}", response_model=MqttMappingResponse)
+def update_mqtt_mapping(
+    mapping_id: str,
+    payload: MqttMappingUpdateRequest,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.update_mapping(mapping_id, payload, current_user=current_user)
+
+
+@router.post("/mappings/{mapping_id}/approve", response_model=MqttMappingResponse)
+def approve_mqtt_mapping(
+    mapping_id: str,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.approve_mapping(mapping_id, current_user=current_user)
+
+
+@router.post("/mappings/{mapping_id}/revoke", response_model=MqttMappingResponse)
+def revoke_mqtt_mapping(
+    mapping_id: str,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.revoke_mapping(mapping_id, current_user=current_user)
+
+
+@router.get("/mappings/{mapping_id}/thresholds", response_model=MqttMappingThresholds)
+def get_mqtt_mapping_thresholds(
+    mapping_id: str,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.get_thresholds(mapping_id, current_user=current_user)
+
+
+@router.put("/mappings/{mapping_id}/thresholds", response_model=MqttMappingResponse)
+def update_mqtt_mapping_thresholds(
+    mapping_id: str,
+    payload: MqttMappingThresholds,
+    current_user: User = CurrentUserDep,
+    service: MqttMappingService = MappingServiceDep,
+):
+    return service.update_thresholds(mapping_id, payload, current_user=current_user)

--- a/backend/services/mqtt_mapping_service.py
+++ b/backend/services/mqtt_mapping_service.py
@@ -1,28 +1,27 @@
-"""Centralized MQTT authorization helpers for mapping and read operations.
-
-This module owns all permission checks introduced by the MQTT authorization slice
-(PR2). Route-level code should call :func:`require_mqtt_permission` instead of
-repeating permission logic.
-"""
+"""Centralized MQTT authorization and mapping helpers."""
 
 from __future__ import annotations
 
-from fastapi import HTTPException, status
-from models.user import User, UserPermission, UserRole
+from uuid import uuid4
 
-# Public permission kind strings. Kept as plain strings to keep dependency
-# surfaces explicit for route code and future migration of source-of-truth.
+from fastapi import HTTPException, status
+from models.mqtt import MqttMappingCreateRequest, MqttMappingThresholds, MqttMappingUpdateRequest
+from models.user import User, UserPermission, UserRole
+from repositories.mqtt_mapping_repo import (
+    MappingConflictError,
+    MappingNotFoundError,
+    MqttMappingRepo,
+    get_mqtt_mapping_repo,
+)
+
 MQTT_READ_PERMISSION_KIND = "MQTT_READ"
 MQTT_MAPPING_MANAGE_PERMISSION_KIND = "MQTT_MAPPING_MANAGE"
 
-# Backward-compatibility fallback when enum extension cannot be used in the
-# deployment/runtime environment. Must remain centralized in a single constant.
 MQTT_PERMISSION_COMPATIBILITY_MAP: dict[str, list[str]] = {
     MQTT_READ_PERMISSION_KIND: [UserPermission.CI_VIEW.value],
     MQTT_MAPPING_MANAGE_PERMISSION_KIND: [UserPermission.CI_EDIT.value],
 }
 
-# Explicitly supported permission kinds for this helper.
 _SUPPORTED_MQTT_PERMISSION_KINDS = set(MQTT_PERMISSION_COMPATIBILITY_MAP)
 
 
@@ -37,11 +36,7 @@ def _supports_explicit_mqtt_permissions() -> bool:
 
 
 def _required_permissions_for_kind(kind: str) -> list[str]:
-    """Return the required permission values for ``kind``.
-
-    If native enum values are unavailable, resolves a single centralized
-    compatibility fallback mapping.
-    """
+    """Return the required permission values for ``kind``."""
     if kind not in _SUPPORTED_MQTT_PERMISSION_KINDS:
         raise ValueError(f"Unknown MQTT permission kind: {kind}")
 
@@ -72,11 +67,7 @@ def _user_has_permission(current_user: User, permission: str) -> bool:
 
 
 def require_mqtt_permission(kind: str, current_user: User) -> None:
-    """Assert that ``current_user`` has the required MQTT permission for ``kind``.
-
-    Raises:
-        HTTPException: with 403 when permission is missing.
-    """
+    """Assert that ``current_user`` has the required MQTT permission for ``kind``."""
     required_permissions = _required_permissions_for_kind(kind)
 
     if any(_user_has_permission(current_user, permission) for permission in required_permissions):
@@ -86,3 +77,150 @@ def require_mqtt_permission(kind: str, current_user: User) -> None:
         status_code=status.HTTP_403_FORBIDDEN,
         detail=f"Permission denied: {kind} required",
     )
+
+
+class MqttMappingService:
+    """Application service for MQTT mapping lifecycle and thresholds."""
+
+    def __init__(self, repo: MqttMappingRepo | None = None):
+        self._repo = repo if repo is not None else get_mqtt_mapping_repo()
+
+    @staticmethod
+    def _actor(current_user: User) -> str:
+        return current_user.username
+
+    @staticmethod
+    def _raise_http_error(exc: Exception) -> None:
+        if isinstance(exc, MappingNotFoundError):
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        if isinstance(exc, MappingConflictError):
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise exc
+
+    @staticmethod
+    def _threshold_values(
+        thresholds: MqttMappingThresholds | None,
+    ) -> tuple[float | None, float | None, str | None]:
+        if thresholds is None:
+            return None, None, None
+        return thresholds.warning, thresholds.critical, thresholds.operator
+
+    def list_mappings(self, current_user: User, status_filter: str | None = None) -> list[dict]:
+        require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
+        return self._repo.list_mappings(status=status_filter)
+
+    def create_mapping(self, payload: MqttMappingCreateRequest, current_user: User) -> dict:
+        require_mqtt_permission(MQTT_MAPPING_MANAGE_PERMISSION_KIND, current_user)
+        warning, critical, operator = self._threshold_values(payload.thresholds)
+        try:
+            return self._repo.create_draft(
+                mapping_id=str(uuid4()),
+                source_device_id=payload.source_device_id,
+                source_metric_id=payload.source_metric_id,
+                source_metric_name=payload.source_metric_name,
+                target_ci_id=payload.target_ci_id,
+                target_metric_def_id=payload.target_metric_def_id,
+                created_by=self._actor(current_user),
+                warning=warning,
+                critical=critical,
+                operator=operator,
+            )
+        except Exception as exc:
+            self._raise_http_error(exc)
+            raise
+
+    def update_mapping(
+        self,
+        mapping_id: str,
+        payload: MqttMappingUpdateRequest,
+        current_user: User,
+    ) -> dict:
+        require_mqtt_permission(MQTT_MAPPING_MANAGE_PERMISSION_KIND, current_user)
+        if payload.thresholds is None:
+            current = self._repo.get_mapping(mapping_id)
+            if current is None:
+                raise HTTPException(status_code=404, detail=f"Mapping not found: {mapping_id}")
+            warning = current.get("warning")
+            critical = current.get("critical")
+            operator = current.get("operator")
+        else:
+            warning, critical, operator = self._threshold_values(payload.thresholds)
+        try:
+            return self._repo.update_draft(
+                mapping_id=mapping_id,
+                source_metric_name=payload.source_metric_name,
+                target_ci_id=payload.target_ci_id,
+                target_metric_def_id=payload.target_metric_def_id,
+                warning=warning,
+                critical=critical,
+                operator=operator,
+            )
+        except Exception as exc:
+            self._raise_http_error(exc)
+            raise
+
+    def approve_mapping(self, mapping_id: str, current_user: User) -> dict:
+        require_mqtt_permission(MQTT_MAPPING_MANAGE_PERMISSION_KIND, current_user)
+        try:
+            return self._repo.approve(mapping_id=mapping_id, approved_by=self._actor(current_user))
+        except Exception as exc:
+            self._raise_http_error(exc)
+            raise
+
+    def revoke_mapping(self, mapping_id: str, current_user: User) -> dict:
+        require_mqtt_permission(MQTT_MAPPING_MANAGE_PERMISSION_KIND, current_user)
+        try:
+            return self._repo.revoke(mapping_id=mapping_id, revoked_by=self._actor(current_user))
+        except Exception as exc:
+            self._raise_http_error(exc)
+            raise
+
+    def get_thresholds(self, mapping_id: str, current_user: User) -> dict:
+        require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
+        mappings = [
+            mapping for mapping in self._repo.list_mappings() if mapping.get("id") == mapping_id
+        ]
+        if not mappings:
+            raise HTTPException(status_code=404, detail=f"Mapping not found: {mapping_id}")
+        mapping = mappings[0]
+        return {
+            "operator": mapping.get("operator"),
+            "warning": mapping.get("warning"),
+            "critical": mapping.get("critical"),
+        }
+
+    def update_thresholds(
+        self,
+        mapping_id: str,
+        thresholds: MqttMappingThresholds,
+        current_user: User,
+    ) -> dict:
+        require_mqtt_permission(MQTT_MAPPING_MANAGE_PERMISSION_KIND, current_user)
+        mapping = self._repo.get_mapping(mapping_id)
+        if mapping is None:
+            raise HTTPException(status_code=404, detail=f"Mapping not found: {mapping_id}")
+        if mapping.get("status") != "APPROVED":
+            raise HTTPException(
+                status_code=409,
+                detail="Thresholds can only be updated for APPROVED mappings",
+            )
+        try:
+            return self._repo.update_thresholds(
+                mapping_id=mapping_id,
+                warning=thresholds.warning,
+                critical=thresholds.critical,
+                operator=thresholds.operator,
+            )
+        except Exception as exc:
+            self._raise_http_error(exc)
+            raise
+
+
+_mapping_service: MqttMappingService | None = None
+
+
+def get_mqtt_mapping_service() -> MqttMappingService:
+    global _mapping_service
+    if _mapping_service is None:
+        _mapping_service = MqttMappingService()
+    return _mapping_service

--- a/backend/services/mqtt_raw_reading_service.py
+++ b/backend/services/mqtt_raw_reading_service.py
@@ -1,0 +1,47 @@
+"""Read-only MQTT raw telemetry API service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from database import get_db
+from models.mqtt import MQTT_RAW_CLASSIFICATION
+from repositories.device_metric_repo import DeviceMetricRepo
+
+
+class MqttRawReadingService:
+    """Expose raw MQTT Device/Metric data as explicitly non-KPI telemetry."""
+
+    def __init__(self, repo: DeviceMetricRepo | None = None):
+        self._repo = repo if repo is not None else DeviceMetricRepo(get_db())
+
+    @staticmethod
+    def _mark_non_kpi(payload: dict[str, Any]) -> dict[str, Any]:
+        if "device_id" not in payload and "id" in payload:
+            payload["device_id"] = payload["id"]
+        if "metric_id" not in payload and "id" in payload:
+            payload["metric_id"] = payload["id"]
+        payload["classification"] = MQTT_RAW_CLASSIFICATION
+        payload["kpi_eligible"] = False
+        return payload
+
+    def list_devices(self) -> list[dict[str, Any]]:
+        return [self._mark_non_kpi(dict(device)) for device in self._repo.list_devices()]
+
+    def list_device_metrics(self, device_id: str) -> list[dict[str, Any]]:
+        metrics = self._repo.list_metrics_with_mapping_status(device_id)
+        return [self._mark_non_kpi(dict(metric)) for metric in metrics]
+
+    def list_latest_readings(self, limit: int = 100) -> list[dict[str, Any]]:
+        readings = self._repo.list_latest_readings(limit=limit)
+        return [self._mark_non_kpi(dict(reading)) for reading in readings]
+
+
+_raw_reading_service: MqttRawReadingService | None = None
+
+
+def get_mqtt_raw_reading_service() -> MqttRawReadingService:
+    global _raw_reading_service
+    if _raw_reading_service is None:
+        _raw_reading_service = MqttRawReadingService()
+    return _raw_reading_service

--- a/backend/tests/test_mqtt_mapping_repo.py
+++ b/backend/tests/test_mqtt_mapping_repo.py
@@ -48,6 +48,7 @@ def test_create_draft_persists_draft_status(mock_neo4j_driver):
 
     # Existence checks pass.
     mock_neo4j_driver.mock_session.set_response("match (d:device)", [{"c": 1}])
+    mock_neo4j_driver.mock_session.set_response("has_metric", [{"c": 1}])
     mock_neo4j_driver.mock_session.set_response("match (c:ci)", [{"c": 1}])
     mock_neo4j_driver.mock_session.set_response("match (md:metricdef)", [{"c": 1}])
 
@@ -114,6 +115,37 @@ def test_create_draft_rejects_duplicate_mapping_id(mock_neo4j_driver):
 
 
 # ── existence helpers ────────────────────────────────────────────────────────
+
+
+def test_create_draft_requires_source_metric_from_source_topic_device(mock_neo4j_driver):
+    """create_draft should require source metrics to belong to source-topic devices."""
+    from repositories.mqtt_mapping_repo import MappingNotFoundError, MqttMappingRepo
+
+    mock_neo4j_driver.mock_session.set_response(
+        "match (m:mqttmetricmapping) where m.id = $mapping_id",
+        [],
+    )
+    mock_neo4j_driver.mock_session.set_response("match (d:device)", [{"c": 1}])
+    mock_neo4j_driver.mock_session.set_response("has_metric", [{"c": 0}])
+
+    repo = MqttMappingRepo(driver=mock_neo4j_driver)
+    with pytest.raises(MappingNotFoundError):
+        repo.create_draft(
+            mapping_id="map-001",
+            source_device_id=SOURCE_DEVICE_ID,
+            source_metric_id=SOURCE_METRIC_ID,
+            source_metric_name=SOURCE_METRIC_NAME,
+            target_ci_id=TARGET_CI_ID,
+            target_metric_def_id=TARGET_METRIC_DEF_ID,
+            created_by=CREATED_BY,
+        )
+
+    source_metric_query = [
+        query["query"].lower()
+        for query in mock_neo4j_driver.mock_session.queries
+        if "has_metric" in query["query"].lower()
+    ][0]
+    assert "source_topic is not null" in source_metric_query
 
 
 def test_create_draft_rejects_missing_source(mock_neo4j_driver):

--- a/backend/tests/test_mqtt_mapping_service.py
+++ b/backend/tests/test_mqtt_mapping_service.py
@@ -1,0 +1,220 @@
+"""Service tests for MQTT mapping lifecycle authorization and validation."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from models.mqtt import MqttMappingCreateRequest, MqttMappingThresholds, MqttMappingUpdateRequest
+from models.user import User, UserPermission
+from repositories.mqtt_mapping_repo import MappingConflictError, MappingNotFoundError
+from services.mqtt_mapping_service import MqttMappingService
+
+
+class _RepoStub:
+    def __init__(self):
+        self.created = None
+        self.updated = None
+        self.thresholds = None
+        self.raise_on_create = None
+        self.mappings = [
+            {
+                "id": "map-1",
+                "status": "DRAFT",
+                "operator": ">=",
+                "warning": 70.0,
+                "critical": 90.0,
+            }
+        ]
+
+    def get_mapping(self, mapping_id):
+        for mapping in self.mappings:
+            if mapping["id"] == mapping_id:
+                return mapping
+        return None
+
+    def list_mappings(self, status=None):
+        if status is None:
+            return self.mappings
+        return [mapping for mapping in self.mappings if mapping["status"] == status]
+
+    def create_draft(self, **kwargs):
+        if self.raise_on_create:
+            raise self.raise_on_create
+        self.created = kwargs
+        return {"id": kwargs["mapping_id"], "status": "DRAFT", **kwargs}
+
+    def update_draft(self, **kwargs):
+        self.updated = kwargs
+        return {"id": kwargs["mapping_id"], "status": "DRAFT", **kwargs}
+
+    def approve(self, mapping_id, approved_by):
+        return {"id": mapping_id, "status": "APPROVED", "approved_by": approved_by}
+
+    def revoke(self, mapping_id, revoked_by):
+        return {"id": mapping_id, "status": "REVOKED", "revoked_by": revoked_by}
+
+    def update_thresholds(self, **kwargs):
+        self.thresholds = kwargs
+        return {"id": kwargs["mapping_id"], "status": "APPROVED", **kwargs}
+
+
+def _user(permissions=None):
+    return User(username="operator", role="OPERATOR", permissions=permissions or [])
+
+
+def test_create_mapping_requires_mapping_permission():
+    service = MqttMappingService(repo=_RepoStub())
+    payload = MqttMappingCreateRequest(
+        source_device_id="rtu-1",
+        source_metric_id="rtu-1/temp",
+        source_metric_name="temp",
+        target_ci_id="ci-1",
+        target_metric_def_id="temperature",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        service.create_mapping(payload, _user([UserPermission.MQTT_READ.value]))
+
+    assert exc.value.status_code == 403
+
+
+def test_create_mapping_persists_thresholds_and_actor():
+    repo = _RepoStub()
+    service = MqttMappingService(repo=repo)
+    payload = MqttMappingCreateRequest(
+        source_device_id="rtu-1",
+        source_metric_id="rtu-1/temp",
+        source_metric_name="temp",
+        target_ci_id="ci-1",
+        target_metric_def_id="temperature",
+        thresholds=MqttMappingThresholds(operator=">=", warning=70, critical=90),
+    )
+
+    result = service.create_mapping(payload, _user([UserPermission.MQTT_MAPPING_MANAGE.value]))
+
+    assert result["status"] == "DRAFT"
+    assert repo.created["created_by"] == "operator"
+    assert repo.created["warning"] == 70
+    assert repo.created["critical"] == 90
+    assert repo.created["operator"] == ">="
+
+
+def test_create_mapping_translates_missing_source_to_404():
+    repo = _RepoStub()
+    repo.raise_on_create = MappingNotFoundError("Source device not found")
+    service = MqttMappingService(repo=repo)
+    payload = MqttMappingCreateRequest(
+        source_device_id="missing",
+        source_metric_id="missing/temp",
+        source_metric_name="temp",
+        target_ci_id="ci-1",
+        target_metric_def_id="temperature",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        service.create_mapping(payload, _user([UserPermission.MQTT_MAPPING_MANAGE.value]))
+
+    assert exc.value.status_code == 404
+
+
+def test_create_mapping_translates_conflict_to_409():
+    repo = _RepoStub()
+    repo.raise_on_create = MappingConflictError("duplicate")
+    service = MqttMappingService(repo=repo)
+    payload = MqttMappingCreateRequest(
+        source_device_id="rtu-1",
+        source_metric_id="rtu-1/temp",
+        source_metric_name="temp",
+        target_ci_id="ci-1",
+        target_metric_def_id="temperature",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        service.create_mapping(payload, _user([UserPermission.MQTT_MAPPING_MANAGE.value]))
+
+    assert exc.value.status_code == 409
+
+
+def test_update_thresholds_requires_mapping_permission():
+    service = MqttMappingService(repo=_RepoStub())
+
+    with pytest.raises(HTTPException) as exc:
+        service.update_thresholds(
+            "map-1",
+            MqttMappingThresholds(operator=">=", warning=70, critical=90),
+            _user([UserPermission.MQTT_READ.value]),
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_get_thresholds_requires_read_permission():
+    service = MqttMappingService(repo=_RepoStub())
+
+    thresholds = service.get_thresholds("map-1", _user([UserPermission.MQTT_READ.value]))
+
+    assert thresholds == {"operator": ">=", "warning": 70.0, "critical": 90.0}
+
+
+def test_update_thresholds_requires_approved_mapping():
+    repo = _RepoStub()
+    service = MqttMappingService(repo=repo)
+
+    with pytest.raises(HTTPException) as exc:
+        service.update_thresholds(
+            "map-1",
+            MqttMappingThresholds(operator=">=", warning=75, critical=95),
+            _user([UserPermission.MQTT_MAPPING_MANAGE.value]),
+        )
+
+    assert exc.value.status_code == 409
+    assert repo.thresholds is None
+
+
+def test_update_thresholds_updates_approved_mapping():
+    repo = _RepoStub()
+    repo.mappings[0]["status"] = "APPROVED"
+    service = MqttMappingService(repo=repo)
+
+    service.update_thresholds(
+        "map-1",
+        MqttMappingThresholds(operator=">=", warning=75, critical=95),
+        _user([UserPermission.MQTT_MAPPING_MANAGE.value]),
+    )
+
+    assert repo.thresholds["warning"] == 75
+    assert repo.thresholds["critical"] == 95
+
+
+def test_update_mapping_passes_partial_fields_to_repo():
+    repo = _RepoStub()
+    service = MqttMappingService(repo=repo)
+
+    service.update_mapping(
+        "map-1",
+        MqttMappingUpdateRequest(
+            source_metric_name="temperature",
+            thresholds=MqttMappingThresholds(operator=">=", warning=60, critical=85),
+        ),
+        _user([UserPermission.MQTT_MAPPING_MANAGE.value]),
+    )
+
+    assert repo.updated["source_metric_name"] == "temperature"
+    assert repo.updated["warning"] == 60
+    assert repo.updated["critical"] == 85
+    assert repo.updated["operator"] == ">="
+
+
+def test_update_mapping_without_thresholds_preserves_existing_thresholds():
+    repo = _RepoStub()
+    service = MqttMappingService(repo=repo)
+
+    service.update_mapping(
+        "map-1",
+        MqttMappingUpdateRequest(source_metric_name="temperature"),
+        _user([UserPermission.MQTT_MAPPING_MANAGE.value]),
+    )
+
+    assert repo.updated["warning"] == 70.0
+    assert repo.updated["critical"] == 90.0
+    assert repo.updated["operator"] == ">="

--- a/backend/tests/test_mqtt_router.py
+++ b/backend/tests/test_mqtt_router.py
@@ -1,0 +1,214 @@
+"""Router tests for MQTT raw visibility and mapping APIs."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from models.user import User, UserPermission
+from routers import mqtt
+from services.mqtt_raw_reading_service import MqttRawReadingService
+
+
+class _RawService:
+    def list_devices(self):
+        return [
+            {
+                "device_id": "rtu-1",
+                "name": "RTU 1",
+                "classification": "RAW_MQTT_NON_KPI",
+                "kpi_eligible": False,
+                "mapped_metrics_count": 0,
+                "unmapped_metrics_count": 1,
+            }
+        ]
+
+    def list_device_metrics(self, device_id):
+        return [
+            {
+                "device_id": device_id,
+                "metric_id": f"{device_id}/temp",
+                "name": "temp",
+                "last_value": 42.0,
+                "classification": "RAW_MQTT_NON_KPI",
+                "kpi_eligible": False,
+                "mapping_status": "UNMAPPED",
+            }
+        ]
+
+    def list_latest_readings(self, limit=100):
+        return [
+            {
+                "device_id": "rtu-1",
+                "metric_id": "rtu-1/temp",
+                "name": "temp",
+                "last_value": 42.0,
+                "classification": "RAW_MQTT_NON_KPI",
+                "kpi_eligible": False,
+                "mapping_status": "UNMAPPED",
+            }
+        ]
+
+
+class _MappingService:
+    def __init__(self):
+        self.created = None
+        self.thresholds = None
+
+    def list_mappings(self, current_user, status_filter=None):
+        return [
+            {
+                "id": "map-1",
+                "source_device_id": "rtu-1",
+                "source_metric_id": "rtu-1/temp",
+                "source_metric_name": "temp",
+                "target_ci_id": "ci-1",
+                "target_metric_def_id": "temperature",
+                "status": status_filter or "DRAFT",
+            }
+        ]
+
+    def create_mapping(self, payload, current_user):
+        self.created = payload
+        return {
+            "id": "map-1",
+            "source_device_id": payload.source_device_id,
+            "source_metric_id": payload.source_metric_id,
+            "source_metric_name": payload.source_metric_name,
+            "target_ci_id": payload.target_ci_id,
+            "target_metric_def_id": payload.target_metric_def_id,
+            "status": "DRAFT",
+        }
+
+    def update_mapping(self, mapping_id, payload, current_user):
+        return {"id": mapping_id, "status": "DRAFT"}
+
+    def approve_mapping(self, mapping_id, current_user):
+        return {"id": mapping_id, "status": "APPROVED"}
+
+    def revoke_mapping(self, mapping_id, current_user):
+        return {"id": mapping_id, "status": "REVOKED"}
+
+    def get_thresholds(self, mapping_id, current_user):
+        return {"operator": ">=", "warning": 70, "critical": 90}
+
+    def update_thresholds(self, mapping_id, thresholds, current_user):
+        self.thresholds = thresholds
+        return {
+            "id": mapping_id,
+            "status": "APPROVED",
+            "operator": thresholds.operator,
+            "warning": thresholds.warning,
+            "critical": thresholds.critical,
+        }
+
+
+def _user(permissions=None):
+    return User(username="operator", role="OPERATOR", permissions=permissions or [])
+
+
+def _client(user=None, mapping_service=None):
+    app = FastAPI()
+    app.include_router(mqtt.router, prefix="/api")
+    app.dependency_overrides[mqtt._current_user] = lambda: user or _user(
+        [UserPermission.MQTT_READ.value, UserPermission.MQTT_MAPPING_MANAGE.value]
+    )
+    app.dependency_overrides[mqtt._raw_service] = lambda: _RawService()
+    app.dependency_overrides[mqtt._mapping_service] = lambda: mapping_service or _MappingService()
+    return TestClient(app)
+
+
+def test_raw_service_maps_repository_ids_to_api_fields():
+    class Repo:
+        def list_devices(self):
+            return [{"id": "rtu-1", "name": "RTU 1"}]
+
+        def list_metrics_with_mapping_status(self, device_id):
+            return [
+                {"id": f"{device_id}/temp", "device_id": device_id, "mapping_status": "UNMAPPED"}
+            ]
+
+        def list_latest_readings(self, limit=100):
+            return [{"id": "rtu-1/temp", "device_id": "rtu-1", "mapping_status": "UNMAPPED"}]
+
+    service = MqttRawReadingService(repo=Repo())
+
+    assert service.list_devices()[0]["device_id"] == "rtu-1"
+    assert service.list_device_metrics("rtu-1")[0]["metric_id"] == "rtu-1/temp"
+    assert service.list_latest_readings()[0]["metric_id"] == "rtu-1/temp"
+
+
+def test_raw_devices_are_labeled_non_kpi():
+    response = _client().get("/api/mqtt/devices")
+
+    assert response.status_code == 200
+    assert response.json()[0]["classification"] == "RAW_MQTT_NON_KPI"
+    assert response.json()[0]["kpi_eligible"] is False
+
+
+def test_raw_metrics_include_unmapped_status():
+    response = _client().get("/api/mqtt/devices/rtu-1/metrics")
+
+    assert response.status_code == 200
+    assert response.json()[0]["mapping_status"] == "UNMAPPED"
+    assert response.json()[0]["kpi_eligible"] is False
+
+
+def test_raw_readings_require_mqtt_read_permission():
+    response = _client(user=_user([])).get("/api/mqtt/readings")
+
+    assert response.status_code == 403
+
+
+def test_create_mapping_uses_mapping_service():
+    mapping_service = _MappingService()
+    response = _client(mapping_service=mapping_service).post(
+        "/api/mqtt/mappings",
+        json={
+            "source_device_id": "rtu-1",
+            "source_metric_id": "rtu-1/temp",
+            "source_metric_name": "temp",
+            "target_ci_id": "ci-1",
+            "target_metric_def_id": "temperature",
+            "thresholds": {"operator": ">=", "warning": 70, "critical": 90},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "DRAFT"
+    assert mapping_service.created.source_device_id == "rtu-1"
+
+
+def test_invalid_threshold_operator_returns_422():
+    response = _client().put(
+        "/api/mqtt/mappings/map-1/thresholds",
+        json={"operator": "between", "warning": 70, "critical": 90},
+    )
+
+    assert response.status_code == 422
+
+
+def test_approve_and_revoke_mapping_endpoints():
+    client = _client()
+
+    approve = client.post("/api/mqtt/mappings/map-1/approve")
+    revoke = client.post("/api/mqtt/mappings/map-1/revoke")
+
+    assert approve.status_code == 200
+    assert approve.json()["status"] == "APPROVED"
+    assert revoke.status_code == 200
+    assert revoke.json()["status"] == "REVOKED"
+
+
+def test_threshold_read_and_update_endpoints():
+    client = _client()
+
+    get_response = client.get("/api/mqtt/mappings/map-1/thresholds")
+    put_response = client.put(
+        "/api/mqtt/mappings/map-1/thresholds",
+        json={"operator": ">=", "warning": 75, "critical": 95},
+    )
+
+    assert get_response.status_code == 200
+    assert get_response.json()["warning"] == 70
+    assert put_response.status_code == 200
+    assert put_response.json()["warning"] == 75

--- a/openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr3.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr3.md
@@ -1,0 +1,55 @@
+# Apply Progress — integrate-mqtt-readings-monitoring (PR3 scope)
+
+## Scope
+
+PR3 implements raw MQTT API visibility plus mapping/threshold CRUD API foundations only.
+
+## Files changed
+
+- `backend/models/mqtt.py`
+- `backend/repositories/device_metric_repo.py`
+- `backend/repositories/mqtt_mapping_repo.py`
+- `backend/services/mqtt_raw_reading_service.py`
+- `backend/services/mqtt_mapping_service.py`
+- `backend/routers/mqtt.py`
+- `backend/main.py`
+- `backend/tests/test_mqtt_router.py`
+- `backend/tests/test_mqtt_mapping_service.py`
+
+## TDD evidence
+
+- RED tests were added for raw non-KPI visibility, permission-gated router access, mapping CRUD/approve/revoke endpoints, threshold validation, and service-level permission/error translation.
+- GREEN implementation adds models, raw read service, router registration, mapping service CRUD wrappers, and repository read/update support.
+
+## Verification
+
+Completed:
+
+```bash
+cd backend && . .venv/bin/activate && ruff check --config ruff.toml --fix models/mqtt.py repositories/device_metric_repo.py repositories/mqtt_mapping_repo.py services/mqtt_raw_reading_service.py services/mqtt_mapping_service.py routers/mqtt.py main.py tests/test_mqtt_router.py tests/test_mqtt_mapping_service.py tests/test_mqtt_mapping_repo.py
+# All checks passed
+
+python -m black models/mqtt.py repositories/device_metric_repo.py repositories/mqtt_mapping_repo.py services/mqtt_raw_reading_service.py services/mqtt_mapping_service.py routers/mqtt.py main.py tests/test_mqtt_router.py tests/test_mqtt_mapping_service.py tests/test_mqtt_mapping_repo.py
+# 2 files reformatted, 8 files left unchanged
+
+ruff check --config ruff.toml models/mqtt.py repositories/device_metric_repo.py repositories/mqtt_mapping_repo.py services/mqtt_raw_reading_service.py services/mqtt_mapping_service.py routers/mqtt.py main.py tests/test_mqtt_router.py tests/test_mqtt_mapping_service.py tests/test_mqtt_mapping_repo.py
+# All checks passed
+
+python -m pytest tests/test_mqtt_router.py tests/test_mqtt_mapping_service.py tests/test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness tests/test_mqtt_permissions.py tests/test_mqtt_mapping_repo.py tests/test_mqtt_runtime_status_repo.py tests/test_mqtt_runtime_status_service.py -q
+# 49 passed, 2 warnings
+```
+
+## Out of scope
+
+- PR4 bridge/KPI writes/event path.
+- PR5 subscriber runtime entrypoint/compose wiring.
+- MQTT runtime/status API surface.
+- Mapping audit API surface until audit records are implemented.
+
+## Review remediation
+
+- Raw MQTT queries are scoped to source-topic devices to avoid exposing ordinary device metrics as raw MQTT telemetry.
+- Raw service maps repository `id` fields to public `device_id` / `metric_id` response fields.
+- Source metric relationship validation prevents mappings to nonexistent or unrelated raw metrics.
+- Partial mapping updates preserve existing thresholds when thresholds are omitted.
+- Threshold updates are accepted only for `APPROVED` mappings to preserve lifecycle boundaries.


### PR DESCRIPTION
Closes #321

## Descripción del Cambio
PR3 de la cadena #321. Agrega la superficie API para consultar lecturas MQTT crudas y administrar mappings/thresholds sin escribir todavía en KPI/eventos.

Incluye:
- modelos de respuesta/request para MQTT raw, mappings y thresholds;
- router `/api/mqtt/*` para dispositivos/metrics/readings raw y CRUD de mappings;
- servicio raw que marca los datos como `RAW_MQTT_NON_KPI` y `kpi_eligible=false`;
- validación para limitar lecturas/mappings a dispositivos MQTT con `source_topic`;
- lifecycle de thresholds restringido a mappings `APPROVED`;
- tests de router, servicio y repositorio para permisos, shape de API, lifecycle y regresiones.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Refactor (Cambio interno sin modificar comportamiento)
- [ ] Chore (Mantenimiento/tooling)

## Cambios
| Archivo | Cambio |
| --- | --- |
| `backend/models/mqtt.py` | Agrega DTOs para raw readings, mappings y thresholds. |
| `backend/routers/mqtt.py` | Registra endpoints PR3 de raw MQTT y mapping/threshold CRUD. |
| `backend/main.py` | Monta el router MQTT. |
| `backend/services/mqtt_raw_reading_service.py` | Normaliza raw readings como datos no-KPI y adapta IDs públicos. |
| `backend/services/mqtt_mapping_service.py` | Extiende permisos PR2 con lifecycle de mapping/thresholds. |
| `backend/repositories/device_metric_repo.py` | Agrega consultas raw MQTT con scope `source_topic`. |
| `backend/repositories/mqtt_mapping_repo.py` | Agrega list/update/threshold support y validación de source metric. |
| `backend/tests/test_mqtt_router.py` | Cubre endpoints y contratos HTTP principales. |
| `backend/tests/test_mqtt_mapping_service.py` | Cubre permisos, errores y lifecycle de thresholds. |
| `backend/tests/test_mqtt_mapping_repo.py` | Agrega regresiones para validación de source metric. |
| `openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr3.md` | Documenta evidencia PR3 y remediaciones de review. |

## Validación
- [x] Ruff en archivos backend tocados.
- [x] Black en archivos backend tocados.
- [x] Focused tests:
  `cd backend && . .venv/bin/activate && python -m pytest tests/test_mqtt_router.py tests/test_mqtt_mapping_service.py tests/test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness tests/test_mqtt_permissions.py tests/test_mqtt_mapping_repo.py tests/test_mqtt_runtime_status_repo.py tests/test_mqtt_runtime_status_service.py -q`
- [x] Resultado: `49 passed, 2 warnings`.

## Review / excepción aceptada
- [x] `review-risk`: sin findings finales.
- [x] `review-reliability`: sin findings finales.
- [x] `review-readability`: findings bloqueantes remediados; quedan sugerencias estructurales no bloqueantes.
- [x] `review-resilience`: marcó falta de hooks de observabilidad/error-rate para los nuevos endpoints. Se acepta excepción para PR3; observabilidad queda para una slice posterior antes de runtime/bridge productivo.

## Fuera de alcance
- PR4 bridge/KPI writes/event path.
- PR5 subscriber runtime entrypoint/compose wiring.
- API de runtime/status MQTT.
- API de audit hasta implementar persistencia real de audit records.

## Checklist
- [x] Issue aprobado vinculado (`Closes #321`).
- [x] Exactamente un label `type:*` será aplicado: `type:feature`.
- [x] Commit convencional sin `Co-Authored-By`.
- [x] No scripts modificados.
- [x] SDD/OpenSpec actualizado para PR3.
