### PR TITLE
docs(cmdb): add graph level-of-detail design

### DIFF
--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/apply-progress.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/apply-progress.md
@@ -1,0 +1,91 @@
+# Apply Progress — CMDB Graph Level-of-Detail
+
+## Structured status snapshot
+- change: `cmdb-graph-level-of-detail`
+- artifactStore: `openspec`
+- applyState: `ready`
+- actionContext.mode: `repo-local` (inferred from direct repository workspace execution)
+- actionContext.allowedEditRoots: [repository root]
+- actionContext.warnings: []
+- nextRecommended: `verify`
+- task completion at start: not explicitly persisted; all listed tasks are now complete in this design-only apply pass
+
+## Completed work
+
+### Persisted task updates
+All work units required for this design-only slice were completed and checkboxes in `tasks.md` were updated from `- [ ]` to `- [x]`:
+
+- Phase 1 items 1.1–1.3
+- Phase 2 items 2.1–2.3
+- Phase 3 items 3.1–3.4
+- Phase 4 items 4.1–4.2
+- Phase 5 items 5.1–5.3
+- Added Apply-phase evidence checklist (4A.1–4A.5)
+
+### Files changed
+- `openspec/changes/cmdb-graph-level-of-detail/tasks.md`
+  - Verified all required design artifacts and preserved scope assumptions.
+  - Documented design/spec/security compatibility checks.
+  - Added design-only apply evidence section with explicit pass bullets.
+  - Confirmed in-scope follow-up slices remain out-of-scope implementation work.
+- `openspec/changes/cmdb-graph-level-of-detail/proposal.md`
+  - Marked design acceptance checklist items as complete based on explicit design/spec/apply evidence.
+- `openspec/changes/cmdb-graph-level-of-detail/apply-progress.md`
+  - Added explicit Strict-TDD cycle evidence table and no-code scope evidence.
+
+## Design consistency evidence
+- Confirmed proposal/scope are design-only and do not include application code changes.
+- Confirmed `spec` ↔ `design` mapping covers: overview payload, detail payload, security parity, frontend orchestration, rollout/non-goals.
+- Confirmed no design statement expands scope beyond proposal assumptions.
+- Confirmed explicit user-directed constraints:
+  - Location-first overview,
+  - demand-driven detail via click/expand + committed search/filter,
+  - no zoom-threshold driven detail expansion,
+  - `/graph/full` backward compatibility preserved (shape and semantics unchanged in this slice).
+- Confirmed security continuity constraints:
+  - hidden/absent indistinguishable behavior documented,
+  - visible-only resolution for search ambiguity/match/no-match states,
+  - no hidden-candidate oracle behavior,
+  - sensitive-field policy split between overview (never expose raw sensitive metadata) and detail (reuse existing `/graph/full` projection policy), with stronger `/graph/full` redaction deferred as follow-up.
+
+## TDD / evidence mode
+- STRICT TDD is active. This apply slice is design-only and limited to OpenSpec documentation.
+- No backend/frontend code or automated tests were edited, added, or executed in this slice.
+- `RED/GREEN/TRIANGULATE/REFACTOR` were performed as OpenSpec/manual evidence checkpoints because no production code/test harness is in scope.
+
+## TDD Cycle Evidence
+
+| Cycle | What was attempted | Artifact evidence | Result |
+|---|---|---|---|
+| RED | Establish the failing-test baseline for an implementation change. | Not applicable for this design-only slice; no production code or test files are in scope. | **N/A (design-only exception)** |
+| GREEN | Implement minimal change to satisfy the requirement set and verify with tests. | `openspec/changes/cmdb-graph-level-of-detail/proposal.md`, `specs/cmdb-graph-level-of-detail/spec.md`, `design.md`, `tasks.md` | Manual evidence only: all acceptance and consistency checks are recorded in `tasks.md` and design/spec cross-checks. |
+| TRIANGULATE | Validate behavior via alternate checks/review paths. | `tasks.md` (phases 2,3,4,5), `design.md` section cross-links, and design/security non-regressions notes in this document | Confirmed requirement-to-design mapping, scope boundaries, and security parity constraints without changing executable code. |
+| REFACTOR | Refine implementation while preserving behavior and tests. | No application code changes to refactor; only OpenSpec wording and evidence alignment were adjusted | **Not applicable** in this phase |
+
+### Evidence for no-code scope
+- Scope-limited verification is recorded across:
+  - `openspec/changes/cmdb-graph-level-of-detail/tasks.md` (all 4A.1–4A.5 + phases 1–5 marked complete)
+  - `openspec/changes/cmdb-graph-level-of-detail/proposal.md` (design acceptance checklist)
+  - `openspec/changes/cmdb-graph-level-of-detail/design.md` (contracts, trigger matrix, rollout sequencing, and security parity)
+  - `openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md` (requirements and scenarios)
+- No automated test commands were run because this change is outside application implementation scope.
+
+## Deviations
+- No design artifacts were changed beyond consistency/sign-off updates.
+- No backend/frontend implementation files were modified.
+
+## Workload / PR boundary
+- Estimated changed lines after sync/archive are above the 400-line review budget (`~1609` inserted lines). This is a docs/OpenSpec-only PR linked to #230 and requires full 4R pre-PR review evidence rather than chained implementation slices.
+- Delivery strategy remains `ask-on-risk`; chained PRs were recommended as `No`.
+- PR boundary: single PR (design-only OpenSpec updates).
+
+## Remaining tasks
+- [ ] None (all design/signoff tasks in `openspec/changes/cmdb-graph-level-of-detail/tasks.md` are now checked).
+
+## Recommended next action
+- Proceed to `/sdd-verify` for change `cmdb-graph-level-of-detail`.
+
+
+## Archived-path note
+
+Some command examples and artifact references above may use the active change path (`openspec/changes/cmdb-graph-level-of-detail/...`) because they record the phase execution before archive. The PR-ready archived artifacts now live under `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/`, with the synchronized canonical spec at `openspec/specs/cmdb-graph-level-of-detail/spec.md`.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/archive-report.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/archive-report.md
@@ -1,0 +1,89 @@
+# Archive Report — CMDB Graph Level-of-Detail
+
+## Status
+
+**PASS — archived to OpenSpec archive convention.**
+
+## Structured status and action context
+
+| Field | Finding |
+|---|---|
+| Change | `cmdb-graph-level-of-detail` |
+| Artifact store | `openspec` |
+| Action context | `repo-local` |
+| Allowed edit roots | Repository root |
+| Verification | PASS (`verify-report.md` present and passing) |
+| Sync | PASS (`sync-report.md` present and `status: synced`) |
+
+## Artifacts read
+
+- `openspec/changes/cmdb-graph-level-of-detail/proposal.md`
+- `openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md`
+- `openspec/changes/cmdb-graph-level-of-detail/design.md`
+- `openspec/changes/cmdb-graph-level-of-detail/tasks.md`
+- `openspec/changes/cmdb-graph-level-of-detail/apply-progress.md`
+- `openspec/changes/cmdb-graph-level-of-detail/verify-report.md`
+- `openspec/changes/cmdb-graph-level-of-detail/sync-report.md`
+- `openspec/config.yaml`
+
+## Domains synced
+
+- `cmdb-graph-level-of-detail`
+
+## Requirement sync summary
+
+### ADDED requirements
+
+- Overview payload contract for first paint
+- Detail subgraph payload contract
+- Security and authorization parity
+- Frontend orchestration for initial render and explicit detail loading
+- Non-goals and out-of-scope constraints
+- Design-only acceptance criteria
+
+### MODIFIED requirements
+
+- None
+
+### REMOVED requirements
+
+- None
+
+## Task completion gate
+
+PASS — no unchecked implementation task markers remain in `tasks.md`.
+
+Validated immediately before archive write:
+
+```text
+grep -R "^\s*- \[ \]" openspec/changes/cmdb-graph-level-of-detail/tasks.md || true
+# no output
+```
+
+## Verification summary
+
+- `verify-report.md` is PASS.
+- No `FAIL`, `BLOCKED`, or `CRITICAL` markers remain.
+- The slice remains design-only; no backend/frontend application files were edited.
+- Strict TDD evidence was documented in `apply-progress.md` for the no-code scope.
+
+## Collision and merge checks
+
+- Active same-domain collision: none.
+- Destructive sync/merge: none.
+- Legacy flat spec only: no.
+- Explicit archive-time sync approval: not required.
+
+## Archived path
+
+- `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/`
+
+## Notes
+
+- OpenSpec persistence completed locally.
+- Engram was not used for this archive path.
+
+
+## Archived-path note
+
+Some command examples and artifact references above may use the active change path (`openspec/changes/cmdb-graph-level-of-detail/...`) because they record the phase execution before archive. The PR-ready archived artifacts now live under `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/`, with the synchronized canonical spec at `openspec/specs/cmdb-graph-level-of-detail/spec.md`.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/design.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/design.md
@@ -1,0 +1,556 @@
+# CMDB Graph Level-of-Detail Design
+
+This design keeps `/graph/full` unchanged and introduces an overview-first topology path for large CMDB graphs. The first implementation slices should render location-level clusters from a summary payload, then fetch detailed subgraphs only after explicit operator intent: cluster click/expand, or committed search/filter context. No application code is changed by this design slice.
+
+## Design decisions
+
+| Area | Decision |
+|---|---|
+| Compatibility | Keep `GET /graph/full` response shape and polling behavior unchanged for existing consumers. |
+| First paint | Add a dedicated overview contract for location-cluster summaries instead of reusing full node/link arrays. |
+| Detail loading | Add a dedicated detail/subgraph contract keyed by cluster/segment and current filters. |
+| Initial cluster axis | Location is the only required first-slice axis. Use stable fallback bucket `Unassigned` for missing location metadata. |
+| Triggers | Detail loads only on click/expand and committed search/filter targeting. Zoom threshold expansion is out of scope. |
+| Security | Overview and detail MUST share the same principal, tenant/location scope, filtering, hidden/absent cluster response semantics, and aggregate suppression policy. Overview never includes raw sensitive fields; detail reuses the existing authorized projection helper/policy used by `/graph/full` once confirmed. |
+| Rollout | Ship additive endpoints/services first, migrate `GraphCMDB` behind a fallback path, leave `NetworkVisualizer` on `/graph/full` until explicitly migrated. |
+
+## Current architecture context
+
+Current graph loading is full-payload first:
+
+- `backend/routers/links.py` exposes `GET /graph/full` with optional `layer`, `location`, and `owner` filters.
+- `backend/services/link_service.py#get_full_graph()` maps repository results into `{ nodes, links }` and includes `public_ip` in node metadata today.
+- `backend/repositories/topology_repo.py#get_filtered_graph_data()` queries all matching CI nodes and links with location scoping for non-admin users.
+- `frontend/services/queryResources.ts#fetchGraphTopology()` always calls `/graph/full`.
+- `frontend/hooks/queries/useGraphTopologyQuery.ts` polls that full topology every 30 seconds.
+- `frontend/components/GraphCMDB.tsx` already computes location clusters client-side after full hydration.
+- `frontend/components/NetworkVisualizer.tsx` calls `/api/graph/full` directly and polls every 5 seconds.
+
+The design moves the scalability boundary from client-side clustering after full hydration to server-provided overview and demand-driven detail.
+
+## API contract strategy
+
+### Existing compatibility endpoint
+
+`GET /graph/full` remains unchanged.
+
+```http
+GET /graph/full?layer=router&location=DC-1&owner=NOC
+```
+
+Response stays the current shape and existing semantics. The sample below is compatibility documentation for the current full topology shape; this LOD design does not introduce new `/graph/full` redaction behavior.
+
+```json
+{
+  "nodes": [
+    {
+      "id": "ci-1",
+      "label": "edge-01",
+      "type": "router",
+      "status": "ACTIVE",
+      "location": { "lat": -34.6, "long": -58.4 },
+      "location_name": "DC-1",
+      "ip": "10.0.0.1",
+      "public_ip": "203.0.113.10",
+      "metrics": [],
+      "metadata": { "id": "ci-1", "location_name": "DC-1" }
+    }
+  ],
+  "links": [
+    { "source": "ci-1", "target": "ci-2", "relationship": "CONNECTS_TO" }
+  ]
+}
+```
+
+No follow-up implementation slice may change this response shape or existing semantics as part of LOD rollout. If a stronger redaction policy is required for `/graph/full`, that must be handled as a separate security change outside issue #230.
+
+### New overview endpoint
+
+Prefer an additive endpoint over a mode flag because it is easier to cache, monitor, and migrate without weakening `/graph/full` semantics.
+
+```http
+GET /graph/overview?axis=location&layer=<csv>&location=<csv>&owner=<csv>&cursor=<opaque>
+```
+
+Design-level response:
+
+```json
+{
+  "axis": "location",
+  "filters": {
+    "layer": ["router"],
+    "location": ["DC-1", "DC-2"],
+    "owner": []
+  },
+  "generated_at": "2026-07-08T12:00:00Z",
+  "revision": "topology:1720440000:42",
+  "aggregate_policy": {
+    "minimum_count": 5,
+    "low_cardinality_mode": "suppress_or_bucket",
+    "breakdowns_role_gated": true
+  },
+  "clusters": [
+    {
+      "id": "location:DC-1",
+      "axis": "location",
+      "key": "DC-1",
+      "label": "DC-1",
+      "node_count": 1240,
+      "link_count": 3100,
+      "status_counts": { "ACTIVE": 1180, "WARNING": 45, "CRITICAL": 15, "suppressed": false },
+      "type_counts": { "router": 120, "switch": 360, "server": 760, "other": 0 },
+      "geo": { "lat": -34.6, "long": -58.4, "quality": "derived_centroid", "precision": "city" },
+      "has_more_detail": true,
+      "detail_href": "/graph/detail/location%3ADC-1"
+    },
+    {
+      "id": "location:__unassigned__",
+      "axis": "location",
+      "key": "__unassigned__",
+      "label": "Unassigned",
+      "node_count": 32,
+      "link_count": 12,
+      "status_counts": { "breakdown_suppressed": true },
+      "type_counts": { "breakdown_suppressed": true },
+      "geo": null,
+      "has_more_detail": true,
+      "detail_href": "/graph/detail/location%3A__unassigned__"
+    }
+  ],
+  "inter_cluster_links": [
+    {
+      "source_cluster_id": "location:DC-1",
+      "target_cluster_id": "location:DC-2",
+      "relationship": "CONNECTS_TO",
+      "count": 48,
+      "weight": 48,
+      "medium_counts": { "breakdown_suppressed": true }
+    }
+  ],
+  "legend": {
+    "statuses": ["ACTIVE", "WARNING", "CRITICAL"],
+    "axis_label": "Location"
+  },
+  "page": {
+    "has_more": false,
+    "next_cursor": null
+  }
+}
+```
+
+Contract notes:
+
+- `clusters[].id` MUST be stable for the same axis/key pair and safe to pass to the detail endpoint.
+- `inter_cluster_links` MUST aggregate only links visible to the caller.
+- Overview MUST NOT include per-node sensitive metadata, including `public_ip`, external DNS names, NAT addresses, MAC addresses, precise endpoint coordinates, serial numbers, provider account identifiers, or comparable infrastructure identifiers.
+- `geo` is optional and must use safe aggregate/derived coordinates only. It must not disclose hidden node coordinates; low-cardinality locations must use coarse precision, suppression, or no geo value.
+- Aggregate disclosure policy is mandatory: exact cluster `node_count`, cluster `link_count`, status/type/medium counts, edge weights, and geo breakdowns are returned only when each disclosed bucket/value has at least `minimum_count = 5` visible records or the principal has explicit aggregate-breakdown permission. Otherwise values are suppressed, rounded, ranged, or folded into non-count `other`/`suppressed` metadata.
+- `revision` is an opaque cache/invalidation token. It should change when the visible topology subset changes.
+- Pagination is optional for the first slice but the response reserves `page` for very high cluster counts.
+
+### New detail/subgraph endpoint
+
+`cluster_id` encodes the axis using the stable format `<axis>:<url-safe-key>`. For the first slice, only `location:*` cluster ids are accepted. The detail endpoint MUST derive `axis` from `cluster_id`; an `axis` query parameter is not part of the public contract. If a future compatibility layer accepts `axis`, contradictory values MUST fail validation with `400 invalid_request` before authorization-sensitive lookup.
+
+```http
+GET /graph/detail/{cluster_id}?layer=<csv>&location=<csv>&owner=<csv>&search=<term>&cursor=<opaque>&limit=500
+```
+
+Design-level authorized response:
+
+```json
+{
+  "cluster": {
+    "id": "location:DC-1",
+    "axis": "location",
+    "key": "DC-1",
+    "label": "DC-1"
+  },
+  "filters": {
+    "layer": ["router"],
+    "location": ["DC-1"],
+    "owner": [],
+    "search": "edge"
+  },
+  "generated_at": "2026-07-08T12:00:03Z",
+  "revision": "topology:1720440003:43",
+  "nodes": [
+    {
+      "id": "ci-1",
+      "label": "edge-01",
+      "type": "router",
+      "status": "ACTIVE",
+      "location": { "lat": -34.6, "long": -58.4 },
+      "location_name": "DC-1",
+      "ip": "10.0.0.1",
+      "public_ip": "203.0.113.10",
+      "metrics": [],
+      "metadata": { "id": "ci-1", "location_name": "DC-1" },
+      "parent_cluster_id": "location:DC-1",
+      "projection": {
+        "restricted_fields_redacted": false
+      }
+    }
+  ],
+  "links": [
+    {
+      "source": "ci-1",
+      "target": "ci-2",
+      "relationship": "CONNECTS_TO",
+      "medium": "vpn",
+      "parent_cluster_ids": ["location:DC-1"],
+      "boundary": "internal"
+    },
+    {
+      "source": "ci-1",
+      "target": "ci-9",
+      "relationship": "CONNECTS_TO",
+      "parent_cluster_ids": ["location:DC-1", "location:DC-2"],
+      "boundary": "external_stub"
+    }
+  ],
+  "empty_reason": null,
+  "page": {
+    "has_more": true,
+    "next_cursor": "opaque-next-detail-cursor",
+    "limit": 500
+  }
+}
+```
+
+Empty result semantics for visible clusters with no filter/search matches:
+
+```json
+{
+  "cluster": { "id": "location:DC-1", "axis": "location", "key": "DC-1", "label": "DC-1" },
+  "nodes": [],
+  "links": [],
+  "empty_reason": "no_matches",
+  "page": { "has_more": false, "next_cursor": null, "limit": 500 }
+}
+```
+
+Hidden or absent cluster semantics use one indistinguishable response:
+
+```json
+{
+  "cluster": null,
+  "nodes": [],
+  "links": [],
+  "empty_reason": "unavailable",
+  "page": { "has_more": false, "next_cursor": null, "limit": 500 }
+}
+```
+
+Allowed `empty_reason` values:
+
+- `no_matches`: the cluster is visible, but the committed filters/search hide all visible nodes.
+- `unavailable`: the cluster id is outside the caller's visible topology or does not exist. The same status code, body shape, headers, timing budget, and absence of cluster metadata MUST be used for hidden and absent clusters.
+
+Sensitive-field projection examples:
+
+These examples define the intended detail projection behavior after a follow-up implementation confirms and reuses the existing authorized projection helper/policy used by `/graph/full`. They do not change `/graph/full` behavior in this design slice.
+
+Authorized detail node for a principal with explicit sensitive-metadata permission under the confirmed existing projection policy:
+
+```json
+{
+  "id": "ci-1",
+  "ip": "10.0.0.1",
+  "public_ip": "203.0.113.10",
+  "metadata": { "external_dns": "edge-01.example.net", "nat_ip": "198.51.100.7" },
+  "projection": { "restricted_fields_redacted": false }
+}
+```
+
+Redacted detail node for a principal without that permission, if supported by the confirmed existing projection policy:
+
+```json
+{
+  "id": "ci-1",
+  "ip": "10.0.0.1",
+  "public_ip": null,
+  "metadata": { "external_dns": null, "nat_ip": null },
+  "projection": {
+    "restricted_fields_redacted": true,
+    "redacted_fields": ["public_ip", "metadata.external_dns", "metadata.nat_ip"]
+  }
+}
+```
+
+Detail contract notes:
+
+- Detail nodes SHOULD reuse existing node field semantics so the frontend can merge detail without introducing a second node renderer.
+- `public_ip` and comparable sensitive metadata in detail MUST follow the confirmed existing authorized projection helper/policy used by `/graph/full`. If the current full-graph policy needs stronger redaction, that is a separate security change, not part of the LOD rollout.
+- Overview responses MUST never include sensitive node metadata, even for authorized principals.
+- Boundary links may be returned as `external_stub` when the other endpoint is outside the expanded cluster but visible enough for context. Hidden endpoints MUST NOT be leaked through stubs.
+- Large clusters MUST support pagination or bounded limits before production rollout.
+
+## Backend design
+
+### Router responsibilities
+
+Add two read-only routes in the topology router layer:
+
+- `GET /graph/overview`
+  - validates `axis=location` for first slice,
+  - accepts the same filter vocabulary as `/graph/full`,
+  - passes the authenticated principal to the service layer,
+  - returns overview DTOs only.
+- `GET /graph/detail/{cluster_id}`
+  - validates cluster id format and derives axis from the id,
+  - rejects contradictory or unsupported axis information before lookup,
+  - accepts same filters plus optional committed `search`, `cursor`, and `limit`,
+  - passes authenticated principal to the service layer,
+  - returns a bounded subgraph DTO.
+
+`GET /graph/full` remains routed to the current full-graph service.
+
+### Service responsibilities
+
+Introduce service-level operations conceptually equivalent to:
+
+- `get_graph_overview(current_user, axis="location", layer=None, location=None, owner=None, cursor=None)`
+- `get_graph_detail(current_user, cluster_id, layer=None, location=None, owner=None, search=None, cursor=None, limit=500)`
+
+The service layer owns:
+
+- computing `is_admin` and `allowed_locations` exactly as the current full graph path does,
+- returning empty payloads for non-admin users with no allowed locations,
+- resolving search/filter match counts only after authorization filtering and only over visible candidates plus allowed public axes/labels,
+- ensuring hidden candidates never affect ambiguity decisions, no-match behavior, detail hydration, pagination, timing, status codes, or response body shape,
+- mapping repository rows to DTOs,
+- deriving stable cluster ids (`location:<url-safe-key>`) and deriving the axis from those ids for detail requests,
+- building `revision` tokens,
+- applying the confirmed existing authorized projection helper/policy to detail payloads,
+- returning the same externally observable response for hidden and absent clusters,
+- avoiding any mutation side effects.
+
+### Repository responsibilities
+
+Add repository queries that do not materialize the entire graph unless explicitly requested:
+
+- overview cluster aggregation by `n.location_name`, including node counts, status counts, type counts, and optional derived geo summaries;
+- aggregate inter-cluster links by source/target cluster and relationship/medium;
+- detail node query for a selected location cluster with current filters/search/limit;
+- detail link query for visible internal links and bounded external stubs.
+
+Security filtering must be composed before aggregation and search/filter resolution. For non-admin users, location scope must constrain overview, detail, and search matching in a way that cannot expose hidden cluster existence through counts, labels, edge weights, match counts, ambiguity states, no-match states, pagination metadata, timing, or detail-hydration decisions.
+
+### Security parity approach
+
+Use one shared graph visibility policy for all graph read paths:
+
+```text
+principal + allowed_locations + user filters + field projection
+  -> visible graph subset
+  -> overview aggregation OR detail materialization OR full graph mapping
+```
+
+Parity requirements for implementation slices:
+
+- A non-admin with `allowed_locations == []` receives empty overview and empty detail results, matching current full graph behavior.
+- Overview counts and inter-cluster weights are computed only after tenant/location filtering.
+- Restricted fields such as `public_ip` are never derivable from overview aggregates, and detail uses the same confirmed authorized projection helper/policy as `/graph/full`.
+- Search/filter parameters cannot bypass location scope.
+- Search/filter ambiguity and match counts are computed only over visible candidates and allowed public axes/labels after authorization filtering.
+- If exactly one visible candidate matches, detail behavior is based on that visible match even when hidden candidates also exist.
+- If zero visible candidates match, the no-match behavior is identical whether hidden candidates exist or not.
+- Unknown and hidden `cluster_id` values MUST NOT reveal whether the cluster exists globally; both cases use the same status code, response body shape, absence of cluster metadata, headers, and timing budget.
+
+### Sensitive-field and aggregate disclosure policy
+
+| Data category | Authorized principal | Principal without permission | Overview behavior |
+|---|---|---|---|
+| `public_ip` | Detail MAY return it for visible nodes only according to the confirmed existing authorized projection helper/policy used by `/graph/full`. | Detail MUST follow that same confirmed policy. Any stronger `/graph/full` redaction is separate security work. | Never returned. |
+| Comparable sensitive metadata (`external_dns`, NAT/public addresses, MAC addresses, serial numbers, provider account identifiers, precise endpoint coordinates) | Detail MAY return it for visible nodes only according to the confirmed existing authorized projection helper/policy used by `/graph/full`. | Detail MUST follow that same confirmed policy. Any stronger `/graph/full` redaction is separate security work. | Never returned. |
+| Cluster `node_count` / `link_count` | Exact counts MAY be returned when the count is at least 5 visible records or the principal has `graph:aggregate_breakdown:read`. | Counts below 5 MUST be suppressed, rounded, or represented as safe ranges/non-count metadata. | Same rule. |
+| Status/type/medium counts and link weights | Exact buckets MAY be returned when each bucket has at least 5 visible records or the principal has `graph:aggregate_breakdown:read`. | Buckets below 5 MUST be suppressed, rounded, or folded into non-count `other`/`suppressed` metadata. | Same rule. |
+| Geo summaries | MAY use coarse derived aggregate coordinates when backed by at least 5 visible nodes or aggregate-breakdown permission. | MUST be omitted or coarsened for low-cardinality clusters/links. | Same rule; never precise endpoint coordinates. |
+
+The implementation must apply suppression after authorization filtering. Suppressed buckets MUST NOT expose hidden values through totals, labels, inter-cluster weights, tooltips, legends, or pagination metadata.
+
+## Frontend orchestration design
+
+### Query model
+
+Add separate frontend resource/query concepts in follow-up implementation slices:
+
+- `fetchGraphOverview(filters, { axis: "location" })`
+- `fetchGraphDetail(clusterId, filters, { search, cursor, limit })`
+- `useGraphOverviewQuery(filters)`
+- `useGraphDetailQuery(clusterId, filters, searchContext)`
+
+Keep `fetchGraphTopology()` and `useGraphTopologyQuery()` on `/graph/full` for compatibility until consumers migrate.
+
+### State model
+
+`GraphCMDB` should move to an overview-first state shape:
+
+```ts
+type GraphLodState = {
+  mode: "overview" | "mixed" | "fallbackFull";
+  axis: "location";
+  filters: {
+    layer: string[];
+    location: string[];
+    owner: string[];
+  };
+  overviewRevision?: string;
+  clustersById: Record<string, OverviewCluster>;
+  interClusterLinks: OverviewClusterLink[];
+  expandedClusterIds: string[];
+  detailByClusterId: Record<string, {
+    status: "idle" | "loading" | "ready" | "error" | "empty";
+    revision?: string;
+    nodes: GraphNode[];
+    links: GraphLink[];
+    page?: { has_more: boolean; next_cursor?: string | null };
+    error?: string;
+  }>;
+  committedSearch?: {
+    term: string;
+    targetClusterId?: string;
+  };
+};
+```
+
+Render flow:
+
+1. Initial page load requests `/graph/overview?axis=location`.
+2. The scene renders cluster nodes and aggregate inter-cluster links.
+3. Click/expand on a cluster sets `expandedClusterIds` and fetches detail for that cluster only.
+4. Detail nodes/links mount inside or around the selected cluster while overview clusters remain as navigation context.
+5. Search/filter commits update overview context first. Resolution is computed only over visible candidates and allowed public axes/labels after authorization filtering.
+6. Detail fetches only when the authorized visible result set resolves to exactly one visible cluster or the operator explicitly selects one visible cluster from multiple visible results. Hidden candidates must not change this behavior.
+7. Multiple visible, no-visible-match, or ambiguous-visible search/filter results stay in overview/search-results mode and MUST NOT hydrate the full topology.
+8. If overview fails or the feature flag is disabled, the component falls back to existing `/graph/full` behavior.
+
+### Trigger matrix
+
+| Operator action | Overview refetch | Detail fetch | Notes |
+|---|---:|---:|---|
+| Initial topology page load | Yes | No | First paint is summary only. |
+| Cluster click/expand | No, unless stale | Yes | Fetch selected cluster detail only. |
+| Search commit matching exactly one visible cluster | Maybe | Yes | Compute matches after authorization filtering only; fetch detail for that visible target even if hidden candidates also exist. |
+| Search/filter matching multiple visible clusters | Yes | No | Keep overview/search result set; require explicit visible-cluster selection before detail fetch. |
+| Search/filter matching no visible clusters | Yes | No | Show the same empty state and do not fetch detail or `/graph/full`, regardless of whether hidden matches exist. |
+| Ambiguous search/filter term | Yes | No | Ambiguity is based only on visible candidates and allowed public axes/labels; ask for refinement or explicit visible-cluster selection. |
+| Filter commit changing layer/location/owner | Yes | Yes, only after exactly one visible target is resolved or explicitly selected | Reset stale details that no longer match filters. |
+| Manual refresh / polling tick | Yes | Conditional | Refresh expanded detail only when revision changes or detail is visible. |
+| Zoom/pan | No | No | Automatic zoom-threshold expansion is out of scope. |
+| `NetworkVisualizer` route | No change | No change | Continue `/api/graph/full` until a separate migration slice. |
+
+### Merge behavior
+
+- Overview clusters remain canonical for cluster counts and layout.
+- Detail nodes use existing graph node ids and are merged by node id.
+- Detail links are merged by deterministic edge identity: `source + target + relationship + medium?`.
+- When filters change, detail caches whose request context no longer matches MUST be invalidated or marked stale.
+- Expanded detail should persist only while the active filter/search context is compatible with the detail request that produced it.
+
+## Polling, cache, and invalidation rules
+
+### Overview polling
+
+- Replace `GraphCMDB`'s initial full topology polling with overview polling.
+- Start with the current 30-second interval as a compatibility baseline unless performance tests prove a different cadence.
+- Use React Query keys that include `axis`, `layer`, `location`, and `owner`.
+- Treat `revision` changes as the signal to reconcile cluster counts and invalidate incompatible detail caches.
+
+### Detail cache
+
+- Detail query keys include `cluster_id` (which encodes axis), filters, committed search, cursor, and limit.
+- Detail should be fetched only when the cluster is expanded or search/filter context requires it.
+- Do not poll all known clusters. Poll only visible expanded detail, and only while mounted.
+- On overview revision change:
+  - keep compatible expanded cluster ids,
+  - mark their detail stale,
+  - refetch visible detail lazily or on next focus/poll tick,
+  - drop detail for clusters no longer present in overview.
+
+### Fallback cache behavior
+
+If overview/detail endpoints are unavailable, disabled, or return a contract error:
+
+- `GraphCMDB` may fall back to `useGraphTopologyQuery()` and the existing client-side cluster behavior.
+- Existing `NetworkVisualizer` behavior remains untouched.
+- Fallback should be observable through logs/telemetry so rollout issues are visible.
+
+## Migration and rollout sequence
+
+1. **Contract finalization**
+   - Confirm endpoint names, DTO field names, pagination bounds, hidden/absent cluster equivalence, visible-only search resolution, aggregate suppression, and detail sensitive-field projection policy.
+   - Add OpenAPI/Pydantic/TypeScript DTO definitions in implementation planning.
+2. **Backend additive rollout**
+   - Add overview/detail routes and services without changing `/graph/full`.
+   - Add repository aggregation/detail queries with shared visibility policy.
+   - Add security parity tests before frontend migration.
+3. **Frontend dual-path rollout**
+   - Add overview/detail fetchers and query hooks.
+   - Gate `GraphCMDB` LOD mode behind a feature flag or safe capability detection.
+   - Preserve full-graph fallback in the component.
+4. **Consumer migration**
+   - Migrate `GraphCMDB` first because it already has location-cluster rendering.
+   - Leave `NetworkVisualizer` on `/graph/full` until a dedicated route-specific design or migration slice.
+5. **Stabilization**
+   - Compare full vs overview/detail visibility under representative roles and filters.
+   - Monitor endpoint latency, payload size, UI first paint, detail fetch errors, and fallback rate.
+
+Rollback is simple because all contracts are additive: disable the LOD feature flag and continue using `/graph/full`.
+
+## Verification strategy for future implementation slices
+
+### Backend verification
+
+- `/graph/full` regression tests prove the existing response shape remains unchanged.
+- Overview endpoint tests cover location clusters, counts, aggregate inter-cluster weights, filters, empty scope, low-cardinality suppression, and unknown/missing locations.
+- Detail endpoint tests cover explicit cluster detail, search/filter narrowing, pagination, `no_matches`, hidden/absent `unavailable` equivalence, axis-derived cluster id validation, and boundary links.
+- Security parity tests compare the visible node/link universe across full, overview, and detail for admin, scoped non-admin, and empty-scope users.
+- Restricted-field tests verify detail projection reuses the confirmed existing authorized projection helper/policy used by `/graph/full`; any stronger `/graph/full` redaction tests belong to a separate security change.
+- Aggregate disclosure tests verify status/type/medium counts, link weights, and geo summaries are suppressed or bucketed below the minimum safe count.
+
+### Frontend verification
+
+- Query tests prove initial `GraphCMDB` LOD render calls overview, not `/graph/full`.
+- Interaction tests prove cluster click/expand triggers exactly one cluster detail request.
+- Search/filter tests prove match counts and ambiguity are computed only over authorized visible candidates and allowed public axes/labels: exactly one visible match triggers targeted detail fetch even if hidden candidates exist; zero visible matches produce identical no-match behavior with or without hidden candidates; multiple visible or ambiguous visible matches do not hydrate detail or full topology.
+- Zoom/pan tests prove no detail request fires from zoom threshold behavior.
+- Fallback tests prove the existing full topology path still renders when overview/detail is disabled or fails.
+
+### Performance verification
+
+- Measure first-paint payload size and render time for large fixture graphs.
+- Assert overview payload is bounded by cluster cardinality, not CI cardinality.
+- Assert detail requests are bounded by the selected cluster/filter and configured limit.
+
+## Non-goals
+
+- No application code implementation in this change.
+- No change to `/graph/full` response shape or semantics.
+- No automatic zoom-threshold detail expansion.
+- No realtime streaming topology updates.
+- No ML-based or dynamic clustering beyond the first-slice location axis.
+- No visual redesign of `GraphCMDB` or `NetworkVisualizer`.
+- No migration of `NetworkVisualizer` unless a later slice explicitly scopes it.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Overview/search behavior leaks hidden topology | High | Apply visibility filters before aggregation and search resolution, suppress/bucket low-cardinality aggregates, compute ambiguity only over visible candidates, and add scoped parity tests. |
+| Detail endpoint becomes another full graph path | High | Require cluster id, search/filter bounds, pagination, and limit enforcement. |
+| Hidden cluster enumeration through detail lookup | High | Return identical externally observable `unavailable` responses for hidden and absent clusters, with no cluster metadata. |
+| Sensitive metadata leaks through projection-policy drift | High | Confirm and reuse the existing authorized projection helper/policy from `/graph/full` for detail; overview never returns raw sensitive fields. Treat stronger `/graph/full` redaction as separate security work. |
+| Frontend keeps parallel full topology query for filter options | Medium | Replace location options with overview/metadata-compatible source during `GraphCMDB` migration. |
+| `NetworkVisualizer` continues high-frequency full polling | Medium | Leave compatible for now; plan a separate migration because route behavior differs. |
+| Cache invalidation causes stale expanded details | Medium | Use overview `revision`, request-context keys, and stale marking on filter/revision changes. |
+| Contract overfits location axis | Low | Encode axis in `cluster_id` and only accept `location:*` in the first slice. |
+
+## Next implementation slices
+
+1. **Backend contracts and DTOs**: define Pydantic response models, endpoint validation, and shared visibility helpers.
+2. **Backend queries and tests**: implement aggregation/detail repository paths with security parity coverage.
+3. **Frontend query layer**: add overview/detail fetchers, query keys, and fallback-aware hooks.
+4. **GraphCMDB migration**: switch initial render to overview, add explicit expansion/search detail orchestration, preserve fallback.
+5. **Operational hardening**: add telemetry, performance fixtures, and rollout/canary controls.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/exploration.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/exploration.md
@@ -1,0 +1,63 @@
+# Exploration: CMDB Graph Level of Detail
+
+## Issue
+
+GitHub issue #230: `perf(cmdb): plan large-scale graph level-of-detail mode`.
+
+## Summary
+
+The current CMDB topology visualization path can render clusters on the frontend, but it still fetches and prepares the full topology payload first. That means the first scalability bottleneck is not only visual rendering; it is also backend payload size, polling behavior, and frontend simulation over full node/link arrays.
+
+## Current Flow
+
+- `backend/routers/links.py`
+  - Exposes `GET /graph/full` with optional `layer`, `location`, and `owner` filters.
+  - No paging, level-of-detail, summary, or subgraph mode exists today.
+- `backend/services/link_service.py`
+  - `get_full_graph()` enforces user scoping and maps repository data into `{ nodes, links }`.
+- `backend/repositories/topology_repo.py`
+  - `get_filtered_graph_data()` returns full node/link Cypher results with security filters.
+- `frontend/services/queryResources.ts`
+  - `fetchGraphTopology()` always calls `/graph/full`.
+- `frontend/hooks/queries/useGraphTopologyQuery.ts`
+  - React Query polls topology every 30 seconds.
+- `frontend/components/GraphCMDB.tsx`
+  - Uses filtered topology plus a parallel unfiltered query for location options.
+  - Already has location-based cluster rendering and aggregated cluster links.
+- `frontend/components/NetworkVisualizer.tsx`
+  - Calls `/api/graph/full` directly with short polling.
+
+## Relevant Tests
+
+- `backend/tests/test_routers_links.py`
+  - Covers full graph endpoint behavior, scoping, node typing, medium field, and no-leak behavior.
+- `backend/tests/test_topology_repo_nodes.py`
+  - Covers repository-level query shape and filtering/scoping behavior.
+- `frontend/components/__tests__/GraphCMDB.query.test.tsx`
+  - Covers query usage and filter-driven topology calls.
+- `frontend/hooks/queries/resourceQueries.test.tsx`
+  - Covers `/graph/full` polling and shared query behavior.
+
+## Key Discovery
+
+`GraphCMDB.tsx` already contains a useful frontend-side cluster abstraction, but it is built after retrieving the full graph. A proper Level of Detail design should move the first view toward server-provided summaries and on-demand expansion.
+
+## Recommended First Slice
+
+Keep `/graph/full` backward-compatible. Add either:
+
+1. a new overview endpoint, for example `/graph/overview`, or
+2. a `view=overview` mode on a dedicated graph endpoint,
+
+that returns cluster summaries and aggregate links for initial rendering. Then fetch detailed subgraphs only when the user explicitly expands a cluster or commits a search/filter target. Zoom-triggered detail loading is out of scope for this design slice.
+
+## Risks
+
+- High: if the backend still returns the full topology, frontend-only LOD will not solve large graph payload or compute cost.
+- High: multiple frontend callers still fetch full topology, including `GraphCMDB` and `NetworkVisualizer`.
+- Medium: `/graph/full` is an existing behavior contract for tests and possibly tooling; changing its response shape would cause regressions.
+- Medium: any new endpoint must preserve existing authorization and public IP leakage guards.
+
+## CodeGraph Note
+
+The parent session detected `.codegraph/` exists. The exploration subagent reported CodeGraph was unavailable because `.codegraph/manifest.json` was missing and fell back to direct file reads.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/proposal.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/proposal.md
@@ -1,0 +1,102 @@
+# Design for CMDB Graph Level-of-Detail (Issue #230)
+
+## Quick path
+1. Preserve existing `/graph/full` behavior as a compatibility path.
+2. Introduce a design for initial render using summary/overview data (location-cluster first)
+3. Load detailed nodes and links only via explicit interactions (expand/click + search/filter).
+4. Keep authorization and data-leak guards aligned between summary and detail fetch paths.
+5. Publish follow-up implementation slices after design approval.
+
+## Intent
+Operators managing very large CMDB topologies need a faster, usable first paint and lower control-plane strain. The current implementation always pulls the entire topology for all clusters, which causes slow loads and UI stalls before the operator can even choose what to inspect. This proposal defines a design-only slice that reduces initial load by introducing level-of-detail architecture while preserving backward compatibility.
+
+## Problem statement
+- Current behavior: both `GraphCMDB` and `NetworkVisualizer` fetch full topology payloads (`/graph/full`) and rely on client-side filtering/aggregation for display.
+- Resulting gap: payload size, polling overhead, and layout simulation cost grow with graph size, limiting operator productivity before interaction.
+- Required business outcome: make first interaction fast and safe for large datasets by shifting detail retrieval to demand-driven calls.
+
+## Target scope (First slice)
+- **Scope is design-only**; no implementation code is planned in this change.
+- Design first render in **location-based clustering** mode.
+- Detail expansion is triggered by explicit operator actions only:
+  - node/cluster click-to-expand,
+  - search/filter refinement that targets a specific cluster/segment.
+- Keep `/graph/full` endpoint behavior intact as a compatibility and fallback path.
+- Preserve security and scoping guarantees for both summary and detail paths.
+
+## Affected areas (design target)
+- Backend routing and contract strategy around topology APIs.
+- Backend service/repository query patterns for summary vs detail retrieval.
+- Frontend data-fetching strategy for topology graph hooks/services/components.
+- Polling cadence and cache invalidation behavior for summary/detail calls.
+
+## Current-state gap
+- The frontend has useful location-based clustering logic, but it is applied after full graph hydration.
+- There is no explicit overview contract/API that can be safely consumed at scale.
+- Multiple callers remain bound to full-graph fetch semantics.
+- Existing endpoint tests are tied to `/graph/full` contract, creating migration risk if that contract changes.
+
+## Product/business rules and assumptions
+- Backward compatibility is required for `/graph/full` (no response-shape breaking change now).
+- Level-of-detail starts with **Location** clustering for the first slice.
+- Automatic zoom-threshold expansion is intentionally out of scope for this slice.
+- No behavioral change to visualization baseline unless explicitly required by selected implementation slices.
+
+## Recommended design direction (design decision)
+1. **Backward compatibility layer first:** Keep `/graph/full` unchanged and continue supporting existing consumers.
+2. **Overview-first loading:** Introduce (or reserve) a dedicated path for overview/summary responses used by GraphCMDB initial render (cluster aggregates, counts, top-level links).
+3. **Demand-based detail fetching:** Add a detail endpoint contract that resolves a cluster identifier and returns only requested subgraph details with same auth/scoping semantics.
+4. **Trigger matrix:** Detail load only on explicit user action (click/expand / search / filter), not automatic zoom.
+5. **Security parity:** Reuse server-side scoping and filtering logic so summary and detail both enforce tenant/user visibility, collapse hidden and absent cluster responses into the same externally observable result, compute search ambiguity/match counts only over visible candidates and allowed public axes, and apply the confirmed existing authorized projection policy to detail sensitive fields. This design does not change `/graph/full` response shape or existing semantics.
+
+## Risks and mitigations
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Incomplete security parity between overview and detail | Medium | Reuse existing repository filter pipeline; require security test updates in follow-up implementation slice. Hidden and absent clusters must use the same externally observable response. |
+| Sensitive metadata exposure through detail payloads | High | Overview never includes sensitive node metadata. Detail reuses the confirmed existing authorized projection helper/policy used by `/graph/full`. Any stronger `/graph/full` redaction is a separate security change, not part of this design slice. |
+| Aggregate disclosure through low-cardinality summaries | High | Suppress or bucket aggregates below the minimum safe count and role-gate detailed breakdowns. |
+| Over-scoping of design to implementation and large architectural drift | Medium | Explicitly scope this change to design decisions, data contracts, and migration sequencing only. |
+| Stakeholder mismatch on interaction semantics | Medium | Document and align on trigger matrix and cluster expansion contract before implementation. |
+
+## Rollback strategy
+- If this design is rejected, revert to the current `/graph/full`-driven workflow without changes outside planning docs.
+- If partially adopted, disable the new LOD path and fall back to existing full graph calls from both GraphCMDB and NetworkVisualizer until end-to-end parity is proven.
+
+## Design acceptance criteria
+- [x] A clear level-of-detail architecture is defined for: overview retrieval, detail retrieval, auth/scoping, and client state orchestration.
+- [x] `/graph/full` contract remains backward-compatible and documented as unchanged for this slice.
+- [x] Explicit interaction triggers are defined for detail loading, including exact search/filter behavior for one match, multiple matches, no matches, and ambiguous matches.
+- [x] Location remains the only required first-slice clustering axis.
+- [x] Security and authorization expectations for both payload types are explicitly documented, including hidden/absent cluster equivalence, visible-only search ambiguity/match counts, detail sensitive-field projection policy, and aggregate suppression.
+- [x] A migration and verification plan is provided for follow-up implementation slices.
+- [x] Design includes a scope boundary note that excludes realtime streaming, ML clustering, and visual redesign unless future slices justify it.
+
+## Recommended follow-up implementation slices
+1. **Slice A – Contract & data shape finalization**
+   - Finalize overview/detail API contracts, pagination rules, and caching/invalidation expectations.
+2. **Slice B – Backend rollout (safe compatibility)**
+   - Add overview endpoint or parameterized mode, implement detail endpoint, keep `/graph/full` untouched.
+3. **Slice C – Frontend topology orchestration**
+   - Update query strategy for initial load + explicit-detail fetching paths; handle old and new paths in parallel during transition.
+
+## Non-goals (explicit + conservative inferences)
+- No complete visualizer rewrite in this change.
+- No realtime streaming of graph changes.
+- No ML-based clustering/auto-clustering.
+- No primary visual polish objective unless explicitly justified in a later business-slice decision.
+
+## Proposal question round
+These questions are to tighten PRD alignment before locking this design for implementation.
+
+1. What operator-level success metric should we use to stop loading more detail automatically (e.g., time-to-first-render target or max initial payload size)?
+2. For explicit search/filter, should detail loading replace the current root view, or open as an additive detail panel/subgraph overlay while preserving current context?
+3. In rollout, should GraphCMDB be the exclusive frontend owner of LOD behavior first, or should `NetworkVisualizer` share the same summary/detail contract in this change (even in design only) as a requirement?
+4. If a cluster is expanded and then filters change, should expanded detail persist, reset, or be versioned by filter context?
+5. What is the minimum “safe rollout” criterion for allowing removal of any remaining `/graph/full` callers in later slices (e.g., 30-day canary, error budget, or operator sign-off)?
+
+## Assumptions after Round 1
+- Scope excludes implementation and limits delivery to design decisions for this change.
+- Location-based clustering is the default first-slice grouping.
+- Automatic zoom-triggered expansion remains out of scope.
+- Existing `/graph/full` contract is preserved in this iteration.
+- Design will include explicit follow-up slices to execute changes safely after approval.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md
@@ -1,0 +1,188 @@
+# CMDB Graph Level-of-Detail Specification
+
+## Purpose
+
+Define the design-only behavior for introducing level-of-detail loading to CMDB topology views so that first render is overview-driven, detail data is loaded only by explicit operator action, security guarantees are unchanged, and `/graph/full` remains backward-compatible.
+
+## Requirements
+
+### Requirement: Overview payload contract for first paint
+
+The system MUST define an overview payload contract used for the initial CMDB topology render, scoped to a first-slice **Location** clustering axis.
+
+The overview payload MUST include:
+- cluster identifiers and display labels for clusters visible to the caller,
+- aggregate node and link counts per cluster after authorization filtering,
+- high-level inter-cluster link counts/weights after authorization filtering,
+- metadata required to render the current location-level topology legend and summary cards,
+- suppression or bucketing metadata for low-cardinality aggregates,
+- pagination / continuation signals only if needed by the design.
+
+The overview payload MUST NOT include per-node sensitive metadata such as `public_ip`, external DNS names, NAT addresses, precise endpoint coordinates, serial numbers, provider account identifiers, or comparable infrastructure identifiers.
+
+#### Scenario: First render uses overview contract
+- GIVEN the topology view loads for the first time,
+- WHEN initial data is requested,
+- THEN the client MUST use the overview contract rather than a full node/link dump for first paint.
+
+#### Scenario: Initial cluster axis is location
+- GIVEN no additional user interaction has occurred,
+- WHEN cluster grouping is computed,
+- THEN grouping MUST default to Location and MAY include stable tie-breakers for nodes without location metadata.
+
+#### Scenario: `/graph/full` remains compatible with overview introduction
+- GIVEN existing consumers still call `/graph/full`,
+- WHEN no changes are required by this slice,
+- THEN the endpoint MUST continue returning the existing full topology shape.
+
+#### Scenario: Low-cardinality overview aggregates are protected
+- GIVEN a visible cluster, link group, status/type/medium bucket, weight, or geo bucket has fewer than the configured safe minimum count,
+- WHEN the overview payload is built,
+- THEN the design MUST suppress the exact value or bucket it into an `other`/`suppressed` aggregate unless the principal has explicit aggregate-breakdown permission.
+
+### Requirement: Detail subgraph payload contract
+
+The system MUST define a detail retrieval contract for a selected cluster/segment that returns only the nodes and links relevant to that selection.
+
+Search/filter resolution MUST be computed only after authorization filtering and only over visible candidates plus allowed public axes/labels. Hidden candidates MUST NOT affect match counts, ambiguity decisions, status codes, response body shape, timing, pagination, or whether detail hydration occurs.
+
+The detail payload MUST include:
+- the requested cluster/segment identifier only when the cluster is visible to the caller,
+- selected node/link records with existing field semantics,
+- parent summary reference fields enabling incremental merge back into overview context,
+- auth-related projection flags (for parity with overview security),
+- clear empty-result semantics when filters hide all visible details.
+
+The detail endpoint MUST derive the cluster axis from `cluster_id` and MUST reject contradictory query parameters instead of accepting conflicting `axis` values.
+
+#### Scenario: Detail payload is demand-driven
+- GIVEN a user explicitly selects a cluster for expansion,
+- WHEN a detail fetch is triggered,
+- THEN only subgraph detail for that cluster/segment MUST be returned.
+
+#### Scenario: Search/filter-driven detail fetch
+- GIVEN a user applies search or filter narrowing to a cluster/segment,
+- WHEN the new view context is established,
+- THEN the client MUST request detail only for the relevant target context, and not for the entire topology.
+
+#### Scenario: Search resolves exactly one visible cluster
+- GIVEN a committed search/filter resolves to exactly one visible cluster after authorization filtering,
+- AND hidden candidates may or may not exist outside the caller's scope,
+- WHEN detail is requested,
+- THEN the client MUST fetch detail for that visible cluster only, with behavior based solely on the visible match.
+
+#### Scenario: Search resolves multiple visible clusters
+- GIVEN a committed search/filter resolves to multiple visible clusters after authorization filtering,
+- WHEN results are shown,
+- THEN the client MUST keep the overview result set and require explicit operator selection before fetching detail.
+
+#### Scenario: Search resolves no visible clusters
+- GIVEN a committed search/filter resolves to no visible clusters after authorization filtering,
+- AND hidden candidates may or may not exist outside the caller's scope,
+- WHEN results are shown,
+- THEN the client MUST show the same empty overview/search state and MUST NOT fetch full topology detail regardless of hidden candidates.
+
+#### Scenario: Search is ambiguous
+- GIVEN a committed search/filter is ambiguous among multiple visible candidates or allowed public axes/labels after authorization filtering,
+- WHEN results are shown,
+- THEN the client MUST avoid detail hydration and ask for refinement or explicit visible-cluster selection.
+
+#### Scenario: No unsolicited detail expansion
+- GIVEN zoom level changes but no explicit expand/search/filter action,
+- WHEN render updates,
+- THEN no additional detail call MAY be triggered by zoom threshold logic.
+
+### Requirement: Security and authorization parity between summary and detail
+
+The system MUST apply equivalent authorization and tenant scoping to overview and detail responses. This design slice does not change `/graph/full` response shape or existing semantics.
+
+Sensitive-field policy for future LOD endpoints:
+- overview responses MUST NOT include raw sensitive fields,
+- detail responses MUST use the same existing authorized projection helper/policy as `/graph/full` once the implementation slice confirms that helper/policy,
+- any stronger redaction policy for `/graph/full` is a separate security change and is not part of this design slice.
+
+#### Scenario: Scoped callers receive equivalent visibility
+- GIVEN the same authenticated principal and tenant scope,
+- WHEN summary and detail endpoints are called with identical filters,
+- THEN the visible node/link set MUST be a subset-equivalent constrained by the same policy.
+
+#### Scenario: Restricted fields follow LOD-sensitive-field policy
+- GIVEN a principal without permission to receive restricted attributes,
+- WHEN overview and detail payloads are fetched,
+- THEN overview MUST omit raw restricted fields entirely,
+- AND detail MUST apply the existing authorized projection helper/policy used by `/graph/full` once confirmed in implementation planning.
+
+#### Scenario: Authorized sensitive metadata is scoped
+- GIVEN a principal has explicit sensitive-metadata permission for the requested tenant/location scope,
+- WHEN detail payloads are fetched for visible nodes,
+- THEN sensitive fields MAY be returned only according to the confirmed existing `/graph/full` projection policy and MUST still be excluded from overview aggregates.
+
+#### Scenario: Hidden and absent clusters are indistinguishable
+- GIVEN a principal requests a cluster id that is outside their scope or does not exist,
+- WHEN the detail endpoint responds,
+- THEN the externally observable status code, response body shape, and absence of cluster metadata MUST be identical for both cases.
+
+#### Scenario: Security regressions are detectable across payload types
+- GIVEN a limited or empty scope principal,
+- WHEN both payload types are requested,
+- THEN responses MUST NOT expose data outside that principal's tenant boundaries in either payload type.
+
+### Requirement: Frontend orchestration for initial render and explicit detail loading
+
+The frontend topology orchestration MUST separate overview orchestration from explicit detail orchestration and define state transitions for both.
+
+#### Scenario: Initial orchestration is overview-first
+- GIVEN a topology page opens,
+- WHEN orchestration begins,
+- THEN initial polling/state MUST prioritize overview payload retrieval and rendering before any detail hydration.
+
+#### Scenario: Explicit expansion path
+- GIVEN a cluster is clicked or expanded,
+- WHEN expansion completes,
+- THEN the orchestration layer MUST load and mount detail payload for only that cluster and merge it into the rendered scene as a delimited subgraph.
+
+#### Scenario: Explicit search/filter refresh path
+- GIVEN a search or filter action changes target cluster context,
+- WHEN action commits,
+- THEN orchestration MUST resolve target candidates only after authorization filtering,
+- AND MUST trigger detail retrieval only when exactly one visible target is resolved or the operator explicitly selects one visible target from multiple visible results.
+
+#### Scenario: Backward compatibility for polling consumers
+- GIVEN a consumer that still relies on `/graph/full`,
+- WHEN no equivalent compatibility strategy exists in a given frontend slice,
+- THEN that consumer MUST continue to function using existing polling behavior without hard dependency on new payload contracts.
+
+### Requirement: Non-goals and out-of-scope constraints
+
+The design-only slice MUST NOT include automatic demand-generation of detail through zoom-threshold expansion, and MUST NOT include real-time streaming, ML-based clustering, or a visual redesign.
+
+#### Scenario: Automatic zoom-triggered expansion is out of scope
+- GIVEN the user zooms to any level,
+- WHEN no explicit action is made,
+- THEN detail loading MUST NOT occur based on zoom threshold alone.
+
+#### Scenario: No streaming or ML clustering in this slice
+- GIVEN implementation planning begins,
+- WHEN work items are enumerated,
+- THEN no task under this change MAY target streaming pipelines or ML-driven cluster generation.
+
+### Requirement: Design-only acceptance criteria
+
+The change MUST be completed as a design artifact only and MUST include explicit follow-up implementation slices.
+
+The design MUST include approval-ready artifacts for: overview contract, detail contract, trigger matrix, auth parity checks, migration path, and follow-up slices.
+
+#### Scenario: Design artifacts define all required contracts
+- GIVEN the design review is conducted,
+- WHEN reviewers inspect the approved spec,
+- THEN each contract (overview, detail, auth parity, trigger matrix, backward compatibility) MUST be explicitly documented and testable by review.
+
+#### Scenario: Follow-up implementation plan is explicit
+- GIVEN the scope is reviewed for this change,
+- WHEN design sign-off is requested,
+- THEN the spec MUST list ordered follow-up implementation slices for contract finalization, backend rollout, and frontend orchestration migration.
+
+#### Scenario: No code implementation is introduced in this change
+- GIVEN the change is executed,
+- WHEN artifact diff is produced,
+- THEN no application code under `backend/` or `frontend/` MUST be changed.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/sync-report.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/sync-report.md
@@ -1,0 +1,93 @@
+# Sync Report — CMDB Graph Level-of-Detail
+
+- **status**: `synced`
+- **next_recommended**: `sdd-archive`
+
+## Scope and gating
+
+- Change: `cmdb-graph-level-of-detail`
+- Action context:
+  - mode: `repo-local`
+  - allowedEditRoots: repository root (present)
+- Artifact store: `openspec`
+- verify-report present: ✅ `openspec/changes/cmdb-graph-level-of-detail/verify-report.md`
+- verify result: PASS (no FAIL/BLOCKED/CRITICAL markers)
+- change type: design-only docs update
+- destructive delta type: none (`REMOVED`/large `MODIFIED` blocks detected)
+- explicit archive sync approval: not required
+
+## Structured status
+
+```json
+{
+  "change": "cmdb-graph-level-of-detail",
+  "artifactStore": "openspec",
+  "actionContext": {
+    "mode": "repo-local",
+    "allowedEditRoots": ["repository root"]
+  },
+  "status": "synced",
+  "nextRecommended": "sdd-archive"
+}
+```
+
+## Domains synced
+
+- `cmdb-graph-level-of-detail`
+
+## Canonical files updated
+
+- Added new canonical spec: `openspec/specs/cmdb-graph-level-of-detail/spec.md`
+  - Source: `openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md`
+  - Applied as-file copy (canonical did not previously exist)
+
+## Requirement sync summary
+
+### ADDED requirements
+
+- Added requirement families from change spec to canonical:
+  - Overview payload contract for first paint
+  - Detail subgraph payload contract
+  - Security and authorization parity
+  - Frontend orchestration for initial render and explicit detail loading
+  - Non-goals and out-of-scope constraints
+  - Design-only acceptance criteria
+
+### MODIFIED requirements
+
+- None (new canonical domain spec)
+
+### REMOVED requirements
+
+- None
+
+## Collision and guard checks
+
+- Active same-domain collision: none
+  - No other `openspec/changes/**/specs/cmdb-graph-level-of-detail/spec.md` entries found.
+- Legacy flat spec format in this change: none
+- RENAMED requirement block: none
+- Destructive sync approvals/blockers: none
+
+## Validation performed
+
+- Confirmed required artifacts existed:
+  - proposal, change spec, design, tasks, verify-report
+- Confirmed `verify-report.md` is present and `PASS`
+- Confirmed no `FAIL`, `BLOCKED`, or `CRITICAL` markers in verify output
+- Confirmed verify command checks all tasks are complete:
+  - `grep -R "^\s*- \[ \]" openspec/changes/cmdb-graph-level-of-detail/tasks.md || true`
+- Copied canonical spec:
+  - `cp openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md openspec/specs/cmdb-graph-level-of-detail/spec.md`
+- Confirmed canonical destination now exists:
+  - `ls -l openspec/specs/cmdb-graph-level-of-detail/spec.md`
+
+## Outcome
+
+- `cmdb-graph-level-of-detail` is synchronized in canonical OpenSpec specs as a design-only change with PASS verification.
+- Ready to proceed to archive.
+
+
+## Archived-path note
+
+Some command examples and artifact references above may use the active change path (`openspec/changes/cmdb-graph-level-of-detail/...`) because they record the phase execution before archive. The PR-ready archived artifacts now live under `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/`, with the synchronized canonical spec at `openspec/specs/cmdb-graph-level-of-detail/spec.md`.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/tasks.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: CMDB Graph Level-of-Detail (Issue #230, Design-only)
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~1609 inserted lines after sync/archive |
+| 400-line budget risk | High after sync/archive |
+| Chained PRs recommended | No |
+| Suggested split | single PR |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | stacked-to-main |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: stacked-to-main
+400-line budget risk: High after sync/archive
+
+## Phase 1 — Scope and artifact preconditions
+
+- [x] 1.1 Confirm required artifacts exist and match this change scope: `openspec/changes/cmdb-graph-level-of-detail/proposal.md`, `openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md`, `openspec/changes/cmdb-graph-level-of-detail/design.md`.
+- [x] 1.2 Confirm optional context was considered: `openspec/changes/cmdb-graph-level-of-detail/exploration.md`.
+- [x] 1.3 Validate and document (in `openspec/changes/cmdb-graph-level-of-detail/tasks.md` notes) that this slice is **design-only** and must not include backend/frontend implementation changes.
+
+## Phase 2 — Design/spec alignment verification
+
+- [x] 2.1 Add or validate a spec-to-design mapping section in `openspec/changes/cmdb-graph-level-of-detail/design.md` that maps each `spec.md` requirement family to the concrete design section (overview payload, detail payload, security parity, frontend orchestration, rollout/non-goals).
+- [x] 2.2 Verify spec Scenario coverage for this slice in `design.md` and call out any missing scenario with concrete follow-up task entries rather than in-scope edits.
+- [x] 2.3 Verify `design.md` clearly documents all out-of-scope constraints from `spec.md` (no auto zoom-triggered expansion, no streaming/ML clustering, no real-time/full-graph redesign in this slice).
+
+## Phase 3 — Security and compatibility consistency checks
+
+- [x] 3.1 Verify `design.md` explicitly enforces hidden-versus-absent cluster indistinguishability and that hidden candidates never alter match/ambiguity/empty behavior (`empty_reason` parity, timing/shape/status equivalence).
+- [x] 3.2 Verify `design.md` and `spec.md` both state visible-only search/ambiguity resolution (`only visible candidates + allowed public axes/labels`) for both overview and detail requests.
+- [x] 3.3 Verify `design.md` documents **no `/graph/full` semantic or redaction change** for this LOD slice and references that stronger redaction belongs to a separate security change.
+- [x] 3.4 Verify sensitive-field policy is explicit: overview omits raw sensitive metadata; detail reuses existing confirmed projection policy from `/graph/full` for visible nodes only.
+
+## Phase 4 — OpenSpec consistency and review artifact
+
+- [x] 4.1 Produce a consistency check pass in `openspec/changes/cmdb-graph-level-of-detail/tasks.md` (or companion design appendix) confirming:
+  - location-only first-slice axis,
+  - cluster click/expand + committed search/filter are the only demand-driven detail triggers,
+  - `/graph/full` compatibility guarantee is preserved,
+  - explicit follow-up implementation slices are separated from this change.
+- [x] 4.2 Prepare final design-signoff evidence by reviewing all acceptance criteria in `openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md` against the design and recording pass/fail for each requirement before apply.
+
+## Explicit follow-up implementation slice recommendations (OUT OF SCOPE of this change)
+
+- **Slice A (Contract Finalization)**: finalize Pydantic/TypeScript DTO contracts, pagination limits, and route-level validation for `/graph/overview` and `/graph/detail/{cluster_id}`.
+- **Slice B (Backend Rollout)**: implement additive backend services/routes/repositories for overview + detail with shared visibility policy and security parity.
+- **Slice C (Frontend Orchestration)**: migrate `GraphCMDB` to overview-first + explicit detail fetch flow, including query/cache lifecycle and fallback behavior.
+- **Slice D (Consumer Hardening)**: migrate remaining callers (e.g., `NetworkVisualizer`) once dedicated design/operational criteria are approved.
+- **Slice E (Security hardening follow-up)**: implement any `/graph/full` redaction strengthening if required as separate issue workstream (NOT in #230).
+
+## Verification tasks for OpenSpec/design consistency only
+
+- [x] 5.1 Re-run a three-way consistency pass across:
+  - `proposal.md`
+  - `specs/cmdb-graph-level-of-detail/spec.md`
+  - `design.md`
+  and confirm no requirement in spec is unaddressed and no design statement expands scope beyond proposal.
+- [x] 5.2 Confirm every hard requirement in `design.md` can be traced back to one of: explicit user direction, design scope, or technical necessity from `exploration.md`.
+- [x] 5.3 Confirm no backend/frontend file paths are included in this PR scope list for this change.
+
+## Apply-phase evidence (design-only consistency sign-off)
+
+- [x] 4A.1 **Artifact scope and mode confirmed**: The work is design-only and all edits are confined to OpenSpec docs under `openspec/changes/cmdb-graph-level-of-detail/`.
+- [x] 4A.2 **Scope invariants preserved**: Design retains location-first overview, explicit demand-driven detail via click/expand + search/filter, and no zoom-threshold expansion trigger.
+- [x] 4A.3 **Backward compatibility preserved**: `/graph/full` response shape and semantics are explicitly protected; compatibility rollback path is documented.
+- [x] 4A.4 **Security parity preserved**: hidden/absent indistinguishable behavior, visible-only search resolution, aggregate suppression policy, and projection policy constraints are documented and not broadened in this slice.
+- [x] 4A.5 **Spec-to-design requirement matrix validated**:
+  - Requirement families in `spec.md` map to: **overview payload**, **detail payload**, **security parity**, **frontend orchestration**, **rollout/non-goals** in `design.md` (sections explicitly present).
+  - No requirement expands scope beyond proposal; all expansion paths are marked follow-up slices.
+  - No `/graph/full` redaction/shape change is introduced in this design slice.

--- a/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/verify-report.md
+++ b/openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/verify-report.md
@@ -1,0 +1,165 @@
+# Verify Report — CMDB Graph Level-of-Detail
+
+## Status
+
+**PASS — design-only verification complete.**
+
+The previous Strict TDD blocker is fixed: `apply-progress.md` now contains a clear `TDD Cycle Evidence` table for a design-only OpenSpec slice. The evidence does not claim production implementation, application tests, or backend/frontend code changes.
+
+## Structured status and action context
+
+| Field | Finding |
+|---|---|
+| Change | `cmdb-graph-level-of-detail` |
+| Artifact store | `openspec` |
+| Change root | `openspec/changes/cmdb-graph-level-of-detail` |
+| Native status before this report | `nextRecommended: verify`; task progress 20/20 complete; archive blocked only because previous verify report was not passing |
+| Action context | `repo-local` |
+| Allowed edit roots | Repository root |
+| Ownership/scope | Verified changed files are confined to OpenSpec docs for this change; no backend/frontend implementation files changed |
+
+## Spec coverage
+
+| Requirement family | Result |
+|---|---|
+| Overview payload contract for first paint | PASS — `design.md` defines `/graph/overview`, location-first clustering, aggregate counts/weights, legend metadata, optional pagination, and sensitive-field exclusion. |
+| Detail subgraph payload contract | PASS — `design.md` defines `/graph/detail/{cluster_id}`, derives axis from `cluster_id`, rejects contradictory axis data, includes selected node/link payload, parent references, projection flags, pagination, and empty-result semantics. |
+| Security and authorization parity | PASS — shared visibility policy, authorization-before-aggregation/search, hidden/absent indistinguishability, visible-only ambiguity resolution, and sensitive-field policy are documented. |
+| Frontend orchestration | PASS — overview-first load, explicit click/expand/search/filter detail loading, fallback to `/graph/full`, compatible polling/cache behavior, and no unsolicited detail loading are documented. |
+| Non-goals/out-of-scope | PASS — no zoom-threshold expansion, streaming, ML clustering, visual redesign, or implementation code in this slice. |
+| Design-only acceptance criteria | PASS — overview contract, detail contract, trigger matrix, auth parity checks, migration path, and follow-up slices are documented and reviewable. |
+
+## Task completion status
+
+PASS — no unchecked implementation/design task markers remain in `tasks.md`.
+
+Command result:
+
+```bash
+grep -R "^\s*- \[ \]" openspec/changes/cmdb-graph-level-of-detail/tasks.md || true
+# no output
+```
+
+## Strict TDD compliance
+
+| Check | Result | Details |
+|---|---|---|
+| Strict TDD active | PASS | `openspec/config.yaml` has `sdd.tdd_policy: strict_tdd`; prompt also states strict mode is active. |
+| TDD Cycle Evidence table present | PASS | `apply-progress.md:56` contains `## TDD Cycle Evidence`; `apply-progress.md:58` contains the cycle table header. |
+| Evidence scope | PASS | Evidence explicitly states this is design-only and no production code/test files are in scope. |
+| RED/GREEN overclaim risk | PASS | RED is marked `N/A (design-only exception)`; GREEN is described as manual evidence only over OpenSpec artifacts. No app tests are claimed. |
+| Reported test files cross-reference | N/A | No test files were reported or changed. |
+| GREEN execution | N/A | No application tests are relevant because no backend/frontend code changed. |
+| Assertion quality audit | N/A | No changed/created test files; no assertions to audit. |
+
+**Strict TDD compliance:** PASS for this design-only slice. Manual/OpenSpec evidence is acceptable because no application implementation or test harness changes are in scope.
+
+## Security and compatibility correction verification
+
+| Correction | Result |
+|---|---|
+| Hidden vs absent indistinguishable | PASS — `design.md` defines identical `unavailable` semantics with same externally observable response and no cluster metadata. |
+| Visible-only search/ambiguity resolution | PASS — search/filter match counts and ambiguity are computed only after authorization filtering over visible candidates plus allowed public axes/labels. |
+| Hidden-candidate oracle prevention | PASS — hidden candidates cannot affect match counts, ambiguity decisions, no-match behavior, detail hydration, pagination, timing, status codes, or response shape. |
+| `/graph/full` compatibility | PASS — `GET /graph/full` remains unchanged; no response-shape or semantic change is introduced by this LOD design slice. |
+| Aggregate disclosure policy | PASS — low-cardinality counts/weights/geo summaries are suppressed, rounded, or bucketed after authorization filtering unless aggregate-breakdown permission exists. |
+| Sensitive field policy | PASS — overview never exposes raw sensitive metadata; detail reuses the confirmed existing `/graph/full` projection helper/policy for visible nodes only. |
+
+## Proposal acceptance criteria evidence
+
+PASS — proposal acceptance criteria are now checked and are backed by design/spec/apply evidence. They do not claim production implementation.
+
+Evidence:
+
+```text
+proposal.md:66-72 all design acceptance criteria are checked [x].
+apply-progress.md records only OpenSpec/design evidence and explicitly states no backend/frontend code or automated tests were edited, added, or executed.
+```
+
+## Implementation scope verification
+
+PASS — no backend/frontend implementation files changed.
+
+Commands:
+
+```bash
+git status --porcelain=v1 --untracked-files=all -- backend frontend && git diff --name-only -- backend frontend
+# no output
+```
+
+Current changed/untracked files are limited to this OpenSpec change:
+
+```text
+openspec/changes/cmdb-graph-level-of-detail/apply-progress.md
+openspec/changes/cmdb-graph-level-of-detail/design.md
+openspec/changes/cmdb-graph-level-of-detail/exploration.md
+openspec/changes/cmdb-graph-level-of-detail/proposal.md
+openspec/changes/cmdb-graph-level-of-detail/specs/cmdb-graph-level-of-detail/spec.md
+openspec/changes/cmdb-graph-level-of-detail/tasks.md
+openspec/changes/cmdb-graph-level-of-detail/verify-report.md
+```
+
+## Review workload / PR boundary
+
+PASS WITH REVIEW ESCALATION — the design-only apply forecast was low before sync/archive, but the final PR diff is oversized because it includes archived artifacts plus canonical spec. Full 4R pre-PR review is required and recorded separately before PR creation.
+
+| Forecast item | Verification |
+|---|---|
+| Chained PRs recommended | No — respected. |
+| 400-line budget risk | High after sync/archive — full 4R pre-PR review required before PR creation. |
+| Chain strategy | `stacked-to-main` recorded, not applicable because chained PRs were not recommended. |
+| Boundary | Single PR, design-only OpenSpec artifact updates. No backend/frontend scope creep. |
+
+## Validation commands
+
+```bash
+# Native OpenSpec/Gentle status
+gentle-ai sdd-status cmdb-graph-level-of-detail --cwd "$PWD" --json --instructions
+# Result: verify ready; taskProgress 20/20 complete; archive blocked only because previous verify report was not passing.
+
+# OpenSpec CLI availability
+if command -v openspec >/dev/null 2>&1; then openspec validate cmdb-graph-level-of-detail --strict; else echo 'openspec CLI not available'; fi
+# Result: openspec CLI not available.
+
+# Changed-file and backend/frontend scope checks
+git status --porcelain=v1 --untracked-files=all
+git status --porcelain=v1 --untracked-files=all -- backend frontend && git diff --name-only -- backend frontend
+# Result: no backend/frontend changes.
+
+# Task checkbox verification
+grep -R "^\s*- \[ \]" openspec/changes/cmdb-graph-level-of-detail/tasks.md || true
+# Result: no matches.
+
+# Strict TDD evidence location
+grep -n "^## TDD Cycle Evidence\|^| Cycle |" openspec/changes/cmdb-graph-level-of-detail/apply-progress.md
+# Result: table found at lines 56 and 58.
+```
+
+## Post-archive PR readiness update
+
+This report was originally generated before archive. Active-path command examples above reflect the pre-archive verification moment. For PR review, the current staged artifacts are:
+
+```text
+openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/
+openspec/specs/cmdb-graph-level-of-detail/spec.md
+```
+
+Final staged size is approximately 1609 inserted lines, so this docs/OpenSpec PR exceeds the 400-line review budget. The PR must carry explicit full 4R pre-PR review evidence before creation.
+
+Additional post-archive checks:
+
+```bash
+git status --porcelain=v1 --untracked-files=all -- backend frontend
+git diff --cached --name-only -- backend frontend
+git diff --cached --numstat
+```
+
+Expected result: no backend/frontend files staged; oversized diff is OpenSpec documentation only.
+
+## Blockers
+
+None.
+
+## Final recommendation
+
+Archived and ready for PR after full 4R pre-PR review evidence is clean.

--- a/openspec/specs/cmdb-graph-level-of-detail/spec.md
+++ b/openspec/specs/cmdb-graph-level-of-detail/spec.md
@@ -1,0 +1,188 @@
+# CMDB Graph Level-of-Detail Specification
+
+## Purpose
+
+Define the design-only behavior for introducing level-of-detail loading to CMDB topology views so that first render is overview-driven, detail data is loaded only by explicit operator action, security guarantees are unchanged, and `/graph/full` remains backward-compatible.
+
+## Requirements
+
+### Requirement: Overview payload contract for first paint
+
+The system MUST define an overview payload contract used for the initial CMDB topology render, scoped to a first-slice **Location** clustering axis.
+
+The overview payload MUST include:
+- cluster identifiers and display labels for clusters visible to the caller,
+- aggregate node and link counts per cluster after authorization filtering,
+- high-level inter-cluster link counts/weights after authorization filtering,
+- metadata required to render the current location-level topology legend and summary cards,
+- suppression or bucketing metadata for low-cardinality aggregates,
+- pagination / continuation signals only if needed by the design.
+
+The overview payload MUST NOT include per-node sensitive metadata such as `public_ip`, external DNS names, NAT addresses, precise endpoint coordinates, serial numbers, provider account identifiers, or comparable infrastructure identifiers.
+
+#### Scenario: First render uses overview contract
+- GIVEN the topology view loads for the first time,
+- WHEN initial data is requested,
+- THEN the client MUST use the overview contract rather than a full node/link dump for first paint.
+
+#### Scenario: Initial cluster axis is location
+- GIVEN no additional user interaction has occurred,
+- WHEN cluster grouping is computed,
+- THEN grouping MUST default to Location and MAY include stable tie-breakers for nodes without location metadata.
+
+#### Scenario: `/graph/full` remains compatible with overview introduction
+- GIVEN existing consumers still call `/graph/full`,
+- WHEN no changes are required by this slice,
+- THEN the endpoint MUST continue returning the existing full topology shape.
+
+#### Scenario: Low-cardinality overview aggregates are protected
+- GIVEN a visible cluster, link group, status/type/medium bucket, weight, or geo bucket has fewer than the configured safe minimum count,
+- WHEN the overview payload is built,
+- THEN the design MUST suppress the exact value or bucket it into an `other`/`suppressed` aggregate unless the principal has explicit aggregate-breakdown permission.
+
+### Requirement: Detail subgraph payload contract
+
+The system MUST define a detail retrieval contract for a selected cluster/segment that returns only the nodes and links relevant to that selection.
+
+Search/filter resolution MUST be computed only after authorization filtering and only over visible candidates plus allowed public axes/labels. Hidden candidates MUST NOT affect match counts, ambiguity decisions, status codes, response body shape, timing, pagination, or whether detail hydration occurs.
+
+The detail payload MUST include:
+- the requested cluster/segment identifier only when the cluster is visible to the caller,
+- selected node/link records with existing field semantics,
+- parent summary reference fields enabling incremental merge back into overview context,
+- auth-related projection flags (for parity with overview security),
+- clear empty-result semantics when filters hide all visible details.
+
+The detail endpoint MUST derive the cluster axis from `cluster_id` and MUST reject contradictory query parameters instead of accepting conflicting `axis` values.
+
+#### Scenario: Detail payload is demand-driven
+- GIVEN a user explicitly selects a cluster for expansion,
+- WHEN a detail fetch is triggered,
+- THEN only subgraph detail for that cluster/segment MUST be returned.
+
+#### Scenario: Search/filter-driven detail fetch
+- GIVEN a user applies search or filter narrowing to a cluster/segment,
+- WHEN the new view context is established,
+- THEN the client MUST request detail only for the relevant target context, and not for the entire topology.
+
+#### Scenario: Search resolves exactly one visible cluster
+- GIVEN a committed search/filter resolves to exactly one visible cluster after authorization filtering,
+- AND hidden candidates may or may not exist outside the caller's scope,
+- WHEN detail is requested,
+- THEN the client MUST fetch detail for that visible cluster only, with behavior based solely on the visible match.
+
+#### Scenario: Search resolves multiple visible clusters
+- GIVEN a committed search/filter resolves to multiple visible clusters after authorization filtering,
+- WHEN results are shown,
+- THEN the client MUST keep the overview result set and require explicit operator selection before fetching detail.
+
+#### Scenario: Search resolves no visible clusters
+- GIVEN a committed search/filter resolves to no visible clusters after authorization filtering,
+- AND hidden candidates may or may not exist outside the caller's scope,
+- WHEN results are shown,
+- THEN the client MUST show the same empty overview/search state and MUST NOT fetch full topology detail regardless of hidden candidates.
+
+#### Scenario: Search is ambiguous
+- GIVEN a committed search/filter is ambiguous among multiple visible candidates or allowed public axes/labels after authorization filtering,
+- WHEN results are shown,
+- THEN the client MUST avoid detail hydration and ask for refinement or explicit visible-cluster selection.
+
+#### Scenario: No unsolicited detail expansion
+- GIVEN zoom level changes but no explicit expand/search/filter action,
+- WHEN render updates,
+- THEN no additional detail call MAY be triggered by zoom threshold logic.
+
+### Requirement: Security and authorization parity between summary and detail
+
+The system MUST apply equivalent authorization and tenant scoping to overview and detail responses. This design slice does not change `/graph/full` response shape or existing semantics.
+
+Sensitive-field policy for future LOD endpoints:
+- overview responses MUST NOT include raw sensitive fields,
+- detail responses MUST use the same existing authorized projection helper/policy as `/graph/full` once the implementation slice confirms that helper/policy,
+- any stronger redaction policy for `/graph/full` is a separate security change and is not part of this design slice.
+
+#### Scenario: Scoped callers receive equivalent visibility
+- GIVEN the same authenticated principal and tenant scope,
+- WHEN summary and detail endpoints are called with identical filters,
+- THEN the visible node/link set MUST be a subset-equivalent constrained by the same policy.
+
+#### Scenario: Restricted fields follow LOD-sensitive-field policy
+- GIVEN a principal without permission to receive restricted attributes,
+- WHEN overview and detail payloads are fetched,
+- THEN overview MUST omit raw restricted fields entirely,
+- AND detail MUST apply the existing authorized projection helper/policy used by `/graph/full` once confirmed in implementation planning.
+
+#### Scenario: Authorized sensitive metadata is scoped
+- GIVEN a principal has explicit sensitive-metadata permission for the requested tenant/location scope,
+- WHEN detail payloads are fetched for visible nodes,
+- THEN sensitive fields MAY be returned only according to the confirmed existing `/graph/full` projection policy and MUST still be excluded from overview aggregates.
+
+#### Scenario: Hidden and absent clusters are indistinguishable
+- GIVEN a principal requests a cluster id that is outside their scope or does not exist,
+- WHEN the detail endpoint responds,
+- THEN the externally observable status code, response body shape, and absence of cluster metadata MUST be identical for both cases.
+
+#### Scenario: Security regressions are detectable across payload types
+- GIVEN a limited or empty scope principal,
+- WHEN both payload types are requested,
+- THEN responses MUST NOT expose data outside that principal's tenant boundaries in either payload type.
+
+### Requirement: Frontend orchestration for initial render and explicit detail loading
+
+The frontend topology orchestration MUST separate overview orchestration from explicit detail orchestration and define state transitions for both.
+
+#### Scenario: Initial orchestration is overview-first
+- GIVEN a topology page opens,
+- WHEN orchestration begins,
+- THEN initial polling/state MUST prioritize overview payload retrieval and rendering before any detail hydration.
+
+#### Scenario: Explicit expansion path
+- GIVEN a cluster is clicked or expanded,
+- WHEN expansion completes,
+- THEN the orchestration layer MUST load and mount detail payload for only that cluster and merge it into the rendered scene as a delimited subgraph.
+
+#### Scenario: Explicit search/filter refresh path
+- GIVEN a search or filter action changes target cluster context,
+- WHEN action commits,
+- THEN orchestration MUST resolve target candidates only after authorization filtering,
+- AND MUST trigger detail retrieval only when exactly one visible target is resolved or the operator explicitly selects one visible target from multiple visible results.
+
+#### Scenario: Backward compatibility for polling consumers
+- GIVEN a consumer that still relies on `/graph/full`,
+- WHEN no equivalent compatibility strategy exists in a given frontend slice,
+- THEN that consumer MUST continue to function using existing polling behavior without hard dependency on new payload contracts.
+
+### Requirement: Non-goals and out-of-scope constraints
+
+The design-only slice MUST NOT include automatic demand-generation of detail through zoom-threshold expansion, and MUST NOT include real-time streaming, ML-based clustering, or a visual redesign.
+
+#### Scenario: Automatic zoom-triggered expansion is out of scope
+- GIVEN the user zooms to any level,
+- WHEN no explicit action is made,
+- THEN detail loading MUST NOT occur based on zoom threshold alone.
+
+#### Scenario: No streaming or ML clustering in this slice
+- GIVEN implementation planning begins,
+- WHEN work items are enumerated,
+- THEN no task under this change MAY target streaming pipelines or ML-driven cluster generation.
+
+### Requirement: Design-only acceptance criteria
+
+The change MUST be completed as a design artifact only and MUST include explicit follow-up implementation slices.
+
+The design MUST include approval-ready artifacts for: overview contract, detail contract, trigger matrix, auth parity checks, migration path, and follow-up slices.
+
+#### Scenario: Design artifacts define all required contracts
+- GIVEN the design review is conducted,
+- WHEN reviewers inspect the approved spec,
+- THEN each contract (overview, detail, auth parity, trigger matrix, backward compatibility) MUST be explicitly documented and testable by review.
+
+#### Scenario: Follow-up implementation plan is explicit
+- GIVEN the scope is reviewed for this change,
+- WHEN design sign-off is requested,
+- THEN the spec MUST list ordered follow-up implementation slices for contract finalization, backend rollout, and frontend orchestration migration.
+
+#### Scenario: No code implementation is introduced in this change
+- GIVEN the change is executed,
+- WHEN artifact diff is produced,
+- THEN no application code under `backend/` or `frontend/` MUST be changed.


### PR DESCRIPTION
Closes #230

## Description of Change

Adds the archived OpenSpec/SDD design for CMDB graph Level-of-Detail planning and syncs the canonical spec.

## Type of Change
- [ ] Feat (New functionality)
- [ ] Fix (Bug fix)
- [x] Docs (Documentation)
- [ ] Performance (Optimization)

## Summary
- Defines overview-first Location clustering for large CMDB graph first paint.
- Defines demand-driven detail loading via explicit expand/click and committed search/filter targets.
- Captures security constraints: no hidden-cluster oracle, visible-only search ambiguity, aggregate disclosure rules, and `/graph/full` compatibility.
- Archives the verified SDD artifacts and adds the synchronized canonical OpenSpec spec.

## Changes

| File | Change |
|------|--------|
| `openspec/specs/cmdb-graph-level-of-detail/spec.md` | Adds canonical CMDB graph LOD specification. |
| `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/` | Archives proposal, spec, design, tasks, apply progress, sync, verify, and archive reports. |

## How it was tested
- [x] SDD verify PASS: `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/verify-report.md`
- [x] SDD sync completed: `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/sync-report.md`
- [x] SDD archive completed: `openspec/changes/archive/2026-07-08-cmdb-graph-level-of-detail/archive-report.md`
- [x] Full 4R pre-PR review completed because the docs/OpenSpec diff exceeds 400 lines: risk, resilience, readability, and reliability all returned no findings.
- [x] Confirmed no backend/frontend application files were changed.

## Security Checklist
- [x] I verified there are NO secrets or API keys in the code.
- [x] Changes respect `.gitignore`.
- [x] The code follows the defined folder structure.

## Contributor Checklist
- [x] Linked an approved issue (`Closes #230`).
- [x] Added exactly one `type:*` label: `type:docs`.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.