### PR TITLE
fix(events): prevent propagated event duplication

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -14,8 +14,6 @@ from neo4j import GraphDatabase
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(os.path.join(os.path.dirname(__file__), "../backend"))
 
-from sqlalchemy import text  # noqa: E402
-
 from config import get_icmp_settings, get_polling_pipeline_settings  # noqa: E402
 from polling.icmp_measurements import (  # noqa: E402
     ICMP_AVAILABILITY_METRIC_ID,
@@ -47,6 +45,7 @@ from services.polling_event_lifecycle import (  # noqa: E402
     is_snmp_no_response_failure,
     normalized_protocol,
 )
+from sqlalchemy import text  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -14,6 +14,8 @@ from neo4j import GraphDatabase
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(os.path.join(os.path.dirname(__file__), "../backend"))
 
+from sqlalchemy import text  # noqa: E402
+
 from config import get_icmp_settings, get_polling_pipeline_settings  # noqa: E402
 from polling.icmp_measurements import (  # noqa: E402
     ICMP_AVAILABILITY_METRIC_ID,
@@ -45,7 +47,6 @@ from services.polling_event_lifecycle import (  # noqa: E402
     is_snmp_no_response_failure,
     normalized_protocol,
 )
-from sqlalchemy import text  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -227,10 +227,12 @@ def _log_observe_only_cycle(
 
 def _count_monitored_cis(session) -> int:
     """Return the stable count of distinct CIs with active metric assignments."""
-    record = session.run("""
+    record = session.run(
+        """
         MATCH (n:CI)-[:HAS_METRIC]->(:MetricDef)
         RETURN count(DISTINCT n) AS cis_monitored
-    """).single()
+    """
+    ).single()
     if not record:
         return 0
     return int(record.get("cis_monitored") or 0)
@@ -246,11 +248,13 @@ def _base_severity_from_criticality(criticality) -> str:
 
 def _previous_latency_ms(db, node_id: str, before: datetime) -> float | None:
     result = db.execute(
-        text("""
+        text(
+            """
             SELECT value FROM metric_values
             WHERE node_id = :node_id AND metric_id = :metric_id AND time < :before
             ORDER BY time DESC LIMIT 1
-        """),
+        """
+        ),
         {"node_id": node_id, "metric_id": ICMP_LATENCY_METRIC_ID, "before": before},
     )
     row = result.first() if hasattr(result, "first") else None
@@ -510,7 +514,9 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
 
     root_rows = [row for row in availability_events if row.get("correlation_type") != "PROPAGATED"]
-    propagated_rows = [row for row in availability_events if row.get("correlation_type") == "PROPAGATED"]
+    propagated_rows = [
+        row for row in availability_events if row.get("correlation_type") == "PROPAGATED"
+    ]
 
     # Serialize concurrent writers per (ci_id, metric_id, event_type) triplet
     # before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) Event write (issue #322).
@@ -916,7 +922,8 @@ def poll_snmp():
     try:
         with driver.session() as session:
             # Enhanced query: Get CI credentials and Metric metadata
-            result = session.run("""
+            result = session.run(
+                """
                 MATCH (n:CI)-[r:HAS_METRIC]->(m:MetricDef)
                 WITH n, r, m,
                      coalesce(m.polling_interval, 60) as interval,
@@ -930,7 +937,8 @@ def poll_snmp():
                        m.metric_kind as metric_kind,
                        m.availability_source as availability_source,
                        interval
-            """)
+            """
+            )
 
             records = list(result)
             records.sort(

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -301,6 +301,54 @@ def _resolve_correlation(cache, ci_id, metric_id):
     return {"correlation_type": "ROOT", "propagated_from": None, "root_cause_ci_id": ci_id}
 
 
+def _build_propagated_root_update_comment(row):
+    return (
+        f"CI '{row.get('node_id')}' is affected by root cause CI '{row.get('root_cause_ci_id')}' "
+        "reported by child dependency polling."
+    )
+
+
+def _update_propagated_root_events(session, propagated_rows):
+    """Attach propagated children to existing ROOT events without creating child events."""
+    if not propagated_rows:
+        return
+    for row in propagated_rows:
+        row["affected_ci_comment"] = _build_propagated_root_update_comment(row)
+
+    query = """
+        UNWIND $propagated_rows AS row
+        MATCH (root:Event {id: row.propagated_from})
+        WHERE root.status IN ['OPEN', 'ACK', 'RECOVERED']
+          AND row.propagated_from IS NOT NULL
+          AND row.node_id IS NOT NULL
+          AND coalesce(root.correlation_type, 'ROOT') = 'ROOT'
+        WITH root, row,
+             CASE
+               WHEN root.affected_ci_ids IS NULL OR size(root.affected_ci_ids) = 0 THEN [row.node_id]
+               WHEN row.node_id IN root.affected_ci_ids THEN root.affected_ci_ids
+               ELSE root.affected_ci_ids + [row.node_id]
+             END AS affected_ci_ids
+        SET root.affected_ci_ids = affected_ci_ids,
+            root.affected_ci_count = size(affected_ci_ids),
+            root.comments = CASE
+              WHEN root.comments IS NULL OR size(root.comments) = 0 THEN [row.affected_ci_comment]
+              WHEN row.affected_ci_comment IN root.comments THEN root.comments
+              ELSE root.comments + [row.affected_ci_comment]
+            END
+        RETURN count(row) AS updated_roots
+    """
+
+    result = session.run(query, propagated_rows=propagated_rows)
+    summary = result.single() if hasattr(result, "single") else None
+    updated_roots = int(summary.get("updated_roots") or 0) if summary else 0
+    if updated_roots < len(propagated_rows):
+        logger.warning(
+            "topology_rca_propagated_root_update_partial rows=%s updated_roots=%s",
+            len(propagated_rows),
+            updated_roots,
+        )
+
+
 def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=None):
     failures = _dedupe_snmp_collection_failures(failures)
     if not failures:
@@ -312,6 +360,10 @@ def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=Non
         cache = {}
     for row in failures:
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
+
+    root_rows = [row for row in failures if row.get("correlation_type") != "PROPAGATED"]
+    propagated_rows = [row for row in failures if row.get("correlation_type") == "PROPAGATED"]
+
     # Serialize concurrent writers for the same (ci_id, metric_id, event_type)
     # triplet before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) Event write
     # (issue #322). The pg_advisory_xact_lock is transaction-scoped: poll_snmp
@@ -335,99 +387,105 @@ def _refresh_snmp_collection_failures(session, failures, cache=None, lock_db=Non
                 event_type,
                 writer_context="snmp_worker_collection_failure",
             )
-    primary_query = """
-        UNWIND $failures AS row
-        MATCH (n:CI {id: row.node_id})
-        MATCH (m:MetricDef {id: row.metric_id})
-        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
-        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
-          AND (
-            existing.event_type = 'COLLECTION_FAILURE'
-            OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
-          )
-          AND (existing.failure_family = 'SNMP_NO_RESPONSE' OR existing.failure_family IS NULL)
-          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
-        WITH row, n, m, head(collect(existing)) AS existing
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
-            CREATE (created:Event {
-                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
-                status: 'OPEN', severity: row.severity, message: row.message,
-                event_type: row.event_type, failure_family: row.failure_family,
-                source_protocol: row.source_protocol, created_at: datetime(),
-                last_seen: datetime(), ack: false,
-                correlation_type: row.correlation_type,
-                propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id,
-                poll_collector_id: $poll_collector_id
-            })
-            MERGE (n)-[:HAS_EVENT]->(created)
-            MERGE (created)-[:TRIGGERED_BY]->(m)
+
+    if root_rows:
+        primary_query = """
+            UNWIND $failures AS row
+            MATCH (n:CI {id: row.node_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+              AND (
+                existing.event_type = 'COLLECTION_FAILURE'
+                OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+              )
+              AND (existing.failure_family = 'SNMP_NO_RESPONSE' OR existing.failure_family IS NULL)
+              AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                    status: 'OPEN', severity: row.severity, message: row.message,
+                    event_type: row.event_type, failure_family: row.failure_family,
+                    source_protocol: row.source_protocol, created_at: datetime(),
+                    last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type,
+                    propagated_from: row.propagated_from,
+                    root_cause_ci_id: row.root_cause_ci_id,
+                    poll_collector_id: $poll_collector_id
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.status = 'OPEN', existing.severity = row.severity,
+                    existing.message = row.message, existing.last_seen = datetime(),
+                    existing.recovered_at = NULL, existing.ack = false,
+                    existing.event_type = row.event_type,
+                    existing.failure_family = row.failure_family,
+                    existing.source_protocol = row.source_protocol,
+                    existing.poll_collector_id = $poll_collector_id
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+        """
+        # Fallback Cypher — hand-written to avoid dangling-comma artifacts
+        # that naive ``.replace()`` would leave in the SET clause
+        # (verify-report CRITICAL #1 — issue #340). The CREATE row-dict
+        # removal is safe because the next line is ``})``; the SET clause
+        # removal requires also dropping the trailing comma after
+        # ``existing.source_protocol = row.source_protocol``.
+        fallback_query = """
+            UNWIND $failures AS row
+            MATCH (n:CI {id: row.node_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+              AND (
+                existing.event_type = 'COLLECTION_FAILURE'
+                OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
+              )
+              AND (existing.failure_family = 'SNMP_NO_RESPONSE' OR existing.failure_family IS NULL)
+              AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                    status: 'OPEN', severity: row.severity, message: row.message,
+                    event_type: row.event_type, failure_family: row.failure_family,
+                    source_protocol: row.source_protocol, created_at: datetime(),
+                    last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type,
+                    propagated_from: row.propagated_from,
+                    root_cause_ci_id: row.root_cause_ci_id
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.status = 'OPEN', existing.severity = row.severity,
+                    existing.message = row.message, existing.last_seen = datetime(),
+                    existing.recovered_at = NULL, existing.ack = false,
+                    existing.event_type = row.event_type,
+                    existing.failure_family = row.failure_family,
+                    existing.source_protocol = row.source_protocol
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+        """
+        run_with_cypher_param_fallback(
+            session,
+            primary_query,
+            {"failures": root_rows, "poll_collector_id": POLL_COLLECTOR_ID},
+            fallback_query,
+            {"failures": root_rows},
+            is_poll_collector_id_undefined_error,
+            logger,
         )
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
-            SET existing.status = 'OPEN', existing.severity = row.severity,
-                existing.message = row.message, existing.last_seen = datetime(),
-                existing.recovered_at = NULL, existing.ack = false,
-                existing.event_type = row.event_type,
-                existing.failure_family = row.failure_family,
-                existing.source_protocol = row.source_protocol,
-                existing.poll_collector_id = $poll_collector_id
-            MERGE (n)-[:HAS_EVENT]->(existing)
-            MERGE (existing)-[:TRIGGERED_BY]->(m)
-        )
-    """
-    # Fallback Cypher — hand-written to avoid dangling-comma artifacts
-    # that naive ``.replace()`` would leave in the SET clause
-    # (verify-report CRITICAL #1 — issue #340). The CREATE row-dict
-    # removal is safe because the next line is ``})``; the SET clause
-    # removal requires also dropping the trailing comma after
-    # ``existing.source_protocol = row.source_protocol``.
-    fallback_query = """
-        UNWIND $failures AS row
-        MATCH (n:CI {id: row.node_id})
-        MATCH (m:MetricDef {id: row.metric_id})
-        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
-        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
-          AND (
-            existing.event_type = 'COLLECTION_FAILURE'
-            OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')
-          )
-          AND (existing.failure_family = 'SNMP_NO_RESPONSE' OR existing.failure_family IS NULL)
-          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
-        WITH row, n, m, head(collect(existing)) AS existing
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
-            CREATE (created:Event {
-                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
-                status: 'OPEN', severity: row.severity, message: row.message,
-                event_type: row.event_type, failure_family: row.failure_family,
-                source_protocol: row.source_protocol, created_at: datetime(),
-                last_seen: datetime(), ack: false,
-                correlation_type: row.correlation_type,
-                propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id
-            })
-            MERGE (n)-[:HAS_EVENT]->(created)
-            MERGE (created)-[:TRIGGERED_BY]->(m)
-        )
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
-            SET existing.status = 'OPEN', existing.severity = row.severity,
-                existing.message = row.message, existing.last_seen = datetime(),
-                existing.recovered_at = NULL, existing.ack = false,
-                existing.event_type = row.event_type,
-                existing.failure_family = row.failure_family,
-                existing.source_protocol = row.source_protocol
-            MERGE (n)-[:HAS_EVENT]->(existing)
-            MERGE (existing)-[:TRIGGERED_BY]->(m)
-        )
-    """
-    run_with_cypher_param_fallback(
-        session,
-        primary_query,
-        {"failures": failures, "poll_collector_id": POLL_COLLECTOR_ID},
-        fallback_query,
-        {"failures": failures},
-        is_poll_collector_id_undefined_error,
-        logger,
-    )
+
+    # Keep PROPAGATED children from creating their own child events.
+    # Instead, attach affected-CI metadata to the ROOT event.
+    _update_propagated_root_events(session, propagated_rows)
 
 
 def _availability_source(value: Any) -> str | None:
@@ -450,6 +508,10 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
         cache = {}
     for row in availability_events:
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
+
+    root_rows = [row for row in availability_events if row.get("correlation_type") != "PROPAGATED"]
+    propagated_rows = [row for row in availability_events if row.get("correlation_type") == "PROPAGATED"]
+
     # Serialize concurrent writers per (ci_id, metric_id, event_type) triplet
     # before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) Event write (issue #322).
     # The pg_advisory_xact_lock is transaction-scoped: poll_snmp owns the
@@ -473,102 +535,108 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
                 event_type,
                 writer_context="snmp_worker_icmp_availability",
             )
-    primary_query = """
-        UNWIND $availability_events AS row
-        WITH row WHERE row.event_type = 'AVAILABILITY'
-          AND row.source_protocol = 'ICMP'
-          AND row.availability_source IN ['PING', 'ICMP']
-        MATCH (n:CI {id: row.node_id})
-        MATCH (m:MetricDef {id: row.metric_id})
-        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
-        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
-          AND existing.event_type = 'AVAILABILITY'
-          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
-          AND existing.availability_source IN ['PING', 'ICMP']
-          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
-        WITH row, n, m, head(collect(existing)) AS existing
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
-            CREATE (created:Event {
-                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
-                status: 'OPEN', severity: row.severity, message: row.message,
-                event_type: row.event_type, source_protocol: row.source_protocol,
-                availability_source: row.availability_source,
-                created_at: datetime(), last_seen: datetime(), ack: false,
-                correlation_type: row.correlation_type,
-                propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id,
-                poll_collector_id: $poll_collector_id
-            })
-            MERGE (n)-[:HAS_EVENT]->(created)
-            MERGE (created)-[:TRIGGERED_BY]->(m)
+
+    if root_rows:
+        primary_query = """
+            UNWIND $availability_events AS row
+            WITH row WHERE row.event_type = 'AVAILABILITY'
+              AND row.source_protocol = 'ICMP'
+              AND row.availability_source IN ['PING', 'ICMP']
+            MATCH (n:CI {id: row.node_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+              AND existing.event_type = 'AVAILABILITY'
+              AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+              AND existing.availability_source IN ['PING', 'ICMP']
+              AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                    status: 'OPEN', severity: row.severity, message: row.message,
+                    event_type: row.event_type, source_protocol: row.source_protocol,
+                    availability_source: row.availability_source,
+                    created_at: datetime(), last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type,
+                    propagated_from: row.propagated_from,
+                    root_cause_ci_id: row.root_cause_ci_id,
+                    poll_collector_id: $poll_collector_id
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.status = 'OPEN', existing.severity = row.severity,
+                    existing.message = row.message, existing.last_seen = datetime(),
+                    existing.recovered_at = NULL, existing.ack = false,
+                    existing.event_type = row.event_type,
+                    existing.source_protocol = row.source_protocol,
+                    existing.availability_source = row.availability_source,
+                    existing.poll_collector_id = $poll_collector_id
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+        """
+        # Fallback Cypher — hand-written (see #340, verify-report CRITICAL #1).
+        # Drops the trailing comma after
+        # ``existing.availability_source = row.availability_source`` that a
+        # naive ``.replace()`` would leave dangling before ``MERGE``.
+        fallback_query = """
+            UNWIND $availability_events AS row
+            WITH row WHERE row.event_type = 'AVAILABILITY'
+              AND row.source_protocol = 'ICMP'
+              AND row.availability_source IN ['PING', 'ICMP']
+            MATCH (n:CI {id: row.node_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
+            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+              AND existing.event_type = 'AVAILABILITY'
+              AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+              AND existing.availability_source IN ['PING', 'ICMP']
+              AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                    status: 'OPEN', severity: row.severity, message: row.message,
+                    event_type: row.event_type, source_protocol: row.source_protocol,
+                    availability_source: row.availability_source,
+                    created_at: datetime(), last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type,
+                    propagated_from: row.propagated_from,
+                    root_cause_ci_id: row.root_cause_ci_id
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.status = 'OPEN', existing.severity = row.severity,
+                    existing.message = row.message, existing.last_seen = datetime(),
+                    existing.recovered_at = NULL, existing.ack = false,
+                    existing.event_type = row.event_type,
+                    existing.source_protocol = row.source_protocol,
+                    existing.availability_source = row.availability_source
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+        """
+        run_with_cypher_param_fallback(
+            session,
+            primary_query,
+            {
+                "availability_events": root_rows,
+                "poll_collector_id": POLL_COLLECTOR_ID,
+            },
+            fallback_query,
+            {"availability_events": root_rows},
+            is_poll_collector_id_undefined_error,
+            logger,
         )
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
-            SET existing.status = 'OPEN', existing.severity = row.severity,
-                existing.message = row.message, existing.last_seen = datetime(),
-                existing.recovered_at = NULL, existing.ack = false,
-                existing.event_type = row.event_type,
-                existing.source_protocol = row.source_protocol,
-                existing.availability_source = row.availability_source,
-                existing.poll_collector_id = $poll_collector_id
-            MERGE (n)-[:HAS_EVENT]->(existing)
-            MERGE (existing)-[:TRIGGERED_BY]->(m)
-        )
-    """
-    # Fallback Cypher — hand-written (see #340, verify-report CRITICAL #1).
-    # Drops the trailing comma after
-    # ``existing.availability_source = row.availability_source`` that a
-    # naive ``.replace()`` would leave dangling before ``MERGE``.
-    fallback_query = """
-        UNWIND $availability_events AS row
-        WITH row WHERE row.event_type = 'AVAILABILITY'
-          AND row.source_protocol = 'ICMP'
-          AND row.availability_source IN ['PING', 'ICMP']
-        MATCH (n:CI {id: row.node_id})
-        MATCH (m:MetricDef {id: row.metric_id})
-        OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
-        WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
-          AND existing.event_type = 'AVAILABILITY'
-          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
-          AND existing.availability_source IN ['PING', 'ICMP']
-          AND (existing.source_protocol IS NULL OR toUpper(existing.source_protocol) = row.source_protocol)
-        WITH row, n, m, head(collect(existing)) AS existing
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
-            CREATE (created:Event {
-                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
-                status: 'OPEN', severity: row.severity, message: row.message,
-                event_type: row.event_type, source_protocol: row.source_protocol,
-                availability_source: row.availability_source,
-                created_at: datetime(), last_seen: datetime(), ack: false,
-                correlation_type: row.correlation_type,
-                propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id
-            })
-            MERGE (n)-[:HAS_EVENT]->(created)
-            MERGE (created)-[:TRIGGERED_BY]->(m)
-        )
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
-            SET existing.status = 'OPEN', existing.severity = row.severity,
-                existing.message = row.message, existing.last_seen = datetime(),
-                existing.recovered_at = NULL, existing.ack = false,
-                existing.event_type = row.event_type,
-                existing.source_protocol = row.source_protocol,
-                existing.availability_source = row.availability_source
-            MERGE (n)-[:HAS_EVENT]->(existing)
-            MERGE (existing)-[:TRIGGERED_BY]->(m)
-        )
-    """
-    run_with_cypher_param_fallback(
-        session,
-        primary_query,
-        {
-            "availability_events": availability_events,
-            "poll_collector_id": POLL_COLLECTOR_ID,
-        },
-        fallback_query,
-        {"availability_events": availability_events},
-        is_poll_collector_id_undefined_error,
-        logger,
-    )
+
+    # Keep PROPAGATED children from creating their own child events.
+    # Instead, attach affected-CI metadata to the ROOT event.
+    _update_propagated_root_events(session, propagated_rows)
 
 
 def _recover_icmp_availability_events(session, updates):
@@ -627,6 +695,10 @@ def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
         cache = {}
     for row in breaches:
         row.update(_resolve_correlation(cache, row.get("node_id"), row.get("metric_id")))
+
+    root_rows = [row for row in breaches if row.get("correlation_type") != "PROPAGATED"]
+    propagated_rows = [row for row in breaches if row.get("correlation_type") == "PROPAGATED"]
+
     # Serialize concurrent writers per (ci_id, metric_id, event_type) triplet
     # before the Neo4j OPTIONAL MATCH + FOREACH(CREATE) Event write (issue #322).
     # The pg_advisory_xact_lock is transaction-scoped: poll_snmp owns the
@@ -650,92 +722,98 @@ def _refresh_icmp_latency_events(session, updates, cache=None, lock_db=None):
                 event_type,
                 writer_context="snmp_worker_icmp_latency",
             )
-    primary_query = """
-        UNWIND $breaches AS row
-        MATCH (n:CI {id: row.node_id})
-        MATCH (m:MetricDef {id: row.metric_id})
-        OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH'})
-        WHERE existing.status IN ['OPEN', 'ACK']
-          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
-        WITH row, n, m, head(collect(existing)) AS existing
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
-            CREATE (created:Event {
-                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
-                event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
-                message: row.message, source_protocol: row.source_protocol,
-                last_seen: datetime(), ack: false,
-                correlation_type: row.correlation_type,
-                propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id,
-                poll_collector_id: $poll_collector_id
-            })
-            MERGE (n)-[:HAS_EVENT]->(created)
-            MERGE (created)-[:TRIGGERED_BY]->(m)
+
+    if root_rows:
+        primary_query = """
+            UNWIND $breaches AS row
+            MATCH (n:CI {id: row.node_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH'})
+            WHERE existing.status IN ['OPEN', 'ACK']
+              AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                    event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
+                    message: row.message, source_protocol: row.source_protocol,
+                    last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type,
+                    propagated_from: row.propagated_from,
+                    root_cause_ci_id: row.root_cause_ci_id,
+                    poll_collector_id: $poll_collector_id
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.severity = row.status,
+                    existing.message = row.message,
+                    existing.source_protocol = row.source_protocol,
+                    existing.last_seen = datetime(),
+                    existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
+                    existing.recovered_at = NULL,
+                    existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
+                    existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id),
+                    existing.poll_collector_id = $poll_collector_id
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+        """
+        # Fallback Cypher — hand-written (see #340, verify-report CRITICAL #1).
+        # Drops the trailing comma after
+        # ``existing.root_cause_ci_id = coalesce(...)`` that a naive
+        # ``.replace()`` would leave dangling before ``MERGE``.
+        fallback_query = """
+            UNWIND $breaches AS row
+            MATCH (n:CI {id: row.node_id})
+            MATCH (m:MetricDef {id: row.metric_id})
+            OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH'})
+            WHERE existing.status IN ['OPEN', 'ACK']
+              AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
+            WITH row, n, m, head(collect(existing)) AS existing
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
+                CREATE (created:Event {
+                    id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
+                    event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
+                    message: row.message, source_protocol: row.source_protocol,
+                    last_seen: datetime(), ack: false,
+                    correlation_type: row.correlation_type,
+                    propagated_from: row.propagated_from,
+                    root_cause_ci_id: row.root_cause_ci_id
+                })
+                MERGE (n)-[:HAS_EVENT]->(created)
+                MERGE (created)-[:TRIGGERED_BY]->(m)
+            )
+            FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
+                SET existing.severity = row.status,
+                    existing.message = row.message,
+                    existing.source_protocol = row.source_protocol,
+                    existing.last_seen = datetime(),
+                    existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
+                    existing.recovered_at = NULL,
+                    existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
+                    existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id)
+                MERGE (n)-[:HAS_EVENT]->(existing)
+                MERGE (existing)-[:TRIGGERED_BY]->(m)
+            )
+        """
+        run_with_cypher_param_fallback(
+            session,
+            primary_query,
+            {
+                "breaches": root_rows,
+                "poll_collector_id": POLL_COLLECTOR_ID,
+            },
+            fallback_query,
+            {"breaches": root_rows},
+            is_poll_collector_id_undefined_error,
+            logger,
         )
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
-            SET existing.severity = row.status,
-                existing.message = row.message,
-                existing.source_protocol = row.source_protocol,
-                existing.last_seen = datetime(),
-                existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
-                existing.recovered_at = NULL,
-                existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
-                existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id),
-                existing.poll_collector_id = $poll_collector_id
-            MERGE (n)-[:HAS_EVENT]->(existing)
-            MERGE (existing)-[:TRIGGERED_BY]->(m)
-        )
-    """
-    # Fallback Cypher — hand-written (see #340, verify-report CRITICAL #1).
-    # Drops the trailing comma after
-    # ``existing.root_cause_ci_id = coalesce(...)`` that a naive
-    # ``.replace()`` would leave dangling before ``MERGE``.
-    fallback_query = """
-        UNWIND $breaches AS row
-        MATCH (n:CI {id: row.node_id})
-        MATCH (m:MetricDef {id: row.metric_id})
-        OPTIONAL MATCH (n)-[:HAS_EVENT]->(existing:Event {metric_id: row.metric_id, event_type: 'THRESHOLD_BREACH'})
-        WHERE existing.status IN ['OPEN', 'ACK']
-          AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
-        WITH row, n, m, head(collect(existing)) AS existing
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [1] ELSE [] END |
-            CREATE (created:Event {
-                id: randomUUID(), ci_id: row.node_id, metric_id: row.metric_id,
-                event_type: 'THRESHOLD_BREACH', status: 'OPEN', severity: row.status,
-                message: row.message, source_protocol: row.source_protocol,
-                last_seen: datetime(), ack: false,
-                correlation_type: row.correlation_type,
-                propagated_from: row.propagated_from,
-                root_cause_ci_id: row.root_cause_ci_id
-            })
-            MERGE (n)-[:HAS_EVENT]->(created)
-            MERGE (created)-[:TRIGGERED_BY]->(m)
-        )
-        FOREACH (_ IN CASE WHEN existing IS NULL THEN [] ELSE [1] END |
-            SET existing.severity = row.status,
-                existing.message = row.message,
-                existing.source_protocol = row.source_protocol,
-                existing.last_seen = datetime(),
-                existing.ack = CASE WHEN existing.status = 'ACK' THEN existing.ack ELSE false END,
-                existing.recovered_at = NULL,
-                existing.correlation_type = coalesce(existing.correlation_type, 'ROOT'),
-                existing.root_cause_ci_id = coalesce(existing.root_cause_ci_id, row.node_id)
-            MERGE (n)-[:HAS_EVENT]->(existing)
-            MERGE (existing)-[:TRIGGERED_BY]->(m)
-        )
-    """
-    run_with_cypher_param_fallback(
-        session,
-        primary_query,
-        {
-            "breaches": breaches,
-            "poll_collector_id": POLL_COLLECTOR_ID,
-        },
-        fallback_query,
-        {"breaches": breaches},
-        is_poll_collector_id_undefined_error,
-        logger,
-    )
+
+    # Keep PROPAGATED children from creating their own child events.
+    # Instead, attach affected-CI metadata to the ROOT event.
+    _update_propagated_root_events(session, propagated_rows)
 
 
 def _recover_icmp_latency_events(session, updates):

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -227,12 +227,10 @@ def _log_observe_only_cycle(
 
 def _count_monitored_cis(session) -> int:
     """Return the stable count of distinct CIs with active metric assignments."""
-    record = session.run(
-        """
+    record = session.run("""
         MATCH (n:CI)-[:HAS_METRIC]->(:MetricDef)
         RETURN count(DISTINCT n) AS cis_monitored
-    """
-    ).single()
+    """).single()
     if not record:
         return 0
     return int(record.get("cis_monitored") or 0)
@@ -248,13 +246,11 @@ def _base_severity_from_criticality(criticality) -> str:
 
 def _previous_latency_ms(db, node_id: str, before: datetime) -> float | None:
     result = db.execute(
-        text(
-            """
+        text("""
             SELECT value FROM metric_values
             WHERE node_id = :node_id AND metric_id = :metric_id AND time < :before
             ORDER BY time DESC LIMIT 1
-        """
-        ),
+        """),
         {"node_id": node_id, "metric_id": ICMP_LATENCY_METRIC_ID, "before": before},
     )
     row = result.first() if hasattr(result, "first") else None
@@ -922,8 +918,7 @@ def poll_snmp():
     try:
         with driver.session() as session:
             # Enhanced query: Get CI credentials and Metric metadata
-            result = session.run(
-                """
+            result = session.run("""
                 MATCH (n:CI)-[r:HAS_METRIC]->(m:MetricDef)
                 WITH n, r, m,
                      coalesce(m.polling_interval, 60) as interval,
@@ -937,8 +932,7 @@ def poll_snmp():
                        m.metric_kind as metric_kind,
                        m.availability_source as availability_source,
                        interval
-            """
-            )
+            """)
 
             records = list(result)
             records.sort(

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -5,9 +5,9 @@ Strict TDD: tests written FIRST, then implementation.
 Covers:
 - Task 2: ``_resolve_correlation`` helper (pure dict lookup, never raises).
 - Task 3: ``poll_snmp`` cache-build wiring (ENABLE_TOPOLOGY_RCA kill-switch,
-  cache built BEFORE the three CREATE sites, local to one cycle).
-- Task 4: the three CREATE sites decorate rows from the cache instead of
-  hardcoding ``correlation_type: 'ROOT'``.
+  cache built BEFORE the three refresh helpers, local to one cycle).
+- Task 4: propagated rows enrich root-event affected-CI metadata instead of
+  creating child operator events.
 - Task 10: failure-fallback resilience (cache-build raises → events still
   created as ROOT, UNWIND...CREATE ran, warning logged).
 """
@@ -99,33 +99,17 @@ def test_resolve_correlation_uses_ci_metric_pair_key():
 
 
 # ---------------------------------------------------------------------------
-# Task 4 — three CREATE sites decorate rows from the cache
+# Task 4 — propagated rows enrich root metadata instead of creating child Events
 # ---------------------------------------------------------------------------
-# Each _refresh_* helper now accepts an optional ``cache`` parameter (default
-# empty dict for backward compatibility with pre-existing tests). When a row's
-# (node_id, metric_id) hits the cache, the UNWIND CREATE emits PROPAGATED with
-# the resolved parent; otherwise ROOT as before. We assert on the row dicts
-# that get passed to ``session.run`` (the UNWIND $rows param), since the Cypher
-# itself references row.correlation_type / row.propagated_from /
-# row.root_cause_ci_id.
-
-
-def _capture_run_params(session):
-    """Return the list of (query, params) captured by a MockNeo4jSession-like object."""
-    return session.queries
-
-
-def _find_unwind_create_call(captured):
-    """Find the captured session.run call that contains 'UNWIND' + 'CREATE'."""
-    for entry in captured:
-        q = entry["query"].upper()
-        if "UNWIND" in q and "CREATE" in q:
-            return entry
-    return None
+# Each _refresh_* helper accepts an optional ``cache`` parameter (default empty
+# dict for backward compatibility with pre-existing tests). A row whose
+# (node_id, metric_id) hits the cache is routed to root-event affected-CI
+# enrichment; cache misses remain ROOT rows and use the existing Event
+# create/update path.
 
 
 def test_snmp_collection_failure_propagates_when_parent_open():
-    """Parent OPEN → child COLLECTION_FAILURE event row is PROPAGATED."""
+    """Propagated collection-failure rows update parent ROOT metadata, no child rows."""
     from engines.snmp_worker import _refresh_snmp_collection_failures
 
     session = MagicMock()
@@ -146,15 +130,17 @@ def test_snmp_collection_failure_propagates_when_parent_open():
         cache=cache,
     )
 
-    # Find the UNWIND run call and inspect the row.
     calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
-    assert calls, "expected a UNWIND ... CREATE call"
-    rows_param = calls[0].kwargs["failures"]
+    assert calls, "expected an UNWIND call"
+    query = calls[0].args[0]
+    rows_param = calls[0].kwargs["propagated_rows"]
     assert rows_param[0]["correlation_type"] == "PROPAGATED"
     assert rows_param[0]["propagated_from"] == "evt-A"
     assert rows_param[0]["root_cause_ci_id"] == "ci-A"
-    # And the CREATE block references row.* (no hardcoded 'ROOT' literal at this site).
-    assert "row.correlation_type" in calls[0].args[0]
+    assert "CREATE (created" not in query
+    assert "row.node_id IN root.affected_ci_ids" in query
+    assert "row.affected_ci_comment IN root.comments" in query
+    assert "root.last_seen = datetime()" not in query
 
 
 def test_snmp_collection_failure_root_when_no_parent():
@@ -186,7 +172,7 @@ def test_snmp_collection_failure_root_when_no_parent():
 
 
 def test_icmp_availability_propagates_when_parent_open():
-    """Availability CREATE site: parent OPEN → PROPAGATED."""
+    """Availability propagation updates parent ROOT metadata, not child rows."""
     from engines.snmp_worker import _refresh_icmp_availability_events
 
     session = MagicMock()
@@ -210,10 +196,14 @@ def test_icmp_availability_propagates_when_parent_open():
     )
 
     calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
-    rows_param = calls[0].kwargs["availability_events"]
+    query = calls[0].args[0]
+    rows_param = calls[0].kwargs["propagated_rows"]
     assert rows_param[0]["correlation_type"] == "PROPAGATED"
     assert rows_param[0]["propagated_from"] == "evt-A"
     assert rows_param[0]["root_cause_ci_id"] == "ci-A"
+    assert "CREATE (created" not in query
+    assert "row.node_id IN root.affected_ci_ids" in query
+    assert "root.last_seen = datetime()" not in query
 
 
 def test_icmp_availability_root_when_no_parent():
@@ -246,7 +236,7 @@ def test_icmp_availability_root_when_no_parent():
 
 
 def test_icmp_latency_breach_propagates_when_parent_open():
-    """Latency CREATE site: parent OPEN → PROPAGATED."""
+    """Latency propagation updates parent ROOT metadata, not child rows."""
     from engines.snmp_worker import _refresh_icmp_latency_events
 
     session = MagicMock()
@@ -268,10 +258,102 @@ def test_icmp_latency_breach_propagates_when_parent_open():
     )
 
     calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
-    rows_param = calls[0].kwargs["breaches"]
+    query = calls[0].args[0]
+    rows_param = calls[0].kwargs["propagated_rows"]
     assert rows_param[0]["correlation_type"] == "PROPAGATED"
     assert rows_param[0]["propagated_from"] == "evt-A"
     assert rows_param[0]["root_cause_ci_id"] == "ci-A"
+    assert "CREATE (created" not in query
+    assert "row.node_id IN root.affected_ci_ids" in query
+    assert "root.last_seen = datetime()" not in query
+
+
+class _FakeUpdateResult:
+    def __init__(self, updated_roots: int):
+        self._updated_roots = updated_roots
+
+    def single(self):
+        return {"updated_roots": self._updated_roots}
+
+
+class _FakeRootUpdateSession:
+    def __init__(self):
+        self.root = {
+            "id": "evt-A",
+            "status": "OPEN",
+            "correlation_type": "ROOT",
+            "affected_ci_ids": [],
+            "affected_ci_count": 0,
+            "comments": [],
+            "last_seen": "root-observed-at",
+        }
+        self.child_events = []
+        self.queries = []
+
+    def run(self, query, **kwargs):
+        self.queries.append({"query": query, "kwargs": kwargs})
+        updated = 0
+        for row in kwargs.get("propagated_rows", []):
+            if row.get("propagated_from") != self.root["id"]:
+                continue
+            if self.root.get("status") not in {"OPEN", "ACK", "RECOVERED"}:
+                continue
+            if self.root.get("correlation_type", "ROOT") != "ROOT":
+                continue
+            node_id = row.get("node_id")
+            comment = row.get("affected_ci_comment")
+            if node_id and node_id not in self.root["affected_ci_ids"]:
+                self.root["affected_ci_ids"].append(node_id)
+            self.root["affected_ci_count"] = len(self.root["affected_ci_ids"])
+            if comment and comment not in self.root["comments"]:
+                self.root["comments"].append(comment)
+            updated += 1
+        return _FakeUpdateResult(updated)
+
+
+def test_propagated_rows_do_not_generate_duplicate_child_events_or_notes_on_repeated_polls():
+    """Repeated propagated rows update one root-event affected entry exactly once."""
+    from engines.snmp_worker import _update_propagated_root_events
+
+    session = _FakeRootUpdateSession()
+    row = {
+        "node_id": "ci-E",
+        "metric_id": "cpu-load",
+        "correlation_type": "PROPAGATED",
+        "propagated_from": "evt-A",
+        "root_cause_ci_id": "ci-A",
+    }
+
+    _update_propagated_root_events(session, [dict(row)])
+    _update_propagated_root_events(session, [dict(row)])
+
+    assert session.child_events == []
+    assert session.root["affected_ci_ids"] == ["ci-E"]
+    assert session.root["affected_ci_count"] == 1
+    assert len(session.root["comments"]) == 1
+    assert session.root["last_seen"] == "root-observed-at"
+    assert all("CREATE (created" not in entry["query"] for entry in session.queries)
+    assert all("root.last_seen = datetime()" not in entry["query"] for entry in session.queries)
+
+
+def test_propagated_root_update_logs_when_cached_parent_is_stale(caplog):
+    """A stale propagated_from cache hit must produce an operational signal."""
+    from engines.snmp_worker import _update_propagated_root_events
+
+    session = _FakeRootUpdateSession()
+    row = {
+        "node_id": "ci-E",
+        "metric_id": "cpu-load",
+        "correlation_type": "PROPAGATED",
+        "propagated_from": "missing-root-event",
+        "root_cause_ci_id": "ci-A",
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _update_propagated_root_events(session, [row])
+
+    assert session.root["affected_ci_ids"] == []
+    assert "topology_rca_propagated_root_update_partial" in caplog.text
 
 
 def test_icmp_latency_breach_root_when_no_parent():
@@ -521,12 +603,12 @@ def test_cache_is_local_to_poll_snmp_cycle(monkeypatch):
 
 def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
     """End-to-end: build_open_parent_index cache hit flows through poll_snmp()
-    into a PROPAGATED CREATE row.
+    into a propagated child update against the parent ROOT.
 
     Guards the C1 regression (cache built BEFORE the CREATE sites). Unlike the
     Task-3 tests which patch build_open_parent_index to return {}, this test
-    populates the cache with a real parent entry and asserts the UNWIND CREATE
-    row captured on the fake session carries the propagated correlation fields.
+    populates the cache with a real parent entry and asserts the propagated
+    metadata update query is used instead of creating child events.
     """
     import config as _config
     monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
@@ -556,25 +638,17 @@ def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
     # Cache-build was called with the (ci_id, metric_id) pairs set.
     mock_build.assert_called_once()
 
-    # Find the UNWIND...CREATE call captured on the session and inspect the row.
-    create_calls = [
+    # Find the propagated-root update call captured on the session and inspect rows.
+    propagated_calls = [
         c for c in mock_session.queries
-        if "UNWIND" in c["query"] and "CREATE" in c["query"]
+        if "UNWIND" in c["query"] and "propagated_rows" in c["query"]
     ]
-    assert create_calls, "expected a UNWIND ... CREATE call to be captured"
+    assert propagated_calls, "expected a propagated_rows UNWIND call to be captured"
 
-    failures_param = create_calls[0]["params"].get("failures", [])
-    assert failures_param, "expected at least one failure row from poll_snmp"
+    rows = propagated_calls[0]["params"].get("propagated_rows", [])
+    assert rows, "expected at least one propagated row from poll_snmp"
 
-    propagated_rows = [
-        row for row in failures_param
-        if row.get("correlation_type") == "PROPAGATED"
-    ]
-    assert propagated_rows, (
-        "expected at least one PROPAGATED failure row when cache is populated"
-    )
-
-    row = propagated_rows[0]
+    row = rows[0]
     assert row["correlation_type"] == "PROPAGATED"
     assert row["propagated_from"] == "evt-A"
     assert row["root_cause_ci_id"] == "ci-A"

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -115,15 +115,17 @@ def test_snmp_collection_failure_propagates_when_parent_open():
 
     _refresh_snmp_collection_failures(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "cpu-load",
-            "severity": "WARNING",
-            "message": "Metric Collection Failed: cpu-load",
-            "event_type": "COLLECTION_FAILURE",
-            "failure_family": "SNMP_NO_RESPONSE",
-            "source_protocol": "SNMP",
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "cpu-load",
+                "severity": "WARNING",
+                "message": "Metric Collection Failed: cpu-load",
+                "event_type": "COLLECTION_FAILURE",
+                "failure_family": "SNMP_NO_RESPONSE",
+                "source_protocol": "SNMP",
+            }
+        ],
         cache=cache,
     )
 
@@ -149,15 +151,17 @@ def test_snmp_collection_failure_root_when_no_parent():
 
     _refresh_snmp_collection_failures(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "cpu-load",
-            "severity": "WARNING",
-            "message": "Metric Collection Failed: cpu-load",
-            "event_type": "COLLECTION_FAILURE",
-            "failure_family": "SNMP_NO_RESPONSE",
-            "source_protocol": "SNMP",
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "cpu-load",
+                "severity": "WARNING",
+                "message": "Metric Collection Failed: cpu-load",
+                "event_type": "COLLECTION_FAILURE",
+                "failure_family": "SNMP_NO_RESPONSE",
+                "source_protocol": "SNMP",
+            }
+        ],
         cache={},
     )
 
@@ -178,17 +182,19 @@ def test_icmp_availability_propagates_when_parent_open():
 
     _refresh_icmp_availability_events(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "PING-CHECK",
-            "protocol": "ICMP",
-            "source_protocol": "ICMP",
-            "availability_source": "PING",
-            "event_type": "AVAILABILITY",
-            "severity": "CRITICAL",
-            "message": "Service/Host Down: PING-CHECK",
-            "value": 0.0,
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "PING-CHECK",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "availability_source": "PING",
+                "event_type": "AVAILABILITY",
+                "severity": "CRITICAL",
+                "message": "Service/Host Down: PING-CHECK",
+                "value": 0.0,
+            }
+        ],
         cache=cache,
     )
 
@@ -212,17 +218,19 @@ def test_icmp_availability_root_when_no_parent():
 
     _refresh_icmp_availability_events(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "PING-CHECK",
-            "protocol": "ICMP",
-            "source_protocol": "ICMP",
-            "availability_source": "PING",
-            "event_type": "AVAILABILITY",
-            "severity": "CRITICAL",
-            "message": "Service/Host Down: PING-CHECK",
-            "value": 0.0,
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "PING-CHECK",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "availability_source": "PING",
+                "event_type": "AVAILABILITY",
+                "severity": "CRITICAL",
+                "message": "Service/Host Down: PING-CHECK",
+                "value": 0.0,
+            }
+        ],
         cache={},
     )
 
@@ -242,15 +250,17 @@ def test_icmp_latency_breach_propagates_when_parent_open():
 
     _refresh_icmp_latency_events(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "icmp_latency_ms",
-            "protocol": "ICMP",
-            "source_protocol": "ICMP",
-            "event_type": "THRESHOLD_BREACH",
-            "status": "WARNING",
-            "message": "Latency warning",
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "event_type": "THRESHOLD_BREACH",
+                "status": "WARNING",
+                "message": "Latency warning",
+            }
+        ],
         cache=cache,
     )
 
@@ -362,15 +372,17 @@ def test_icmp_latency_breach_root_when_no_parent():
 
     _refresh_icmp_latency_events(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "icmp_latency_ms",
-            "protocol": "ICMP",
-            "source_protocol": "ICMP",
-            "event_type": "THRESHOLD_BREACH",
-            "status": "WARNING",
-            "message": "Latency warning",
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "event_type": "THRESHOLD_BREACH",
+                "status": "WARNING",
+                "message": "Latency warning",
+            }
+        ],
         cache={},
     )
 
@@ -394,15 +406,17 @@ def test_refresh_helpers_accept_cache_kwarg_backward_compat():
     # No cache kwarg — must not raise.
     _refresh_icmp_latency_events(
         session,
-        [{
-            "node_id": "ci-E",
-            "metric_id": "icmp_latency_ms",
-            "protocol": "ICMP",
-            "source_protocol": "ICMP",
-            "event_type": "THRESHOLD_BREACH",
-            "status": "WARNING",
-            "message": "Latency warning",
-        }],
+        [
+            {
+                "node_id": "ci-E",
+                "metric_id": "icmp_latency_ms",
+                "protocol": "ICMP",
+                "source_protocol": "ICMP",
+                "event_type": "THRESHOLD_BREACH",
+                "status": "WARNING",
+                "message": "Latency warning",
+            }
+        ],
     )
 
     calls = [c for c in session.run.call_args_list if "UNWIND" in c.args[0]]
@@ -433,10 +447,18 @@ def _build_poll_snmp_mocks():
 
 
 _POLL_RECORD = {
-    "node_id": "ci-001", "metric_id": "CPU", "protocol": "SNMP",
-    "ip": "192.168.1.1", "community": "public", "oid": "1.3.6.1",
-    "port": 161, "metric_name": "CPU", "criticality": 3,
-    "metric_kind": None, "availability_source": None, "interval": 60,
+    "node_id": "ci-001",
+    "metric_id": "CPU",
+    "protocol": "SNMP",
+    "ip": "192.168.1.1",
+    "community": "public",
+    "oid": "1.3.6.1",
+    "port": 161,
+    "metric_name": "CPU",
+    "criticality": 3,
+    "metric_kind": None,
+    "availability_source": None,
+    "interval": 60,
 }
 
 
@@ -448,18 +470,22 @@ def test_enable_topology_rca_false_skips_cache_build(monkeypatch):
     """
     # The setting is a singleton; reset it so the env var takes effect.
     import config as _config
+
     monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "false")
     monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
 
     mock_session, mock_driver = _build_poll_snmp_mocks()
     mock_session.set_response("match", [_POLL_RECORD])
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
-         patch("engines.snmp_worker.bulk_insert_metrics"), \
-         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
-         patch("engines.snmp_worker.build_open_parent_index") as mock_build:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()),
+        patch("engines.snmp_worker.bulk_insert_metrics"),
+        patch("engines.snmp_worker.fetch_snmp_value", return_value=None),
+        patch("engines.snmp_worker.build_open_parent_index") as mock_build,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()
 
     mock_build.assert_not_called()
@@ -472,18 +498,22 @@ def test_enable_topology_rca_true_calls_build_open_parent_index(monkeypatch):
     populated, giving the cache-build real (ci_id, metric_id) pairs to resolve.
     """
     import config as _config
+
     monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
     monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
 
     mock_session, mock_driver = _build_poll_snmp_mocks()
     mock_session.set_response("match", [_POLL_RECORD])
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
-         patch("engines.snmp_worker.bulk_insert_metrics"), \
-         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
-         patch("engines.snmp_worker.build_open_parent_index", return_value={}) as mock_build:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()),
+        patch("engines.snmp_worker.bulk_insert_metrics"),
+        patch("engines.snmp_worker.fetch_snmp_value", return_value=None),
+        patch("engines.snmp_worker.build_open_parent_index", return_value={}) as mock_build,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()
 
     mock_build.assert_called_once()
@@ -496,18 +526,22 @@ def test_enable_topology_rca_true_calls_build_open_parent_index(monkeypatch):
 def test_enable_topology_rca_defaults_to_true_when_unset(monkeypatch):
     """No env var set → topology RCA is ON by default (kill-switch default true)."""
     import config as _config
+
     monkeypatch.delenv("ENABLE_TOPOLOGY_RCA", raising=False)
     monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
 
     mock_session, mock_driver = _build_poll_snmp_mocks()
     mock_session.set_response("match", [_POLL_RECORD])
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
-         patch("engines.snmp_worker.bulk_insert_metrics"), \
-         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
-         patch("engines.snmp_worker.build_open_parent_index", return_value={}) as mock_build:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()),
+        patch("engines.snmp_worker.bulk_insert_metrics"),
+        patch("engines.snmp_worker.fetch_snmp_value", return_value=None),
+        patch("engines.snmp_worker.build_open_parent_index", return_value={}) as mock_build,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()
 
     mock_build.assert_called_once()
@@ -522,22 +556,26 @@ def test_cache_failure_falls_back_to_root_and_still_creates_events(monkeypatch, 
     failure_updates path is exercised end-to-end.
     """
     import config as _config
+
     monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
     monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
 
     mock_session, mock_driver = _build_poll_snmp_mocks()
     mock_session.set_response("match", [_POLL_RECORD])
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
-         patch("engines.snmp_worker.bulk_insert_metrics"), \
-         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
-         patch(
-             "engines.snmp_worker.build_open_parent_index",
-             side_effect=RuntimeError("neo4j connection lost"),
-         ) as mock_build, \
-         caplog.at_level(logging.WARNING):
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()),
+        patch("engines.snmp_worker.bulk_insert_metrics"),
+        patch("engines.snmp_worker.fetch_snmp_value", return_value=None),
+        patch(
+            "engines.snmp_worker.build_open_parent_index",
+            side_effect=RuntimeError("neo4j connection lost"),
+        ) as mock_build,
+        caplog.at_level(logging.WARNING),
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()  # must not raise
 
     # Cache-build was attempted and raised.
@@ -545,8 +583,7 @@ def test_cache_failure_falls_back_to_root_and_still_creates_events(monkeypatch, 
 
     # The UNWIND...CREATE call for SNMP collection failures still ran.
     create_calls = [
-        c for c in mock_session.queries
-        if "UNWIND" in c["query"] and "CREATE" in c["query"]
+        c for c in mock_session.queries if "UNWIND" in c["query"] and "CREATE" in c["query"]
     ]
     assert create_calls, (
         "UNWIND...CREATE must still run after cache-build failure — "
@@ -567,6 +604,7 @@ def test_cache_is_local_to_poll_snmp_cycle(monkeypatch):
     The second cycle's cache must not inherit the first's empty state.
     """
     import config as _config
+
     monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
     monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
 
@@ -581,12 +619,15 @@ def test_cache_is_local_to_poll_snmp_cycle(monkeypatch):
             raise result
         return result
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
-         patch("engines.snmp_worker.bulk_insert_metrics"), \
-         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
-         patch("engines.snmp_worker.build_open_parent_index", side_effect=fake_build) as mock_build:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()),
+        patch("engines.snmp_worker.bulk_insert_metrics"),
+        patch("engines.snmp_worker.fetch_snmp_value", return_value=None),
+        patch("engines.snmp_worker.build_open_parent_index", side_effect=fake_build) as mock_build,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()  # cycle 1: cache-build raises → cache={}
         poll_snmp()  # cycle 2: cache-build returns dict → cache used
 
@@ -608,6 +649,7 @@ def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
     metadata update query is used instead of creating child events.
     """
     import config as _config
+
     monkeypatch.setenv("ENABLE_TOPOLOGY_RCA", "true")
     monkeypatch.setattr(_config, "_polling_pipeline_settings", None)
 
@@ -621,15 +663,18 @@ def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
         }
     }
 
-    with patch("engines.snmp_worker.driver", mock_driver), \
-         patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()), \
-         patch("engines.snmp_worker.bulk_insert_metrics"), \
-         patch("engines.snmp_worker.fetch_snmp_value", return_value=None), \
-         patch(
-             "engines.snmp_worker.build_open_parent_index",
-             return_value=populated_cache,
-         ) as mock_build:
+    with (
+        patch("engines.snmp_worker.driver", mock_driver),
+        patch("engines.snmp_worker.SessionLocal", return_value=MagicMock()),
+        patch("engines.snmp_worker.bulk_insert_metrics"),
+        patch("engines.snmp_worker.fetch_snmp_value", return_value=None),
+        patch(
+            "engines.snmp_worker.build_open_parent_index",
+            return_value=populated_cache,
+        ) as mock_build,
+    ):
         from engines.snmp_worker import poll_snmp
+
         poll_snmp()
 
     # Cache-build was called with the (ci_id, metric_id) pairs set.
@@ -637,7 +682,8 @@ def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
 
     # Find the propagated-root update call captured on the session and inspect rows.
     propagated_calls = [
-        c for c in mock_session.queries
+        c
+        for c in mock_session.queries
         if "UNWIND" in c["query"] and "propagated_rows" in c["query"]
     ]
     assert propagated_calls, "expected a propagated_rows UNWIND call to be captured"
@@ -649,5 +695,3 @@ def test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end(monkeypatch):
     assert row["correlation_type"] == "PROPAGATED"
     assert row["propagated_from"] == "evt-A"
     assert row["root_cause_ci_id"] == "ci-A"
-
-

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -21,7 +21,6 @@ import pytest
 
 from engines.snmp_worker import _resolve_correlation
 
-
 # ---------------------------------------------------------------------------
 # Task 2 — _resolve_correlation helper
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from engines import snmp_worker
 from engines.snmp_worker import _resolve_correlation
 
 

--- a/backend/tests/test_snmp_worker_correlation.py
+++ b/backend/tests/test_snmp_worker_correlation.py
@@ -18,7 +18,6 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from engines.snmp_worker import _resolve_correlation
 
 # ---------------------------------------------------------------------------

--- a/openspec/changes/fix-collector-event-emission-cypher-rejection/apply-progress.md
+++ b/openspec/changes/fix-collector-event-emission-cypher-rejection/apply-progress.md
@@ -400,3 +400,73 @@ hard cap (orchestrator's instruction: "If your new commits push it over
   contradict the single-PR strategy)
 
 Re-apply is complete. Ready for re-verify.
+
+---
+
+## Follow-up (post-#341) — prevent propagated child duplication in topology RCA
+
+### Status
+
+complete (bounded bugfix implemented in this slice).
+
+### Scope
+
+A narrow regression fix to `backend/engines/snmp_worker.py` and
+`backend/tests/test_snmp_worker_correlation.py` so propagated rows do not create
+new child Event nodes under an existing root.
+
+### What changed
+
+- Added `_build_propagated_root_update_comment(row)` helper for idempotent
+  per-propagated-row comment strings.
+- Added `_update_propagated_root_events(session, propagated_rows)`:
+  - MATCHes the `root` event by `row.propagated_from`.
+  - Ensures only non-closed ROOT rows are updated (`status IN ['OPEN','ACK','RECOVERED']`).
+  - Appends `row.node_id` to `root.affected_ci_ids` only when absent.
+  - Sets/extends `root.affected_ci_count` from `size(affected_ci_ids)`.
+  - Appends `row`-scoped comment to `root.comments` only when absent.
+  - Returns `updated_roots` and logs `topology_rca_propagated_root_update_partial` when a cached parent event is stale or only partially matched.
+  - Does not update `root.last_seen` or `root.poll_collector_id` from child-only propagated rows, so repeated child polls do not make the root event look freshly observed.
+
+- Updated three refresh helpers to split rows into:
+  - `root_rows` -> unchanged CREATE/UPDATE Event logic with `correlation_type=ROOT`,
+    existing `poll_collector_id` behavior preserved.
+  - `propagated_rows` -> root metadata enrichment only; no child Event create.
+
+- Added/updated tests in
+  `backend/tests/test_snmp_worker_correlation.py`:
+  - `test_snmp_collection_failure_propagates_when_parent_open`
+  - `test_icmp_availability_propagates_when_parent_open`
+  - `test_icmp_latency_breach_propagates_when_parent_open`
+  - `test_propagated_rows_do_not_generate_duplicate_child_events_or_notes_on_repeated_polls`
+  - `test_poll_snmp_cache_hit_propagates_to_create_row_end_to_end`
+
+### Test results
+
+| Scope | Passed | Failed | Notes |
+|-------|--------|--------|-------|
+| `backend/tests/test_snmp_worker_cypher_fallback.py` | 9 | 0 | Existing focused fallback suite unchanged |
+| `backend/tests/test_snmp_worker_correlation.py` | 24 | 0 | New and existing regression coverage for propagated rows, including stale-parent warning |
+
+`/tmp/next-gen-test-venv-py311/bin/python -m pytest backend/tests/test_snmp_worker_cypher_fallback.py backend/tests/test_snmp_worker_correlation.py` passed: 33/33, 1 deprecation warning
+
+### Deviations from task estimates
+
+This work started from an already-open change and reused existing CI coverage; scope stayed below
+400 lines of production code. Net behavior change is small and constrained to writer
+correlation branches.
+
+### PR readiness
+
+- Root behavior for non-propagated failures is unchanged.
+- Propagated cache hits now only enrich existing ROOT events.
+- End-to-end repeated polls keep updates idempotent and do not emit duplicate child
+  events.
+
+### TDD Cycle Evidence
+
+| Task | Test File | Layer | RED | GREEN | TRIANGULATE | REFACTOR |
+|------|-----------|-------|-----|-------|-------------|----------|
+| `_build_propagated_root_update_comment` + helper wiring | `backend/tests/test_snmp_worker_correlation.py` | Unit/logic + integration-shape | ✅ Written (`test_snmp_collection_failure_propagates_when_parent_open` etc.) | ✅ Passed (`23/23` in file) | ✅ Covered repeated-poll and non-parent edge cases | ✅ In place |
+| Per-helper split root/propagated row routing (`_refresh_*` helpers) | `backend/tests/test_snmp_worker.py` / correlation file | Integration/unit | ✅ Existing/new regression harness covered lock and shape updates | ✅ Passed (`5/5` for targeted helper tests + correlation tests) | ✅ Multiple event-types (collection + availability + latency) | ✅ No-op in production behavior retained |
+| Propagated root-enrichment query shape | `backend/tests/test_snmp_worker_cypher_fallback.py` | Integration (mocked Neo4j session) | ✅ Existing fallback tests and new assertions reused | ✅ Passed (`9/9`) | ✅ Repeated calls verified idempotent metadata growth conditions | ✅ None needed |


### PR DESCRIPTION
Closes #388

## Descripción del Cambio
- Prevents topology-RCA propagated child rows from creating additional operator `Event` nodes.
- Enriches the root event idempotently with affected CI metadata/comments.
- Adds regression coverage for repeated propagated polls and stale parent/root cache handling.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| File | Change |
|------|--------|
| `backend/engines/snmp_worker.py` | Routes propagated rows to root-event affected-CI enrichment instead of child event creation. |
| `backend/tests/test_snmp_worker_correlation.py` | Adds propagated-row idempotency and stale-root warning tests. |
| `openspec/changes/fix-collector-event-emission-cypher-rejection/apply-progress.md` | Documents the follow-up fix and verification evidence. |

## ¿Cómo se probó?
- [x] `/tmp/next-gen-test-venv-py311/bin/python -m pytest backend/tests/test_snmp_worker_cypher_fallback.py backend/tests/test_snmp_worker_correlation.py` → `33 passed, 1 warning`
- [x] `/tmp/next-gen-test-venv-py311/bin/python -m pytest backend/tests/test_snmp_worker.py -k "refresh_icmp_latency_events or refresh_icmp_availability_events or refresh_snmp_collection_failures" -q` → `5 passed, 32 deselected, 1 warning`
- [x] `python3 -m py_compile backend/engines/snmp_worker.py backend/tests/test_snmp_worker_correlation.py`
- [x] Full 4R pre-PR review: risk/resilience no findings; readability/reliability warnings documented as follow-up quality concerns.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Review workload
This PR exceeds the 400-line review budget because it updates three existing Cypher writer paths plus regression tests and apply-progress notes. A full 4R review was run before opening.