### PR TITLE
feat(mqtt): bridge readings into monitoring events

### DIFF
--- a/backend/migrations/004_mqtt_metric_result_idempotency.cypher
+++ b/backend/migrations/004_mqtt_metric_result_idempotency.cypher
@@ -1,0 +1,4 @@
+// PR4 MQTT bridge idempotency guard for replay-safe event/result writes.
+
+CREATE CONSTRAINT metric_result_idempotency_key_unique IF NOT EXISTS
+FOR (r:MetricResult) REQUIRE r.idempotency_key IS UNIQUE;

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -315,6 +315,42 @@ def build_event_rows(envelopes: Iterable[Mapping[str, Any]]) -> list[dict[str, A
     return rows
 
 
+def _dedupe_idempotent_rows(rows: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Drop duplicate payloads that share the same ``idempotency_key``.
+
+    Duplicate payloads are possible when the same payload is retried before the
+    upstream caller persists idempotency state. For MQTT bridge replays, only the
+    latest payload for a given key matters; earlier duplicates must not repeat
+    side-effectful Cypher writes.
+    """
+    deduped: list[dict[str, Any]] = []
+    latest_index_by_key: dict[str, int] = {}
+    for row in rows:
+        row_dict = dict(row)
+        row_idempotency_key = row_dict.get("idempotency_key")
+        if row_idempotency_key is None:
+            deduped.append(row_dict)
+            continue
+
+        prior_index = latest_index_by_key.get(row_idempotency_key)
+        if prior_index is None:
+            latest_index_by_key[row_idempotency_key] = len(deduped)
+            deduped.append(row_dict)
+            continue
+
+        prior_row = deduped[prior_index]
+        row_observed_at = row_dict.get("observed_at")
+        prior_observed_at = prior_row.get("observed_at")
+        if prior_observed_at is None or row_observed_at is None:
+            deduped[prior_index] = row_dict
+            continue
+
+        if row_observed_at >= prior_observed_at:
+            deduped[prior_index] = row_dict
+
+    return deduped
+
+
 def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]], lock_db=None) -> int:
     """Apply latest metric/result/event updates with batched UNWIND queries.
 
@@ -341,7 +377,7 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]], lock_db=
         callers (``writer_pool.run_writer_once``) always pass the leased
         ``timescale_db`` as ``lock_db``.
     """
-    rows = build_event_rows(envelopes)
+    rows = _dedupe_idempotent_rows(build_event_rows(envelopes))
     if not rows:
         return 0
     latest_metric_rows = _latest_metric_rows(rows)
@@ -349,19 +385,47 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]], lock_db=
     non_collection_state_rows = _dedupe_non_collection_latest_state(rows)
     non_collection_event_rows = _non_collection_event_rows(non_collection_state_rows)
     with driver.session() as session:
-        session.run(
-            """
-            UNWIND $rows AS row
-            MATCH (n:CI {id: row.ci_id})
-            MATCH (m:MetricDef {id: row.metric_id})
-            MERGE (n)-[r:HAS_METRIC]->(m)
-            SET r.last_value = row.value, r.last_updated = datetime(), r.status = row.status, r.last_message = row.message
-            CREATE (res:MetricResult {timestamp: datetime(), value: row.value, status: row.status})
-            CREATE (n)-[:HAS_RESULT]->(res)
-            CREATE (res)-[:FOR_METRIC]->(m)
-            """,
-            rows=latest_metric_rows,
-        )
+        rows_with_idempotency = [
+            row for row in latest_metric_rows if row.get("idempotency_key") is not None
+        ]
+        rows_without_idempotency = [
+            row for row in latest_metric_rows if row.get("idempotency_key") is None
+        ]
+        if rows_with_idempotency:
+            session.run(
+                """
+                UNWIND $rows AS row
+                MATCH (n:CI {id: row.ci_id})
+                MATCH (m:MetricDef {id: row.metric_id})
+                MERGE (n)-[r:HAS_METRIC]->(m)
+                SET r.last_value = row.value, r.last_updated = datetime(), r.status = row.status, r.last_message = row.message
+                MERGE (res:MetricResult {idempotency_key: row.idempotency_key})
+                ON CREATE SET
+                    res.timestamp = datetime(),
+                    res.value = row.value,
+                    res.status = row.status
+                ON MATCH SET
+                    res.value = row.value,
+                    res.status = row.status
+                MERGE (n)-[:HAS_RESULT]->(res)
+                MERGE (res)-[:FOR_METRIC]->(m)
+                """,
+                rows=rows_with_idempotency,
+            )
+        if rows_without_idempotency:
+            session.run(
+                """
+                UNWIND $rows AS row
+                MATCH (n:CI {id: row.ci_id})
+                MATCH (m:MetricDef {id: row.metric_id})
+                MERGE (n)-[r:HAS_METRIC]->(m)
+                SET r.last_value = row.value, r.last_updated = datetime(), r.status = row.status, r.last_message = row.message
+                CREATE (res:MetricResult {timestamp: datetime(), value: row.value, status: row.status})
+                CREATE (n)-[:HAS_RESULT]->(res)
+                CREATE (res)-[:FOR_METRIC]->(m)
+                """,
+                rows=rows_without_idempotency,
+            )
 
         # COLLECTION_FAILURE batch — sorted lock acquisition per design §4.
         if lock_db is not None and collection_failure_rows:

--- a/backend/repositories/mqtt_mapping_repo.py
+++ b/backend/repositories/mqtt_mapping_repo.py
@@ -319,6 +319,70 @@ class MqttMappingRepo:
                 ),
             )
 
+    def list_mappings_for_source(
+        self, source_device_id: str, source_metric_id: str
+    ) -> list[dict[str, Any]]:
+        """Return mappings for a source metric, regardless of mapping status.
+
+        The result set includes all lifecycle states so callers can apply
+        fail-closed policy explicitly.
+        """
+        with self._session() as tx:
+            query = """
+                MATCH (m:MqttMetricMapping)
+                WHERE m.source_device_id = $source_device_id
+                  AND m.source_metric_id = $source_metric_id
+                RETURN
+                    m.id AS id,
+                    m.source_device_id AS source_device_id,
+                    m.source_metric_id AS source_metric_id,
+                    m.source_metric_name AS source_metric_name,
+                    m.target_ci_id AS target_ci_id,
+                    m.target_metric_def_id AS target_metric_def_id,
+                    m.status AS status,
+                    m.version AS version,
+                    m.warning AS warning,
+                    m.critical AS critical,
+                    m.operator AS operator,
+                    m.approved_by AS approved_by,
+                    m.approved_at AS approved_at
+                ORDER BY m.created_at DESC, m.id
+            """
+            rows = tx.run(
+                query,
+                source_device_id=source_device_id,
+                source_metric_id=source_metric_id,
+            ).data()
+            return [
+                self._record(
+                    row,
+                    (
+                        "id",
+                        "source_device_id",
+                        "source_metric_id",
+                        "source_metric_name",
+                        "target_ci_id",
+                        "target_metric_def_id",
+                        "status",
+                        "version",
+                        "warning",
+                        "critical",
+                        "operator",
+                        "approved_by",
+                        "approved_at",
+                    ),
+                )
+                for row in rows
+            ]
+
+    # Compatibility alias retained for existing callers/tests.
+    def list_approved_mappings_for_source(
+        self,
+        source_device_id: str,
+        source_metric_id: str,
+    ) -> list[dict[str, Any]]:
+        return self.list_mappings_for_source(source_device_id, source_metric_id)
+
     def approve(
         self,
         mapping_id: str,

--- a/backend/repositories/mqtt_metric_sample_receipt_repo.py
+++ b/backend/repositories/mqtt_metric_sample_receipt_repo.py
@@ -1,0 +1,236 @@
+"""Data access for MQTT metric sample receipt tracking (idempotency + retries)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from models.mqtt_metric_sample_receipt import MqttMetricSampleReceipt
+from postgres_db import SessionLocal
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+RECEIPT_STATUS_PENDING_METRIC = "PENDING_METRIC"
+RECEIPT_STATUS_PENDING_EVENT = "PENDING_EVENT"
+RECEIPT_STATUS_COMPLETE = "COMPLETE"
+RECEIPT_STATUS_FAILED = "FAILED"
+
+
+class MqttMetricSampleReceiptRepository:
+    """Persist and query mapping bridge dedupe receipts."""
+
+    def __init__(self, session_factory: Callable[[], Session] | None = None):
+        self._session_factory = session_factory or SessionLocal
+
+    def _get_db(self) -> Session:
+        return self._session_factory()
+
+    @staticmethod
+    def _to_dict(record: MqttMetricSampleReceipt | None) -> dict[str, Any] | None:
+        if record is None:
+            return None
+        return {
+            "idempotency_key": record.idempotency_key,
+            "mapping_id": record.mapping_id,
+            "source_device_id": record.source_device_id,
+            "source_metric_id": record.source_metric_id,
+            "observed_at": record.observed_at,
+            "value_hash": record.value_hash,
+            "status": record.status,
+            "timescale_written_at": record.timescale_written_at,
+            "event_written_at": record.event_written_at,
+            "last_error": record.last_error,
+        }
+
+    @staticmethod
+    def _ensure_datetime(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+    def get_receipt(self, idempotency_key: str) -> dict[str, Any] | None:
+        """Return one receipt for the idempotency key, if any."""
+        db = self._get_db()
+        try:
+            row = (
+                db.query(MqttMetricSampleReceipt)
+                .filter(MqttMetricSampleReceipt.idempotency_key == idempotency_key)
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            payload = self._to_dict(row)
+            if payload is not None:
+                payload["observed_at"] = self._ensure_datetime(payload["observed_at"])
+                payload["timescale_written_at"] = self._ensure_datetime(
+                    payload["timescale_written_at"]
+                )
+                payload["event_written_at"] = self._ensure_datetime(payload["event_written_at"])
+            return payload
+        finally:
+            db.close()
+
+    def create_receipt(
+        self,
+        *,
+        idempotency_key: str,
+        mapping_id: str,
+        source_device_id: str,
+        source_metric_id: str,
+        observed_at: datetime,
+        value_hash: str,
+        status: str,
+    ) -> dict[str, Any]:
+        """Create a new receipt row."""
+        db = self._get_db()
+        try:
+            record = MqttMetricSampleReceipt(
+                idempotency_key=idempotency_key,
+                mapping_id=mapping_id,
+                source_device_id=source_device_id,
+                source_metric_id=source_metric_id,
+                observed_at=observed_at,
+                value_hash=value_hash,
+                status=status,
+            )
+            db.add(record)
+            db.commit()
+            db.refresh(record)
+            return self._to_dict(record)
+        except Exception:
+            db.rollback()
+            existing = self.get_receipt(idempotency_key)
+            if existing is not None:
+                return existing
+            raise
+        finally:
+            db.close()
+
+    def mark_timescale_written(
+        self,
+        idempotency_key: str,
+        *,
+        status: str,
+        now: datetime,
+    ) -> dict[str, Any]:
+        """Mark metric write done and keep event state for downstream retries."""
+        db = self._get_db()
+        try:
+            row = (
+                db.query(MqttMetricSampleReceipt)
+                .filter(MqttMetricSampleReceipt.idempotency_key == idempotency_key)
+                .one_or_none()
+            )
+            if row is None:
+                raise ValueError(f"Receipt not found: {idempotency_key}")
+            row.status = status
+            row.timescale_written_at = now
+            row.last_error = None
+            db.commit()
+            db.refresh(row)
+            return self._to_dict(row)
+        finally:
+            db.close()
+
+    def mark_event_written(
+        self,
+        idempotency_key: str,
+        *,
+        status: str,
+        now: datetime,
+    ) -> dict[str, Any]:
+        db = self._get_db()
+        try:
+            row = (
+                db.query(MqttMetricSampleReceipt)
+                .filter(MqttMetricSampleReceipt.idempotency_key == idempotency_key)
+                .one_or_none()
+            )
+            if row is None:
+                raise ValueError(f"Receipt not found: {idempotency_key}")
+            row.status = status
+            row.event_written_at = now
+            row.last_error = None
+            db.commit()
+            db.refresh(row)
+            return self._to_dict(row)
+        finally:
+            db.close()
+
+    def mark_event_failed(
+        self,
+        idempotency_key: str,
+        *,
+        status: str,
+        error: str,
+        now: datetime,
+    ) -> dict[str, Any]:
+        db = self._get_db()
+        try:
+            row = (
+                db.query(MqttMetricSampleReceipt)
+                .filter(MqttMetricSampleReceipt.idempotency_key == idempotency_key)
+                .one_or_none()
+            )
+            if row is None:
+                raise ValueError(f"Receipt not found: {idempotency_key}")
+            row.status = status
+            row.event_written_at = None
+            row.last_error = error
+            row.timescale_written_at = row.timescale_written_at or now
+            db.commit()
+            db.refresh(row)
+            return self._to_dict(row)
+        finally:
+            db.close()
+
+    def mark_failed(
+        self,
+        idempotency_key: str,
+        *,
+        status: str,
+        error: str,
+        now: datetime,
+    ) -> dict[str, Any]:
+        db = self._get_db()
+        try:
+            row = (
+                db.query(MqttMetricSampleReceipt)
+                .filter(MqttMetricSampleReceipt.idempotency_key == idempotency_key)
+                .one_or_none()
+            )
+            if row is None:
+                raise ValueError(f"Receipt not found: {idempotency_key}")
+            row.status = status
+            row.last_error = error
+            db.commit()
+            db.refresh(row)
+            return self._to_dict(row)
+        finally:
+            db.close()
+
+    def ensure_schema(self) -> None:
+        db = self._get_db()
+        try:
+            db.execute(
+                text(
+                    "CREATE TABLE IF NOT EXISTS mqtt_metric_sample_receipts (\n"
+                    "    idempotency_key TEXT PRIMARY KEY,\n"
+                    "    mapping_id TEXT NOT NULL,\n"
+                    "    source_device_id TEXT NOT NULL,\n"
+                    "    source_metric_id TEXT NOT NULL,\n"
+                    "    observed_at TIMESTAMPTZ NOT NULL,\n"
+                    "    value_hash TEXT NOT NULL,\n"
+                    "    status TEXT NOT NULL,\n"
+                    "    timescale_written_at TIMESTAMPTZ,\n"
+                    "    event_written_at TIMESTAMPTZ,\n"
+                    "    last_error TEXT\n"
+                    ")"
+                )
+            )
+            db.commit()
+        finally:
+            db.close()

--- a/backend/routers/mqtt.py
+++ b/backend/routers/mqtt.py
@@ -20,6 +20,7 @@ from services.mqtt_mapping_service import (
     require_mqtt_permission,
 )
 from services.mqtt_raw_reading_service import MqttRawReadingService, get_mqtt_raw_reading_service
+from services.mqtt_runtime_status import get_mqtt_runtime_status_service
 
 router = APIRouter(
     prefix="/mqtt",
@@ -40,9 +41,14 @@ def _mapping_service() -> MqttMappingService:
     return get_mqtt_mapping_service()
 
 
+def _runtime_status_service():
+    return get_mqtt_runtime_status_service()
+
+
 CurrentUserDep = Depends(_current_user)
 RawServiceDep = Depends(_raw_service)
 MappingServiceDep = Depends(_mapping_service)
+RuntimeStatusServiceDep = Depends(_runtime_status_service)
 
 
 @router.get("/devices", response_model=list[MqttRawDeviceResponse])
@@ -72,6 +78,15 @@ def list_mqtt_latest_readings(
 ):
     require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
     return service.list_latest_readings(limit=limit)
+
+
+@router.get("/status")
+def get_mqtt_status(
+    current_user: User = CurrentUserDep,
+    status_service=RuntimeStatusServiceDep,
+):
+    require_mqtt_permission(MQTT_READ_PERMISSION_KIND, current_user)
+    return status_service.get_status()
 
 
 @router.get("/mappings", response_model=list[MqttMappingResponse])

--- a/backend/services/mqtt/subscriber.py
+++ b/backend/services/mqtt/subscriber.py
@@ -31,11 +31,13 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from config import get_mqtt_settings
+from postgres_db import SessionLocal
 from repositories.device_metric_repo import get_device_metric_repo
 from services.mqtt.client import connect_mqtt
 from services.mqtt.metrics import metrics
 from services.mqtt.parsers.base import ParseError
 from services.mqtt.topic_router import TopicRouter
+from services.mqtt_bridge_service import get_mqtt_bridge_service
 
 if TYPE_CHECKING:
     from services.mqtt.parsers.base import Reading
@@ -182,11 +184,10 @@ async def _persist_reading(reading: Reading) -> None:
     """Persist a canonical :class:`Reading` via :class:`DeviceMetricRepo`.
 
     Replaces the PR2b stub. Implements the Q6 clean cutover: the new subscriber
-    persists ONLY to ``(:Device)-[:HAS_METRIC]->(:Metric)`` nodes — it never
-    calls the legacy persistence path. The legacy helper
-    :func:`services.mqtt.parsers.bliiot_s475e.process_telemetry_message` is
-    intentionally NOT called from here; it remains in the codebase for
-    back-compat only (external callers + the legacy test suite).
+    persists ONLY to :class:`Device` and :class:`Metric` nodes via
+    :class:`DeviceMetricRepo`. It never calls the legacy persistence path. The
+    legacy helper :func:`services.mqtt.parsers.bliiot_s475e.process_telemetry_message`
+    remains importable for back-compat only (external callers + the legacy test suite).
 
     Contract (per design §2.6 and Q1/Q2 decisions):
 
@@ -256,3 +257,15 @@ async def _persist_reading(reading: Reading) -> None:
             )
         except Exception as e:
             raise RuntimeError(f"Metric upsert failed for {metric_id!r}: {e}") from e
+
+    # Bridge to KPI/event path is failure-observability-only by design.
+    # Raw persistence must remain independent; never block on bridge failures.
+    try:
+        bridge_service = get_mqtt_bridge_service(event_writer_lock_db=SessionLocal)
+        bridge_service.process_reading(reading)
+    except Exception:
+        logger.warning(
+            "Bridge processing failed for device=%r: continuing raw persistence",
+            reading.device_id,
+            exc_info=True,
+        )

--- a/backend/services/mqtt_bridge_service.py
+++ b/backend/services/mqtt_bridge_service.py
@@ -1,0 +1,541 @@
+"""Service layer for MQTT raw-to-monitoring bridge.
+
+- resolve approved mappings only
+- write metric sample to Timescale
+- write events to Neo4j via event rows
+- use receipts for idempotency and status transitions
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import Any
+
+from database import get_db as get_neo4j_db
+from polling.event_writer import batch_update_events
+from postgres_db import SessionLocal
+from repositories.metric_repo import insert_metric_value
+from repositories.mqtt_mapping_repo import MqttMappingRepo
+from repositories.mqtt_metric_sample_receipt_repo import (
+    RECEIPT_STATUS_COMPLETE,
+    RECEIPT_STATUS_FAILED,
+    RECEIPT_STATUS_PENDING_EVENT,
+    RECEIPT_STATUS_PENDING_METRIC,
+    MqttMetricSampleReceiptRepository,
+)
+from services.mqtt.parsers.base import MetricReading, Reading
+from services.mqtt_runtime_status import get_mqtt_runtime_status_service
+from sqlalchemy.exc import IntegrityError
+
+MQTT_MAPPING_UNMAPPED_OUTCOME = "SKIPPED_UNMAPPED"
+MQTT_MAPPING_DRAFT_OUTCOME = "SKIPPED_DRAFT"
+MQTT_MAPPING_REVOKED_OUTCOME = "SKIPPED_REVOKED"
+MQTT_MAPPING_AMBIGUOUS_OUTCOME = "BLOCKED_AMBIGUOUS_MAPPING"
+MQTT_MAPPING_NON_NUMERIC_OUTCOME = "SKIPPED_NON_NUMERIC"
+MQTT_MAPPING_DUPLICATE_OUTCOME = "SKIPPED_DUPLICATE"
+MQTT_MAPPING_APPROVED_OUTCOME = "MAPPED_PERSISTED"
+MQTT_MAPPING_EVENT_PENDING_OUTCOME = "MAPPED_EVENT_PENDING"
+MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME = "MAPPED_EVENT_RETRY_SUCCESS"
+
+
+class _DefaultMetricWriter:
+    def __call__(self, node_id: str, metric_id: str, value: float, observed_at: datetime) -> None:
+        db = SessionLocal()
+        try:
+            insert_metric_value(
+                db=db,
+                node_id=node_id,
+                metric_id=metric_id,
+                value=value,
+                timestamp=observed_at,
+            )
+        finally:
+            db.close()
+
+
+class _DefaultRuntimeStatusService:
+    def __init__(self) -> None:
+        self._service = get_mqtt_runtime_status_service()
+
+    def record_bridge_outcome(self, outcome: str) -> None:
+        if outcome in {
+            MQTT_MAPPING_APPROVED_OUTCOME,
+            MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME,
+            MQTT_MAPPING_DUPLICATE_OUTCOME,
+        }:
+            self._service.increment_counter("mapped_writes_total")
+        elif outcome in {
+            MQTT_MAPPING_UNMAPPED_OUTCOME,
+            MQTT_MAPPING_DRAFT_OUTCOME,
+            MQTT_MAPPING_REVOKED_OUTCOME,
+            MQTT_MAPPING_AMBIGUOUS_OUTCOME,
+            MQTT_MAPPING_NON_NUMERIC_OUTCOME,
+        }:
+            self._service.increment_counter("unmapped_skips_total")
+        else:
+            self._service.increment_counter("failed_writes_total")
+
+
+class MqttBridgeService:
+    """Deterministic, fail-closed bridge between MQTT raw readings and KPI writes."""
+
+    def __init__(
+        self,
+        *,
+        mapping_repo: MqttMappingRepo | None = None,
+        receipt_repo: MqttMetricSampleReceiptRepository | None = None,
+        metric_writer: Callable[[str, str, float, datetime], Any] | None = None,
+        event_writer: Callable[[Any, list[dict[str, Any]], Any], Any] | None = None,
+        runtime_status_service: Any | None = None,
+        event_writer_driver: Any | None = None,
+        event_writer_lock_db: Callable[[], Any] | None = None,
+        now_provider: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._mapping_repo = mapping_repo or MqttMappingRepo()
+        self._receipt_repo = receipt_repo or MqttMetricSampleReceiptRepository()
+        self._metric_writer = metric_writer or _DefaultMetricWriter()
+        self._event_writer = event_writer or batch_update_events
+        self._runtime_status_service = runtime_status_service or _DefaultRuntimeStatusService()
+        self._event_writer_driver = (
+            event_writer_driver if event_writer_driver is not None else get_neo4j_db()
+        )
+        self._event_writer_lock_db = event_writer_lock_db
+        self._now = now_provider or (lambda: datetime.now(UTC))
+
+    @staticmethod
+    def _normalize_observed_at(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+    @staticmethod
+    def _canonical_numeric(value: Any) -> tuple[float | None, bool]:
+        if isinstance(value, bool):
+            return None, False
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return None, False
+        return numeric, True
+
+    @staticmethod
+    def _value_hash(
+        mapping_id: str, source_metric_id: str, value: float, observed_at: datetime
+    ) -> str:
+        payload = {
+            "mapping_id": mapping_id,
+            "source_metric_id": source_metric_id,
+            "value": value,
+            "observed_at": MqttBridgeService._normalize_observed_at(observed_at)
+            .isoformat()
+            .replace(
+                "+00:00",
+                "Z",
+            ),
+        }
+        return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _idempotency_key(
+        mapping_id: str,
+        source_metric_id: str,
+        observed_at: datetime,
+        value_hash: str,
+    ) -> str:
+        return f"mqtt:{mapping_id}:{source_metric_id}:{MqttBridgeService._normalize_observed_at(observed_at).isoformat()}:{value_hash}"
+
+    def _make_event_payload(
+        self,
+        *,
+        reading: Reading,
+        metric: MetricReading,
+        mapping: dict[str, Any],
+        value: float,
+        idempotency_key: str,
+        observed_at: datetime,
+    ) -> dict[str, Any]:
+        return {
+            "idempotency_key": idempotency_key,
+            "protocol": "MQTT",
+            "source_protocol": "MQTT",
+            "ci_id": mapping["target_ci_id"],
+            "metric_id": mapping["target_metric_def_id"],
+            "value": {"numeric": value},
+            "status": "OK",
+            "observed_at": observed_at.isoformat(),
+            "metadata": {
+                "mapping_id": mapping["id"],
+                "source_device_id": reading.device_id,
+                "source_metric_id": f"{reading.device_id}/{metric.name}",
+                "source_metric_name": mapping.get("source_metric_name") or metric.name,
+                "operator": mapping.get("operator") or ">=",
+                "warning": mapping.get("warning"),
+                "critical": mapping.get("critical"),
+            },
+        }
+
+    def _record_outcome(self, outcome: str) -> None:
+        self._runtime_status_service.record_bridge_outcome(outcome)
+
+    def _mark_timescale_written(self, idempotency_key: str, now: datetime) -> None:
+        if hasattr(self._receipt_repo, "mark_timescale_written"):
+            self._receipt_repo.mark_timescale_written(
+                idempotency_key,
+                status=RECEIPT_STATUS_PENDING_EVENT,
+                now=now,
+            )
+            return
+        self._receipt_repo.update_receipt_status(
+            idempotency_key,
+            status=RECEIPT_STATUS_PENDING_EVENT,
+            timescale_written_at=now,
+            last_error=None,
+        )
+
+    def _mark_event_written(self, idempotency_key: str, now: datetime) -> None:
+        if hasattr(self._receipt_repo, "mark_event_written"):
+            self._receipt_repo.mark_event_written(
+                idempotency_key,
+                status=RECEIPT_STATUS_COMPLETE,
+                now=now,
+            )
+            return
+        self._receipt_repo.update_receipt_status(
+            idempotency_key,
+            status=RECEIPT_STATUS_COMPLETE,
+            event_written_at=now,
+            last_error=None,
+        )
+
+    def _mark_event_failed(self, idempotency_key: str, now: datetime, error: str) -> None:
+        if hasattr(self._receipt_repo, "mark_event_failed"):
+            self._receipt_repo.mark_event_failed(
+                idempotency_key,
+                status=RECEIPT_STATUS_PENDING_EVENT,
+                error=error,
+                now=now,
+            )
+            return
+        self._receipt_repo.update_receipt_status(
+            idempotency_key,
+            status=RECEIPT_STATUS_PENDING_EVENT,
+            last_error=error,
+            event_written_at=None,
+        )
+
+    def _mark_failed(self, idempotency_key: str, now: datetime, error: str) -> None:
+        if hasattr(self._receipt_repo, "mark_failed"):
+            self._receipt_repo.mark_failed(
+                idempotency_key,
+                status=RECEIPT_STATUS_FAILED,
+                error=error,
+                now=now,
+            )
+            return
+        self._receipt_repo.update_receipt_status(
+            idempotency_key,
+            status=RECEIPT_STATUS_FAILED,
+            last_error=error,
+        )
+
+    def _invoke_event_writer(self, payloads: list[dict[str, Any]]) -> None:
+        lock_db = None
+        try:
+            if self._event_writer_lock_db is not None:
+                lock_db = self._event_writer_lock_db()
+
+            if lock_db is not None:
+                self._event_writer(
+                    self._event_writer_driver,
+                    payloads,
+                    lock_db=lock_db,
+                )
+            else:
+                self._event_writer(
+                    self._event_writer_driver,
+                    payloads,
+                )
+        finally:
+            if lock_db is not None:
+                close = getattr(lock_db, "close", None)
+                if callable(close):
+                    close()
+
+    def _write_events_and_update_receipt(
+        self,
+        *,
+        idempotency_key: str,
+        payload: list[dict[str, Any]],
+        success_outcome: str,
+        pending_outcome: str,
+    ) -> tuple[str, dict[str, str] | None]:
+        try:
+            self._invoke_event_writer(payload)
+            self._mark_event_written(
+                idempotency_key,
+                self._now(),
+            )
+            return success_outcome, None
+        except Exception as exc:
+            self._mark_event_failed(
+                idempotency_key,
+                self._now(),
+                str(exc),
+            )
+            return pending_outcome, {"error": str(exc)}
+
+    def _resolve_approved_mapping(
+        self,
+        source_device_id: str,
+        source_metric_id: str,
+    ) -> tuple[dict[str, Any] | None, str]:
+        if hasattr(self._mapping_repo, "list_mappings_for_source"):
+            mappings = self._mapping_repo.list_mappings_for_source(
+                source_device_id=source_device_id,
+                source_metric_id=source_metric_id,
+            )
+        else:
+            mappings = self._mapping_repo.list_approved_mappings_for_source(
+                source_device_id=source_device_id,
+                source_metric_id=source_metric_id,
+            )
+        approved = [m for m in mappings if str(m.get("status") or "").upper() == "APPROVED"]
+
+        if len(approved) == 1:
+            return approved[0], MQTT_MAPPING_APPROVED_OUTCOME
+
+        if len(approved) > 1:
+            return None, MQTT_MAPPING_AMBIGUOUS_OUTCOME
+
+        if not mappings:
+            return None, MQTT_MAPPING_UNMAPPED_OUTCOME
+
+        statuses = {str(item.get("status") or "").upper() for item in mappings}
+        if statuses == {"DRAFT"}:
+            return None, MQTT_MAPPING_DRAFT_OUTCOME
+        if statuses == {"REVOKED"}:
+            return None, MQTT_MAPPING_REVOKED_OUTCOME
+
+        return None, MQTT_MAPPING_AMBIGUOUS_OUTCOME
+
+    def process_reading(self, reading: Reading) -> list[dict[str, Any]]:
+        outcomes: list[dict[str, Any]] = []
+        observed_at = self._normalize_observed_at(reading.timestamp)
+
+        for metric in reading.metrics:
+            source_metric_id = f"{reading.device_id}/{metric.name}"
+            numeric, ok = self._canonical_numeric(metric.value)
+
+            if not ok:
+                outcome = MQTT_MAPPING_NON_NUMERIC_OUTCOME
+                self._record_outcome(outcome)
+                outcomes.append(
+                    {
+                        "source_device_id": reading.device_id,
+                        "source_metric_id": source_metric_id,
+                        "mapping_id": None,
+                        "idempotency_key": None,
+                        "outcome": outcome,
+                    }
+                )
+                continue
+
+            mapping, outcome = self._resolve_approved_mapping(
+                source_device_id=reading.device_id,
+                source_metric_id=source_metric_id,
+            )
+            if mapping is None:
+                self._record_outcome(outcome)
+                outcomes.append(
+                    {
+                        "source_device_id": reading.device_id,
+                        "source_metric_id": source_metric_id,
+                        "mapping_id": None,
+                        "idempotency_key": None,
+                        "outcome": outcome,
+                    }
+                )
+                continue
+
+            mapping_id = str(mapping["id"])
+            value_hash = self._value_hash(mapping_id, source_metric_id, numeric, observed_at)
+            idempotency_key = self._idempotency_key(
+                mapping_id,
+                source_metric_id,
+                observed_at,
+                value_hash,
+            )
+
+            receipt = self._receipt_repo.get_receipt(idempotency_key)
+            if receipt is None:
+                self._receipt_repo.create_receipt(
+                    idempotency_key=idempotency_key,
+                    mapping_id=mapping_id,
+                    source_device_id=reading.device_id,
+                    source_metric_id=source_metric_id,
+                    observed_at=observed_at,
+                    value_hash=value_hash,
+                    status=RECEIPT_STATUS_PENDING_METRIC,
+                )
+                receipt = self._receipt_repo.get_receipt(idempotency_key)
+
+            if receipt is None:
+                self._mark_failed(
+                    idempotency_key,
+                    self._now(),
+                    "Receipt could not be created",
+                )
+                outcome = RECEIPT_STATUS_FAILED
+                self._record_outcome(outcome)
+                outcomes.append(
+                    {
+                        "source_device_id": reading.device_id,
+                        "source_metric_id": source_metric_id,
+                        "mapping_id": mapping_id,
+                        "idempotency_key": idempotency_key,
+                        "outcome": outcome,
+                        "error": "Receipt creation failed",
+                    }
+                )
+                continue
+
+            if receipt.get("status") == RECEIPT_STATUS_COMPLETE:
+                outcome = MQTT_MAPPING_DUPLICATE_OUTCOME
+                self._record_outcome(outcome)
+                outcomes.append(
+                    {
+                        "source_device_id": reading.device_id,
+                        "source_metric_id": source_metric_id,
+                        "mapping_id": mapping_id,
+                        "idempotency_key": idempotency_key,
+                        "outcome": outcome,
+                    }
+                )
+                continue
+
+            payload = self._make_event_payload(
+                reading=reading,
+                metric=metric,
+                mapping=mapping,
+                value=numeric,
+                idempotency_key=idempotency_key,
+                observed_at=observed_at,
+            )
+
+            if receipt.get("status") == RECEIPT_STATUS_PENDING_EVENT:
+                outcome, event_error = self._write_events_and_update_receipt(
+                    idempotency_key=idempotency_key,
+                    payload=[payload],
+                    success_outcome=MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME,
+                    pending_outcome=MQTT_MAPPING_EVENT_PENDING_OUTCOME,
+                )
+                outcome_entry = {
+                    "source_device_id": reading.device_id,
+                    "source_metric_id": source_metric_id,
+                    "mapping_id": mapping_id,
+                    "idempotency_key": idempotency_key,
+                    "outcome": outcome,
+                }
+                if event_error is not None:
+                    outcome_entry["error"] = event_error["error"]
+                self._record_outcome(outcome)
+                outcomes.append(outcome_entry)
+                continue
+
+            metric_written = False
+            try:
+                self._metric_writer(
+                    mapping["target_ci_id"],
+                    mapping["target_metric_def_id"],
+                    numeric,
+                    observed_at,
+                )
+                metric_written = True
+            except IntegrityError:
+                # Duplicate Timescale sample in the same key range should be treated as
+                # idempotent (event-only path should be used next).
+                metric_written = True
+            except Exception as exc:
+                self._mark_failed(
+                    idempotency_key,
+                    self._now(),
+                    str(exc),
+                )
+                outcome = RECEIPT_STATUS_FAILED
+                self._record_outcome(outcome)
+                outcomes.append(
+                    {
+                        "source_device_id": reading.device_id,
+                        "source_metric_id": source_metric_id,
+                        "mapping_id": mapping_id,
+                        "idempotency_key": idempotency_key,
+                        "outcome": outcome,
+                        "error": str(exc),
+                    }
+                )
+                continue
+
+            if metric_written:
+                with suppress(Exception):
+                    self._mark_timescale_written(
+                        idempotency_key,
+                        self._now(),
+                    )
+
+                outcome, event_error = self._write_events_and_update_receipt(
+                    idempotency_key=idempotency_key,
+                    payload=[payload],
+                    success_outcome=MQTT_MAPPING_APPROVED_OUTCOME,
+                    pending_outcome=MQTT_MAPPING_EVENT_PENDING_OUTCOME,
+                )
+            else:
+                outcome = RECEIPT_STATUS_FAILED
+                event_error = {"error": "Metric was not written"}
+
+            outcome_entry = {
+                "source_device_id": reading.device_id,
+                "source_metric_id": source_metric_id,
+                "mapping_id": mapping_id,
+                "idempotency_key": idempotency_key,
+                "outcome": outcome,
+            }
+            if event_error is not None:
+                outcome_entry["error"] = event_error["error"]
+            self._record_outcome(outcome)
+            outcomes.append(outcome_entry)
+
+        return outcomes
+
+
+_bridge_service: MqttBridgeService | None = None
+
+
+def get_mqtt_bridge_service(
+    mapping_repo: MqttMappingRepo | None = None,
+    receipt_repo: MqttMetricSampleReceiptRepository | None = None,
+    metric_writer: Callable[[str, str, float, datetime], Any] | None = None,
+    event_writer: Callable[[Any, list[dict[str, Any]], Any], Any] | None = None,
+    runtime_status_service: Any | None = None,
+    event_writer_driver: Any | None = None,
+    event_writer_lock_db: Callable[[], Any] | None = None,
+    now_provider: Callable[[], datetime] | None = None,
+) -> MqttBridgeService:
+    global _bridge_service
+    if _bridge_service is None:
+        _bridge_service = MqttBridgeService(
+            mapping_repo=mapping_repo,
+            receipt_repo=receipt_repo,
+            metric_writer=metric_writer,
+            event_writer=event_writer,
+            runtime_status_service=runtime_status_service,
+            event_writer_driver=event_writer_driver,
+            event_writer_lock_db=event_writer_lock_db,
+            now_provider=now_provider,
+        )
+    elif event_writer_lock_db is not None:
+        _bridge_service._event_writer_lock_db = event_writer_lock_db
+    return _bridge_service

--- a/backend/tests/test_mqtt_bridge_service.py
+++ b/backend/tests/test_mqtt_bridge_service.py
@@ -1,0 +1,674 @@
+"""Unit tests for MQTT mapping bridge processing and idempotent KPI/event semantics.
+
+RED phase first: these tests define the bridge gating, idempotency, and
+partial-failure behavior before implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from services.mqtt.parsers.base import MetricReading, Reading
+from services.mqtt_bridge_service import (
+    MQTT_MAPPING_AMBIGUOUS_OUTCOME,
+    MQTT_MAPPING_APPROVED_OUTCOME,
+    MQTT_MAPPING_DRAFT_OUTCOME,
+    MQTT_MAPPING_DUPLICATE_OUTCOME,
+    MQTT_MAPPING_EVENT_PENDING_OUTCOME,
+    MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME,
+    MQTT_MAPPING_NON_NUMERIC_OUTCOME,
+    MQTT_MAPPING_REVOKED_OUTCOME,
+    MQTT_MAPPING_UNMAPPED_OUTCOME,
+    MqttBridgeService,
+    _DefaultRuntimeStatusService,
+)
+from sqlalchemy.exc import IntegrityError
+
+
+@dataclass
+class _Mapping:
+    source_device_id: str
+    source_metric_id: str
+    source_metric_name: str
+    target_ci_id: str
+    target_metric_def_id: str
+    operator: str
+    warning: float
+    critical: float
+    status: str
+
+
+class _MappingRepo:
+    def __init__(self, mappings: list[_Mapping]):
+        self._mappings = mappings
+        self.calls: list[tuple[str, str]] = []
+
+    def list_mappings_for_source(
+        self, source_device_id: str, source_metric_id: str
+    ) -> list[dict[str, Any]]:
+        self.calls.append((source_device_id, source_metric_id))
+        return [
+            {
+                "id": f"map-{i + 1}",
+                "source_device_id": mapping.source_device_id,
+                "source_metric_id": mapping.source_metric_id,
+                "source_metric_name": mapping.source_metric_name,
+                "target_ci_id": mapping.target_ci_id,
+                "target_metric_def_id": mapping.target_metric_def_id,
+                "operator": mapping.operator,
+                "warning": mapping.warning,
+                "critical": mapping.critical,
+                "status": mapping.status,
+            }
+            for i, mapping in enumerate(self._mappings)
+            if mapping.source_device_id == source_device_id
+            and mapping.source_metric_id == source_metric_id
+        ]
+
+    # Backward-compatible method name used by older service versions.
+    def list_approved_mappings_for_source(self, source_device_id: str, source_metric_id: str):
+        return self.list_mappings_for_source(source_device_id, source_metric_id)
+
+
+class _MetricRepo:
+    def __init__(self):
+        self.calls: list[tuple[str, str, float, datetime]] = []
+
+    def insert_metric_value(
+        self, node_id: str, metric_id: str, value: float, observed_at: datetime
+    ) -> dict[str, Any]:
+        self.calls.append((node_id, metric_id, value, observed_at))
+        return {
+            "node_id": node_id,
+            "metric_id": metric_id,
+            "value": value,
+        }
+
+
+class _FailingMetricWriter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, float, datetime]] = []
+
+    def __call__(self, node_id: str, metric_id: str, value: float, observed_at: datetime) -> None:
+        self.calls.append((node_id, metric_id, value, observed_at))
+        if len(self.calls) == 1:
+            raise IntegrityError("duplicate sample", None, None)
+
+
+class _EventWriter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, list[dict[str, Any]], dict[str, Any] | None]] = []
+        self.should_fail_first = False
+
+    def __call__(
+        self,
+        neo4j_driver: Any,
+        payload: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        lock_db = kwargs.get("lock_db")
+        self.calls.append((neo4j_driver, payload, {"lock_db": lock_db}))
+        if self.should_fail_first:
+            self.should_fail_first = False
+            raise RuntimeError("event write failed")
+
+
+class _StatusService:
+    def __init__(self):
+        self.outcomes: list[str] = []
+
+    def record_bridge_outcome(self, outcome: str, **kwargs) -> None:
+        self.outcomes.append(outcome)
+
+
+class _StatusCounterService(_StatusService):
+    def __init__(self) -> None:
+        super().__init__()
+        self.counters: list[str] = []
+
+    def increment_counter(self, counter: str, delta: int = 1) -> None:
+        self.counters.append(counter)
+
+
+class _ReceiptRepo:
+    def __init__(self):
+        self.records: dict[str, dict[str, Any]] = {}
+
+    def get_receipt(self, idempotency_key: str) -> dict[str, Any] | None:
+        return self.records.get(idempotency_key)
+
+    def create_receipt(
+        self,
+        *,
+        idempotency_key: str,
+        mapping_id: str,
+        source_device_id: str,
+        source_metric_id: str,
+        observed_at: datetime,
+        value_hash: str,
+        status: str,
+    ) -> dict[str, Any]:
+        record = {
+            "idempotency_key": idempotency_key,
+            "mapping_id": mapping_id,
+            "source_device_id": source_device_id,
+            "source_metric_id": source_metric_id,
+            "observed_at": observed_at,
+            "value_hash": value_hash,
+            "status": status,
+            "timescale_written_at": None,
+            "event_written_at": None,
+            "last_error": None,
+        }
+        self.records[idempotency_key] = record
+        return record
+
+    def create_or_update_receipt(self, payload: dict[str, Any]) -> dict[str, Any]:
+        existing = self.records.get(payload["idempotency_key"])
+        if existing is None:
+            return self.create_receipt(
+                idempotency_key=payload["idempotency_key"],
+                mapping_id=payload["mapping_id"],
+                source_device_id=payload["source_device_id"],
+                source_metric_id=payload["source_metric_id"],
+                observed_at=payload["observed_at"],
+                value_hash=payload["value_hash"],
+                status=payload.get("status", MQTT_MAPPING_UNMAPPED_OUTCOME),
+            )
+        existing.update(payload)
+        return existing
+
+    def update_receipt_status(
+        self,
+        idempotency_key: str,
+        *,
+        status: str | None = None,
+        timescale_written_at: datetime | None = None,
+        event_written_at: datetime | None = None,
+        last_error: str | None = None,
+    ) -> dict[str, Any]:
+        record = self.records[idempotency_key]
+        if status is not None:
+            record["status"] = status
+        if timescale_written_at is not None:
+            record["timescale_written_at"] = timescale_written_at
+        if event_written_at is not None:
+            record["event_written_at"] = event_written_at
+        if last_error is not None:
+            record["last_error"] = last_error
+        return record
+
+    def mark_timescale_written(self, idempotency_key: str, *, status: str, now: datetime):
+        return self.update_receipt_status(
+            idempotency_key,
+            status=status,
+            timescale_written_at=now,
+            last_error=None,
+        )
+
+    def mark_event_written(self, idempotency_key: str, *, status: str, now: datetime):
+        return self.update_receipt_status(
+            idempotency_key,
+            status=status,
+            event_written_at=now,
+            last_error=None,
+        )
+
+    def mark_event_failed(self, idempotency_key: str, *, status: str, error: str, now: datetime):
+        return self.update_receipt_status(
+            idempotency_key,
+            status=status,
+            event_written_at=None,
+            last_error=error,
+        )
+
+    def mark_failed(self, idempotency_key: str, *, status: str, error: str, now: datetime):
+        return self.update_receipt_status(
+            idempotency_key,
+            status=status,
+            last_error=error,
+        )
+
+
+class _FailingTimescaleMarkReceiptRepo(_ReceiptRepo):
+    def __init__(self) -> None:
+        super().__init__()
+        self.timescale_written_calls = 0
+
+    def mark_timescale_written(self, idempotency_key: str, *, status: str, now: datetime):
+        self.timescale_written_calls += 1
+        if self.timescale_written_calls == 1:
+            raise RuntimeError("timescale state update failed")
+        return super().mark_timescale_written(idempotency_key, status=status, now=now)
+
+
+class _FailingEventMarkReceiptRepo(_ReceiptRepo):
+    def __init__(self) -> None:
+        super().__init__()
+        self.event_written_calls = 0
+
+    def mark_event_written(self, idempotency_key: str, *, status: str, now: datetime):
+        self.event_written_calls += 1
+        if self.event_written_calls == 1:
+            raise RuntimeError("event state update failed")
+        return super().mark_event_written(idempotency_key, status=status, now=now)
+
+
+class _IdempotentEventWriter:
+    def __init__(self) -> None:
+        self.calls = []
+        self.seen = set[tuple[str, Any]]()
+
+    def __call__(
+        self,
+        neo4j_driver: Any,
+        payload: list[dict[str, Any]],
+        **kwargs: Any,
+    ) -> None:
+        row = payload[0]
+        self.calls.append((neo4j_driver, payload, kwargs))
+        if ("idempotency_key", row["idempotency_key"]) in self.seen:
+            return
+        self.seen.add(("idempotency_key", row["idempotency_key"]))
+
+
+FIXED_TS = datetime(2026, 8, 1, 12, 34, 56, tzinfo=UTC)
+
+
+def _reading(value: float = 12.5) -> Reading:
+    return Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=FIXED_TS,
+        metrics=(MetricReading(name="temperature", value=value, unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+
+def _approved_mapping() -> _Mapping:
+    return _Mapping(
+        source_device_id="rtu-1",
+        source_metric_id="rtu-1/temperature",
+        source_metric_name="temperature",
+        target_ci_id="ci-1",
+        target_metric_def_id="temperature",
+        operator=">=",
+        warning=70,
+        critical=90,
+        status="APPROVED",
+    )
+
+
+@pytest.mark.parametrize(
+    "mappings,outcome",
+    [
+        ([], MQTT_MAPPING_UNMAPPED_OUTCOME),
+        (
+            [
+                _Mapping(
+                    "rtu-1",
+                    "rtu-1/temperature",
+                    "temperature",
+                    "ci-1",
+                    "temp",
+                    ">=",
+                    70,
+                    90,
+                    "DRAFT",
+                )
+            ],
+            MQTT_MAPPING_DRAFT_OUTCOME,
+        ),
+        (
+            [
+                _Mapping(
+                    "rtu-1",
+                    "rtu-1/temperature",
+                    "temperature",
+                    "ci-1",
+                    "temp",
+                    ">=",
+                    70,
+                    90,
+                    "REVOKED",
+                )
+            ],
+            MQTT_MAPPING_REVOKED_OUTCOME,
+        ),
+        (
+            [
+                _Mapping(
+                    "rtu-1",
+                    "rtu-1/temperature",
+                    "temperature",
+                    "ci-1",
+                    "temp",
+                    ">=",
+                    70,
+                    90,
+                    "APPROVED",
+                ),
+                _Mapping(
+                    "rtu-1",
+                    "rtu-1/temperature",
+                    "temperature",
+                    "ci-2",
+                    "temp",
+                    ">=",
+                    70,
+                    90,
+                    "APPROVED",
+                ),
+            ],
+            MQTT_MAPPING_AMBIGUOUS_OUTCOME,
+        ),
+    ],
+)
+def test_blocked_mapping_states_do_not_write_kpi_data(
+    mappings: list[_Mapping], outcome: str
+) -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    mapping_repo = _MappingRepo(mappings)
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    result = service.process_reading(_reading())
+
+    assert mapping_repo.calls == [("rtu-1", "rtu-1/temperature")]
+    assert result[0]["outcome"] == outcome
+    assert metric_repo.calls == []
+    assert event_writer.calls == []
+    assert status_service.outcomes[-1] == outcome
+
+
+def test_non_numeric_metric_reading_is_skipped() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    reading = Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=FIXED_TS,
+        metrics=(MetricReading(name="temperature", value="25C", unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+    result = service.process_reading(reading)
+
+    assert result[0]["outcome"] == MQTT_MAPPING_NON_NUMERIC_OUTCOME
+    assert metric_repo.calls == []
+    assert event_writer.calls == []
+
+
+def test_approved_mapping_writes_metric_then_event_with_mapping_thresholds() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    result = service.process_reading(_reading(value=12.5))
+
+    assert result[0]["outcome"] == MQTT_MAPPING_APPROVED_OUTCOME
+    assert len(metric_repo.calls) == 1
+    assert metric_repo.calls[0] == ("ci-1", "temperature", 12.5, FIXED_TS)
+    assert len(event_writer.calls) == 1
+    payload = event_writer.calls[0][1][0]
+    assert payload["protocol"] == "MQTT"
+    assert payload["source_protocol"] == "MQTT"
+    assert payload["ci_id"] == "ci-1"
+    assert payload["metric_id"] == "temperature"
+    assert payload["value"] == {"numeric": 12.5}
+    assert payload["metadata"]["operator"] == ">="
+    assert payload["metadata"]["warning"] == 70
+    assert payload["metadata"]["critical"] == 90
+    assert payload["metadata"]["source_metric_id"] == "rtu-1/temperature"
+    assert payload["idempotency_key"].startswith("mqtt:")
+    assert status_service.outcomes[-1] == MQTT_MAPPING_APPROVED_OUTCOME
+
+
+def test_duplicate_payload_is_skipped_after_successful_complete_receipt() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    first = service.process_reading(_reading(value=18.0))
+    second = service.process_reading(_reading(value=18.0))
+
+    assert first[0]["outcome"] == MQTT_MAPPING_APPROVED_OUTCOME
+    assert second[0]["outcome"] == MQTT_MAPPING_DUPLICATE_OUTCOME
+    assert len(metric_repo.calls) == 1
+    assert len(event_writer.calls) == 1
+    assert status_service.outcomes[-1] == MQTT_MAPPING_DUPLICATE_OUTCOME
+
+
+def test_duplicate_metric_insert_retries_event_only_without_rewriting_metric() -> None:
+    metric_repo = _FailingMetricWriter()
+    event_writer = _EventWriter()
+    event_writer.should_fail_first = True
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    first = service.process_reading(_reading(value=44.4))
+    second = service.process_reading(_reading(value=44.4))
+
+    assert first[0]["outcome"] == MQTT_MAPPING_EVENT_PENDING_OUTCOME
+    assert second[0]["outcome"] == MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME
+    assert len(metric_repo.calls) == 1
+    assert len(event_writer.calls) == 2
+
+
+def test_partial_event_failure_retries_event_only_without_rewriting_metric() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    event_writer.should_fail_first = True
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    first = service.process_reading(_reading(value=42.1))
+    second = service.process_reading(_reading(value=42.1))
+
+    assert first[0]["outcome"] == MQTT_MAPPING_EVENT_PENDING_OUTCOME
+    assert second[0]["outcome"] == MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME
+    assert len(metric_repo.calls) == 1
+    assert len(event_writer.calls) == 2
+    assert status_service.outcomes[-2:] == [
+        MQTT_MAPPING_EVENT_PENDING_OUTCOME,
+        MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME,
+    ]
+
+
+def test_pending_receipt_without_timescale_is_not_rewritten_to_timescale() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    status_service = _StatusService()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    key = service._idempotency_key(
+        "map-1",
+        "rtu-1/temperature",
+        FIXED_TS,
+        service._value_hash("map-1", "rtu-1/temperature", 12.5, FIXED_TS),
+    )
+    receipt_repo.create_receipt(
+        idempotency_key=key,
+        mapping_id="map-1",
+        source_device_id="rtu-1",
+        source_metric_id="rtu-1/temperature",
+        observed_at=FIXED_TS,
+        value_hash=service._value_hash("map-1", "rtu-1/temperature", 12.5, FIXED_TS),
+        status="PENDING_EVENT",
+    )
+
+    result = service.process_reading(_reading(value=12.5))
+
+    assert result[0]["outcome"] == MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME
+    assert metric_repo.calls == []
+    assert len(event_writer.calls) == 1
+
+
+def test_timescale_mark_failure_stays_retryable_without_duplicate_metric_write() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _EventWriter()
+    event_writer.should_fail_first = True
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _FailingTimescaleMarkReceiptRepo()
+    status_service = _StatusService()
+
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    first = service.process_reading(_reading(value=55.0))
+    second = service.process_reading(_reading(value=55.0))
+
+    assert first[0]["outcome"] == MQTT_MAPPING_EVENT_PENDING_OUTCOME
+    assert second[0]["outcome"] == MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME
+    assert len(metric_repo.calls) == 1
+    assert len(event_writer.calls) == 2
+
+
+def test_event_success_without_event_receipt_mark_stays_idempotent_on_retry() -> None:
+    metric_repo = _MetricRepo()
+    event_writer = _IdempotentEventWriter()
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _FailingEventMarkReceiptRepo()
+    status_service = _StatusService()
+
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=metric_repo.insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=status_service,
+        event_writer_driver=object(),
+    )
+
+    first = service.process_reading(_reading(value=61.0))
+    second = service.process_reading(_reading(value=61.0))
+
+    assert first[0]["outcome"] == MQTT_MAPPING_EVENT_PENDING_OUTCOME
+    assert second[0]["outcome"] == MQTT_MAPPING_EVENT_RETRY_SUCCESS_OUTCOME
+    assert len(event_writer.calls) == 2
+
+
+def test_event_writer_receives_lock_db_when_factory_provided() -> None:
+    class _DB:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    lock_db = _DB()
+    lock_factory_called = {"count": 0}
+
+    class _CountingFactory:
+        def __call__(self) -> _DB:
+            lock_factory_called["count"] += 1
+            return lock_db
+
+    mapping_repo = _MappingRepo([_approved_mapping()])
+    receipt_repo = _ReceiptRepo()
+    event_writer = _EventWriter()
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=receipt_repo,
+        metric_writer=_MetricRepo().insert_metric_value,
+        event_writer=event_writer,
+        event_writer_driver=object(),
+        event_writer_lock_db=_CountingFactory(),
+        runtime_status_service=_StatusService(),
+    )
+
+    service.process_reading(_reading())
+
+    assert lock_factory_called["count"] == 1
+    _, _, kwargs = event_writer.calls[0]
+    assert kwargs["lock_db"] is lock_db
+    assert lock_db.closed is True
+
+
+def test_mapped_event_pending_is_counted_as_failed() -> None:
+    runtime_status = _StatusCounterService()
+    runtime = _DefaultRuntimeStatusService()
+    runtime._service = runtime_status
+
+    runtime.record_bridge_outcome(MQTT_MAPPING_EVENT_PENDING_OUTCOME)
+
+    assert runtime_status.counters == ["failed_writes_total"]

--- a/backend/tests/test_mqtt_kpi_gate_regression.py
+++ b/backend/tests/test_mqtt_kpi_gate_regression.py
@@ -1,0 +1,210 @@
+"""Regression tests ensuring KPI writes stay strictly approved-only."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from services.mqtt.parsers.base import MetricReading, Reading
+from services.mqtt_bridge_service import (
+    MQTT_MAPPING_AMBIGUOUS_OUTCOME,
+    MQTT_MAPPING_APPROVED_OUTCOME,
+    MQTT_MAPPING_DRAFT_OUTCOME,
+    MQTT_MAPPING_REVOKED_OUTCOME,
+    MqttBridgeService,
+)
+
+
+class _MappingRepo:
+    def __init__(self, mappings_by_call):
+        self.calls = 0
+        self._mappings_by_call = mappings_by_call
+
+    def list_approved_mappings_for_source(self, source_device_id: str, source_metric_id: str):
+        mapping = self._mappings_by_call[self.calls]
+        self.calls += 1
+        return mapping
+
+
+class _ReceiptRepo:
+    def __init__(self) -> None:
+        self.records = {}
+
+    def get_receipt(self, idempotency_key: str):
+        return self.records.get(idempotency_key)
+
+    def create_receipt(self, **payload):
+        self.records[payload["idempotency_key"]] = {
+            **payload,
+            "status": payload["status"],
+            "timescale_written_at": None,
+            "event_written_at": None,
+            "last_error": None,
+        }
+        return self.records[payload["idempotency_key"]]
+
+    def mark_timescale_written(self, idempotency_key: str, **payload):
+        self.records[idempotency_key].update(payload)
+        return self.records[idempotency_key]
+
+    def mark_event_written(self, idempotency_key: str, **payload):
+        self.records[idempotency_key].update(payload)
+        return self.records[idempotency_key]
+
+    def mark_event_failed(self, idempotency_key: str, **payload):
+        self.records[idempotency_key].update(payload)
+        return self.records[idempotency_key]
+
+    def mark_failed(self, idempotency_key: str, **payload):
+        self.records[idempotency_key].update(payload)
+        return self.records[idempotency_key]
+
+
+class _StatusService:
+    def __init__(self):
+        self.calls = []
+
+    def record_bridge_outcome(self, outcome: str, **kwargs) -> None:
+        self.calls.append(outcome)
+
+
+def _reading(value: float) -> Reading:
+    return Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        metrics=(MetricReading(name="temperature", value=value, unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+
+def test_kpi_bridge_is_approved_only() -> None:
+    metric_calls = []
+
+    class _MetricRepo:
+        def __call__(self, node_id, metric_id, value, observed_at):
+            raise AssertionError("Unapproved mappings must not reach Timescale")
+
+    mapping_repo = _MappingRepo(
+        mappings_by_call=[
+            [
+                {
+                    "id": "map-1",
+                    "source_device_id": "rtu-1",
+                    "source_metric_id": "rtu-1/temperature",
+                    "source_metric_name": "temperature",
+                    "target_ci_id": "ci-1",
+                    "target_metric_def_id": "temperature",
+                    "operator": ">=",
+                    "warning": 70,
+                    "critical": 90,
+                    "status": "DRAFT",
+                }
+            ],
+            [
+                {
+                    "id": "map-1",
+                    "source_device_id": "rtu-1",
+                    "source_metric_id": "rtu-1/temperature",
+                    "source_metric_name": "temperature",
+                    "target_ci_id": "ci-1",
+                    "target_metric_def_id": "temperature",
+                    "operator": ">=",
+                    "warning": 70,
+                    "critical": 90,
+                    "status": "REVOKED",
+                }
+            ],
+            [
+                {
+                    "id": "map-1",
+                    "source_device_id": "rtu-1",
+                    "source_metric_id": "rtu-1/temperature",
+                    "source_metric_name": "temperature",
+                    "target_ci_id": "ci-1",
+                    "target_metric_def_id": "temperature",
+                    "operator": ">=",
+                    "warning": 70,
+                    "critical": 90,
+                    "status": "APPROVED",
+                },
+                {
+                    "id": "map-2",
+                    "source_device_id": "rtu-1",
+                    "source_metric_id": "rtu-1/temperature",
+                    "source_metric_name": "temperature",
+                    "target_ci_id": "ci-2",
+                    "target_metric_def_id": "temperature",
+                    "operator": ">=",
+                    "warning": 70,
+                    "critical": 90,
+                    "status": "APPROVED",
+                },
+            ],
+        ]
+    )
+
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=_ReceiptRepo(),
+        metric_writer=lambda *_args: metric_calls.append(_args),
+        event_writer=lambda *_args, **_kwargs: None,
+        runtime_status_service=_StatusService(),
+        event_writer_driver=object(),
+    )
+
+    results = [
+        service.process_reading(_reading(55.0)),
+        service.process_reading(_reading(56.0)),
+        service.process_reading(_reading(57.0)),
+    ]
+
+    outcomes = [result[0]["outcome"] for result in results]
+    assert outcomes == [
+        MQTT_MAPPING_DRAFT_OUTCOME,
+        MQTT_MAPPING_REVOKED_OUTCOME,
+        MQTT_MAPPING_AMBIGUOUS_OUTCOME,
+    ]
+    assert metric_calls == []
+
+
+def test_approved_mapping_still_writes_kpi_path() -> None:
+    status = _StatusService()
+    metric_calls = []
+
+    class _MetricRepo:
+        def __call__(self, node_id, metric_id, value, observed_at):
+            metric_calls.append((node_id, metric_id, value))
+
+    mapping_repo = _MappingRepo(
+        mappings_by_call=[
+            [
+                {
+                    "id": "map-1",
+                    "source_device_id": "rtu-1",
+                    "source_metric_id": "rtu-1/temperature",
+                    "source_metric_name": "temperature",
+                    "target_ci_id": "ci-1",
+                    "target_metric_def_id": "temperature",
+                    "operator": ">=",
+                    "warning": 70,
+                    "critical": 90,
+                    "status": "APPROVED",
+                }
+            ]
+        ]
+    )
+
+    service = MqttBridgeService(
+        mapping_repo=mapping_repo,
+        receipt_repo=_ReceiptRepo(),
+        metric_writer=_MetricRepo(),
+        event_writer=lambda *_args, **_kwargs: None,
+        runtime_status_service=status,
+        event_writer_driver=object(),
+    )
+
+    result = service.process_reading(_reading(61.0))
+
+    assert result[0]["outcome"] == MQTT_MAPPING_APPROVED_OUTCOME
+    assert metric_calls == [("ci-1", "temperature", 61.0)]

--- a/backend/tests/test_mqtt_mapped_event_flow.py
+++ b/backend/tests/test_mqtt_mapped_event_flow.py
@@ -1,0 +1,161 @@
+"""Regression tests for event metadata propagation in MQTT KPI bridge path."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from services.mqtt.parsers.base import MetricReading, Reading
+from services.mqtt_bridge_service import (
+    MQTT_MAPPING_APPROVED_OUTCOME,
+    MqttBridgeService,
+)
+
+
+class _EventWriter:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __call__(self, neo4j_driver, payload):
+        self.calls.append((neo4j_driver, payload))
+
+
+class _MappingRepo:
+    def __init__(self, mapping_over_time: list[dict[str, object]]):
+        self._mapping_over_time = mapping_over_time
+        self.calls = 0
+
+    def list_approved_mappings_for_source(self, source_device_id: str, source_metric_id: str):
+        mapping = self._mapping_over_time[min(self.calls, len(self._mapping_over_time) - 1)]
+        self.calls += 1
+        return [mapping]
+
+
+class _ReceiptRepo:
+    def __init__(self) -> None:
+        self.records = {}
+
+    def get_receipt(self, idempotency_key: str):
+        return self.records.get(idempotency_key)
+
+    def create_receipt(self, **payload):
+        self.records[payload["idempotency_key"]] = {
+            **payload,
+            "status": payload["status"],
+            "timescale_written_at": None,
+            "event_written_at": None,
+            "last_error": None,
+        }
+        return self.records[payload["idempotency_key"]]
+
+    def update_receipt_status(self, idempotency_key: str, **payload):
+        self.records[idempotency_key].update(payload)
+        return self.records[idempotency_key]
+
+
+class _MetricRepo:
+    def insert_metric_value(self, node_id, metric_id, value, observed_at):
+        return {"node_id": node_id, "metric_id": metric_id}
+
+
+class _StatusService:
+    def record_bridge_outcome(self, outcome: str, **kwargs) -> None:
+        pass
+
+
+def _reading(value: float, at: datetime) -> Reading:
+    return Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=at,
+        metrics=(MetricReading(name="temperature", value=value, unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+
+def test_event_metadata_uses_current_thresholds_from_mapping() -> None:
+    mapping_v1 = {
+        "id": "map-1",
+        "source_device_id": "rtu-1",
+        "source_metric_id": "rtu-1/temperature",
+        "source_metric_name": "temperature",
+        "target_ci_id": "ci-1",
+        "target_metric_def_id": "temperature",
+        "operator": ">=",
+        "warning": 80,
+        "critical": 95,
+        "status": "APPROVED",
+    }
+    mapping_v2 = {
+        **mapping_v1,
+        "warning": 50,
+        "critical": 75,
+    }
+
+    event_writer = _EventWriter()
+    service = MqttBridgeService(
+        mapping_repo=_MappingRepo([mapping_v1, mapping_v2]),
+        receipt_repo=_ReceiptRepo(),
+        metric_writer=_MetricRepo().insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=_StatusService(),
+        event_writer_driver=object(),
+    )
+
+    first_ts = datetime(2026, 8, 1, 12, 34, 56, tzinfo=UTC)
+    second_ts = datetime(2026, 8, 1, 12, 34, 57, tzinfo=UTC)
+
+    first = service.process_reading(_reading(20.0, first_ts))
+    second = service.process_reading(_reading(21.0, second_ts))
+
+    assert first[0]["outcome"] == MQTT_MAPPING_APPROVED_OUTCOME
+    assert second[0]["outcome"] == MQTT_MAPPING_APPROVED_OUTCOME
+    assert len(event_writer.calls) == 2
+    first_payload = event_writer.calls[0][1][0]
+    second_payload = event_writer.calls[1][1][0]
+
+    assert first_payload["metadata"]["warning"] == 80
+    assert first_payload["metadata"]["critical"] == 95
+    assert second_payload["metadata"]["warning"] == 50
+    assert second_payload["metadata"]["critical"] == 75
+    assert first_payload["metadata"]["source_metric_name"] == "temperature"
+    assert second_payload["metadata"]["source_metric_name"] == "temperature"
+
+
+def test_event_payload_keeps_protocol_and_observation_time() -> None:
+    event_writer = _EventWriter()
+    service = MqttBridgeService(
+        mapping_repo=_MappingRepo(
+            [
+                {
+                    "id": "map-1",
+                    "source_device_id": "rtu-1",
+                    "source_metric_id": "rtu-1/temperature",
+                    "source_metric_name": "temperature",
+                    "target_ci_id": "ci-1",
+                    "target_metric_def_id": "temperature",
+                    "operator": "<",
+                    "warning": 40,
+                    "critical": 60,
+                    "status": "APPROVED",
+                }
+            ]
+        ),
+        receipt_repo=_ReceiptRepo(),
+        metric_writer=_MetricRepo().insert_metric_value,
+        event_writer=event_writer,
+        runtime_status_service=_StatusService(),
+        event_writer_driver=object(),
+    )
+
+    observed_at = datetime(2026, 8, 1, 13, 0, 0, tzinfo=UTC)
+
+    result = service.process_reading(_reading(39.0, observed_at))
+
+    payload = event_writer.calls[0][1][0]
+    assert payload["observed_at"] == observed_at.isoformat()
+    assert payload["protocol"] == "MQTT"
+    assert payload["source_protocol"] == "MQTT"
+    assert payload["metadata"]["operator"] == "<"
+    assert payload["idempotency_key"].startswith("mqtt:")
+    assert result[0]["mapping_id"] == "map-1"

--- a/backend/tests/test_mqtt_router.py
+++ b/backend/tests/test_mqtt_router.py
@@ -9,6 +9,23 @@ from routers import mqtt
 from services.mqtt_raw_reading_service import MqttRawReadingService
 
 
+class _StatusService:
+    def get_status(self):
+        return {
+            "service_name": "mqtt-subscriber",
+            "configured": True,
+            "running": True,
+            "connected": True,
+            "subscribed_patterns": ["rtu/+/telemetry"],
+            "mapped_writes_total": 5,
+            "unmapped_skips_total": 2,
+            "failed_writes_total": 1,
+            "last_error": None,
+            "reason_code": None,
+            "is_stale": False,
+        }
+
+
 class _RawService:
     def list_devices(self):
         return [
@@ -106,7 +123,7 @@ def _user(permissions=None):
     return User(username="operator", role="OPERATOR", permissions=permissions or [])
 
 
-def _client(user=None, mapping_service=None):
+def _client(user=None, mapping_service=None, status_service=None):
     app = FastAPI()
     app.include_router(mqtt.router, prefix="/api")
     app.dependency_overrides[mqtt._current_user] = lambda: user or _user(
@@ -114,6 +131,8 @@ def _client(user=None, mapping_service=None):
     )
     app.dependency_overrides[mqtt._raw_service] = lambda: _RawService()
     app.dependency_overrides[mqtt._mapping_service] = lambda: mapping_service or _MappingService()
+    if status_service is not None:
+        app.dependency_overrides[mqtt._runtime_status_service] = lambda: status_service
     return TestClient(app)
 
 
@@ -212,3 +231,14 @@ def test_threshold_read_and_update_endpoints():
     assert get_response.json()["warning"] == 70
     assert put_response.status_code == 200
     assert put_response.json()["warning"] == 75
+
+
+def test_status_endpoint_exposes_bridge_counters():
+    response = _client(status_service=_StatusService()).get("/api/mqtt/status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["mapped_writes_total"] == 5
+    assert payload["unmapped_skips_total"] == 2
+    assert payload["failed_writes_total"] == 1
+    assert payload["service_name"] == "mqtt-subscriber"

--- a/backend/tests/test_mqtt_subscriber_bridge_integration.py
+++ b/backend/tests/test_mqtt_subscriber_bridge_integration.py
@@ -1,0 +1,153 @@
+"""Subscriber integration tests for MQTT bridge invocation from raw persistence."""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime
+
+import pytest
+from services.mqtt.parsers.base import MetricReading, Reading
+
+
+@pytest.mark.asyncio
+async def test_persist_reading_invokes_bridge_without_breaking_raw_flow(monkeypatch) -> None:
+    class _MetricRepo:
+        def __init__(self) -> None:
+            self.device_calls = []
+            self.metric_calls = []
+
+        def upsert_device(
+            self, device_id: str, name: str, location_id: str | None = None, **kwargs
+        ) -> dict[str, str]:
+            self.device_calls.append((device_id, location_id, name))
+            return {"id": device_id}
+
+        def upsert_metric(
+            self,
+            *,
+            metric_id: str,
+            device_id: str,
+            name: str,
+            value: float,
+            unit: str | None = None,
+            ts=None,
+            tags: dict[str, str] | None = None,
+            **kwargs,
+        ) -> None:
+            self.metric_calls.append((metric_id, device_id, name, value, ts))
+
+    metric_repo = _MetricRepo()
+    bridge_calls: list[Reading] = []
+
+    class _BridgeService:
+        def process_reading(self, reading: Reading):
+            bridge_calls.append(reading)
+            return [{"outcome": "SKIPPED_UNMAPPED"}]
+
+    module = importlib.import_module("services.mqtt.subscriber")
+    monkeypatch.setattr(module, "get_device_metric_repo", lambda: metric_repo)
+    monkeypatch.setattr(module, "get_mqtt_bridge_service", lambda **kwargs: _BridgeService())
+
+    reading = Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        metrics=(MetricReading(name="temperature", value=20.0, unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+    await module._persist_reading(reading)
+
+    assert metric_repo.device_calls == [("rtu-1", "loc-1", "rtu-1")]
+    assert metric_repo.metric_calls == [
+        (
+            "rtu-1/temperature",
+            "rtu-1",
+            "temperature",
+            20.0,
+            datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        ),
+    ]
+    assert len(bridge_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_bridge_failure_does_not_break_raw_persistence(monkeypatch) -> None:
+    class _MetricRepo:
+        def upsert_device(
+            self, device_id: str, name: str, location_id: str | None = None, **kwargs
+        ) -> dict[str, str]:
+            return {"id": device_id}
+
+        def upsert_metric(self, **kwargs):
+            return None
+
+    module = importlib.import_module("services.mqtt.subscriber")
+    monkeypatch.setattr(module, "get_device_metric_repo", lambda: _MetricRepo())
+    monkeypatch.setattr(
+        module,
+        "get_mqtt_bridge_service",
+        lambda **kwargs: type(
+            "Bridge",
+            (),
+            {
+                "process_reading": staticmethod(
+                    lambda _r: (_ for _ in ()).throw(RuntimeError("bridge unavailable"))
+                )
+            },
+        )(),
+    )
+
+    reading = Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        metrics=(MetricReading(name="temperature", value=20.0, unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+    # No exception should escape _persist_reading when the bridge fails.
+    await module._persist_reading(reading)
+
+
+@pytest.mark.asyncio
+async def test_persist_reading_builds_bridge_with_lock_factory_when_available(monkeypatch) -> None:
+    class _MetricRepo:
+        def upsert_device(
+            self, device_id: str, name: str, location_id: str | None = None, **kwargs
+        ) -> dict[str, str]:
+            return {"id": device_id}
+
+        def upsert_metric(self, **kwargs):
+            return None
+
+    captured: dict[str, object] = {}
+
+    class _BridgeService:
+        def process_reading(self, _reading: Reading) -> list[dict[str, str]]:
+            return [{"outcome": "SKIPPED_UNMAPPED"}]
+
+    instance = _BridgeService()
+
+    def _bridge_factory(**kwargs: object) -> _BridgeService:
+        captured["kwargs"] = kwargs
+        return instance
+
+    module = importlib.import_module("services.mqtt.subscriber")
+    monkeypatch.setattr(module, "get_device_metric_repo", lambda: _MetricRepo())
+    monkeypatch.setattr(module, "get_mqtt_bridge_service", _bridge_factory)
+
+    reading = Reading(
+        device_id="rtu-1",
+        location_id="loc-1",
+        timestamp=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+        metrics=(MetricReading(name="temperature", value=20.0, unit="C"),),
+        source_topic="rtu/loc-1/rtu-1/telemetry",
+        parser_name="bliiot",
+    )
+
+    await module._persist_reading(reading)
+
+    assert captured["kwargs"]["event_writer_lock_db"] is module.SessionLocal

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -5,7 +5,7 @@ from tests.conftest import MockNeo4jDriver
 
 def _event_row(value: float | None = 97.0, status="OK", metadata=None):
     return {
-        "idempotency_key": "idem-1",
+        "idempotency_key": None,
         "ci_id": "ci-1",
         "metric_id": "cpu",
         "protocol": "SNMP",
@@ -199,7 +199,7 @@ def test_event_writer_uses_unwind_for_latest_breach_and_recovery_updates():
     queries = "\n".join(q["query"] for q in driver.mock_session.queries)
     assert queries.count("UNWIND $rows AS row") >= 3
     assert "MERGE (n)-[r:HAS_METRIC]->(m)" in queries
-    assert "CREATE (res:MetricResult" in queries
+    assert "CREATE (res:MetricResult" in queries or "MERGE (res:MetricResult" in queries
     assert "status: 'OPEN'" in queries
     assert "id: randomUUID()" in queries
     assert "e.id = coalesce(e.id, randomUUID())" not in queries
@@ -207,6 +207,47 @@ def test_event_writer_uses_unwind_for_latest_breach_and_recovery_updates():
     assert "correlation_type" in queries
     assert "root_cause_ci_id" in queries
     assert "PROPAGATED" in queries
+
+
+def test_event_writer_deduplicates_idempotent_payload_rows_before_metric_result_write():
+    from polling.event_writer import batch_update_events
+
+    driver = MockNeo4jDriver()
+    first_payload = {**_event_row(95.0), "idempotency_key": "idem-1"}
+    duplicate_payload = {**first_payload, "value": {"numeric": 95.0, "raw": 95.0}}
+
+    batch_update_events(
+        driver,
+        [first_payload, duplicate_payload],
+    )
+
+    metric_queries = [
+        q
+        for q in driver.mock_session.queries
+        if "MetricResult" in q["query"] and "MERGE" in q["query"]
+    ]
+    assert len(metric_queries) == 1
+    deduped_rows = metric_queries[0]["params"]["rows"]
+    assert len(deduped_rows) == 1
+    assert deduped_rows[0]["idempotency_key"] == first_payload["idempotency_key"]
+    assert deduped_rows[0]["ci_id"] == first_payload["ci_id"]
+    assert deduped_rows[0]["metric_id"] == first_payload["metric_id"]
+    assert "MERGE (res)-[:FOR_METRIC]->(m)" in metric_queries[0]["query"]
+    assert "CREATE (res)-[:FOR_METRIC]->(m)" not in metric_queries[0]["query"]
+
+
+def test_metric_result_idempotency_migration_adds_uniqueness_guard():
+    from pathlib import Path
+
+    migration = (
+        Path(__file__).resolve().parents[1] / "migrations/004_mqtt_metric_result_idempotency.cypher"
+    )
+
+    assert migration.exists()
+    cypher = migration.read_text().lower()
+    assert "metricresult" in cypher
+    assert "idempotency_key" in cypher
+    assert "is unique" in cypher
 
 
 def test_event_writer_icmp_success_recovers_only_icmp_availability_events():

--- a/openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr4.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr4.md
@@ -1,0 +1,133 @@
+# Apply Progress — integrate-mqtt-readings-monitoring (PR4 scope)
+
+## Scope
+
+PR4 implements fail-closed MQTT→monitoring bridge behavior, idempotent receipt-driven deduplication, and failure-safe subscriber wiring.
+
+## Completed tasks (PR4)
+
+- [x] Add/extend bridge contract tests for unmapped/invalid mappings, approved write path, idempotency, and partial event failure retry behavior.
+- [x] Implement `backend/services/mqtt_bridge_service.py` with:
+  - approved-only mapping gate
+  - deterministic idempotency keys + mapped sample receipts
+  - metric write + event write sequencing
+  - status-aware retry only on event step
+- [x] Invoke bridge service from `backend/services/mqtt/subscriber.py` after raw persistence with non-fatal failure handling.
+- [x] Extend `/api/mqtt/status` endpoint to expose runtime bridge counters.
+- [x] Add regression tests proving approved-only KPI writes, threshold propagation, and subscriber/raw-bridge isolation.
+
+## Files changed
+
+- `backend/services/mqtt_bridge_service.py`
+- `backend/services/mqtt/subscriber.py`
+- `backend/polling/event_writer.py`
+- `backend/repositories/mqtt_mapping_repo.py`
+- `backend/repositories/mqtt_metric_sample_receipt_repo.py`
+- `backend/migrations/004_mqtt_metric_result_idempotency.cypher`
+- `backend/routers/mqtt.py`
+- `backend/tests/test_mqtt_bridge_service.py`
+- `backend/tests/test_mqtt_mapped_event_flow.py`
+- `backend/tests/test_mqtt_kpi_gate_regression.py`
+- `backend/tests/test_mqtt_subscriber_bridge_integration.py`
+- `backend/tests/test_polling_event_writer.py`
+- `backend/tests/test_mqtt_router.py`
+- `openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr4.md`
+
+## Verification
+
+### TDD evidence
+
+| Phase | Command | Result |
+|---|---|---|
+| RED | `./backend/.venv/bin/pytest backend/tests/test_mqtt_bridge_service.py` (before implementation snapshot) | New gate-path tests added first |
+| GREEN | `./backend/.venv/bin/pytest backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py` | PASS |
+| TRIANGULATE | Cross-verified with existing router/subscriber/runtime suites: `./backend/.venv/bin/pytest backend/tests/test_mqtt_router.py backend/tests/test_mqtt_subscriber_loop.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py` | PASS |
+| SAFETY NET | `cd backend && ../backend/.venv/bin/python -m pytest` | Known-baseline unrelated failures: 2 auth cookie-domain assertions and 4 Docker/testcontainers advisory-lock failures; PR4 focused suites pass. |
+| REFACTOR | Formatting / lint pass: `ruff`, `black` on touched files | PASS |
+
+### TDD Cycle Evidence
+
+| PR4 task | RED evidence | GREEN evidence | TRIANGULATE evidence | SAFETY NET evidence | REFACTOR evidence |
+|---|---|---|---|---|---|
+| Fail-closed bridge gate | Added `test_mqtt_bridge_service.py` cases for unmapped, `DRAFT`, `REVOKED`, ambiguous, and non-numeric readings before bridge implementation. | `MqttBridgeService.process_reading()` resolves approved mappings only and returns `SKIPPED_UNMAPPED`, `SKIPPED_DRAFT`, `SKIPPED_REVOKED`, `BLOCKED_AMBIGUOUS_MAPPING`, or `SKIPPED_NON_NUMERIC` before metric/event calls. | `test_mqtt_kpi_gate_regression.py` proves unapproved readings do not call KPI/event writers. | Focused PR4 bridge/regression command passed; full suite failures are existing auth cookie/Docker testcontainers issues outside PR4 files. | Ruff/Black passed on bridge, repository, router, subscriber, and test files. |
+| Idempotent KPI write and event path | Added approved mapping, duplicate payload, and partial event failure retry tests before receipt-driven implementation. | `mqtt_metric_sample_receipt_repo.py` plus bridge receipt state transitions implement `PENDING_EVENT`, `COMPLETE`, and `FAILED` semantics. | `test_mqtt_mapped_event_flow.py` proves threshold metadata reaches the event writer; duplicate and partial retry tests prove no duplicate sample writes. | Focused bridge + mapped event suites passed. | Formatting/lint completed after implementation. |
+| Subscriber bridge integration | Added subscriber integration test proving bridge failures do not break raw persistence/ACK behavior. | `services/mqtt/subscriber.py` invokes the bridge after raw persistence and catches/logs bridge failures. | Existing subscriber loop tests passed alongside PR4 integration tests. | Router/subscriber/runtime focused command passed. | Ruff/Black passed. |
+| Bridge outcome counters | Added/extended router status tests for bridge counters. | `/api/mqtt/status` exposes runtime status plus `mapped_writes_total`, `unmapped_skips_total`, and `failed_writes_total`. | Runtime status service/repo tests passed with router tests. | Focused router/runtime command passed. | Formatting/lint completed. |
+| PR4 blocker remediation (locking + idempotent MetricResult) | Added lock-factory and idempotent row regression coverage before blocker-fix implementation. | Subscriber now passes `SessionLocal` into `get_mqtt_bridge_service(event_writer_lock_db=...)`; `polling.event_writer` merges `MetricResult`, `HAS_RESULT`, and `FOR_METRIC` for idempotent rows keyed by `idempotency_key`; migration `004_mqtt_metric_result_idempotency.cypher` adds a uniqueness guard. | `test_polling_event_writer.py` and `test_mqtt_subscriber_bridge_integration.py` validate dedupe behavior, replay-safe relationships, uniqueness guard, and lock propagation. | Focused blocker tests: 32 passed. | Ruff/Black completed on touched files. |
+
+### Focused test evidence
+
+```bash
+./backend/.venv/bin/pytest backend/tests/test_mqtt_bridge_service.py \
+  backend/tests/test_mqtt_mapped_event_flow.py \
+  backend/tests/test_mqtt_kpi_gate_regression.py \
+  backend/tests/test_mqtt_subscriber_bridge_integration.py
+# 20 passed
+
+./backend/.venv/bin/pytest backend/tests/test_mqtt_router.py \
+  backend/tests/test_mqtt_subscriber_loop.py \
+  backend/tests/test_mqtt_runtime_status_service.py \
+  backend/tests/test_mqtt_runtime_status_repo.py
+# 27 passed
+```
+
+```bash
+./backend/.venv/bin/ruff check --fix backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py
+# All checks passed
+
+./backend/.venv/bin/black backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py
+# Reformatted/normalized files
+```
+
+## Remaining tasks
+
+- [ ] None (PR4 scope completed).
+
+## Workload / PR boundary
+
+- Chained PR mode is in effect for this issue (`feature-branch-chain` in change tasks).
+- PR4 remains the bridge/fail-closed slice boundary.
+
+## Continuation: PR4 blocker remediation
+
+- [x] Restore `backend/services/mqtt_bridge_service.py` after prior refactor corruption and keep it stable.
+- [x] Keep `list_mappings_for_source` as primary method and retain compatibility fallback to `list_approved_mappings_for_source` for legacy tests/callers.
+- [x] Normalize receipt lifecycle states with explicit `PENDING_METRIC`, `PENDING_EVENT`, `COMPLETE`, and `FAILED` transitions.
+- [x] Add/extend edge-case tests for:
+  - idempotent metric writer handling on `IntegrityError`
+  - event-only retry path (including `PENDING_EVENT` replays)
+  - lock-db writer path and pending-event counter semantics
+- [x] Keep counter semantics so event-only pending outcomes are tracked as failed-write counters.
+- [x] Add Neo4j uniqueness guard for `MetricResult.idempotency_key` and make idempotent replay use `MERGE` for `FOR_METRIC` relationships.
+
+### Continuation evidence
+
+```bash
+./backend/.venv/bin/pytest backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py
+# 20 passed
+
+./backend/.venv/bin/pytest backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_subscriber_bridge_integration.py
+# 32 passed (includes new PR4 blocker coverage)
+
+./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py backend/tests/test_mqtt_subscriber_loop.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py -q
+# 78 passed, 2 warnings
+
+./backend/.venv/bin/ruff check backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/polling/event_writer.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py
+# All checks passed
+
+./backend/.venv/bin/black --check backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/polling/event_writer.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py
+# 12 files would be left unchanged
+```
+
+## Continuation risks / notes
+
+- PR4 blocker remediation is complete for this slice:
+  - subscriber now injects caller-owned SQLAlchemy lock session into bridge calls
+  - metric-result write path now deduplicates idempotent payloads and preserves MQTT replay semantics via idempotency_key MERGE
+  - subscriber integration test now validates lock factory propagation (`event_writer_lock_db`)
+  - event_writer idempotent duplicate test added
+- No new blockers identified.
+
+## Risks / Notes
+
+- None blocking; remaining work is PR5 runtime entrypoint and runtime-status behavior hardening.

--- a/openspec/changes/integrate-mqtt-readings-monitoring/tasks.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/tasks.md
@@ -120,7 +120,7 @@ Chain strategy: feature-branch-chain
 
 **Scope:** `backend/services/mqtt_bridge_service.py`, `backend/services/mqtt/subscriber.py`, `backend/services/mqtt_mapping_service.py`, `backend/repositories/mqtt_mapping_repo.py`, `backend/repositories/mqtt_runtime_status_repo.py`, `backend/polling/event_writer.py` (call site only), `backend/repositories/metric_repo.py` (shared write path if needed), `backend/tests/test_mqtt_bridge_service.py`, `backend/tests/test_mqtt_mapped_event_flow.py`, `backend/tests/test_mqtt_kpi_gate_regression.py`, `backend/tests/test_mqtt_subscriber_bridge_integration.py`.
 
-1. **[RED] Add negative/positive bridge tests first**
+1. - [x] **[RED] Add negative/positive bridge tests first**
    - Add/extend:
      - `backend/tests/test_mqtt_bridge_service.py` for outcomes:
        - unmapped, `DRAFT`, `REVOKED`, ambiguous mapping -> no Timescale/event writes
@@ -128,7 +128,7 @@ Chain strategy: feature-branch-chain
        - duplicate payload/idempotency -> skip duplicate writes
        - partial failure after metric persistence retries only event step.
 
-2. **[GREEN] Add fail-closed bridge service**
+2. - [x] **[GREEN] Add fail-closed bridge service**
    - Implement `backend/services/mqtt_bridge_service.py`:
      - resolve approved mapping only
      - map raw samples to `(ci_id, metric_id)`
@@ -138,21 +138,21 @@ Chain strategy: feature-branch-chain
    - Insert metric via existing Timescale path (`metric_repo.insert_metric_value`) and call `polling.event_writer.batch_update_events()` only through bridge envelope.
    - Preserve source-to-history: raw data is already persisted regardless of bridge outcome.
 
-3. **[GREEN] Wire fail-closed path in subscriber ingestion**
+3. - [x] **[GREEN] Wire fail-closed path in subscriber ingestion**
    - Update `backend/services/mqtt/subscriber.py:_persist_reading` to invoke bridge service after successful raw write.
    - Ensure bridge failures are observable and do not block raw ACK policy for raw raw persistence failures.
 
-4. **[GREEN] Add idempotency/state updates and outcome surfacing**
+4. - [x] **[GREEN] Add idempotency/state updates and outcome surfacing**
    - Use receipt status transitions to support:
      - `PENDING_EVENT`, `COMPLETE`, `FAILED`
    - On `TIMESCALE_WRITE` success and event failure, persist `PENDING_EVENT` and retry only event generation on the next cycle.
    - Expose outcome counters in `mqtt/status`.
 
-5. **[TRIANGULATE] Regression and safety proof**
+5. - [x] **[TRIANGULATE] Regression and safety proof**
    - Add `backend/tests/test_mqtt_kpi_gate_regression.py` proving unmapped/unapproved reads cannot alter `metric_values`, `/api/metrics/.../history`, or event write rows.
    - Add `backend/tests/test_mqtt_mapped_event_flow.py` proving mapped writes evaluate thresholds through existing event path and threshold updates apply without remapping.
 
-6. **[REFACTOR] Tighten edge handling**
+6. - [x] **[REFACTOR] Tighten edge handling**
    - Normalize ambiguous mapping behavior to explicit fail-closed outcomes (`SKIPPED_UNMAPPED`, `BLOCKED_AMBIGUOUS_MAPPING`, etc.).
    - Keep raw path unchanged for ingestion observability.
 

--- a/openspec/changes/integrate-mqtt-readings-monitoring/verify-report.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/verify-report.md
@@ -1,0 +1,159 @@
+# Verify Report — integrate-mqtt-readings-monitoring PR4 final verification
+
+## Status
+
+**PASS for PR4** — the previous PR4 blocker is resolved. The migration guard test now resolves `backend/migrations/004_mqtt_metric_result_idempotency.cypher` relative to `Path(__file__).resolve().parents[1]`, and the PR4 focused suites are green from repo-root execution. The touched migration/event-writer test file is also green when executed from the configured backend working directory.
+
+Whole-change archive is **not ready** because PR5 remains future scope for the overall `integrate-mqtt-readings-monitoring` change.
+
+## Structured Status and Action Context
+
+```yaml
+schemaName: spec-driven
+changeName: integrate-mqtt-readings-monitoring
+artifactStore: openspec
+planningHome:
+  root: /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring
+  changesDir: openspec/changes
+changeRoot: openspec/changes/integrate-mqtt-readings-monitoring
+artifactPaths:
+  proposal:
+    - openspec/changes/integrate-mqtt-readings-monitoring/proposal.md
+  design:
+    - openspec/changes/integrate-mqtt-readings-monitoring/design.md
+  tasks:
+    - openspec/changes/integrate-mqtt-readings-monitoring/tasks.md
+  applyProgress:
+    - openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr4.md
+  verifyReport:
+    - openspec/changes/integrate-mqtt-readings-monitoring/verify-report.md
+artifacts:
+  proposal: done
+  design: done
+  tasks: done
+  applyProgress: done
+  verifyReport: done
+taskProgress:
+  uncheckedImplementationMarkers: 0
+applyState: pr4_done
+dependencies:
+  verify: ready
+  archive: blocked_by_future_pr5_scope
+actionContext:
+  mode: repo-local
+  workspaceRoot: /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring
+  branch: feat/issue-321-mqtt-monitoring-pr4-bridge
+  warnings:
+    - Full backend suite still has known unrelated auth cookie-domain and Docker/testcontainers advisory-lock failures.
+nextRecommended: pr4-ready-for-pr-review
+isNonAuthoritative: false
+```
+
+## Spec Coverage / PR4 Acceptance
+
+| Requirement / focus | Result | Evidence |
+|---|---:|---|
+| Raw MQTT remains non-KPI unless explicitly approved | PASS | PR4 gate/regression tests pass in the 78-test focused command. |
+| Approved mapping enables KPI/event bridge writes | PASS | Bridge and mapped-event tests validate approved-only writes and threshold envelope propagation. |
+| Unapproved/ambiguous mapping fails closed | PASS | Bridge tests cover unmapped, `DRAFT`, `REVOKED`, ambiguous, and non-numeric outcomes without Timescale/event writes. |
+| Idempotent KPI write/event path | PASS | Receipt lifecycle tests and event-writer tests cover duplicate payloads, `PENDING_EVENT` retry, and no duplicate sample/event behavior. |
+| Migration uniqueness guard | PASS | `backend/migrations/004_mqtt_metric_result_idempotency.cypher` contains the `MetricResult.idempotency_key` uniqueness constraint; `tests/test_polling_event_writer.py` now uses a cwd-safe path. |
+| Subscriber bridge wiring with event-writer lock session | PASS | Subscriber bridge integration tests pass. |
+| Review evidence | PASS with warning | review-risk, review-resilience, and review-reliability: no findings. review-readability: PASS with non-blocking duplicate-skip counter warning. |
+
+## Task Completion Status
+
+- PR4 implementation tasks in `tasks.md`: checked `[x]`.
+- Unchecked implementation task markers matching `^\s*- \[ \]` in `tasks.md`: **none found**.
+- Whole-change archive: **not ready**; PR5 runtime subscriber topology remains future scope.
+
+## Strict TDD Compliance
+
+Strict TDD is active via `openspec/config.yaml` and session instructions.
+
+| Check | Result | Details |
+|---|---:|---|
+| `TDD Cycle Evidence` table present | PASS | `apply-progress-pr4.md` contains `### TDD Cycle Evidence`. |
+| Reported test files exist | PASS | PR4 bridge, mapped flow, KPI gate, subscriber bridge, event writer, router, subscriber loop, runtime service, and runtime repo tests exist and were executed. |
+| RED evidence cross-reference | PASS | Apply-progress lists test-first evidence for PR4 tasks; corresponding test files exist in the codebase. |
+| GREEN confirmed | PASS | Focused PR4 command passed: `78 passed, 2 warnings`. Backend-cwd event-writer file command passed: `30 passed`. |
+| Triangulation adequate | PASS | PR4 behavior is covered across service, subscriber integration, router/runtime, event-writer, and regression tests. |
+| Safety net | PASS with external warnings | Focused PR4 safety net is green. Full backend command still has unrelated failures outside PR4 acceptance. |
+
+### Test Layer Distribution
+
+| Layer | Tests | Files | Tools |
+|---|---:|---:|---|
+| Unit/service | 43+ | 3 | pytest |
+| Integration/API/subscriber | 14+ | 3 | pytest / FastAPI test utilities |
+| Runtime/repository focused | 21 | 3 | pytest |
+| E2E | 0 | 0 | not used for PR4 |
+| **Total focused executed** | **78** | **9** | pytest |
+
+### Assertion Quality
+
+Changed/created PR4 tests were scanned for tautologies, ghost loops, type-only assertions alone, smoke-only tests, and CSS implementation-detail assertions. No blocking assertion-quality issue was found. Empty-list assertions in event/bridge tests are paired with side-effect assertions proving no metric/event writes under blocked conditions.
+
+## Review Workload / PR Boundary
+
+- `tasks.md` forecast: chained PRs recommended, 400-line budget risk high, `feature-branch-chain` selected.
+- PR4 remains within the bridge/fail-closed/idempotent KPI-write/event path boundary.
+- No PR5 runtime entrypoint/docker-compose work was included.
+- Scope boundary: **respected**.
+- `size:exception`: not used; chained PR strategy is the active workload control.
+
+## Verification Commands and Evidence
+
+```bash
+cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring && grep -nE '^\s*- \[ \]' openspec/changes/integrate-mqtt-readings-monitoring/tasks.md || true
+# No matches found
+```
+
+```bash
+cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring && ./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py backend/tests/test_mqtt_subscriber_loop.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py -q
+# 78 passed, 2 warnings in 2.13s
+```
+
+```bash
+cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring && ./backend/.venv/bin/ruff check backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/polling/event_writer.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py && ./backend/.venv/bin/black --check backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/polling/event_writer.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py
+# Ruff: All checks passed!
+# Black: 12 files would be left unchanged.
+```
+
+```bash
+cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring/backend && ../backend/.venv/bin/python -m pytest tests/test_polling_event_writer.py -q
+# 30 passed in 0.50s
+```
+
+```bash
+cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring/backend && ../backend/.venv/bin/python -m pytest
+# 6 failed, 1625 passed, 1 skipped, 51 warnings in 26.15s
+# Remaining failures are outside PR4 acceptance:
+# - tests/test_auth_router_refresh.py::TestCookieDomainAndSecure::test_get_cookie_domain_and_secure_https_hostname
+# - tests/test_auth_router_refresh.py::TestCookieDomainAndSecure::test_get_cookie_domain_and_secure_cookie_domain_override
+# - tests/test_writer_advisory_lock.py::test_concurrent_writers_block_on_lock
+# - tests/test_writer_advisory_lock.py::test_unsorted_lock_acquisition_deadlocks
+# - tests/test_writer_advisory_lock.py::test_sorted_lock_acquisition_prevents_deadlock
+# - tests/test_writer_advisory_lock.py::test_full_poll_cycle_no_duplicates
+# Docker/testcontainers failures show Docker socket unavailable: FileNotFoundError on Unix socket.
+```
+
+## Findings
+
+### CRITICAL
+
+None for PR4.
+
+### WARNING
+
+1. **Full backend suite still has unrelated failures.** Two auth cookie-domain assertions fail, and four Docker/testcontainers advisory-lock tests fail because Docker socket access is unavailable in this environment. The previous PR4 migration cwd failure is no longer present.
+2. **review-readability non-blocking warning remains.** Duplicate skip behavior is currently counted under `mapped_writes_total`; reviewers accepted this as non-blocking, but counter semantics may deserve clarification later.
+3. **Focused pytest warnings remain.** The 78-test focused run emits SQLAlchemy `declarative_base()` and Python `crypt` deprecation warnings.
+
+### SUGGESTION
+
+- Track the unrelated full-suite failures separately so PR4 evidence does not keep carrying baseline noise.
+
+## Exact Blockers
+
+None for PR4.


### PR DESCRIPTION
Closes #321

## Descripción del Cambio
PR4 de la cadena #321. Conecta lecturas MQTT aprobadas al flujo de monitoring con fail-closed gating, recibos idempotentes y escritura segura de eventos.

Incluye:
- bridge MQTT→monitoring para mappings `APPROVED` únicamente;
- recibos `mqtt_metric_sample_receipts` con estados `PENDING_METRIC`, `PENDING_EVENT`, `COMPLETE`, `FAILED`;
- replay/idempotency para duplicados, fallas parciales de Timescale y reintentos de event writer;
- `lock_db` en el camino productivo del event writer para preservar advisory locks;
- `MetricResult.idempotency_key` con constraint Neo4j y relaciones idempotentes;
- counters de bridge en `/api/mqtt/status`;
- pruebas de gate fail-closed, flujo mapeado, regresión KPI y subscriber integration.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Refactor (Cambio interno sin modificar comportamiento)
- [ ] Chore (Mantenimiento/tooling)

## Chain Context
```text
#377 tracker: feat/issue-321-mqtt-monitoring → main (draft/no-merge)
#378 PR1 foundations ✅ merged into tracker
#381 PR2 permissions ✅ merged into tracker
#382 PR3 raw API + mapping CRUD ✅ merged into tracker
#383 PR4 bridge KPI/event path 📍 current
PR5 runtime subscriber topology ⏭️ next
```

## Cambios
| Archivo | Cambio |
| --- | --- |
| `backend/services/mqtt_bridge_service.py` | Bridge fail-closed, idempotency keys, receipt state machine, KPI/event sequencing. |
| `backend/repositories/mqtt_metric_sample_receipt_repo.py` | Persistence de recibos para dedupe y retry. |
| `backend/repositories/mqtt_mapping_repo.py` | Lookup de mappings por source metric para clasificación fail-closed. |
| `backend/polling/event_writer.py` | Idempotent `MetricResult` path para payloads con `idempotency_key`. |
| `backend/migrations/004_mqtt_metric_result_idempotency.cypher` | Constraint única para `MetricResult.idempotency_key`. |
| `backend/services/mqtt/subscriber.py` | Ejecuta bridge post raw-persistence sin romper ACK/raw path. |
| `backend/routers/mqtt.py` | Expone counters de bridge en status. |
| `backend/tests/test_mqtt_bridge_service.py` | Cubre gate, idempotency, partial retry y counters. |
| `backend/tests/test_mqtt_kpi_gate_regression.py` | Prueba que unapproved/unmapped no contamina KPI/event path. |
| `backend/tests/test_mqtt_mapped_event_flow.py` | Prueba thresholds en event writer. |
| `backend/tests/test_mqtt_subscriber_bridge_integration.py` | Prueba integración subscriber/bridge/lock_db. |
| `backend/tests/test_polling_event_writer.py` | Prueba idempotency_key, relationship replay y migration guard. |
| `openspec/changes/integrate-mqtt-readings-monitoring/*` | Apply progress, verify report y tasks PR4 actualizados. |

## Validación
- [x] Focused PR4 + related regression:
  `./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py backend/tests/test_mqtt_subscriber_loop.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py -q`
- [x] Resultado: `78 passed, 2 warnings`.
- [x] Ruff en archivos backend tocados: pass.
- [x] Black check en archivos backend tocados: pass, `12 files would be left unchanged`.
- [x] `sdd-verify`: PASS.

## Review
- [x] `review-risk`: no findings finales.
- [x] `review-resilience`: no findings finales.
- [x] `review-reliability`: no findings finales.
- [x] `review-readability`: PASS; queda warning no bloqueante sobre contar duplicate skips dentro de `mapped_writes_total`.

## Excepciones / riesgos conocidos
- `size:exception`: este PR supera el presupuesto de 400 líneas porque PR4 necesitó bridge, idempotency, event-writer hardening y pruebas de seguridad en una sola slice coherente.
- Full backend suite tiene fallas baseline no relacionadas ya conocidas: 2 tests de auth cookie-domain y 4 tests Docker/testcontainers/advisory-lock por socket Docker no disponible.
- PR5 sigue fuera de alcance: runtime subscriber entrypoint, compose/topology y prueba operacional completa.

## Checklist
- [x] Issue aprobado vinculado (`Closes #321`).
- [x] Exactamente un label `type:*` será aplicado: `type:feature`.
- [x] Commit convencional sin `Co-Authored-By`.
- [x] No frontend ni compose/runtime PR5.
- [x] SDD/OpenSpec actualizado para PR4.
