### PR TITLE
feat(mqtt): add subscriber runtime topology

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -263,8 +263,47 @@ class MQTTSettings(BaseModel):
         )
 
 
+class MQTTRuntimeSettings(BaseModel):
+    """Runtime topology flags for MQTT subscriber and bridge behavior."""
+
+    bridge_enabled: bool = True
+    missed_heartbeat_seconds: int = 90
+    run_subscriber_in_process: bool = False
+
+    @classmethod
+    def from_env(cls) -> MQTTRuntimeSettings:
+        """Load MQTT runtime settings from environment variables.
+
+        ``MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS`` is the preferred
+        primary key. ``MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS`` remains
+        supported for backward compatibility.
+        """
+
+        missed_heartbeat_seconds = _env_int_bounded(
+            "MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS",
+            default=90,
+            minimum=1,
+            maximum=86_400,
+        )
+
+        if os.getenv("MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS") is None:
+            missed_heartbeat_seconds = _env_int_bounded(
+                "MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS",
+                default=missed_heartbeat_seconds,
+                minimum=1,
+                maximum=86_400,
+            )
+
+        return cls(
+            bridge_enabled=_env_bool("MQTT_MAPPING_BRIDGE_ENABLED", default=True),
+            missed_heartbeat_seconds=missed_heartbeat_seconds,
+            run_subscriber_in_process=_env_bool("ENABLE_MQTT_SUBSCRIBER", default=False),
+        )
+
+
 # Singleton instance (lazy-loaded)
 _mqtt_settings: MQTTSettings | None = None
+_mqtt_runtime_settings: MQTTRuntimeSettings | None = None
 
 
 def get_mqtt_settings() -> MQTTSettings:
@@ -273,6 +312,14 @@ def get_mqtt_settings() -> MQTTSettings:
     if _mqtt_settings is None:
         _mqtt_settings = MQTTSettings.from_env()
     return _mqtt_settings
+
+
+def get_mqtt_runtime_settings() -> MQTTRuntimeSettings:
+    """Return cached MQTT runtime settings (singleton)."""
+    global _mqtt_runtime_settings
+    if _mqtt_runtime_settings is None:
+        _mqtt_runtime_settings = MQTTRuntimeSettings.from_env()
+    return _mqtt_runtime_settings
 
 
 # ---------------------------------------------------------------------------

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime, timedelta
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
-from config import get_time_sync_settings
+from config import get_mqtt_runtime_settings, get_time_sync_settings
 from database import get_db, verify_connection
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -95,6 +95,29 @@ def _reload_system_status_env_settings() -> None:
         "SYSTEM_STATUS_HISTORY_STALE_THRESHOLD_SECONDS",
         default_value=1800,
         minimum=60,
+    )
+
+
+def _should_start_embedded_mqtt_subscriber() -> bool:
+    """Return whether the API process should own a in-process MQTT subscriber."""
+    return get_mqtt_runtime_settings().run_subscriber_in_process
+
+
+def _start_embedded_mqtt_subscriber(*, task_factory=asyncio.create_task) -> None:
+    """Start in-process MQTT subscriber when enabled.
+
+    Isolated in a helper so tests can assert startup behavior without invoking the
+    full startup sequence.
+    """
+    if _should_start_embedded_mqtt_subscriber():
+        from services.mqtt.subscriber import mqtt_subscriber_loop
+
+        task_factory(mqtt_subscriber_loop())
+        logger.info("Embedded MQTT subscriber started in backend process")
+        return
+
+    logger.info(
+        "Embedded MQTT subscriber disabled in backend process (ENABLE_MQTT_SUBSCRIBER=false)"
     )
 
 
@@ -381,6 +404,9 @@ async def startup_event():
         logger.info(
             "Background SNMP Collector in backend process is disabled (DISABLE_BACKEND_COLLECTOR=true)"
         )
+
+    # Start embedded MQTT subscriber only when explicitly enabled.
+    _start_embedded_mqtt_subscriber(task_factory=asyncio.create_task)
 
     # Start Backup Scheduler
     schedule_daily_backup()

--- a/backend/scripts/mqtt_subscriber.py
+++ b/backend/scripts/mqtt_subscriber.py
@@ -1,0 +1,60 @@
+"""Dedicated MQTT subscriber runtime entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from services.mqtt.subscriber import mqtt_subscriber_loop
+from services.mqtt_runtime_status import get_mqtt_runtime_status_service
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_status_update(action: str, callback):
+    """Best-effort runtime status update that never owns process liveness."""
+    try:
+        callback()
+    except Exception:
+        logger.warning("[MQTT] Runtime status update failed during %s", action, exc_info=True)
+
+
+async def run_mqtt_subscriber() -> None:
+    """Run the shared MQTT subscriber process until cancellation or failure."""
+    status_service = get_mqtt_runtime_status_service()
+    _safe_status_update("mark_configured", lambda: status_service.mark_configured(True))
+
+    try:
+        await mqtt_subscriber_loop()
+    finally:
+        # Any shutdown path is reflected in shared status for API-process observability.
+        _safe_status_update("shutdown", lambda: status_service.record_disconnect("SHUTDOWN"))
+
+
+def main(argv=None) -> int:
+    """CLI-compatible entrypoint for ``python -m scripts.mqtt_subscriber``."""
+    del argv
+
+    try:
+        asyncio.run(run_mqtt_subscriber())
+        return 0
+    except KeyboardInterrupt:
+        _safe_status_update(
+            "shutdown",
+            lambda: get_mqtt_runtime_status_service().record_disconnect("SHUTDOWN"),
+        )
+        return 0
+    except Exception as exc:
+        error_text = str(exc)
+        _safe_status_update(
+            "runtime_error",
+            lambda error_text=error_text: get_mqtt_runtime_status_service().record_disconnect(
+                "RUNTIME_ERROR",
+                error_text,
+            ),
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/mqtt/subscriber.py
+++ b/backend/services/mqtt/subscriber.py
@@ -30,7 +30,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from config import get_mqtt_settings
+from config import get_mqtt_runtime_settings, get_mqtt_settings
 from postgres_db import SessionLocal
 from repositories.device_metric_repo import get_device_metric_repo
 from services.mqtt.client import connect_mqtt
@@ -38,6 +38,7 @@ from services.mqtt.metrics import metrics
 from services.mqtt.parsers.base import ParseError
 from services.mqtt.topic_router import TopicRouter
 from services.mqtt_bridge_service import get_mqtt_bridge_service
+from services.mqtt_runtime_status import get_mqtt_runtime_status_service
 
 if TYPE_CHECKING:
     from services.mqtt.parsers.base import Reading
@@ -47,9 +48,22 @@ logger = logging.getLogger(__name__)
 __all__ = ["mqtt_subscriber_loop", "_dispatch", "_persist_reading"]
 
 
+def _safe_status_update(action: str, callback: Any) -> None:
+    """Best-effort runtime status update that never owns subscriber liveness."""
+    try:
+        callback()
+    except Exception:
+        logger.warning("[MQTT] Runtime status update failed during %s", action, exc_info=True)
+
+
 # Reconnect backoff bounds per design §2.6 and REQ-SUB-03.
 _INITIAL_BACKOFF_S = 1.0
 _MAX_BACKOFF_S = 30.0
+
+# Heartbeat cadence for idle loops (seconds). The loop emits periodic heartbeats
+# even without inbound messages so raw subscribers stay visible as running.
+_HEARTBEAT_IDLE_INTERVAL_MIN_S = 5.0
+_HEARTBEAT_IDLE_INTERVAL_MAX_S = 60.0
 
 # 4 KB cap on the serialized ``extra`` blob per Q2 decision. The cap prevents
 # a single message from bloating Neo4j property storage; over-cap payloads are
@@ -69,36 +83,113 @@ async def mqtt_subscriber_loop() -> None:
       * Build a :class:`TopicRouter` from the parser registry.
       * Enter a ``while True`` that opens a connection, subscribes to every
         registered pattern, and consumes inbound messages.
+      * Update shared runtime status on connect/disconnect/heartbeat.
       * On connection error, sleep ``backoff`` seconds, double up to
         ``MAX_BACKOFF_S``, and retry.
       * On ``asyncio.CancelledError``, log and propagate so the container
         shutdown signal is honored.
     """
     settings = get_mqtt_settings()
+    runtime_settings = get_mqtt_runtime_settings()
     router: TopicRouter = TopicRouter()
     backoff = _INITIAL_BACKOFF_S
+    subscribed_patterns = list(router.subscribe_patterns())
+
+    status_service = get_mqtt_runtime_status_service(
+        stale_heartbeat_seconds=runtime_settings.missed_heartbeat_seconds
+    )
+    _safe_status_update("configured", lambda: status_service.mark_configured(True))
 
     while True:
         try:
             async with connect_mqtt(settings) as client:
                 # Connected — reset the backoff so a future drop starts at 1s again.
                 backoff = _INITIAL_BACKOFF_S
-                logger.info(
-                    "[MQTT] Connected; subscribing to %d pattern(s)",
-                    len(router.subscribe_patterns()),
+                _safe_status_update(
+                    "heartbeat",
+                    lambda: status_service.record_heartbeat(
+                        running=True,
+                        connected=True,
+                        subscribed_patterns=subscribed_patterns,
+                    ),
                 )
 
-                for pattern in router.subscribe_patterns():
-                    await client.subscribe(pattern, settings.qos)
-                    logger.debug("[MQTT] Subscribed to pattern %r (qos=%d)", pattern, settings.qos)
+                logger.info(
+                    "[MQTT] Connected; subscribing to %d pattern(s)",
+                    len(subscribed_patterns),
+                )
 
-                async for message in client.messages:
-                    await _dispatch(message, router)
+                for pattern in subscribed_patterns:
+                    await client.subscribe(pattern, settings.qos)
+                    logger.debug(
+                        "[MQTT] Subscribed to pattern %r (qos=%d)",
+                        pattern,
+                        settings.qos,
+                    )
+
+                heartbeat_interval = max(
+                    _HEARTBEAT_IDLE_INTERVAL_MIN_S,
+                    min(
+                        _HEARTBEAT_IDLE_INTERVAL_MAX_S,
+                        runtime_settings.missed_heartbeat_seconds / 3,
+                    ),
+                )
+                next_heartbeat_after = asyncio.get_running_loop().time() + heartbeat_interval
+                message_stream = client.messages.__aiter__()
+                message_task = asyncio.create_task(anext(message_stream))
+
+                try:
+                    while True:
+                        timeout = next_heartbeat_after - asyncio.get_running_loop().time()
+                        if timeout <= 0:
+                            timeout = 0
+
+                        done, _pending = await asyncio.wait({message_task}, timeout=timeout)
+                        if not done:
+                            _safe_status_update(
+                                "heartbeat",
+                                lambda: status_service.record_heartbeat(
+                                    running=True,
+                                    connected=True,
+                                    subscribed_patterns=subscribed_patterns,
+                                ),
+                            )
+                            next_heartbeat_after = (
+                                asyncio.get_running_loop().time() + heartbeat_interval
+                            )
+                            continue
+
+                        message = message_task.result()
+                        message_task = asyncio.create_task(anext(message_stream))
+                        await _dispatch(message, router)
+                        _safe_status_update(
+                            "heartbeat",
+                            lambda: status_service.record_heartbeat(
+                                running=True,
+                                connected=True,
+                                subscribed_patterns=subscribed_patterns,
+                            ),
+                        )
+                        next_heartbeat_after = (
+                            asyncio.get_running_loop().time() + heartbeat_interval
+                        )
+                finally:
+                    if not message_task.done():
+                        message_task.cancel()
 
         except asyncio.CancelledError:
             logger.info("[MQTT] Subscriber cancelled — propagating for container shutdown")
+            _safe_status_update("shutdown", lambda: status_service.record_disconnect("SHUTDOWN"))
             raise
         except Exception as e:
+            error_text = str(e)
+            _safe_status_update(
+                "disconnect",
+                lambda error_text=error_text: status_service.record_disconnect(
+                    reason_code="MQTT_SUBSCRIBER_CONNECTION_ERROR",
+                    error=error_text,
+                ),
+            )
             logger.warning(
                 "[MQTT] Connection error: %s; retrying in %.1fs", e, backoff, exc_info=True
             )
@@ -260,12 +351,13 @@ async def _persist_reading(reading: Reading) -> None:
 
     # Bridge to KPI/event path is failure-observability-only by design.
     # Raw persistence must remain independent; never block on bridge failures.
-    try:
-        bridge_service = get_mqtt_bridge_service(event_writer_lock_db=SessionLocal)
-        bridge_service.process_reading(reading)
-    except Exception:
-        logger.warning(
-            "Bridge processing failed for device=%r: continuing raw persistence",
-            reading.device_id,
-            exc_info=True,
-        )
+    if get_mqtt_runtime_settings().bridge_enabled:
+        try:
+            bridge_service = get_mqtt_bridge_service(event_writer_lock_db=SessionLocal)
+            bridge_service.process_reading(reading)
+        except Exception:
+            logger.warning(
+                "Bridge processing failed for device=%r: continuing raw persistence",
+                reading.device_id,
+                exc_info=True,
+            )

--- a/backend/services/mqtt_runtime_status.py
+++ b/backend/services/mqtt_runtime_status.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+from config import get_mqtt_runtime_settings
 from repositories.mqtt_runtime_status_repo import MqttRuntimeStatusRepo
 
 
@@ -16,10 +17,14 @@ class MqttRuntimeStatusService:
     def __init__(
         self,
         repo: MqttRuntimeStatusRepo | None = None,
-        stale_heartbeat_seconds: int = 90,
+        stale_heartbeat_seconds: int | None = None,
     ):
         self._repo = repo or MqttRuntimeStatusRepo()
-        self._stale_seconds = stale_heartbeat_seconds
+        self._stale_seconds = (
+            stale_heartbeat_seconds
+            if stale_heartbeat_seconds is not None
+            else get_mqtt_runtime_settings().missed_heartbeat_seconds
+        )
 
     @staticmethod
     def _now() -> datetime:
@@ -81,7 +86,7 @@ _status_service: MqttRuntimeStatusService | None = None
 
 def get_mqtt_runtime_status_service(
     repo: MqttRuntimeStatusRepo | None = None,
-    stale_heartbeat_seconds: int = 90,
+    stale_heartbeat_seconds: int | None = None,
 ) -> MqttRuntimeStatusService:
     global _status_service
     if _status_service is None:

--- a/backend/tests/test_mqtt_runtime_entrypoint.py
+++ b/backend/tests/test_mqtt_runtime_entrypoint.py
@@ -1,0 +1,135 @@
+"""Entry-point smoke tests for the dedicated MQTT subscriber runtime process."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+class _StatusService:
+    """Minimal status service spy for entrypoint lifecycle assertions."""
+
+    def __init__(self, fail_configured: bool = False):
+        self.calls: list[tuple[str, tuple, dict]] = []
+        self.fail_configured = fail_configured
+
+    def mark_configured(self, configured):
+        self.calls.append(("mark_configured", (configured,), {}))
+        if self.fail_configured:
+            raise RuntimeError("status store unavailable")
+
+    def mark_running(self, running, reason_code=None):
+        self.calls.append(("mark_running", (running,), {"reason_code": reason_code}))
+
+    def record_disconnect(self, reason_code: str, error: str | None = None):
+        self.calls.append(("record_disconnect", (reason_code,), {"error": error}))
+
+
+def test_runtime_settings_env_contract_prefers_subscriber_stale_alias(monkeypatch):
+    import config
+
+    monkeypatch.setenv("MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS", "30")
+    monkeypatch.setenv("MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS", "120")
+    monkeypatch.setenv("MQTT_MAPPING_BRIDGE_ENABLED", "false")
+    monkeypatch.setenv("ENABLE_MQTT_SUBSCRIBER", "true")
+
+    settings = config.MQTTRuntimeSettings.from_env()
+
+    assert settings.missed_heartbeat_seconds == 30
+    assert settings.bridge_enabled is False
+    assert settings.run_subscriber_in_process is True
+
+
+def test_runtime_settings_env_contract_supports_legacy_stale_alias(monkeypatch):
+    import config
+
+    monkeypatch.delenv("MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS", raising=False)
+    monkeypatch.setenv("MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS", "45")
+
+    settings = config.MQTTRuntimeSettings.from_env()
+
+    assert settings.missed_heartbeat_seconds == 45
+
+
+def test_entrypoint_main_runs_shared_loop(monkeypatch):
+    from scripts import mqtt_subscriber
+
+    status = _StatusService()
+    monkeypatch.setattr(mqtt_subscriber, "get_mqtt_runtime_status_service", lambda: status)
+    loop = AsyncMock()
+    monkeypatch.setattr(mqtt_subscriber, "mqtt_subscriber_loop", loop)
+
+    assert mqtt_subscriber.main([]) == 0
+
+    loop.assert_awaited_once()
+    assert status.calls[0] == ("mark_configured", (True,), {})
+    assert status.calls[1] == ("record_disconnect", ("SHUTDOWN",), {"error": None})
+
+
+def test_entrypoint_status_store_failure_does_not_block_loop(monkeypatch):
+    from scripts import mqtt_subscriber
+
+    status = _StatusService(fail_configured=True)
+    monkeypatch.setattr(mqtt_subscriber, "get_mqtt_runtime_status_service", lambda: status)
+    loop = AsyncMock()
+    monkeypatch.setattr(mqtt_subscriber, "mqtt_subscriber_loop", loop)
+
+    assert mqtt_subscriber.main([]) == 0
+
+    # Entry-point status updates to configure may fail, but the shared loop should
+    # still start and shutdown should still be recorded best-effort.
+    loop.assert_awaited_once()
+    assert any(call[0] == "record_disconnect" and call[1] == ("SHUTDOWN",) for call in status.calls)
+
+
+def test_backend_embedded_subscriber_is_disabled_by_default(monkeypatch):
+    import main
+
+    scheduled = []
+    monkeypatch.setattr(
+        main,
+        "get_mqtt_runtime_settings",
+        lambda: SimpleNamespace(run_subscriber_in_process=False),
+    )
+
+    main._start_embedded_mqtt_subscriber(task_factory=scheduled.append)
+
+    assert scheduled == []
+
+
+def test_backend_embedded_subscriber_starts_only_when_enabled(monkeypatch):
+    import main
+
+    scheduled = []
+    monkeypatch.setattr(
+        main,
+        "get_mqtt_runtime_settings",
+        lambda: SimpleNamespace(run_subscriber_in_process=True),
+    )
+
+    main._start_embedded_mqtt_subscriber(task_factory=scheduled.append)
+
+    assert len(scheduled) == 1
+    scheduled[0].close()
+
+
+def test_entrypoint_main_records_failure_and_returns_one(monkeypatch):
+    from scripts import mqtt_subscriber
+
+    status = _StatusService()
+    monkeypatch.setattr(mqtt_subscriber, "get_mqtt_runtime_status_service", lambda: status)
+    monkeypatch.setattr(
+        mqtt_subscriber,
+        "mqtt_subscriber_loop",
+        AsyncMock(side_effect=RuntimeError("broker connection failed")),
+    )
+
+    assert mqtt_subscriber.main([]) == 1
+
+    assert status.calls[0] == ("mark_configured", (True,), {})
+    assert status.calls[1][0] == "record_disconnect" and status.calls[1][1] == ("SHUTDOWN",)
+    assert status.calls[2] == (
+        "record_disconnect",
+        ("RUNTIME_ERROR",),
+        {"error": "broker connection failed"},
+    )

--- a/backend/tests/test_mqtt_runtime_status.py
+++ b/backend/tests/test_mqtt_runtime_status.py
@@ -1,0 +1,122 @@
+"""Service-level tests for runtime status transitions and stale heartbeat behavior."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from services.mqtt_runtime_status import MqttRuntimeStatusService
+
+pytestmark = [pytest.mark.unit]
+
+
+class _RuntimeRepoStub:
+    def __init__(self):
+        self.row = {
+            "configured": False,
+            "running": False,
+            "connected": False,
+            "subscribed_patterns": [],
+            "last_message_at": None,
+            "last_error": None,
+            "reason_code": None,
+            "mapped_writes_total": 0,
+            "unmapped_skips_total": 0,
+            "failed_writes_total": 0,
+        }
+
+    def get_status(self, stale_after_seconds: int = 90, now: datetime | None = None) -> dict:
+        now = now or datetime.now(UTC)
+        status = dict(self.row)
+        status["is_stale"] = self._is_stale(now, stale_after_seconds)
+
+        if status["is_stale"]:
+            status["running"] = False
+            status["connected"] = False
+            status["reason_code"] = status["reason_code"] or "STALE_HEARTBEAT"
+
+        return status
+
+    def _is_stale(self, now: datetime, stale_after_seconds: int) -> bool:
+        last_message_at = self.row["last_message_at"]
+        if last_message_at is None:
+            return True
+        return (now - last_message_at).total_seconds() > stale_after_seconds
+
+    def update_status(self, **kwargs):
+        clear_reason_code = kwargs.pop("clear_reason_code", False)
+        clear_last_error = kwargs.pop("clear_last_error", False)
+        clear_reason_code = bool(clear_reason_code)
+        clear_last_error = bool(clear_last_error)
+
+        for key in {
+            "configured",
+            "running",
+            "connected",
+            "subscribed_patterns",
+            "last_message_at",
+            "last_error",
+            "reason_code",
+        }:
+            if key in kwargs and kwargs[key] is not None:
+                self.row[key] = kwargs[key]
+
+        if clear_reason_code:
+            self.row["reason_code"] = None
+        if clear_last_error:
+            self.row["last_error"] = None
+
+        return self.row
+
+
+@pytest.fixture
+def repo() -> _RuntimeRepoStub:
+    return _RuntimeRepoStub()
+
+
+def test_stale_heartbeat_marks_subscriber_non_running(repo):
+    service = MqttRuntimeStatusService(repo=repo, stale_heartbeat_seconds=30)
+    service._now = lambda: datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
+
+    service.record_heartbeat(
+        running=True,
+        connected=True,
+        subscribed_patterns=["rtu/+/telemetry"],
+        timestamp=datetime(2026, 7, 1, 10, 0, tzinfo=UTC),
+    )
+
+    status = service.get_status()
+    assert status["running"] is True
+    assert status["connected"] is True
+    assert status["is_stale"] is False
+
+    service._now = lambda: datetime(2026, 7, 1, 10, 1, 1, tzinfo=UTC)
+    stale_status = service.get_status()
+    assert stale_status["is_stale"] is True
+    assert stale_status["running"] is False
+    assert stale_status["connected"] is False
+    assert stale_status["reason_code"] == "STALE_HEARTBEAT"
+
+
+def test_default_status_reports_stale_without_heartbeat(repo):
+    service = MqttRuntimeStatusService(repo=repo)
+    service._now = lambda: datetime(2026, 7, 1, 10, 0, tzinfo=UTC)
+
+    status = service.get_status()
+
+    assert status["is_stale"] is True
+    assert status["running"] is False
+    assert status["connected"] is False
+    assert status["reason_code"] == "STALE_HEARTBEAT"
+
+
+def test_record_disconnect_updates_running_connected_and_reason(repo):
+    service = MqttRuntimeStatusService(repo=repo)
+    service.record_disconnect("BROKER_DISCONNECTED", "connection closed")
+    service._now = lambda: datetime(2026, 7, 1, 10, 5, tzinfo=UTC)
+
+    status = service.get_status()
+    assert status["running"] is False
+    assert status["connected"] is False
+    assert status["reason_code"] == "BROKER_DISCONNECTED"
+    assert status["last_error"] == "connection closed"

--- a/backend/tests/test_mqtt_subscriber_loop.py
+++ b/backend/tests/test_mqtt_subscriber_loop.py
@@ -418,6 +418,97 @@ class TestDispatchMetrics:
             metrics.reset()
 
 
+async def test_persist_reading_skips_bridge_when_disabled(monkeypatch):
+    from services.mqtt.subscriber import _persist_reading
+
+    class _Repo:
+        def __init__(self):
+            self.devices = []
+            self.metrics = []
+
+        def upsert_device(self, **kwargs):
+            self.devices.append(kwargs)
+
+        def upsert_metric(self, **kwargs):
+            self.metrics.append(kwargs)
+
+    repo = _Repo()
+    bridge_calls = []
+    monkeypatch.setattr("services.mqtt.subscriber.get_device_metric_repo", lambda: repo)
+    monkeypatch.setattr(
+        "services.mqtt.subscriber.get_mqtt_runtime_settings",
+        lambda: type("Settings", (), {"bridge_enabled": False})(),
+    )
+    monkeypatch.setattr(
+        "services.mqtt.subscriber.get_mqtt_bridge_service",
+        lambda **kwargs: bridge_calls.append(kwargs),
+    )
+
+    await _persist_reading(
+        _make_reading(metrics=(MetricReading(name="temperature", value=22.0, unit="C"),))
+    )
+
+    assert len(repo.devices) == 1
+    assert len(repo.metrics) == 1
+    assert bridge_calls == []
+
+
+async def test_loop_records_idle_heartbeat_without_messages(monkeypatch):
+    from services.mqtt import subscriber
+
+    class _StatusService:
+        def __init__(self):
+            self.heartbeats = 0
+            self.disconnects = []
+
+        def mark_configured(self, configured):
+            self.configured = configured
+
+        def record_heartbeat(self, **kwargs):
+            self.heartbeats += 1
+
+        def record_disconnect(self, reason_code, error=None):
+            self.disconnects.append((reason_code, error))
+
+    status = _StatusService()
+    mock_client = AsyncMock()
+    mock_client.subscribe = AsyncMock()
+
+    async def waiting_messages():
+        await asyncio.sleep(3600)
+        return
+        yield  # noqa: F841
+
+    mock_client.messages = waiting_messages()
+
+    @asynccontextmanager
+    async def fake_connect(*_args, **_kwargs):
+        yield mock_client
+
+    monkeypatch.setattr(subscriber, "connect_mqtt", fake_connect)
+    monkeypatch.setattr(subscriber, "get_mqtt_runtime_status_service", lambda **kwargs: status)
+    monkeypatch.setattr(
+        subscriber,
+        "get_mqtt_runtime_settings",
+        lambda: type(
+            "Settings",
+            (),
+            {"bridge_enabled": True, "missed_heartbeat_seconds": 1},
+        )(),
+    )
+    monkeypatch.setattr(subscriber, "_HEARTBEAT_IDLE_INTERVAL_MIN_S", 0.01)
+    monkeypatch.setattr(subscriber, "_HEARTBEAT_IDLE_INTERVAL_MAX_S", 0.01)
+
+    task = asyncio.create_task(subscriber.mqtt_subscriber_loop())
+    await asyncio.sleep(0.04)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert status.heartbeats >= 2
+    assert status.disconnects == [("SHUTDOWN", None)]
+
+
 class TestLoopSmoke:
     """Smoke test for mqtt_subscriber_loop: starts, gets cancelled, propagates."""
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,38 @@ services:
       start_period: 15s
     restart: unless-stopped
 
+  # Dedicated MQTT subscriber process
+  mqtt-subscriber:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: nexgen_mqtt_subscriber
+    depends_on:
+      neo4j:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    command: ["python", "-m", "scripts.mqtt_subscriber"]
+    environment:
+      - NEO4J_URI=${NEO4J_URI}
+      - NEO4J_USER=${NEO4J_USER}
+      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
+      - POSTGRES_USER=${POSTGRES_USER:-nexgen_admin}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB:-nexgen_auth}
+      - POSTGRES_HOST=${POSTGRES_HOST:-postgres}
+      - POSTGRES_PORT=${POSTGRES_INTERNAL_PORT:-5432}
+      - MQTT_BROKER_URL=${MQTT_BROKER_URL}
+      - MQTT_USERNAME=${MQTT_USERNAME}
+      - MQTT_PASSWORD=${MQTT_PASSWORD}
+      - MQTT_CLIENT_ID=${MQTT_CLIENT_ID:-nexgen_subscriber}
+      - MQTT_MAPPING_BRIDGE_ENABLED=${MQTT_MAPPING_BRIDGE_ENABLED:-true}
+      - MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS=${MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS:-90}
+      - MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS=${MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS}
+      - ENABLE_MQTT_SUBSCRIBER=true
+      - PYTHONPATH=/app
+    restart: unless-stopped
+
   # Frontend (Vite Service)
   frontend:
     build:

--- a/openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr5.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr5.md
@@ -1,0 +1,63 @@
+# PR5 Apply Progress
+
+## Completed tasks
+
+- [x] Add runtime wiring tests for PR5 (`backend/tests/test_mqtt_runtime_entrypoint.py`, `backend/tests/test_mqtt_runtime_status.py`).
+- [x] Implement dedicated subscriber process entrypoint (`backend/scripts/mqtt_subscriber.py`).
+- [x] Wire runtime configurability (`backend/config.py`, `backend/main.py`).
+- [x] Add `mqtt-subscriber` docker-compose service (`docker-compose.yml`).
+- [x] Triangulate observability behavior with runtime status unit/service tests and subscriber-loop status update coverage.
+
+## Files changed
+
+- `backend/config.py`
+- `backend/services/mqtt_runtime_status.py`
+- `backend/services/mqtt/subscriber.py`
+- `backend/main.py`
+- `backend/scripts/mqtt_subscriber.py`
+- `backend/tests/test_mqtt_runtime_entrypoint.py`
+- `backend/tests/test_mqtt_runtime_status.py`
+- `docker-compose.yml`
+- `openspec/changes/integrate-mqtt-readings-monitoring/tasks.md`
+- `openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr5.md`
+
+## TDD Cycle Evidence
+
+| Task | RED test added | GREEN implementation | Triangulate check |
+|------|----------------|---------------------|------------------|
+| Runtime entrypoint contract | `backend/tests/test_mqtt_runtime_entrypoint.py` | `backend/scripts/mqtt_subscriber.py` | `./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_runtime_entrypoint.py ...` passed |
+| Runtime status transitions | `backend/tests/test_mqtt_runtime_status.py` | `backend/services/mqtt_runtime_status.py` | Runtime status focused suite passed |
+| Subscriber loop ownership/status safety | Existing subscriber loop smoke test exposed DB-status coupling; fixed with best-effort `_safe_status_update` guard | `backend/services/mqtt/subscriber.py` records status without letting status-store failures kill subscriber liveness | Subscriber loop suite passed |
+| Runtime formatting/lint safety net | Ruff/Black run after implementation | Touched runtime files formatted | Ruff and Black check passed |
+
+## Verification evidence
+
+```bash
+./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py backend/tests/test_mqtt_subscriber_loop.py -q
+# 30 passed, 7 warnings
+
+./backend/.venv/bin/ruff check backend/config.py backend/main.py backend/services/mqtt/subscriber.py backend/services/mqtt_runtime_status.py backend/scripts/mqtt_subscriber.py backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py
+# All checks passed
+
+./backend/.venv/bin/black --check backend/config.py backend/main.py backend/services/mqtt/subscriber.py backend/services/mqtt_runtime_status.py backend/scripts/mqtt_subscriber.py backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py
+# 8 files would be left unchanged
+```
+
+## Test commands attempted
+
+- Initial subagent environment lacked pytest, but parent reran all PR5 focused tests through `backend/.venv` successfully.
+
+## Deviations / notes
+
+- Runtime status service now defaults stale heartbeat threshold from `MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS` via `get_mqtt_runtime_settings()`.
+- Subscriber loop now records running/connected/heartbeat to shared status store and uses `MQTT_MAPPING_BRIDGE_ENABLED` as a soft-fail gate for KPI bridge side effects.
+- Runtime status updates are best-effort in both the dedicated entrypoint and shared loop so status-store failure cannot prevent raw subscriber liveness.
+- Focused regression tests cover disabled-by-default backend ownership, explicit embedded subscriber enablement, env-var parsing contracts, idle heartbeat emission without reconnect churn, and bridge-disabled raw persistence.
+- The compose `mqtt-subscriber` service no longer commits a fallback database password or fake broker hostname; those values must come from the environment.
+- Main startup now only starts an in-process MQTT subscriber when `ENABLE_MQTT_SUBSCRIBER=true`.
+- Compose service uses `python -m scripts.mqtt_subscriber` and explicit env controls.
+
+## Remaining tasks
+
+- [ ] Optional manual compose smoke after PR review: confirm `/api/mqtt/status` stale/disconnected behavior with dedicated subscriber absent vs active in a real compose environment.
+- [x] Startup contract documented in tests and compose command (`python -m scripts.mqtt_subscriber`).

--- a/openspec/changes/integrate-mqtt-readings-monitoring/tasks.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/tasks.md
@@ -162,19 +162,19 @@ Chain strategy: feature-branch-chain
 
 **Scope:** `backend/scripts/mqtt_subscriber.py`, `backend/config.py`, `backend/main.py`, `docker-compose.yml`, `backend/repositories/mqtt_runtime_status_repo.py`, `backend/services/mqtt_runtime_status.py`, `backend/tests/test_mqtt_runtime_entrypoint.py`, `backend/tests/test_mqtt_runtime_status.py`.
 
-1. **[RED] Add runtime wiring tests first**
+1. - [x] **[RED] Add runtime wiring tests first**
    - Add `backend/tests/test_mqtt_runtime_entrypoint.py` for startup command behavior and explicit entrypoint semantics.
    - Add `backend/tests/test_mqtt_runtime_status.py` for heartbeat freshness and transition states (`running` true/false, stale heartbeat, disconnect error reason).
 
-2. **[GREEN] Add dedicated subscriber process entrypoint**
+2. - [x] **[GREEN] Add dedicated subscriber process entrypoint**
    - Implement `backend/scripts/mqtt_subscriber.py` that imports and runs the shared mqtt loop.
    - Ensure status service updates `running/connected` and heartbeat timestamps to shared store.
 
-3. **[GREEN] Wire runtime configurability**
+3. - [x] **[GREEN] Wire runtime configurability**
    - Add config flags in `backend/config.py` for `MQTT_MAPPING_BRIDGE_ENABLED` and `MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS` (or equivalent).
    - In `backend/main.py`, avoid implicit in-process subscriber startup; route process ownership to explicit flags/services.
 
-4. **[GREEN] Add deployment wiring**
+4. - [x] **[GREEN] Add deployment wiring**
    - Add `mqtt-subscriber` service in `docker-compose.yml` (explicit command `python -m scripts.mqtt_subscriber`).
 
 5. **[TRIANGULATE] Verify observability behavior end-to-end**

--- a/openspec/changes/integrate-mqtt-readings-monitoring/verify-report.md
+++ b/openspec/changes/integrate-mqtt-readings-monitoring/verify-report.md
@@ -1,159 +1,81 @@
-# Verify Report — integrate-mqtt-readings-monitoring PR4 final verification
+# Verify Report — integrate-mqtt-readings-monitoring PR5 Final
 
 ## Status
 
-**PASS for PR4** — the previous PR4 blocker is resolved. The migration guard test now resolves `backend/migrations/004_mqtt_metric_result_idempotency.cypher` relative to `Path(__file__).resolve().parents[1]`, and the PR4 focused suites are green from repo-root execution. The touched migration/event-writer test file is also green when executed from the configured backend working directory.
+PASS — PR5 runtime subscriber topology and the final idle heartbeat no-cancel/reconnect-churn remediation verify successfully.
 
-Whole-change archive is **not ready** because PR5 remains future scope for the overall `integrate-mqtt-readings-monitoring` change.
+## Structured status and action context findings
 
-## Structured Status and Action Context
+- Active change: `integrate-mqtt-readings-monitoring` inferred from PR5 artifacts in the workspace.
+- Artifact store: OpenSpec repo files (`openspec/config.yaml`).
+- Workspace: `.worktrees/issue-321-mqtt-monitoring`.
+- Branch: `feat/issue-321-mqtt-monitoring-pr5-runtime`.
+- Action context: final verification only; no implementation edits performed. This report was updated as the required verification artifact.
+- Blockers: none.
 
-```yaml
-schemaName: spec-driven
-changeName: integrate-mqtt-readings-monitoring
-artifactStore: openspec
-planningHome:
-  root: /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring
-  changesDir: openspec/changes
-changeRoot: openspec/changes/integrate-mqtt-readings-monitoring
-artifactPaths:
-  proposal:
-    - openspec/changes/integrate-mqtt-readings-monitoring/proposal.md
-  design:
-    - openspec/changes/integrate-mqtt-readings-monitoring/design.md
-  tasks:
-    - openspec/changes/integrate-mqtt-readings-monitoring/tasks.md
-  applyProgress:
-    - openspec/changes/integrate-mqtt-readings-monitoring/apply-progress-pr4.md
-  verifyReport:
-    - openspec/changes/integrate-mqtt-readings-monitoring/verify-report.md
-artifacts:
-  proposal: done
-  design: done
-  tasks: done
-  applyProgress: done
-  verifyReport: done
-taskProgress:
-  uncheckedImplementationMarkers: 0
-applyState: pr4_done
-dependencies:
-  verify: ready
-  archive: blocked_by_future_pr5_scope
-actionContext:
-  mode: repo-local
-  workspaceRoot: /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring
-  branch: feat/issue-321-mqtt-monitoring-pr4-bridge
-  warnings:
-    - Full backend suite still has known unrelated auth cookie-domain and Docker/testcontainers advisory-lock failures.
-nextRecommended: pr4-ready-for-pr-review
-isNonAuthoritative: false
-```
+## Spec coverage
 
-## Spec Coverage / PR4 Acceptance
+PR5 scope from `tasks.md` is covered:
 
-| Requirement / focus | Result | Evidence |
-|---|---:|---|
-| Raw MQTT remains non-KPI unless explicitly approved | PASS | PR4 gate/regression tests pass in the 78-test focused command. |
-| Approved mapping enables KPI/event bridge writes | PASS | Bridge and mapped-event tests validate approved-only writes and threshold envelope propagation. |
-| Unapproved/ambiguous mapping fails closed | PASS | Bridge tests cover unmapped, `DRAFT`, `REVOKED`, ambiguous, and non-numeric outcomes without Timescale/event writes. |
-| Idempotent KPI write/event path | PASS | Receipt lifecycle tests and event-writer tests cover duplicate payloads, `PENDING_EVENT` retry, and no duplicate sample/event behavior. |
-| Migration uniqueness guard | PASS | `backend/migrations/004_mqtt_metric_result_idempotency.cypher` contains the `MetricResult.idempotency_key` uniqueness constraint; `tests/test_polling_event_writer.py` now uses a cwd-safe path. |
-| Subscriber bridge wiring with event-writer lock session | PASS | Subscriber bridge integration tests pass. |
-| Review evidence | PASS with warning | review-risk, review-resilience, and review-reliability: no findings. review-readability: PASS with non-blocking duplicate-skip counter warning. |
+- Dedicated subscriber process entrypoint exists and is tested.
+- Backend embedded subscriber startup is explicit/disabled-by-default unless `ENABLE_MQTT_SUBSCRIBER=true`.
+- Runtime status heartbeat/connected/running/stale/disconnect behavior is covered by focused tests.
+- `docker-compose.yml` includes explicit `mqtt-subscriber` command: `python -m scripts.mqtt_subscriber`.
+- Compose `mqtt-subscriber` now requires environment-provided `POSTGRES_PASSWORD` and `MQTT_BROKER_URL` instead of committing fallback secrets/fake broker defaults.
+- Final resilience remediation is present: idle heartbeat uses `asyncio.wait` over a persistent `anext(message_stream)` task instead of `asyncio.wait_for`, avoiding timeout cancellation of the async iterator.
 
-## Task Completion Status
+## Task completion status
 
-- PR4 implementation tasks in `tasks.md`: checked `[x]`.
-- Unchecked implementation task markers matching `^\s*- \[ \]` in `tasks.md`: **none found**.
-- Whole-change archive: **not ready**; PR5 runtime subscriber topology remains future scope.
+- No unchecked implementation task markers matching `- [ ]` remain in `openspec/changes/integrate-mqtt-readings-monitoring/tasks.md`.
+- `apply-progress-pr5.md` records PR5 tasks complete and contains a `TDD Cycle Evidence` table.
+- Non-blocking remaining item: optional manual compose smoke is still listed in `apply-progress-pr5.md`; automated/code-level startup and status contracts passed.
 
-## Strict TDD Compliance
+## Strict TDD compliance
 
-Strict TDD is active via `openspec/config.yaml` and session instructions.
+Strict TDD is active via `openspec/config.yaml`.
 
-| Check | Result | Details |
-|---|---:|---|
-| `TDD Cycle Evidence` table present | PASS | `apply-progress-pr4.md` contains `### TDD Cycle Evidence`. |
-| Reported test files exist | PASS | PR4 bridge, mapped flow, KPI gate, subscriber bridge, event writer, router, subscriber loop, runtime service, and runtime repo tests exist and were executed. |
-| RED evidence cross-reference | PASS | Apply-progress lists test-first evidence for PR4 tasks; corresponding test files exist in the codebase. |
-| GREEN confirmed | PASS | Focused PR4 command passed: `78 passed, 2 warnings`. Backend-cwd event-writer file command passed: `30 passed`. |
-| Triangulation adequate | PASS | PR4 behavior is covered across service, subscriber integration, router/runtime, event-writer, and regression tests. |
-| Safety net | PASS with external warnings | Focused PR4 safety net is green. Full backend command still has unrelated failures outside PR4 acceptance. |
+- `apply-progress-pr5.md` includes `TDD Cycle Evidence`.
+- Reported test files exist and were executed:
+  - `backend/tests/test_mqtt_runtime_entrypoint.py`
+  - `backend/tests/test_mqtt_runtime_status.py`
+  - `backend/tests/test_mqtt_runtime_status_service.py`
+  - `backend/tests/test_mqtt_runtime_status_repo.py`
+  - `backend/tests/test_mqtt_subscriber_loop.py`
+- Assertion quality check: focused tests assert concrete runtime behavior, including heartbeat count and no disconnect except shutdown. No tautology-only, type-only, ghost-loop-only, or CSS/implementation-detail assertions found in the final remediation test.
 
-### Test Layer Distribution
-
-| Layer | Tests | Files | Tools |
-|---|---:|---:|---|
-| Unit/service | 43+ | 3 | pytest |
-| Integration/API/subscriber | 14+ | 3 | pytest / FastAPI test utilities |
-| Runtime/repository focused | 21 | 3 | pytest |
-| E2E | 0 | 0 | not used for PR4 |
-| **Total focused executed** | **78** | **9** | pytest |
-
-### Assertion Quality
-
-Changed/created PR4 tests were scanned for tautologies, ghost loops, type-only assertions alone, smoke-only tests, and CSS implementation-detail assertions. No blocking assertion-quality issue was found. Empty-list assertions in event/bridge tests are paired with side-effect assertions proving no metric/event writes under blocked conditions.
-
-## Review Workload / PR Boundary
-
-- `tasks.md` forecast: chained PRs recommended, 400-line budget risk high, `feature-branch-chain` selected.
-- PR4 remains within the bridge/fail-closed/idempotent KPI-write/event path boundary.
-- No PR5 runtime entrypoint/docker-compose work was included.
-- Scope boundary: **respected**.
-- `size:exception`: not used; chained PR strategy is the active workload control.
-
-## Verification Commands and Evidence
+## Test / validation commands
 
 ```bash
-cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring && grep -nE '^\s*- \[ \]' openspec/changes/integrate-mqtt-readings-monitoring/tasks.md || true
-# No matches found
+./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py backend/tests/test_mqtt_subscriber_loop.py -q
+# 30 passed, 7 warnings in 3.15s
+
+./backend/.venv/bin/ruff check backend/config.py backend/main.py backend/services/mqtt/subscriber.py backend/services/mqtt_runtime_status.py backend/scripts/mqtt_subscriber.py backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py backend/tests/test_mqtt_subscriber_loop.py
+# All checks passed!
+
+./backend/.venv/bin/black --check backend/config.py backend/main.py backend/services/mqtt/subscriber.py backend/services/mqtt_runtime_status.py backend/scripts/mqtt_subscriber.py backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py backend/tests/test_mqtt_subscriber_loop.py
+# All done! 8 files would be left unchanged.
+
+grep -n "wait_for" backend/services/mqtt/subscriber.py backend/tests/test_mqtt_subscriber_loop.py || true
+# no matches
 ```
 
-```bash
-cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring && ./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py backend/tests/test_mqtt_subscriber_loop.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py -q
-# 78 passed, 2 warnings in 2.13s
-```
+## Remaining warnings
 
-```bash
-cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring && ./backend/.venv/bin/ruff check backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/polling/event_writer.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py && ./backend/.venv/bin/black --check backend/services/mqtt_bridge_service.py backend/services/mqtt/subscriber.py backend/routers/mqtt.py backend/polling/event_writer.py backend/repositories/mqtt_metric_sample_receipt_repo.py backend/repositories/mqtt_mapping_repo.py backend/tests/test_mqtt_bridge_service.py backend/tests/test_mqtt_mapped_event_flow.py backend/tests/test_mqtt_kpi_gate_regression.py backend/tests/test_mqtt_subscriber_bridge_integration.py backend/tests/test_polling_event_writer.py backend/tests/test_mqtt_router.py
-# Ruff: All checks passed!
-# Black: 12 files would be left unchanged.
-```
+Pytest emitted 7 existing deprecation warnings:
 
-```bash
-cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring/backend && ../backend/.venv/bin/python -m pytest tests/test_polling_event_writer.py -q
-# 30 passed in 0.50s
-```
+- SQLAlchemy `declarative_base()` moved to `sqlalchemy.orm.declarative_base()` in `backend/postgres_db.py`.
+- Python `crypt` deprecation from passlib under Python 3.13.
+- pandas/PyArrow future dependency warning from `backend/services/node_service.py`.
+- FastAPI `on_event` deprecation warnings in `backend/main.py` and FastAPI internals.
 
-```bash
-cd /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/issue-321-mqtt-monitoring/backend && ../backend/.venv/bin/python -m pytest
-# 6 failed, 1625 passed, 1 skipped, 51 warnings in 26.15s
-# Remaining failures are outside PR4 acceptance:
-# - tests/test_auth_router_refresh.py::TestCookieDomainAndSecure::test_get_cookie_domain_and_secure_https_hostname
-# - tests/test_auth_router_refresh.py::TestCookieDomainAndSecure::test_get_cookie_domain_and_secure_cookie_domain_override
-# - tests/test_writer_advisory_lock.py::test_concurrent_writers_block_on_lock
-# - tests/test_writer_advisory_lock.py::test_unsorted_lock_acquisition_deadlocks
-# - tests/test_writer_advisory_lock.py::test_sorted_lock_acquisition_prevents_deadlock
-# - tests/test_writer_advisory_lock.py::test_full_poll_cycle_no_duplicates
-# Docker/testcontainers failures show Docker socket unavailable: FileNotFoundError on Unix socket.
-```
+These are non-blocking for PR5 runtime behavior.
 
-## Findings
+## Review workload / PR boundary findings
 
-### CRITICAL
+- `tasks.md` forecast required chained PRs and `feature-branch-chain`.
+- PR5 changes stay within the assigned runtime topology/operational proof slice.
+- No scope creep into prior PR mapping, permission, raw API, or KPI bridge business logic was observed beyond the runtime bridge enablement gate required for PR5 process ownership.
 
-None for PR4.
+## Blockers
 
-### WARNING
-
-1. **Full backend suite still has unrelated failures.** Two auth cookie-domain assertions fail, and four Docker/testcontainers advisory-lock tests fail because Docker socket access is unavailable in this environment. The previous PR4 migration cwd failure is no longer present.
-2. **review-readability non-blocking warning remains.** Duplicate skip behavior is currently counted under `mapped_writes_total`; reviewers accepted this as non-blocking, but counter semantics may deserve clarification later.
-3. **Focused pytest warnings remain.** The 78-test focused run emits SQLAlchemy `declarative_base()` and Python `crypt` deprecation warnings.
-
-### SUGGESTION
-
-- Track the unrelated full-suite failures separately so PR4 evidence does not keep carrying baseline noise.
-
-## Exact Blockers
-
-None for PR4.
+None.


### PR DESCRIPTION
Closes #321

## Descripción del Cambio
PR5 de la cadena #321. Agrega la topología runtime explícita del subscriber MQTT y la prueba operacional de status/heartbeat para cerrar la integración backend.

Incluye:
- entrypoint dedicado `python -m scripts.mqtt_subscriber`;
- servicio `mqtt-subscriber` en `docker-compose.yml`;
- flags runtime para ownership explícito y bridge:
  - `ENABLE_MQTT_SUBSCRIBER`
  - `MQTT_MAPPING_BRIDGE_ENABLED`
  - `MQTT_SUBSCRIBER_STALE_HEARTBEAT_SECONDS`
  - compat: `MQTT_MAPPING_BRIDGE_MISSED_HEARTBEAT_SECONDS`;
- backend API sin subscriber embebido por defecto;
- status updates best-effort para que fallas del status store no maten ingestion;
- heartbeat periódico en idle sin churn de reconnect;
- tests de entrypoint, env contract, stale/fresh status, bridge-disabled raw persistence, y loop idle heartbeat.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Refactor (Cambio interno sin modificar comportamiento)
- [ ] Chore (Mantenimiento/tooling)

## Chain Context
```text
#377 tracker: feat/issue-321-mqtt-monitoring → main (draft/no-merge)
#378 PR1 foundations ✅ merged into tracker
#381 PR2 permissions ✅ merged into tracker
#382 PR3 raw API + mapping/threshold CRUD ✅ merged into tracker
#383 PR4 bridge KPI/event path ✅ merged into tracker
#384 PR5 runtime subscriber topology 📍 current
```

## Cambios
| Archivo | Cambio |
| --- | --- |
| `backend/scripts/mqtt_subscriber.py` | Entry point dedicado para el proceso subscriber. |
| `backend/config.py` | Flags runtime y aliases de heartbeat. |
| `backend/main.py` | Desactiva subscriber embebido por defecto y lo habilita solo por flag explícito. |
| `backend/services/mqtt/subscriber.py` | Status heartbeat/disconnect best-effort, bridge flag, heartbeat en idle sin reconnect churn. |
| `backend/services/mqtt_runtime_status.py` | Umbral stale tomado desde runtime settings. |
| `docker-compose.yml` | Servicio `mqtt-subscriber` con comando explícito. |
| `backend/tests/test_mqtt_runtime_entrypoint.py` | Entry point, env contract y ownership del backend. |
| `backend/tests/test_mqtt_runtime_status.py` | Stale/fresh/disconnect status. |
| `backend/tests/test_mqtt_subscriber_loop.py` | Bridge-disabled raw persistence e idle heartbeat. |
| `openspec/changes/integrate-mqtt-readings-monitoring/*` | Apply progress, verify report y tasks PR5. |

## Validación
- [x] Focused PR5 tests:
  `./backend/.venv/bin/python -m pytest backend/tests/test_mqtt_runtime_entrypoint.py backend/tests/test_mqtt_runtime_status.py backend/tests/test_mqtt_runtime_status_service.py backend/tests/test_mqtt_runtime_status_repo.py backend/tests/test_mqtt_subscriber_loop.py -q`
- [x] Resultado: `30 passed, 7 warnings`.
- [x] Ruff en archivos backend tocados: pass.
- [x] Black check en archivos backend tocados: pass.
- [x] `sdd-verify`: PASS.

## Review
- [x] `review-risk`: no findings finales.
- [x] `review-resilience`: no findings finales.
- [x] `review-reliability`: PASS tras remediar env/idle heartbeat coverage.
- [x] `review-readability`: PASS; sugerencias no bloqueantes sobre helper duplicado y constantes de heartbeat.

## Riesgos conocidos / fuera de alcance
- Full backend suite mantiene fallas baseline no relacionadas: 2 auth cookie-domain y 4 Docker/testcontainers/advisory-lock por ambiente local.
- Smoke manual con compose real queda recomendado antes de rollout operativo, pero tests/compose inspection cubren la aceptación de PR5.
- No frontend.

## Checklist
- [x] Issue aprobado vinculado (`Closes #321`).
- [x] Exactamente un label `type:*` será aplicado: `type:feature`.
- [x] Commit convencional sin `Co-Authored-By`.
- [x] SDD/OpenSpec actualizado para PR5.
