### PR TITLE
feat(itsm): add service catalog and ticket folio module

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,12 +7,12 @@ import platform
 import re
 import shutil
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 try:
     from datetime import UTC
 except ImportError:  # pragma: no cover - py<3.11 compatibility
-    UTC = timezone.utc
+    UTC = UTC
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -183,6 +183,7 @@ from routers import (  # noqa: E402
     cli,
     dictionaries,
     events,
+    itsm_service_catalog,
     links,
     metrics,
     mqtt,
@@ -190,10 +191,9 @@ from routers import (  # noqa: E402
     permissions,
     roles,
     rtus,
+    ticket_folios,
     tunnels,
     users,
-    itsm_service_catalog,
-    ticket_folios,
 )
 
 app = FastAPI(

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
@@ -5,7 +7,12 @@ import platform
 import re
 import shutil
 import threading
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - py<3.11 compatibility
+    UTC = timezone.utc
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -185,6 +192,8 @@ from routers import (  # noqa: E402
     rtus,
     tunnels,
     users,
+    itsm_service_catalog,
+    ticket_folios,
 )
 
 app = FastAPI(
@@ -301,8 +310,10 @@ app.include_router(nodes.router, prefix="/api")
 app.include_router(metrics.router, prefix="/api")
 app.include_router(mqtt.router, prefix="/api")
 app.include_router(catalog.router, prefix="/api")
+app.include_router(itsm_service_catalog.router, prefix="/api")
 app.include_router(links.router, prefix="/api")
 app.include_router(tunnels.router, prefix="/api")
+app.include_router(ticket_folios.router, prefix="/api")
 app.include_router(events.router, prefix="/api")
 app.include_router(backup.router, prefix="/api")
 app.include_router(dictionaries.router, prefix="/api")
@@ -336,6 +347,10 @@ async def startup_event():
     """
     logger.info("Starting up... Verifying DB connection")
     verify_connection()
+
+    from services.itsm_bootstrap import run_service_catalog_startup_checks
+
+    run_service_catalog_startup_checks()
 
     # Initialize TimescaleDB Hypertables
     try:

--- a/backend/migrations/itsm_service_catalog.cypher
+++ b/backend/migrations/itsm_service_catalog.cypher
@@ -1,0 +1,79 @@
+// ITSM Service Catalog and Ticket/Folio migration.
+//
+// This migration introduces identity constraints and query indexes for the new
+// ITSM Service Catalog and Ticket/Folio domains while preserving backward
+// compatibility with existing legacy ServiceCatalog nodes.
+//
+// Runtime policy:
+// - Fail-fast at startup on duplicate or invalid ServiceCatalog identities.
+// - Compatibility backfill runs before strict preflight validation.
+// - Conflicts are rejected before constraints are allowed to continue.
+// - Startup remains deterministic because identity checks run before constraints.
+//
+// Notes:
+// - Idempotent statements use IF NOT EXISTS.
+// - This migration is additive and does not delete or mutate existing Event nodes.
+// - Event snapshot fields on Event nodes are intentionally left untouched.
+
+// -----------------------------------------------------------------------------
+// ServiceCatalog constraints and indexes
+// -----------------------------------------------------------------------------
+
+CREATE CONSTRAINT service_catalog_service_id IF NOT EXISTS
+FOR (sc:ServiceCatalog) REQUIRE sc.service_id IS UNIQUE;
+
+CREATE INDEX service_catalog_active IF NOT EXISTS
+FOR (sc:ServiceCatalog) ON (sc.active);
+
+CREATE INDEX service_catalog_id IF NOT EXISTS
+FOR (sc:ServiceCatalog) ON (sc.id);
+
+// -----------------------------------------------------------------------------
+// TicketFolio constraints and indexes
+// -----------------------------------------------------------------------------
+
+CREATE CONSTRAINT ticket_folio_ticket_id IF NOT EXISTS
+FOR (tf:TicketFolio) REQUIRE tf.ticket_id IS UNIQUE;
+
+CREATE INDEX ticket_folio_status IF NOT EXISTS
+FOR (tf:TicketFolio) ON (tf.status);
+
+CREATE INDEX ticket_folio_service_catalog_id IF NOT EXISTS
+FOR (tf:TicketFolio) ON (tf.service_catalog_id);
+
+CREATE INDEX ticket_folio_archived IF NOT EXISTS
+FOR (tf:TicketFolio) ON (tf.archived);
+
+// -----------------------------------------------------------------------------
+// Compatibility backfill helper (additive only)
+// -----------------------------------------------------------------------------
+// Historical nodes currently storing legacy fields are still expected and should
+// remain readable. The following mapping keeps the new domain shape additive:
+// - sc.service_id = coalesce(sc.service_id, sc.id)
+// - sc.name = coalesce(sc.name, sc.category, sc.id)
+// - sc.tier = coalesce(sc.tier, sc.service_tier)
+// - sc.sla_target_minutes = coalesce(sc.sla_target_minutes, sc.sla_minutes, 0)
+//
+// Runtime startup applies the additive compatibility backfill before strict
+// duplicate/conflict checks and before enabling constraints. This backfill does
+// not modify any Event snapshots or event-derived history.
+
+// -----------------------------------------------------------------------------
+// Relationship note for future extension (not implemented here)
+// -----------------------------------------------------------------------------
+// Optional future relationship kept as derived-only in WU2:
+// MATCH (sc:ServiceCatalog)<-[:FOR_SERVICE]-(tf:TicketFolio)
+//
+// No relationship mutation is performed in this migration.
+
+// -----------------------------------------------------------------------------
+// Rollback notes (manual)
+// -----------------------------------------------------------------------------
+// - DROP CONSTRAINT service_catalog_service_id;
+// - DROP INDEX service_catalog_active;
+// - DROP INDEX service_catalog_id;
+// - DROP CONSTRAINT ticket_folio_ticket_id;
+// - DROP INDEX ticket_folio_status;
+// - DROP INDEX ticket_folio_service_catalog_id;
+// - DROP INDEX ticket_folio_archived;
+

--- a/backend/models/itsm.py
+++ b/backend/models/itsm.py
@@ -1,0 +1,337 @@
+"""ITSM domain models and lifecycle helpers.
+
+This module defines schema objects for Service Catalog and Ticket/Folio with
+explicit backward-compatible aliases for the existing event domain shape:
+
+- ``id`` ↔ ``service_id``
+- ``service_tier`` ↔ ``tier``
+- ``sla_minutes`` ↔ ``sla_target_minutes``
+
+The schemas keep migration/runtime compatibility while moving to
+English-named canonical fields.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+ServiceCatalogId = str
+TicketId = str
+
+
+TICKET_STATUS_ORDER = (
+    "open",
+    "in_progress",
+    "in_validation",
+    "resolved",
+    "closed",
+)
+
+
+class TicketStatus:
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    IN_VALIDATION = "in_validation"
+    RESOLVED = "resolved"
+    CLOSED = "closed"
+
+
+class TicketFolioType:
+    REQUEST = "request"
+    INCIDENT = "incident"
+
+
+class ServiceCatalogCreate(BaseModel):
+    """Input contract for creating ServiceCatalog-like records.
+
+    Canonical fields are English-native names; the legacy aliases are synchronized
+    so both event and inventory-style call sites remain readable during the
+    migration.
+    """
+
+    service_id: str
+    name: str
+    owner_team: str | None = None
+    category: str | None = None
+    tier: str | None = None
+    criticality: str | None = None
+    sla_target_minutes: int = Field(ge=0)
+    active: bool = True
+    updated_by: str | None = None
+
+    # Backward-compatible aliases (kept explicit for migration safety).
+    id: str | None = None
+    service_tier: str | None = None
+    sla_minutes: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @field_validator("service_id")
+    @classmethod
+    def _validate_service_id(cls, value: str) -> str:
+        if not str(value).strip():
+            raise ValueError("service_id cannot be empty")
+        return value
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        if not str(value).strip():
+            raise ValueError("name cannot be empty")
+        return value
+
+    @field_validator("sla_target_minutes")
+    @classmethod
+    def _validate_sla_target_minutes(cls, value: int) -> int:
+        if value < 0:
+            raise ValueError("sla_target_minutes must be >= 0")
+        return value
+
+    @field_validator("sla_minutes")
+    @classmethod
+    def _validate_legacy_sla_minutes(cls, value: int | None) -> int | None:
+        if value is None:
+            return value
+        if value < 0:
+            raise ValueError("sla_minutes must be >= 0")
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_compatibility_aliases(cls, values: Any) -> Any:
+        values = dict(values)
+
+        if "service_id" not in values or values.get("service_id") is None:
+            legacy_service_id = values.get("id")
+            if legacy_service_id:
+                values["service_id"] = legacy_service_id
+
+        if values.get("service_id") is None and values.get("id") is None:
+            raise ValueError("service_id is required (or legacy id as fallback).")
+
+        if values.get("id") is None:
+            values["id"] = values.get("service_id")
+        elif values.get("service_id") != values.get("id"):
+            raise ValueError("service_id and id must match when both are provided.")
+
+        if values.get("service_tier") is not None and values.get("tier") is None:
+            values["tier"] = values.get("service_tier")
+        elif values.get("service_tier") is not None and values.get("tier") is not None:
+            if values.get("service_tier") != values.get("tier"):
+                raise ValueError("service_tier and tier must match when both are provided.")
+
+        if values.get("sla_minutes") is not None:
+            if values.get("sla_target_minutes") is None:
+                values["sla_target_minutes"] = values["sla_minutes"]
+            elif values["sla_target_minutes"] != values["sla_minutes"]:
+                raise ValueError("sla_target_minutes and sla_minutes must match when both are provided.")
+
+        if values.get("sla_target_minutes") is None:
+            values["sla_target_minutes"] = 0
+
+        return values
+
+    @model_validator(mode="after")
+    def _sync_legacy_aliases(self):
+        if self.service_id:
+            self.id = self.id or self.service_id
+        if self.tier:
+            self.service_tier = self.service_tier or self.tier
+        if self.sla_target_minutes is not None:
+            self.sla_minutes = self.sla_target_minutes
+        if self.created_at is None:
+            self.created_at = datetime.utcnow().replace(microsecond=0).isoformat()
+        if self.updated_at is None:
+            self.updated_at = datetime.utcnow().replace(microsecond=0).isoformat()
+        return self
+
+
+class ServiceCatalogUpdate(BaseModel):
+    """Update payload for ServiceCatalog records."""
+
+    service_id: str | None = None
+    name: str | None = None
+    owner_team: str | None = None
+    category: str | None = None
+    tier: str | None = None
+    criticality: str | None = None
+    sla_target_minutes: int | None = None
+    active: bool | None = None
+    updated_by: str | None = None
+
+    # Backward-compatible aliases (kept explicit for compatibility-safe updates).
+    id: str | None = None
+    service_tier: str | None = None
+    sla_minutes: int | None = None
+
+    @field_validator("sla_target_minutes")
+    @classmethod
+    def _validate_sla_target_minutes(cls, value: int | None) -> int | None:
+        if value is None:
+            return value
+        if value < 0:
+            raise ValueError("sla_target_minutes must be >= 0")
+        return value
+
+    @field_validator("sla_minutes")
+    @classmethod
+    def _validate_legacy_sla_minutes(cls, value: int | None) -> int | None:
+        if value is None:
+            return value
+        if value < 0:
+            raise ValueError("sla_minutes must be >= 0")
+        return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_compatibility_aliases(cls, values: Any) -> Any:
+        values = dict(values)
+
+        if values.get("service_id") is None and values.get("id") is not None:
+            values["service_id"] = values["id"]
+
+        if values.get("service_tier") is not None and values.get("tier") is None:
+            values["tier"] = values.get("service_tier")
+        elif values.get("service_tier") is not None and values.get("tier") is not None:
+            if values["service_tier"] != values["tier"]:
+                raise ValueError("service_tier and tier must match when both are provided.")
+
+        if values.get("sla_minutes") is not None and values.get("sla_target_minutes") is None:
+            values["sla_target_minutes"] = values["sla_minutes"]
+        elif values.get("sla_minutes") is not None and values.get("sla_target_minutes") is not None:
+            if values["sla_minutes"] != values["sla_target_minutes"]:
+                raise ValueError("sla_target_minutes and sla_minutes must match when both are provided.")
+
+        return values
+
+    @model_validator(mode="after")
+    def _sync_aliases(self):
+        if self.id is None and self.service_id is not None:
+            self.id = self.service_id
+        if self.service_tier is None and self.tier is not None:
+            self.service_tier = self.tier
+        if self.sla_target_minutes is not None:
+            self.sla_minutes = self.sla_target_minutes
+        return self
+
+
+class ServiceCatalogResponse(ServiceCatalogCreate):
+    """Response contract for ServiceCatalog domain reads."""
+
+    service_id: str
+
+
+class TicketFolioCreate(BaseModel):
+    """Input contract for creating a ticket/folio."""
+
+    ticket_id: str
+    type: str
+    title: str
+    description: str | None = None
+    service_catalog_id: str | None = None
+    status: str = TicketStatus.OPEN
+    archived: bool = False
+    closed_reason: str | None = None
+    updated_by: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @field_validator("type")
+    @classmethod
+    def _validate_type(cls, value: str) -> str:
+        if value not in (TicketFolioType.REQUEST, TicketFolioType.INCIDENT):
+            raise ValueError("type must be either 'request' or 'incident'")
+        return value
+
+    @field_validator("title")
+    @classmethod
+    def _validate_title(cls, value: str) -> str:
+        if not str(value).strip():
+            raise ValueError("title cannot be empty")
+        return value
+
+    @field_validator("status")
+    @classmethod
+    def _validate_status(cls, value: str) -> str:
+        if value not in TICKET_STATUS_ORDER:
+            raise ValueError(f"invalid status '{value}'")
+        return value
+
+    @model_validator(mode="after")
+    def _normalize_defaults(self):
+        if self.status != TicketStatus.OPEN:
+            raise ValueError("New folios must start as 'open'")
+        if self.ticket_id is None or not str(self.ticket_id).strip():
+            raise ValueError("ticket_id is required")
+        return self
+
+
+class TicketFolioUpdate(BaseModel):
+    """Update payload for ticket/folio logical lifecycle operations."""
+
+    title: str | None = None
+    description: str | None = None
+    service_catalog_id: str | None = None
+    status: str | None = None
+    archived: bool | None = None
+    closed_reason: str | None = None
+    updated_by: str | None = None
+
+    @field_validator("title")
+    @classmethod
+    def _validate_update_title(cls, value: str | None) -> str | None:
+        if value is not None and not str(value).strip():
+            raise ValueError("title cannot be empty")
+        return value
+
+    @field_validator("status")
+    @classmethod
+    def _validate_status(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if value not in TICKET_STATUS_ORDER:
+            raise ValueError(f"invalid status '{value}'")
+        return value
+
+
+class TicketFolioUpdateArchive(BaseModel):
+    """Convenience schema for explicit archive transition inputs."""
+
+    archived: bool
+    closed_reason: str | None = None
+
+
+
+def validate_ticket_transition(current_status: str, next_status: str) -> bool:
+    """Validate a single ticket lifecycle transition.
+
+    Returns:
+        True when the transition is valid.
+
+    Raises:
+        ValueError when invalid.
+    """
+
+    if current_status not in TICKET_STATUS_ORDER:
+        raise ValueError(f"Invalid current status '{current_status}'")
+    if next_status not in TICKET_STATUS_ORDER:
+        raise ValueError(f"Invalid next status '{next_status}'")
+    if current_status == next_status:
+        raise ValueError("Ticket status transition to same state is not allowed")
+
+    current_idx = TICKET_STATUS_ORDER.index(current_status)
+    next_idx = TICKET_STATUS_ORDER.index(next_status)
+
+    if current_status == TicketStatus.CLOSED:
+        raise ValueError("Closed folios cannot transition to another state")
+
+    if next_idx != current_idx + 1:
+        raise ValueError(
+            "Invalid ticket status transition. Expected strict forward linear steps."
+        )
+
+    return True

--- a/backend/models/itsm.py
+++ b/backend/models/itsm.py
@@ -130,7 +130,9 @@ class ServiceCatalogCreate(BaseModel):
             if values.get("sla_target_minutes") is None:
                 values["sla_target_minutes"] = values["sla_minutes"]
             elif values["sla_target_minutes"] != values["sla_minutes"]:
-                raise ValueError("sla_target_minutes and sla_minutes must match when both are provided.")
+                raise ValueError(
+                    "sla_target_minutes and sla_minutes must match when both are provided."
+                )
 
         if values.get("sla_target_minutes") is None:
             values["sla_target_minutes"] = 0
@@ -212,7 +214,9 @@ class ServiceCatalogUpdate(BaseModel):
             and values.get("sla_target_minutes") is not None
             and values["sla_minutes"] != values["sla_target_minutes"]
         ):
-            raise ValueError("sla_target_minutes and sla_minutes must match when both are provided.")
+            raise ValueError(
+                "sla_target_minutes and sla_minutes must match when both are provided."
+            )
 
         return values
 
@@ -313,7 +317,6 @@ class TicketFolioUpdateArchive(BaseModel):
     closed_reason: str | None = None
 
 
-
 def validate_ticket_transition(current_status: str, next_status: str) -> bool:
     """Validate a single ticket lifecycle transition.
 
@@ -338,8 +341,6 @@ def validate_ticket_transition(current_status: str, next_status: str) -> bool:
         raise ValueError("Closed folios cannot transition to another state")
 
     if next_idx != current_idx + 1:
-        raise ValueError(
-            "Invalid ticket status transition. Expected strict forward linear steps."
-        )
+        raise ValueError("Invalid ticket status transition. Expected strict forward linear steps.")
 
     return True

--- a/backend/models/itsm.py
+++ b/backend/models/itsm.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-
 ServiceCatalogId = str
 TicketId = str
 
@@ -120,9 +119,12 @@ class ServiceCatalogCreate(BaseModel):
 
         if values.get("service_tier") is not None and values.get("tier") is None:
             values["tier"] = values.get("service_tier")
-        elif values.get("service_tier") is not None and values.get("tier") is not None:
-            if values.get("service_tier") != values.get("tier"):
-                raise ValueError("service_tier and tier must match when both are provided.")
+        elif (
+            values.get("service_tier") is not None
+            and values.get("tier") is not None
+            and values.get("service_tier") != values.get("tier")
+        ):
+            raise ValueError("service_tier and tier must match when both are provided.")
 
         if values.get("sla_minutes") is not None:
             if values.get("sla_target_minutes") is None:
@@ -196,15 +198,21 @@ class ServiceCatalogUpdate(BaseModel):
 
         if values.get("service_tier") is not None and values.get("tier") is None:
             values["tier"] = values.get("service_tier")
-        elif values.get("service_tier") is not None and values.get("tier") is not None:
-            if values["service_tier"] != values["tier"]:
-                raise ValueError("service_tier and tier must match when both are provided.")
+        elif (
+            values.get("service_tier") is not None
+            and values.get("tier") is not None
+            and values["service_tier"] != values["tier"]
+        ):
+            raise ValueError("service_tier and tier must match when both are provided.")
 
         if values.get("sla_minutes") is not None and values.get("sla_target_minutes") is None:
             values["sla_target_minutes"] = values["sla_minutes"]
-        elif values.get("sla_minutes") is not None and values.get("sla_target_minutes") is not None:
-            if values["sla_minutes"] != values["sla_target_minutes"]:
-                raise ValueError("sla_target_minutes and sla_minutes must match when both are provided.")
+        elif (
+            values.get("sla_minutes") is not None
+            and values.get("sla_target_minutes") is not None
+            and values["sla_minutes"] != values["sla_target_minutes"]
+        ):
+            raise ValueError("sla_target_minutes and sla_minutes must match when both are provided.")
 
         return values
 

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Literal
 
@@ -34,6 +36,10 @@ class UserPermission(str, Enum):  # noqa: UP042
     CI_VIEW = "CI_VIEW"
     CI_EDIT = "CI_EDIT"
     CI_DELETE = "CI_DELETE"
+
+    # ITSM
+    ITSM_VIEW = "ITSM_VIEW"
+    ITSM_EDIT = "ITSM_EDIT"
 
     # Diagnostics
     RUN_DIAGNOSTICS = "RUN_DIAGNOSTICS"

--- a/backend/postgres_db.py
+++ b/backend/postgres_db.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 import os
 from dotenv import load_dotenv
 

--- a/backend/postgres_db.py
+++ b/backend/postgres_db.py
@@ -1,7 +1,8 @@
+import os
+
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
-import os
-from dotenv import load_dotenv
 
 load_dotenv()
 
@@ -10,7 +11,7 @@ POSTGRES_USER = os.getenv("POSTGRES_USER", "nexgen_admin").strip("'\"")
 POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "nexgen_password").strip("'\"")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "nexgen_auth").strip("'\"")
 # Host is 'postgres' when running inside container, 'localhost' if running locally
-POSTGRES_HOST = os.getenv("POSTGRES_HOST", "postgres").strip("'\"") 
+POSTGRES_HOST = os.getenv("POSTGRES_HOST", "postgres").strip("'\"")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432").strip("'\"")
 
 SQLALCHEMY_DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"

--- a/backend/postgres_db.py
+++ b/backend/postgres_db.py
@@ -19,12 +19,15 @@ SQLALCHEMY_DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{PO
 # Determine if we are running locally or in docker for connection string adjustment if needed (simplified here)
 # If running outside docker (development), might need localhost
 if os.getenv("RUNNING_LOCALLY", "false").lower() == "true":
-     SQLALCHEMY_DATABASE_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@localhost:{POSTGRES_PORT}/{POSTGRES_DB}"
+    SQLALCHEMY_DATABASE_URL = (
+        f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@localhost:{POSTGRES_PORT}/{POSTGRES_DB}"
+    )
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
 
 def get_pg_db():
     db = SessionLocal()

--- a/backend/repositories/itsm_service_catalog_repo.py
+++ b/backend/repositories/itsm_service_catalog_repo.py
@@ -1,0 +1,245 @@
+"""Repository patterns for ITSM ServiceCatalog records.
+
+These methods are intentionally narrow and query-focused to support WU1's
+backend domain contract boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from database import get_db
+from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
+
+
+_CREATE_SERVICE_CATALOG_QUERY = """
+MERGE (sc:ServiceCatalog {service_id: $service_id})
+ON CREATE SET
+  sc.id = $service_id,
+  sc.name = $name,
+  sc.owner_team = $owner_team,
+  sc.category = $category,
+  sc.tier = $tier,
+  sc.service_tier = $tier,
+  sc.criticality = $criticality,
+  sc.sla_target_minutes = $sla_target_minutes,
+  sc.sla_minutes = $sla_target_minutes,
+  sc.active = $active,
+  sc.created_at = datetime($created_at),
+  sc.updated_at = datetime($updated_at),
+  sc.updated_by = $updated_by
+ON MATCH SET
+  sc.owner_team = coalesce($owner_team, sc.owner_team),
+  sc.category = coalesce($category, sc.category),
+  sc.tier = coalesce($tier, sc.tier),
+  sc.service_tier = coalesce($tier, sc.service_tier),
+  sc.criticality = coalesce($criticality, sc.criticality),
+  sc.sla_target_minutes = coalesce($sla_target_minutes, sc.sla_target_minutes),
+  sc.sla_minutes = coalesce($sla_target_minutes, sc.sla_minutes),
+  sc.active = coalesce($active, sc.active),
+  sc.updated_at = datetime($updated_at),
+  sc.updated_by = $updated_by
+RETURN
+  sc.id AS id,
+  sc.service_id AS service_id,
+  sc.name AS name,
+  sc.owner_team AS owner_team,
+  sc.category AS category,
+  sc.tier AS tier,
+  sc.service_tier AS service_tier,
+  sc.criticality AS criticality,
+  sc.sla_target_minutes AS sla_target_minutes,
+  sc.sla_minutes AS sla_minutes,
+  sc.active AS active,
+  sc.created_at AS created_at,
+  sc.updated_at AS updated_at,
+  sc.updated_by AS updated_by
+"""
+
+_GET_SERVICE_CATALOG_QUERY = """
+MATCH (sc:ServiceCatalog)
+WHERE sc.service_id = $service_id
+RETURN
+  sc.id AS id,
+  sc.service_id AS service_id,
+  sc.name AS name,
+  sc.owner_team AS owner_team,
+  sc.category AS category,
+  sc.tier AS tier,
+  sc.service_tier AS service_tier,
+  sc.criticality AS criticality,
+  sc.sla_target_minutes AS sla_target_minutes,
+  sc.sla_minutes AS sla_minutes,
+  sc.active AS active,
+  sc.created_at AS created_at,
+  sc.updated_at AS updated_at,
+  sc.updated_by AS updated_by
+"""
+
+_LIST_SERVICE_CATALOGS_QUERY = """
+MATCH (sc:ServiceCatalog)
+RETURN
+  sc.id AS id,
+  sc.service_id AS service_id,
+  sc.name AS name,
+  sc.owner_team AS owner_team,
+  sc.category AS category,
+  sc.tier AS tier,
+  sc.service_tier AS service_tier,
+  sc.criticality AS criticality,
+  sc.sla_target_minutes AS sla_target_minutes,
+  sc.sla_minutes AS sla_minutes,
+  sc.active AS active,
+  sc.created_at AS created_at,
+  sc.updated_at AS updated_at,
+  sc.updated_by AS updated_by
+ORDER BY coalesce(sc.updated_at, sc.created_at, "") DESC, sc.name
+LIMIT $limit
+"""
+
+_DEACTIVATE_SERVICE_CATALOG_QUERY = """
+MATCH (sc:ServiceCatalog {service_id: $service_id})
+SET
+  sc.active = false,
+  sc.updated_at = datetime($updated_at),
+  sc.updated_by = $updated_by
+RETURN sc.service_id AS service_id, sc.active AS active
+"""
+
+
+class ServiceCatalogRepository:
+    """Thin repository for ServiceCatalog nodes and compatibility aliases."""
+
+    def __init__(self, driver: Any | None = None):
+        self._driver = driver if driver is not None else get_db()
+
+    @staticmethod
+    def _record(row: Any) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "id": row.get("id") if hasattr(row, "get") else row["id"],
+            "service_id": row.get("service_id") if hasattr(row, "get") else row["service_id"],
+            "name": row.get("name") if hasattr(row, "get") else row["name"],
+            "owner_team": row.get("owner_team") if hasattr(row, "get") else row["owner_team"],
+            "category": row.get("category") if hasattr(row, "get") else row["category"],
+            "tier": row.get("tier") if hasattr(row, "get") else row["tier"],
+            "service_tier": row.get("service_tier") if hasattr(row, "get") else row["service_tier"],
+            "criticality": row.get("criticality") if hasattr(row, "get") else row["criticality"],
+            "sla_target_minutes": row.get("sla_target_minutes") if hasattr(row, "get") else row["sla_target_minutes"],
+            "sla_minutes": row.get("sla_minutes") if hasattr(row, "get") else row["sla_minutes"],
+            "active": row.get("active") if hasattr(row, "get") else row["active"],
+            "created_at": row.get("created_at") if hasattr(row, "get") else row["created_at"],
+            "updated_at": row.get("updated_at") if hasattr(row, "get") else row["updated_at"],
+            "updated_by": row.get("updated_by") if hasattr(row, "get") else row["updated_by"],
+        }
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+    def get_by_id(self, service_id: str) -> dict[str, Any] | None:
+        with self._driver.session() as session:
+            row = session.run(_GET_SERVICE_CATALOG_QUERY, service_id=service_id).single()
+        return self._record(row)
+
+    def list(self, limit: int = 100) -> list[dict[str, Any]]:
+        with self._driver.session() as session:
+            result = session.run(_LIST_SERVICE_CATALOGS_QUERY, limit=limit)
+            return [self._record(row) for row in result if self._record(row) is not None]
+
+    def upsert(self, payload: ServiceCatalogCreate) -> dict[str, Any]:
+        payload = payload if isinstance(payload, ServiceCatalogCreate) else ServiceCatalogCreate(**payload)
+        now = self._now()
+        with self._driver.session() as session:
+            row = session.run(
+                _CREATE_SERVICE_CATALOG_QUERY,
+                service_id=payload.service_id,
+                name=payload.name,
+                owner_team=payload.owner_team,
+                category=payload.category,
+                tier=payload.tier,
+                criticality=payload.criticality,
+                sla_target_minutes=payload.sla_target_minutes,
+                active=payload.active,
+                created_at=payload.created_at or now,
+                updated_at=now,
+                updated_by=payload.updated_by,
+            ).single()
+        return self._record(row) or {}
+
+    def deactivate(self, service_id: str, updated_by: str | None = None) -> dict[str, Any] | None:
+        with self._driver.session() as session:
+            row = session.run(
+                _DEACTIVATE_SERVICE_CATALOG_QUERY,
+                service_id=service_id,
+                updated_at=self._now(),
+                updated_by=updated_by,
+            ).single()
+        return self._record(row)
+
+    def update(self, service_id: str, payload: ServiceCatalogUpdate) -> dict[str, Any] | None:
+        payload = payload if isinstance(payload, ServiceCatalogUpdate) else ServiceCatalogUpdate(**payload)
+        updates = payload.model_dump(exclude_unset=True)
+        if not updates:
+            return self.get_by_id(service_id)
+
+        set_clauses: list[str] = [
+            "sc.updated_at = datetime($updated_at)",
+            "sc.updated_by = coalesce($updated_by, sc.updated_by)",
+        ]
+        if "name" in updates:
+            set_clauses.append("sc.name = $name")
+        if "owner_team" in updates:
+            set_clauses.append("sc.owner_team = $owner_team")
+        if "category" in updates:
+            set_clauses.append("sc.category = $category")
+        if "tier" in updates:
+            set_clauses.append("sc.tier = $tier")
+            set_clauses.append("sc.service_tier = $tier")
+        if "criticality" in updates:
+            set_clauses.append("sc.criticality = $criticality")
+        if "sla_target_minutes" in updates:
+            set_clauses.append("sc.sla_target_minutes = $sla_target_minutes")
+            set_clauses.append("sc.sla_minutes = $sla_target_minutes")
+        if "active" in updates:
+            set_clauses.append("sc.active = $active")
+
+        update_query = """
+        MATCH (sc:ServiceCatalog {service_id: $service_id})
+        SET {}
+        RETURN
+          sc.id AS id,
+          sc.service_id AS service_id,
+          sc.name AS name,
+          sc.owner_team AS owner_team,
+          sc.category AS category,
+          sc.tier AS tier,
+          sc.service_tier AS service_tier,
+          sc.criticality AS criticality,
+          sc.sla_target_minutes AS sla_target_minutes,
+          sc.sla_minutes AS sla_minutes,
+          sc.active AS active,
+          sc.created_at AS created_at,
+          sc.updated_at AS updated_at,
+          sc.updated_by AS updated_by
+        """.format(
+            ",\n  ".join(set_clauses)
+        )
+
+        with self._driver.session() as session:
+            row = session.run(
+                update_query,
+                service_id=service_id,
+                updated_at=self._now(),
+                updated_by=updates.get("updated_by"),
+                name=updates.get("name"),
+                owner_team=updates.get("owner_team"),
+                category=updates.get("category"),
+                tier=updates.get("tier"),
+                criticality=updates.get("criticality"),
+                sla_target_minutes=updates.get("sla_target_minutes"),
+                active=updates.get("active"),
+            ).single()
+        return self._record(row)

--- a/backend/repositories/itsm_service_catalog_repo.py
+++ b/backend/repositories/itsm_service_catalog_repo.py
@@ -6,12 +6,11 @@ backend domain contract boundary.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from database import get_db
 from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
-
 
 _CREATE_SERVICE_CATALOG_QUERY = """
 MERGE (sc:ServiceCatalog {service_id: $service_id})
@@ -137,7 +136,7 @@ class ServiceCatalogRepository:
 
     @staticmethod
     def _now() -> str:
-        return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+        return datetime.now(tz=UTC).replace(microsecond=0).isoformat()
 
     def get_by_id(self, service_id: str) -> dict[str, Any] | None:
         with self._driver.session() as session:
@@ -208,7 +207,7 @@ class ServiceCatalogRepository:
 
         update_query = """
         MATCH (sc:ServiceCatalog {service_id: $service_id})
-        SET {}
+        SET __SET_CLAUSES__
         RETURN
           sc.id AS id,
           sc.service_id AS service_id,
@@ -224,9 +223,7 @@ class ServiceCatalogRepository:
           sc.created_at AS created_at,
           sc.updated_at AS updated_at,
           sc.updated_by AS updated_by
-        """.format(
-            ",\n  ".join(set_clauses)
-        )
+        """.replace("__SET_CLAUSES__", ",\n  ".join(set_clauses))
 
         with self._driver.session() as session:
             row = session.run(

--- a/backend/repositories/itsm_service_catalog_repo.py
+++ b/backend/repositories/itsm_service_catalog_repo.py
@@ -126,7 +126,9 @@ class ServiceCatalogRepository:
             "tier": row.get("tier") if hasattr(row, "get") else row["tier"],
             "service_tier": row.get("service_tier") if hasattr(row, "get") else row["service_tier"],
             "criticality": row.get("criticality") if hasattr(row, "get") else row["criticality"],
-            "sla_target_minutes": row.get("sla_target_minutes") if hasattr(row, "get") else row["sla_target_minutes"],
+            "sla_target_minutes": (
+                row.get("sla_target_minutes") if hasattr(row, "get") else row["sla_target_minutes"]
+            ),
             "sla_minutes": row.get("sla_minutes") if hasattr(row, "get") else row["sla_minutes"],
             "active": row.get("active") if hasattr(row, "get") else row["active"],
             "created_at": row.get("created_at") if hasattr(row, "get") else row["created_at"],
@@ -149,7 +151,11 @@ class ServiceCatalogRepository:
             return [self._record(row) for row in result if self._record(row) is not None]
 
     def upsert(self, payload: ServiceCatalogCreate) -> dict[str, Any]:
-        payload = payload if isinstance(payload, ServiceCatalogCreate) else ServiceCatalogCreate(**payload)
+        payload = (
+            payload
+            if isinstance(payload, ServiceCatalogCreate)
+            else ServiceCatalogCreate(**payload)
+        )
         now = self._now()
         with self._driver.session() as session:
             row = session.run(
@@ -179,7 +185,11 @@ class ServiceCatalogRepository:
         return self._record(row)
 
     def update(self, service_id: str, payload: ServiceCatalogUpdate) -> dict[str, Any] | None:
-        payload = payload if isinstance(payload, ServiceCatalogUpdate) else ServiceCatalogUpdate(**payload)
+        payload = (
+            payload
+            if isinstance(payload, ServiceCatalogUpdate)
+            else ServiceCatalogUpdate(**payload)
+        )
         updates = payload.model_dump(exclude_unset=True)
         if not updates:
             return self.get_by_id(service_id)

--- a/backend/repositories/ticket_folio_repo.py
+++ b/backend/repositories/ticket_folio_repo.py
@@ -1,0 +1,231 @@
+"""Repository patterns for ITSM Ticket/Folio nodes.
+
+These methods focus on query intent for WU1 and intentionally avoid hard-delete
+paths.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from database import get_db
+from models.itsm import TicketFolioCreate, TicketFolioUpdate
+
+
+_CREATE_TICKET_FOLIO_QUERY = """
+MERGE (tf:TicketFolio {ticket_id: $ticket_id})
+ON CREATE SET
+  tf.type = $type,
+  tf.title = $title,
+  tf.description = $description,
+  tf.service_catalog_id = $service_catalog_id,
+  tf.status = $status,
+  tf.archived = $archived,
+  tf.closed_reason = $closed_reason,
+  tf.created_at = datetime($created_at),
+  tf.updated_at = datetime($updated_at),
+  tf.updated_by = $updated_by
+ON MATCH SET
+  tf.type = coalesce($type, tf.type),
+  tf.title = coalesce($title, tf.title),
+  tf.description = coalesce($description, tf.description),
+  tf.service_catalog_id = coalesce($service_catalog_id, tf.service_catalog_id),
+  tf.status = coalesce($status, tf.status),
+  tf.archived = coalesce($archived, tf.archived),
+  tf.closed_reason = coalesce($closed_reason, tf.closed_reason),
+  tf.updated_at = datetime($updated_at),
+  tf.updated_by = coalesce($updated_by, tf.updated_by)
+RETURN
+  tf.ticket_id AS ticket_id,
+  tf.type AS type,
+  tf.title AS title,
+  tf.description AS description,
+  tf.service_catalog_id AS service_catalog_id,
+  tf.status AS status,
+  tf.archived AS archived,
+  tf.closed_reason AS closed_reason,
+  tf.created_at AS created_at,
+  tf.updated_at AS updated_at,
+  tf.updated_by AS updated_by
+"""
+
+_GET_TICKET_FOLIO_QUERY = """
+MATCH (tf:TicketFolio {ticket_id: $ticket_id})
+RETURN
+  tf.ticket_id AS ticket_id,
+  tf.type AS type,
+  tf.title AS title,
+  tf.description AS description,
+  tf.service_catalog_id AS service_catalog_id,
+  tf.status AS status,
+  tf.archived AS archived,
+  tf.closed_reason AS closed_reason,
+  tf.created_at AS created_at,
+  tf.updated_at AS updated_at,
+  tf.updated_by AS updated_by
+"""
+
+_LIST_TICKET_FOLIO_QUERY = """
+MATCH (tf:TicketFolio)
+WHERE ($status IS NULL OR tf.status = $status)
+  AND ($service_catalog_id IS NULL OR tf.service_catalog_id = $service_catalog_id)
+  AND ($archived IS NULL OR tf.archived = $archived)
+RETURN
+  tf.ticket_id AS ticket_id,
+  tf.type AS type,
+  tf.title AS title,
+  tf.description AS description,
+  tf.service_catalog_id AS service_catalog_id,
+  tf.status AS status,
+  tf.archived AS archived,
+  tf.closed_reason AS closed_reason,
+  tf.created_at AS created_at,
+  tf.updated_at AS updated_at,
+  tf.updated_by AS updated_by
+ORDER BY tf.updated_at DESC
+LIMIT $limit
+"""
+
+
+class TicketFolioRepository:
+    """Thin repository for TicketFolio nodes and logical state transitions."""
+
+    def __init__(self, driver: Any | None = None):
+        self._driver = driver if driver is not None else get_db()
+
+    @staticmethod
+    def _record(row: Any) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return {
+            "ticket_id": row.get("ticket_id") if hasattr(row, "get") else row["ticket_id"],
+            "type": row.get("type") if hasattr(row, "get") else row["type"],
+            "title": row.get("title") if hasattr(row, "get") else row["title"],
+            "description": row.get("description") if hasattr(row, "get") else row["description"],
+            "service_catalog_id": row.get("service_catalog_id") if hasattr(row, "get") else row["service_catalog_id"],
+            "status": row.get("status") if hasattr(row, "get") else row["status"],
+            "archived": row.get("archived") if hasattr(row, "get") else row["archived"],
+            "closed_reason": row.get("closed_reason") if hasattr(row, "get") else row["closed_reason"],
+            "created_at": row.get("created_at") if hasattr(row, "get") else row["created_at"],
+            "updated_at": row.get("updated_at") if hasattr(row, "get") else row["updated_at"],
+            "updated_by": row.get("updated_by") if hasattr(row, "get") else row["updated_by"],
+        }
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+    def get(self, ticket_id: str) -> dict[str, Any] | None:
+        with self._driver.session() as session:
+            row = session.run(_GET_TICKET_FOLIO_QUERY, ticket_id=ticket_id).single()
+        return self._record(row)
+
+    def list(
+        self,
+        status: str | None = None,
+        service_catalog_id: str | None = None,
+        archived: bool | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        with self._driver.session() as session:
+            result = session.run(
+                _LIST_TICKET_FOLIO_QUERY,
+                status=status,
+                service_catalog_id=service_catalog_id,
+                archived=archived,
+                limit=limit,
+            )
+            return [self._record(row) for row in result if self._record(row) is not None]
+
+    def upsert(self, payload: TicketFolioCreate) -> dict[str, Any]:
+        payload = payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
+        now = self._now()
+        with self._driver.session() as session:
+            row = session.run(
+                _CREATE_TICKET_FOLIO_QUERY,
+                ticket_id=payload.ticket_id,
+                type=payload.type,
+                title=payload.title,
+                description=payload.description,
+                service_catalog_id=payload.service_catalog_id,
+                status=payload.status,
+                archived=payload.archived,
+                closed_reason=payload.closed_reason,
+                created_at=payload.created_at or now,
+                updated_at=now,
+                updated_by=payload.updated_by,
+            ).single()
+        return self._record(row) or {}
+
+    def update(self, ticket_id: str, payload: TicketFolioUpdate) -> dict[str, Any] | None:
+        payload = payload if isinstance(payload, TicketFolioUpdate) else TicketFolioUpdate(**payload)
+        updates = payload.model_dump(exclude_unset=True)
+        if not updates:
+            return self.get(ticket_id)
+
+        set_clauses: list[str] = [
+            "tf.updated_at = datetime($updated_at)",
+            "tf.updated_by = coalesce($updated_by, tf.updated_by)",
+        ]
+        if "title" in updates:
+            set_clauses.append("tf.title = $title")
+        if "description" in updates:
+            set_clauses.append("tf.description = $description")
+        if "service_catalog_id" in updates:
+            set_clauses.append("tf.service_catalog_id = $service_catalog_id")
+        if "status" in updates:
+            set_clauses.append("tf.status = $status")
+        if "archived" in updates:
+            set_clauses.append("tf.archived = $archived")
+        if "closed_reason" in updates:
+            set_clauses.append("tf.closed_reason = $closed_reason")
+
+        query = """
+        MATCH (tf:TicketFolio {ticket_id: $ticket_id})
+        SET {}
+        RETURN
+          tf.ticket_id AS ticket_id,
+          tf.type AS type,
+          tf.title AS title,
+          tf.description AS description,
+          tf.service_catalog_id AS service_catalog_id,
+          tf.status AS status,
+          tf.archived AS archived,
+          tf.closed_reason AS closed_reason,
+          tf.created_at AS created_at,
+          tf.updated_at AS updated_at,
+          tf.updated_by AS updated_by
+        """.format(
+            ",\n  ".join(set_clauses)
+        )
+
+        with self._driver.session() as session:
+            row = session.run(
+                query,
+                ticket_id=ticket_id,
+                updated_at=self._now(),
+                title=updates.get("title"),
+                description=updates.get("description"),
+                service_catalog_id=updates.get("service_catalog_id"),
+                status=updates.get("status"),
+                archived=updates.get("archived"),
+                closed_reason=updates.get("closed_reason"),
+                updated_by=updates.get("updated_by"),
+            ).single()
+        return self._record(row)
+
+    def sync_service_relationship(self, ticket_id: str, service_catalog_id: str | None) -> None:
+        """Keep the property/reference relationship in sync for compatibility reads."""
+
+        query = """
+        MATCH (tf:TicketFolio {ticket_id: $ticket_id})
+        OPTIONAL MATCH (tf)-[r:FOR_SERVICE]->()
+        DELETE r
+        WITH tf
+        WHERE $service_catalog_id IS NOT NULL
+        MATCH (sc:ServiceCatalog {service_id: $service_catalog_id})
+        MERGE (tf)-[:FOR_SERVICE]->(sc)
+        """
+        with self._driver.session() as session:
+            session.run(query, ticket_id=ticket_id, service_catalog_id=service_catalog_id)

--- a/backend/repositories/ticket_folio_repo.py
+++ b/backend/repositories/ticket_folio_repo.py
@@ -6,12 +6,11 @@ paths.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from database import get_db
 from models.itsm import TicketFolioCreate, TicketFolioUpdate
-
 
 _CREATE_TICKET_FOLIO_QUERY = """
 MERGE (tf:TicketFolio {ticket_id: $ticket_id})
@@ -114,7 +113,7 @@ class TicketFolioRepository:
 
     @staticmethod
     def _now() -> str:
-        return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+        return datetime.now(tz=UTC).replace(microsecond=0).isoformat()
 
     def get(self, ticket_id: str) -> dict[str, Any] | None:
         with self._driver.session() as session:
@@ -183,7 +182,7 @@ class TicketFolioRepository:
 
         query = """
         MATCH (tf:TicketFolio {ticket_id: $ticket_id})
-        SET {}
+        SET __SET_CLAUSES__
         RETURN
           tf.ticket_id AS ticket_id,
           tf.type AS type,
@@ -196,9 +195,7 @@ class TicketFolioRepository:
           tf.created_at AS created_at,
           tf.updated_at AS updated_at,
           tf.updated_by AS updated_by
-        """.format(
-            ",\n  ".join(set_clauses)
-        )
+        """.replace("__SET_CLAUSES__", ",\n  ".join(set_clauses))
 
         with self._driver.session() as session:
             row = session.run(

--- a/backend/repositories/ticket_folio_repo.py
+++ b/backend/repositories/ticket_folio_repo.py
@@ -102,10 +102,14 @@ class TicketFolioRepository:
             "type": row.get("type") if hasattr(row, "get") else row["type"],
             "title": row.get("title") if hasattr(row, "get") else row["title"],
             "description": row.get("description") if hasattr(row, "get") else row["description"],
-            "service_catalog_id": row.get("service_catalog_id") if hasattr(row, "get") else row["service_catalog_id"],
+            "service_catalog_id": (
+                row.get("service_catalog_id") if hasattr(row, "get") else row["service_catalog_id"]
+            ),
             "status": row.get("status") if hasattr(row, "get") else row["status"],
             "archived": row.get("archived") if hasattr(row, "get") else row["archived"],
-            "closed_reason": row.get("closed_reason") if hasattr(row, "get") else row["closed_reason"],
+            "closed_reason": (
+                row.get("closed_reason") if hasattr(row, "get") else row["closed_reason"]
+            ),
             "created_at": row.get("created_at") if hasattr(row, "get") else row["created_at"],
             "updated_at": row.get("updated_at") if hasattr(row, "get") else row["updated_at"],
             "updated_by": row.get("updated_by") if hasattr(row, "get") else row["updated_by"],
@@ -138,7 +142,9 @@ class TicketFolioRepository:
             return [self._record(row) for row in result if self._record(row) is not None]
 
     def upsert(self, payload: TicketFolioCreate) -> dict[str, Any]:
-        payload = payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
+        payload = (
+            payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
+        )
         now = self._now()
         with self._driver.session() as session:
             row = session.run(
@@ -158,7 +164,9 @@ class TicketFolioRepository:
         return self._record(row) or {}
 
     def update(self, ticket_id: str, payload: TicketFolioUpdate) -> dict[str, Any] | None:
-        payload = payload if isinstance(payload, TicketFolioUpdate) else TicketFolioUpdate(**payload)
+        payload = (
+            payload if isinstance(payload, TicketFolioUpdate) else TicketFolioUpdate(**payload)
+        )
         updates = payload.model_dump(exclude_unset=True)
         if not updates:
             return self.get(ticket_id)

--- a/backend/routers/itsm_service_catalog.py
+++ b/backend/routers/itsm_service_catalog.py
@@ -7,23 +7,24 @@ not mutate or trigger event/folio side effects.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
+import services.itsm_service_catalog_service as service_catalog_service
 from fastapi import APIRouter, Depends, HTTPException, Query
 from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
 from models.user import User, UserPermission
 from services.auth_service import check_permission, get_current_active_user
 
-import services.itsm_service_catalog_service as service_catalog_service
-
+CurrentUserDep = Annotated[User, Depends(get_current_active_user)]
+LimitQuery = Annotated[int, Query(ge=1, le=500)]
 
 router = APIRouter(prefix="/itsm/service-catalog", tags=["ITSM Service Catalog"])
 
 
 @router.get("", response_model=list[dict[str, Any]])
 async def list_service_catalogs(
-    limit: int = Query(100, ge=1, le=500),
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
+    limit: LimitQuery = 100,
 ):
     if not check_permission(UserPermission.ITSM_VIEW, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view service catalog")
@@ -33,7 +34,7 @@ async def list_service_catalogs(
 @router.get("/{service_id}", response_model=dict[str, Any])
 async def get_service_catalog(
     service_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_VIEW, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view service catalog")
@@ -43,7 +44,7 @@ async def get_service_catalog(
 @router.post("", response_model=dict[str, Any])
 async def create_service_catalog(
     payload: ServiceCatalogCreate,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to manage service catalog")
@@ -57,7 +58,7 @@ async def create_service_catalog(
 async def update_service_catalog(
     service_id: str,
     payload: ServiceCatalogUpdate,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to update service catalog")
@@ -71,7 +72,7 @@ async def update_service_catalog(
 @router.post("/{service_id}/deactivate", response_model=dict[str, Any])
 async def deactivate_service_catalog(
     service_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to deactivate service catalog")

--- a/backend/routers/itsm_service_catalog.py
+++ b/backend/routers/itsm_service_catalog.py
@@ -1,0 +1,81 @@
+"""Routers for ITSM service catalog domain.
+
+These endpoints are intentionally isolated from event workflows.
+They only manage Service Catalog state via the ITSM API slice and do
+not mutate or trigger event/folio side effects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
+from models.user import User, UserPermission
+from services.auth_service import check_permission, get_current_active_user
+
+import services.itsm_service_catalog_service as service_catalog_service
+
+
+router = APIRouter(prefix="/itsm/service-catalog", tags=["ITSM Service Catalog"])
+
+
+@router.get("", response_model=list[dict[str, Any]])
+async def list_service_catalogs(
+    limit: int = Query(100, ge=1, le=500),
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view service catalog")
+    return service_catalog_service.list_service_catalogs(limit=limit)
+
+
+@router.get("/{service_id}", response_model=dict[str, Any])
+async def get_service_catalog(
+    service_id: str,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view service catalog")
+    return service_catalog_service.get_service_catalog(service_id)
+
+
+@router.post("", response_model=dict[str, Any])
+async def create_service_catalog(
+    payload: ServiceCatalogCreate,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to manage service catalog")
+    return service_catalog_service.create_service_catalog(
+        payload,
+        actor=current_user.username,
+    )
+
+
+@router.put("/{service_id}", response_model=dict[str, Any])
+async def update_service_catalog(
+    service_id: str,
+    payload: ServiceCatalogUpdate,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to update service catalog")
+    return service_catalog_service.update_service_catalog(
+        service_id,
+        payload,
+        actor=current_user.username,
+    )
+
+
+@router.post("/{service_id}/deactivate", response_model=dict[str, Any])
+async def deactivate_service_catalog(
+    service_id: str,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to deactivate service catalog")
+    return service_catalog_service.deactivate_service_catalog(
+        service_id,
+        actor=current_user.username,
+    )

--- a/backend/routers/ticket_folios.py
+++ b/backend/routers/ticket_folios.py
@@ -1,0 +1,99 @@
+"""Routers for ITSM ticket/folio lifecycle.
+
+These endpoints are intentionally isolated from catalog/event automation.
+They expose CRUD + transition operations for ticket folios without
+creating or mutating event relationships as part of this slice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from models.itsm import TicketFolioCreate, TicketFolioUpdate
+from models.user import User, UserPermission
+from services.auth_service import check_permission, get_current_active_user
+
+import services.ticket_folio_service as ticket_folio_service
+
+
+class TicketTransitionRequest(BaseModel):
+    next_status: str
+    closed_reason: str | None = None
+
+
+router = APIRouter(prefix="/itsm/tickets", tags=["ITSM Tickets"])
+
+
+@router.get("", response_model=list[dict[str, Any]])
+async def list_ticket_folios(
+    status: str | None = None,
+    service_catalog_id: str | None = None,
+    archived: bool | None = None,
+    limit: int = Query(100, ge=1, le=500),
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view tickets")
+    return ticket_folio_service.list_ticket_folios(
+        status=status,
+        service_catalog_id=service_catalog_id,
+        archived=archived,
+        limit=limit,
+    )
+
+
+@router.get("/{ticket_id}", response_model=dict[str, Any])
+async def get_ticket_folio(
+    ticket_id: str,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_VIEW, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to view tickets")
+    return ticket_folio_service.get_ticket_folio(ticket_id)
+
+
+@router.post("", response_model=dict[str, Any])
+async def create_ticket_folio(
+    payload: TicketFolioCreate,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to create tickets")
+    return ticket_folio_service.create_ticket_folio(
+        payload,
+        actor=current_user.username,
+    )
+
+
+@router.put("/{ticket_id}", response_model=dict[str, Any])
+async def update_ticket_folio(
+    ticket_id: str,
+    payload: TicketFolioUpdate,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to update tickets")
+    return ticket_folio_service.update_ticket_folio(
+        ticket_id,
+        payload,
+        actor=current_user.username,
+    )
+
+
+@router.post("/{ticket_id}/transition", response_model=dict[str, Any])
+async def transition_ticket_folio(
+    ticket_id: str,
+    payload: TicketTransitionRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    if not check_permission(UserPermission.ITSM_EDIT, current_user):
+        raise HTTPException(status_code=403, detail="Not authorized to transition tickets")
+    return ticket_folio_service.transition_ticket_folio(
+        ticket_id,
+        next_status=payload.next_status,
+        closed_reason=payload.closed_reason,
+        actor=current_user.username,
+    )

--- a/backend/routers/ticket_folios.py
+++ b/backend/routers/ticket_folios.py
@@ -22,7 +22,6 @@ class TicketTransitionRequest(BaseModel):
     closed_reason: str | None = None
 
 
-
 CurrentUserDep = Annotated[User, Depends(get_current_active_user)]
 LimitQuery = Annotated[int, Query(ge=1, le=500)]
 

--- a/backend/routers/ticket_folios.py
+++ b/backend/routers/ticket_folios.py
@@ -7,16 +7,14 @@ creating or mutating event relationships as part of this slice.
 
 from __future__ import annotations
 
-from typing import Any
-
-from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
-
-from models.itsm import TicketFolioCreate, TicketFolioUpdate
-from models.user import User, UserPermission
-from services.auth_service import check_permission, get_current_active_user
+from typing import Annotated, Any
 
 import services.ticket_folio_service as ticket_folio_service
+from fastapi import APIRouter, Depends, HTTPException, Query
+from models.itsm import TicketFolioCreate, TicketFolioUpdate
+from models.user import User, UserPermission
+from pydantic import BaseModel
+from services.auth_service import check_permission, get_current_active_user
 
 
 class TicketTransitionRequest(BaseModel):
@@ -24,16 +22,20 @@ class TicketTransitionRequest(BaseModel):
     closed_reason: str | None = None
 
 
+
+CurrentUserDep = Annotated[User, Depends(get_current_active_user)]
+LimitQuery = Annotated[int, Query(ge=1, le=500)]
+
 router = APIRouter(prefix="/itsm/tickets", tags=["ITSM Tickets"])
 
 
 @router.get("", response_model=list[dict[str, Any]])
 async def list_ticket_folios(
+    current_user: CurrentUserDep,
     status: str | None = None,
     service_catalog_id: str | None = None,
     archived: bool | None = None,
-    limit: int = Query(100, ge=1, le=500),
-    current_user: User = Depends(get_current_active_user),
+    limit: LimitQuery = 100,
 ):
     if not check_permission(UserPermission.ITSM_VIEW, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view tickets")
@@ -48,7 +50,7 @@ async def list_ticket_folios(
 @router.get("/{ticket_id}", response_model=dict[str, Any])
 async def get_ticket_folio(
     ticket_id: str,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_VIEW, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view tickets")
@@ -58,7 +60,7 @@ async def get_ticket_folio(
 @router.post("", response_model=dict[str, Any])
 async def create_ticket_folio(
     payload: TicketFolioCreate,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to create tickets")
@@ -72,7 +74,7 @@ async def create_ticket_folio(
 async def update_ticket_folio(
     ticket_id: str,
     payload: TicketFolioUpdate,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to update tickets")
@@ -87,7 +89,7 @@ async def update_ticket_folio(
 async def transition_ticket_folio(
     ticket_id: str,
     payload: TicketTransitionRequest,
-    current_user: User = Depends(get_current_active_user),
+    current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_EDIT, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to transition tickets")

--- a/backend/seed_roles.py
+++ b/backend/seed_roles.py
@@ -11,6 +11,8 @@ SYSTEM_ROLE_PERMISSION_UPGRADES = {
     "OPERATOR": [
         UserPermission.MQTT_READ.value,
         UserPermission.MQTT_MAPPING_MANAGE.value,
+        UserPermission.ITSM_VIEW.value,
+        UserPermission.ITSM_EDIT.value,
     ],
 }
 
@@ -39,6 +41,8 @@ async def seed_roles():
                 UserPermission.METRICS_VIEW.value,
                 UserPermission.MQTT_READ.value,
                 UserPermission.MQTT_MAPPING_MANAGE.value,
+                UserPermission.ITSM_VIEW.value,
+                UserPermission.ITSM_EDIT.value,
             ],
             "is_system": True,
         },

--- a/backend/services/itsm_bootstrap.py
+++ b/backend/services/itsm_bootstrap.py
@@ -20,7 +20,6 @@ from typing import Any
 
 from database import get_db
 
-
 ITSM_SERVICE_ID_POLICY = "fail-fast: resolve identity conflicts before startup"
 
 _BACKFILL_COMPATIBILITY_QUERY = """
@@ -41,7 +40,7 @@ _PRECHECK_DUPLICATE_CANONICAL_ID_QUERY = """
 MATCH (sc:ServiceCatalog)
 WITH trim(toString(coalesce(sc.service_id, sc.id))) AS canonical_id
 WHERE canonical_id IS NOT NULL AND canonical_id <> ''
-WITH canonical_id, count(sc) AS total
+WITH canonical_id, count(*) AS total
 WHERE total > 1
 RETURN canonical_id, total
 """
@@ -101,7 +100,7 @@ def _extract_cypher_statements(content: str) -> list[str]:
     statements: list[str] = []
     for raw_statement in content.split(";"):
         lines = [line.strip() for line in raw_statement.splitlines() if line.strip()]
-        query_lines = [line for line in lines if not line.lstrip().startswith("//") and not line == "--"]
+        query_lines = [line for line in lines if not line.lstrip().startswith("//") and line != "--"]
         normalized = " ".join(query_lines).strip()
         if not normalized:
             continue

--- a/backend/services/itsm_bootstrap.py
+++ b/backend/services/itsm_bootstrap.py
@@ -1,0 +1,195 @@
+"""Startup preflight checks and migration application for ITSM domain bootstrap.
+
+The ITSM domain keeps existing `ServiceCatalog` and `TicketFolio` nodes in Neo4j.
+Before enabling the new `service_id` identity constraints we run a startup
+preflight with a **fail-fast policy**:
+
+- Duplicate canonical identity values are rejected.
+- Legacy identity rows that are missing/empty or conflicting are rejected.
+
+The startup flow fails with `ItsmBootstrapPreflightError` when any blocker is
+found, because auto-resolving legacy identity collisions could corrupt future
+migrations and API operations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from database import get_db
+
+
+ITSM_SERVICE_ID_POLICY = "fail-fast: resolve identity conflicts before startup"
+
+_BACKFILL_COMPATIBILITY_QUERY = """
+MATCH (sc:ServiceCatalog)
+SET
+  sc.service_id = coalesce(sc.service_id, sc.id),
+  sc.id = coalesce(sc.id, sc.service_id),
+  sc.name = coalesce(sc.name, sc.category, sc.id, sc.service_id),
+  sc.tier = coalesce(sc.tier, sc.service_tier),
+  sc.service_tier = coalesce(sc.service_tier, sc.tier),
+  sc.sla_target_minutes = coalesce(sc.sla_target_minutes, sc.sla_minutes, 0),
+  sc.sla_minutes = coalesce(sc.sla_minutes, sc.sla_target_minutes, 0),
+  sc.active = coalesce(sc.active, true)
+RETURN count(sc) AS backfilled
+"""
+
+_PRECHECK_DUPLICATE_CANONICAL_ID_QUERY = """
+MATCH (sc:ServiceCatalog)
+WITH trim(toString(coalesce(sc.service_id, sc.id))) AS canonical_id
+WHERE canonical_id IS NOT NULL AND canonical_id <> ''
+WITH canonical_id, count(sc) AS total
+WHERE total > 1
+RETURN canonical_id, total
+"""
+
+_PRECHECK_INVALID_IDENTITY_QUERY = """
+MATCH (sc:ServiceCatalog)
+WITH
+  trim(toString(coalesce(sc.service_id, sc.id))) AS canonical_id,
+  sc.service_id AS service_id,
+  sc.id AS legacy_id,
+  trim(toString(sc.service_id)) AS service_id_norm,
+  trim(toString(sc.id)) AS legacy_id_norm
+WHERE
+  (canonical_id IS NULL OR canonical_id = '')
+  OR (service_id_norm IS NOT NULL AND service_id_norm <> ''
+      AND legacy_id_norm IS NOT NULL AND legacy_id_norm <> ''
+      AND service_id_norm <> legacy_id_norm)
+RETURN canonical_id, service_id, legacy_id
+"""
+
+
+class ItsmBootstrapPreflightError(RuntimeError):
+    """Raised when ITSM startup checks detect identity blockers."""
+
+
+@dataclass
+class ItsmPreflightReport:
+    """Structured report produced by ITSM preflight checks."""
+
+    duplicate_catalog_ids: list[str]
+    invalid_catalog_nodes: list[str]
+
+
+def _row_value(record: Any, key: str) -> Any:
+    if hasattr(record, "get"):
+        return record.get(key)
+    return record[key]
+
+
+def _consume_rows(result: Any) -> list[dict[str, Any]]:
+    if result is None:
+        return []
+    if hasattr(result, "data") and callable(result.data):
+        return list(result.data())
+    return [dict(r) for r in result]
+
+
+def _migration_file_path() -> Path:
+    """Return absolute path for the ITSM startup migration script."""
+
+    return Path(__file__).resolve().parent.parent / "migrations" / "itsm_service_catalog.cypher"
+
+
+def _extract_cypher_statements(content: str) -> list[str]:
+    """Split migration text into executable statements and skip comment-only lines."""
+
+    statements: list[str] = []
+    for raw_statement in content.split(";"):
+        lines = [line.strip() for line in raw_statement.splitlines() if line.strip()]
+        query_lines = [line for line in lines if not line.lstrip().startswith("//") and not line == "--"]
+        normalized = " ".join(query_lines).strip()
+        if not normalized:
+            continue
+        statements.append(normalized)
+    return statements
+
+
+def _load_service_catalog_migration_statements() -> list[str]:
+    """Load migration statements from the backend migrations folder."""
+
+    migration_path = _migration_file_path()
+    if not migration_path.exists():
+        return []
+    raw = migration_path.read_text(encoding="utf-8")
+    return _extract_cypher_statements(raw)
+
+
+def run_service_catalog_compatibility_backfill(driver: Any | None = None) -> None:
+    """Normalize legacy ServiceCatalog identity aliases before strict checks."""
+
+    drv = driver if driver is not None else get_db()
+    with drv.session() as session:
+        session.run(_BACKFILL_COMPATIBILITY_QUERY)
+
+
+def run_service_catalog_preflight(driver: Any | None = None) -> ItsmPreflightReport:
+    """Run duplicate/identity checks before applying ITSM constraints.
+
+    Raises:
+        ItsmBootstrapPreflightError: when duplicate canonical IDs or invalid legacy
+            identity data are found.
+    """
+
+    drv = driver if driver is not None else get_db()
+    with drv.session() as session:
+        duplicate_rows = _consume_rows(session.run(_PRECHECK_DUPLICATE_CANONICAL_ID_QUERY))
+        duplicate_ids = [str(_row_value(row, "canonical_id")) for row in duplicate_rows if _row_value(row, "canonical_id")]
+
+        invalid_rows = _consume_rows(session.run(_PRECHECK_INVALID_IDENTITY_QUERY))
+        invalid_ids = [str(_row_value(row, "canonical_id")) for row in invalid_rows if _row_value(row, "canonical_id")]
+
+    if duplicate_ids or invalid_ids:
+        message = (
+            "ITSM catalog preflight failed: "
+            f"policy='{ITSM_SERVICE_ID_POLICY}', "
+            f"duplicate_canonical_ids={duplicate_ids}, "
+            f"invalid_catalog_ids={invalid_ids}"
+        )
+        raise ItsmBootstrapPreflightError(message)
+
+    return ItsmPreflightReport(duplicate_catalog_ids=[], invalid_catalog_nodes=[])
+
+
+def run_service_catalog_migration(driver: Any | None = None, *, statements: list[str] | None = None) -> int:
+    """Apply ITSM migration statements in order.
+
+    Returns:
+        Number of statements executed.
+    """
+
+    executable_statements = statements if statements is not None else _load_service_catalog_migration_statements()
+    if not executable_statements:
+        return 0
+
+    drv = driver if driver is not None else get_db()
+    with drv.session() as session:
+        for statement in executable_statements:
+            session.run(statement)
+
+    return len(executable_statements)
+
+
+def run_service_catalog_startup_checks(driver: Any | None = None, *, apply_migration: bool = True) -> ItsmPreflightReport:
+    """Run startup bootstrap steps for Service Catalog identity safety.
+
+    Steps:
+        1. run preflight identity checks
+        2. apply startup migration statements (idempotent)
+    """
+
+    run_service_catalog_compatibility_backfill(driver=driver)
+    report = run_service_catalog_preflight(driver=driver)
+    if apply_migration:
+        run_service_catalog_migration(driver=driver)
+    return report
+
+
+def validate_service_catalog_preflight(driver: Any | None = None) -> None:
+    """Public validation entrypoint used by startup wiring and unit tests."""
+
+    run_service_catalog_preflight(driver=driver)

--- a/backend/services/itsm_bootstrap.py
+++ b/backend/services/itsm_bootstrap.py
@@ -15,12 +15,14 @@ migrations and API operations.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 from typing import Any
 
 from database import get_db
 
 ITSM_SERVICE_ID_POLICY = "fail-fast: resolve identity conflicts before startup"
+logger = logging.getLogger(__name__)
 
 _BACKFILL_COMPATIBILITY_QUERY = """
 MATCH (sc:ServiceCatalog)
@@ -189,18 +191,27 @@ def run_service_catalog_migration(
 
 def run_service_catalog_startup_checks(
     driver: Any | None = None, *, apply_migration: bool = True
-) -> ItsmPreflightReport:
-    """Run startup bootstrap steps for Service Catalog identity safety.
+) -> ItsmPreflightReport | None:
+    """Run startup checks without blocking API availability on operational failures.
 
-    Steps:
-        1. run preflight identity checks
-        2. apply startup migration statements (idempotent)
+    Identity-integrity conflicts remain explicit fail-fast blockers; transient
+    backfill, preflight, and idempotent migration failures are logged instead.
     """
 
-    run_service_catalog_compatibility_backfill(driver=driver)
-    report = run_service_catalog_preflight(driver=driver)
+    try:
+        run_service_catalog_compatibility_backfill(driver=driver)
+        report = run_service_catalog_preflight(driver=driver)
+    except ItsmBootstrapPreflightError:
+        raise
+    except Exception:
+        logger.exception("ITSM service catalog startup checks failed; continuing API startup")
+        return None
+
     if apply_migration:
-        run_service_catalog_migration(driver=driver)
+        try:
+            run_service_catalog_migration(driver=driver)
+        except Exception:
+            logger.exception("ITSM service catalog migration failed; continuing API startup")
     return report
 
 

--- a/backend/services/itsm_bootstrap.py
+++ b/backend/services/itsm_bootstrap.py
@@ -14,8 +14,8 @@ migrations and API operations.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/backend/services/itsm_bootstrap.py
+++ b/backend/services/itsm_bootstrap.py
@@ -100,7 +100,9 @@ def _extract_cypher_statements(content: str) -> list[str]:
     statements: list[str] = []
     for raw_statement in content.split(";"):
         lines = [line.strip() for line in raw_statement.splitlines() if line.strip()]
-        query_lines = [line for line in lines if not line.lstrip().startswith("//") and line != "--"]
+        query_lines = [
+            line for line in lines if not line.lstrip().startswith("//") and line != "--"
+        ]
         normalized = " ".join(query_lines).strip()
         if not normalized:
             continue
@@ -137,10 +139,18 @@ def run_service_catalog_preflight(driver: Any | None = None) -> ItsmPreflightRep
     drv = driver if driver is not None else get_db()
     with drv.session() as session:
         duplicate_rows = _consume_rows(session.run(_PRECHECK_DUPLICATE_CANONICAL_ID_QUERY))
-        duplicate_ids = [str(_row_value(row, "canonical_id")) for row in duplicate_rows if _row_value(row, "canonical_id")]
+        duplicate_ids = [
+            str(_row_value(row, "canonical_id"))
+            for row in duplicate_rows
+            if _row_value(row, "canonical_id")
+        ]
 
         invalid_rows = _consume_rows(session.run(_PRECHECK_INVALID_IDENTITY_QUERY))
-        invalid_ids = [str(_row_value(row, "canonical_id")) for row in invalid_rows if _row_value(row, "canonical_id")]
+        invalid_ids = [
+            str(_row_value(row, "canonical_id"))
+            for row in invalid_rows
+            if _row_value(row, "canonical_id")
+        ]
 
     if duplicate_ids or invalid_ids:
         message = (
@@ -154,14 +164,18 @@ def run_service_catalog_preflight(driver: Any | None = None) -> ItsmPreflightRep
     return ItsmPreflightReport(duplicate_catalog_ids=[], invalid_catalog_nodes=[])
 
 
-def run_service_catalog_migration(driver: Any | None = None, *, statements: list[str] | None = None) -> int:
+def run_service_catalog_migration(
+    driver: Any | None = None, *, statements: list[str] | None = None
+) -> int:
     """Apply ITSM migration statements in order.
 
     Returns:
         Number of statements executed.
     """
 
-    executable_statements = statements if statements is not None else _load_service_catalog_migration_statements()
+    executable_statements = (
+        statements if statements is not None else _load_service_catalog_migration_statements()
+    )
     if not executable_statements:
         return 0
 
@@ -173,7 +187,9 @@ def run_service_catalog_migration(driver: Any | None = None, *, statements: list
     return len(executable_statements)
 
 
-def run_service_catalog_startup_checks(driver: Any | None = None, *, apply_migration: bool = True) -> ItsmPreflightReport:
+def run_service_catalog_startup_checks(
+    driver: Any | None = None, *, apply_migration: bool = True
+) -> ItsmPreflightReport:
     """Run startup bootstrap steps for Service Catalog identity safety.
 
     Steps:

--- a/backend/services/itsm_service_catalog_service.py
+++ b/backend/services/itsm_service_catalog_service.py
@@ -1,0 +1,129 @@
+"""Service orchestration for ITSM service catalog nodes.
+
+The service layer normalizes input models, enforces read/write guard rails,
+handles partial-update safety, and delegates persistence to the repository.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
+from repositories.itsm_service_catalog_repo import ServiceCatalogRepository
+
+
+def _to_catalog_create(payload: Any) -> ServiceCatalogCreate:
+    return payload if isinstance(payload, ServiceCatalogCreate) else ServiceCatalogCreate(**payload)
+
+
+def _to_catalog_update(payload: Any) -> ServiceCatalogUpdate:
+    return payload if isinstance(payload, ServiceCatalogUpdate) else ServiceCatalogUpdate(**payload)
+
+
+def _http_bad_request(message: str) -> None:
+    raise HTTPException(status_code=400, detail=message)
+
+
+def _http_not_found(service_id: str) -> None:
+    raise HTTPException(status_code=404, detail=f"Service catalog not found: {service_id}")
+
+
+def list_service_catalogs(*, limit: int = 100, repository: ServiceCatalogRepository | None = None):
+    """Return a bounded page of service catalog nodes."""
+
+    repository = repository or ServiceCatalogRepository()
+    return repository.list(limit=limit)
+
+
+def get_service_catalog(service_id: str, *, repository: ServiceCatalogRepository | None = None):
+    """Fetch one service catalog by its canonical id."""
+
+    repository = repository or ServiceCatalogRepository()
+    record = repository.get_by_id(service_id)
+    if not record:
+        _http_not_found(service_id)
+    return record
+
+
+def create_service_catalog(
+    payload: Any,
+    *,
+    actor: str | None = None,
+    repository: ServiceCatalogRepository | None = None,
+):
+    """Create or upsert a service catalog entry.
+
+    This endpoint is idempotent from repository perspective because WU1 uses
+    MERGE. We still keep strict validation and normalize actor metadata here.
+    """
+
+    repository = repository or ServiceCatalogRepository()
+    try:
+        payload_model = _to_catalog_create(payload).model_copy(update={"updated_by": actor})
+    except ValidationError as exc:
+        _http_bad_request(str(exc))
+
+    return repository.upsert(payload_model)
+
+
+def update_service_catalog(
+    service_id: str,
+    payload: Any,
+    *,
+    actor: str | None = None,
+    repository: ServiceCatalogRepository | None = None,
+):
+    """Apply partial updates to one service catalog.
+
+    Partial updates with no mutable fields return the current record without
+    writing (zero side-effects policy).
+    """
+
+    repository = repository or ServiceCatalogRepository()
+    current = repository.get_by_id(service_id)
+    if not current:
+        _http_not_found(service_id)
+
+    try:
+        update_model = _to_catalog_update(payload)
+    except ValidationError as exc:
+        _http_bad_request(str(exc))
+
+    update_values = update_model.model_dump(exclude_unset=True)
+
+    # Authoritative path is service_id in URL.
+    path_fields = {"service_id", "id"}
+    for key in path_fields:
+        if key in update_values and update_values[key] is not None and update_values[key] != service_id:
+            _http_bad_request(f"{key} must match service_id '{service_id}' when provided")
+
+    if not update_values:
+        return current
+
+    normalized_payload = update_model.model_copy(
+        update={
+            "service_id": service_id,
+            "id": service_id,
+            "updated_by": actor,
+        },
+    )
+    return repository.update(service_id, normalized_payload)
+
+
+def deactivate_service_catalog(
+    service_id: str,
+    *,
+    actor: str | None = None,
+    repository: ServiceCatalogRepository | None = None,
+):
+    """Soft deactivate a service catalog (logical delete)."""
+
+    repository = repository or ServiceCatalogRepository()
+    record = repository.deactivate(service_id, updated_by=actor)
+    if not record:
+        _http_not_found(service_id)
+    return record

--- a/backend/services/itsm_service_catalog_service.py
+++ b/backend/services/itsm_service_catalog_service.py
@@ -6,13 +6,11 @@ handles partial-update safety, and delegates persistence to the repository.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from fastapi import HTTPException
-from pydantic import ValidationError
-
 from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
+from pydantic import ValidationError
 from repositories.itsm_service_catalog_repo import ServiceCatalogRepository
 
 

--- a/backend/services/itsm_service_catalog_service.py
+++ b/backend/services/itsm_service_catalog_service.py
@@ -96,7 +96,11 @@ def update_service_catalog(
     # Authoritative path is service_id in URL.
     path_fields = {"service_id", "id"}
     for key in path_fields:
-        if key in update_values and update_values[key] is not None and update_values[key] != service_id:
+        if (
+            key in update_values
+            and update_values[key] is not None
+            and update_values[key] != service_id
+        ):
             _http_bad_request(f"{key} must match service_id '{service_id}' when provided")
 
     if not update_values:

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -8,13 +8,12 @@ checks) before persistence.
 from __future__ import annotations
 
 from fastapi import HTTPException
-from pydantic import ValidationError
-
 from models.itsm import (
     TicketFolioCreate,
     TicketFolioUpdate,
     validate_ticket_transition,
 )
+from pydantic import ValidationError
 from repositories.itsm_service_catalog_repo import ServiceCatalogRepository
 from repositories.ticket_folio_repo import TicketFolioRepository
 

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -1,0 +1,185 @@
+"""Service orchestration for ITSM Ticket/Folio lifecycle.
+
+This service layer validates lifecycle transitions and ensures compatibility
+constraints (status progressions, archive semantics, and catalog reference
+checks) before persistence.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from models.itsm import (
+    TicketFolioCreate,
+    TicketFolioUpdate,
+    validate_ticket_transition,
+)
+from repositories.itsm_service_catalog_repo import ServiceCatalogRepository
+from repositories.ticket_folio_repo import TicketFolioRepository
+
+
+def _to_ticket_create(payload) -> TicketFolioCreate:
+    return payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
+
+
+def _to_ticket_update(payload) -> TicketFolioUpdate:
+    return payload if isinstance(payload, TicketFolioUpdate) else TicketFolioUpdate(**payload)
+
+
+def _raise_bad_request(message: str) -> None:
+    raise HTTPException(status_code=400, detail=message)
+
+
+def _raise_not_found(message: str) -> None:
+    raise HTTPException(status_code=404, detail=message)
+
+
+def _raise_conflict(message: str) -> None:
+    raise HTTPException(status_code=409, detail=message)
+
+
+def _check_catalog_exists(
+    service_catalog_id: str | None,
+    *,
+    catalog_repository: ServiceCatalogRepository | None = None,
+) -> None:
+    if not service_catalog_id:
+        return
+
+    catalog_repository = catalog_repository or ServiceCatalogRepository()
+    catalog = catalog_repository.get_by_id(service_catalog_id)
+    if not catalog:
+        _raise_not_found(f"service_catalog not found: {service_catalog_id}")
+
+
+def _sync_relation(ticket_id: str, service_catalog_id: str | None, repository: TicketFolioRepository) -> None:
+    # Keep property and relationship in sync for migration compatibility.
+    repository.sync_service_relationship(ticket_id, service_catalog_id)
+
+
+def list_ticket_folios(
+    *,
+    status: str | None = None,
+    service_catalog_id: str | None = None,
+    archived: bool | None = None,
+    limit: int = 100,
+    repository: TicketFolioRepository | None = None,
+):
+    repository = repository or TicketFolioRepository()
+    return repository.list(status=status, service_catalog_id=service_catalog_id, archived=archived, limit=limit)
+
+
+def get_ticket_folio(
+    ticket_id: str,
+    *,
+    repository: TicketFolioRepository | None = None,
+):
+    repository = repository or TicketFolioRepository()
+    record = repository.get(ticket_id)
+    if not record:
+        _raise_not_found(f"Ticket folio not found: {ticket_id}")
+    return record
+
+
+def create_ticket_folio(
+    payload,
+    *,
+    actor: str | None = None,
+    repository: TicketFolioRepository | None = None,
+    catalog_repository: ServiceCatalogRepository | None = None,
+):
+    repository = repository or TicketFolioRepository()
+
+    try:
+        payload_model = _to_ticket_create(payload)
+    except ValidationError as exc:
+        _raise_bad_request(str(exc))
+
+    _check_catalog_exists(payload_model.service_catalog_id, catalog_repository=catalog_repository)
+
+    payload_model = payload_model.model_copy(update={"updated_by": actor})
+    created = repository.upsert(payload_model)
+
+    # Keep legacy relationship up to date for read compatibility; property is
+    # authoritative.
+    _sync_relation(created["ticket_id"], created.get("service_catalog_id"), repository)
+    return created
+
+
+def update_ticket_folio(
+    ticket_id: str,
+    payload,
+    *,
+    actor: str | None = None,
+    repository: TicketFolioRepository | None = None,
+    catalog_repository: ServiceCatalogRepository | None = None,
+):
+    repository = repository or TicketFolioRepository()
+
+    current = repository.get(ticket_id)
+    if not current:
+        _raise_not_found(f"Ticket folio not found: {ticket_id}")
+
+    try:
+        update_model = _to_ticket_update(payload)
+    except ValidationError as exc:
+        _raise_bad_request(str(exc))
+
+    updates = update_model.model_dump(exclude_unset=True)
+    if not updates:
+        return current
+
+    if current.get("status") == "closed":
+        _raise_conflict("Closed ticket folios are read-only")
+
+    if "archived" in updates and updates.get("status") != "closed":
+        _raise_conflict("archived can only be changed by transitioning to closed")
+
+    next_status = updates.get("status")
+    if next_status is not None:
+        try:
+            validate_ticket_transition(current["status"], next_status)
+        except ValueError as exc:
+            _raise_conflict(str(exc))
+
+        if next_status == "closed" and not updates.get("closed_reason"):
+            _raise_bad_request("closed_reason is required when transitioning to closed")
+
+    has_service_catalog_update = "service_catalog_id" in updates
+    new_service_catalog_id = updates.get("service_catalog_id")
+    if has_service_catalog_update:
+        _check_catalog_exists(new_service_catalog_id, catalog_repository=catalog_repository)
+
+    normalized_updates = {**updates, "updated_by": actor}
+    if next_status == "closed":
+        normalized_updates["archived"] = True
+
+    updated = repository.update(ticket_id, _to_ticket_update(normalized_updates))
+    if has_service_catalog_update:
+        _sync_relation(ticket_id, new_service_catalog_id, repository)
+
+    return updated
+
+
+def transition_ticket_folio(
+    ticket_id: str,
+    *,
+    next_status: str,
+    closed_reason: str | None = None,
+    actor: str | None = None,
+    repository: TicketFolioRepository | None = None,
+    catalog_repository: ServiceCatalogRepository | None = None,
+):
+    """Explicit transition endpoint facade with the same validation pipeline as update."""
+
+    payload = {"status": next_status}
+    if closed_reason is not None:
+        payload["closed_reason"] = closed_reason
+    return update_ticket_folio(
+        ticket_id,
+        payload,
+        actor=actor,
+        repository=repository,
+        catalog_repository=catalog_repository,
+    )

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -52,7 +52,9 @@ def _check_catalog_exists(
         _raise_not_found(f"service_catalog not found: {service_catalog_id}")
 
 
-def _sync_relation(ticket_id: str, service_catalog_id: str | None, repository: TicketFolioRepository) -> None:
+def _sync_relation(
+    ticket_id: str, service_catalog_id: str | None, repository: TicketFolioRepository
+) -> None:
     # Keep property and relationship in sync for migration compatibility.
     repository.sync_service_relationship(ticket_id, service_catalog_id)
 
@@ -66,7 +68,9 @@ def list_ticket_folios(
     repository: TicketFolioRepository | None = None,
 ):
     repository = repository or TicketFolioRepository()
-    return repository.list(status=status, service_catalog_id=service_catalog_id, archived=archived, limit=limit)
+    return repository.list(
+        status=status, service_catalog_id=service_catalog_id, archived=archived, limit=limit
+    )
 
 
 def get_ticket_folio(

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -99,6 +99,10 @@ def create_ticket_folio(
     except ValidationError as exc:
         _raise_bad_request(str(exc))
 
+    existing = repository.get(payload_model.ticket_id)
+    if existing:
+        _raise_conflict(f"Ticket folio already exists: {payload_model.ticket_id}")
+
     _check_catalog_exists(payload_model.service_catalog_id, catalog_repository=catalog_repository)
 
     payload_model = payload_model.model_copy(update={"updated_by": actor})

--- a/backend/tests/test_auth_extended.py
+++ b/backend/tests/test_auth_extended.py
@@ -617,6 +617,8 @@ class TestPermissionSecurity:
             UserPermission.METRICS_VIEW,
             UserPermission.MQTT_READ,
             UserPermission.MQTT_MAPPING_MANAGE,
+            UserPermission.ITSM_VIEW,
+            UserPermission.ITSM_EDIT,
         }
 
         defined_permissions = set(UserPermission)

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import importlib
 import sys
 import types
+
 try:
     from datetime import UTC, datetime, timedelta
 except ImportError:  # Python < 3.11 compatibility in CI runner
-    from datetime import datetime, timedelta, timezone
+    from datetime import datetime, timedelta
 
-    UTC = timezone.utc
+    UTC = UTC
 
 import pytest
 from fastapi import HTTPException

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import importlib
 import sys
 import types
-from datetime import UTC, datetime, timedelta
+try:
+    from datetime import UTC, datetime, timedelta
+except ImportError:  # Python < 3.11 compatibility in CI runner
+    from datetime import datetime, timedelta, timezone
+
+    UTC = timezone.utc
 
 import pytest
 from fastapi import HTTPException
@@ -1409,3 +1414,33 @@ class TestEventServiceSmoke:
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Event not found"
+
+    def test_get_event_detail_query_does_not_reference_ticket_folio(self, mock_neo4j_session):
+        mock_neo4j_session.set_response(
+            "return e, ci, m, bs, sc",
+            [
+                {
+                    "e": {
+                        "id": "evt-011",
+                        "ci_id": "ci-011",
+                        "status": "OPEN",
+                        "severity": "WARNING",
+                        "message": "Capacity warning",
+                        "created_at": datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+                        "ack": False,
+                    },
+                    "ci": {"id": "ci-011", "name": "Router-11", "ip": "10.0.0.11"},
+                    "m": {"id": "capacity", "protocol": "SNMP"},
+                    "bs": {"id": "svc-011", "name": "Payments"},
+                    "sc": {"id": "sla-011", "category": "PLATFORM", "sla_minutes": 30},
+                }
+            ],
+        )
+
+        get_event_detail = _load_event_service_module().get_event_detail
+
+        get_event_detail("evt-011")
+
+        query = mock_neo4j_session.queries[0]["query"].lower()
+        assert "ticketfolio" not in query
+        assert "for service" not in query

--- a/backend/tests/test_itsm_domain_contracts.py
+++ b/backend/tests/test_itsm_domain_contracts.py
@@ -1,0 +1,193 @@
+"""Work Unit 1 domain contracts for ITSM Service Catalog and Ticket/Folio."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from models.itsm import (
+    ServiceCatalogCreate,
+    TicketFolioCreate,
+    TicketFolioType,
+    TicketFolioUpdate,
+    TicketFolioUpdateArchive,
+    TICKET_STATUS_ORDER,
+    TicketStatus,
+    validate_ticket_transition,
+)
+from services.itsm_bootstrap import run_service_catalog_preflight
+
+
+class TestServiceCatalogDomainContract:
+    """Contract expectations for ServiceCatalog alias compatibility and SLA validation."""
+
+    def test_service_catalog_accepts_canonical_service_id_and_builds_aliases(self):
+        payload = ServiceCatalogCreate(
+            service_id="svc-net-01",
+            name="WAN Platform",
+            category="NETWORK",
+            tier="Gold",
+            sla_target_minutes=45,
+            owner_team="NetOps",
+            criticality="High",
+        )
+
+        assert payload.service_id == "svc-net-01"
+        assert payload.id == "svc-net-01"
+        assert payload.service_tier == "Gold"
+        assert payload.sla_minutes == 45
+        assert payload.sla_target_minutes == 45
+        assert payload.sla_target_minutes >= 0
+
+    def test_service_catalog_accepts_legacy_alias_fields(self):
+        payload = ServiceCatalogCreate(
+            id="svc-legacy-01",
+            name="Legacy Service",
+            category="CORE",
+            service_tier="Silver",
+            sla_minutes=60,
+        )
+
+        assert payload.service_id == "svc-legacy-01"
+        assert payload.id == "svc-legacy-01"
+        assert payload.tier == "Silver"
+        assert payload.sla_target_minutes == 60
+
+    def test_service_catalog_alias_mismatch_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ServiceCatalogCreate(
+                service_id="svc-01",
+                id="svc-02",
+                name="Mismatch",
+                sla_target_minutes=30,
+            )
+
+    def test_service_catalog_rejects_negative_sla_target_minutes(self):
+        with pytest.raises(ValidationError):
+            ServiceCatalogCreate(
+                service_id="svc-neg-01",
+                name="Bad SLA",
+                sla_target_minutes=-1,
+            )
+
+    def test_service_catalog_rejects_negative_legacy_sla_minutes(self):
+        with pytest.raises(ValidationError):
+            ServiceCatalogCreate(
+                id="svc-legacy-neg-01",
+                name="Bad Legacy SLA",
+                sla_minutes=-10,
+                category="NETWORK",
+            )
+
+
+class TestTicketFolioTypeAndLifecycle:
+    """Contract expectations for Ticket/Folio type and linear lifecycle order."""
+
+    def test_ticket_folio_type_is_limited_to_request_and_incident(self):
+        for ticket_type in (TicketFolioType.REQUEST, TicketFolioType.INCIDENT):
+            payload = TicketFolioCreate(
+                type=ticket_type,
+                title="Reset password",
+                description="Request access reset",
+                ticket_id="T-001",
+            )
+            assert payload.type == ticket_type
+
+        with pytest.raises(ValidationError):
+            TicketFolioCreate(
+                type="change",  # invalid
+                title="Change request",
+                ticket_id="T-002",
+            )
+
+    def test_ticket_transition_only_allows_linear_progression(self):
+        assert validate_ticket_transition(TicketStatus.OPEN, TicketStatus.IN_PROGRESS)
+        assert validate_ticket_transition(TicketStatus.IN_PROGRESS, TicketStatus.IN_VALIDATION)
+        assert validate_ticket_transition(TicketStatus.IN_VALIDATION, TicketStatus.RESOLVED)
+        assert validate_ticket_transition(TicketStatus.RESOLVED, TicketStatus.CLOSED)
+
+    def test_ticket_transition_rejects_regressions_and_skips(self):
+        with pytest.raises(ValueError):
+            validate_ticket_transition(TicketStatus.OPEN, TicketStatus.RESOLVED)
+
+        with pytest.raises(ValueError):
+            validate_ticket_transition(TicketStatus.CLOSED, TicketStatus.OPEN)
+
+        with pytest.raises(ValueError):
+            validate_ticket_transition(TicketStatus.OPEN, TicketStatus.OPEN)
+
+    def test_ticket_lifecycle_order_is_strict_linear_contract(self):
+        assert list(TICKET_STATUS_ORDER) == [
+            "open",
+            "in_progress",
+            "in_validation",
+            "resolved",
+            "closed",
+        ]
+
+
+class TestTicketHardDeleteContract:
+    """Ticket/Folio updates should remain logical (archived/closed), not hard-delete."""
+
+    def test_ticket_update_model_models_logical_lifecycle_only(self):
+        fields = TicketFolioUpdate.model_fields
+        assert "archived" in fields
+        assert "closed_reason" in fields
+        assert "status" in fields
+        assert "delete" not in fields
+
+    def test_ticket_archive_request_uses_update_contract(self):
+        payload = TicketFolioUpdateArchive(
+            archived=True,
+            closed_reason="Legacy cleanup",
+        )
+        assert payload.archived is True
+        assert payload.closed_reason == "Legacy cleanup"
+
+
+class TestItsmBootstrapPreflightContract:
+    """Startup preflight should fail only when blockers are present."""
+
+    def test_preflight_passes_on_clean_identity_input(self):
+        session = MagicMock()
+        session.run.side_effect = [
+            [],
+            [],
+        ]
+
+        driver = MagicMock()
+        session_ctx = MagicMock()
+        session_ctx.__enter__.return_value = session
+        session_ctx.__exit__.return_value = False
+        driver.session.return_value = session_ctx
+
+        run_service_catalog_preflight(driver=driver)
+
+    def test_preflight_blocks_duplicate_or_conflicting_catalog_identity(self):
+        session = MagicMock()
+        session.run.side_effect = [
+            [
+                {"canonical_id": "svc-dup", "total": 2},
+                {"canonical_id": "svc-other", "total": 3},
+            ],
+            [
+                {
+                    "canonical_id": "svc-bad",
+                    "service_id": "svc-bad",
+                    "legacy_id": "svc-legacy-bad",
+                }
+            ],
+        ]
+
+        driver = MagicMock()
+        session_ctx = MagicMock()
+        session_ctx.__enter__.return_value = session
+        session_ctx.__exit__.return_value = False
+        driver.session.return_value = session_ctx
+
+        with pytest.raises(RuntimeError) as exc:
+            run_service_catalog_preflight(driver=driver)
+
+        assert "itsm catalog preflight failed" in str(exc.value).lower()

--- a/backend/tests/test_itsm_domain_contracts.py
+++ b/backend/tests/test_itsm_domain_contracts.py
@@ -5,18 +5,17 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import ValidationError
-
 from models.itsm import (
+    TICKET_STATUS_ORDER,
     ServiceCatalogCreate,
     TicketFolioCreate,
     TicketFolioType,
     TicketFolioUpdate,
     TicketFolioUpdateArchive,
-    TICKET_STATUS_ORDER,
     TicketStatus,
     validate_ticket_transition,
 )
+from pydantic import ValidationError
 from services.itsm_bootstrap import run_service_catalog_preflight
 
 

--- a/backend/tests/test_itsm_service_catalog_service.py
+++ b/backend/tests/test_itsm_service_catalog_service.py
@@ -1,0 +1,189 @@
+"""Service-layer tests for ITSM service catalog behavior.
+
+Focus on create/list/update/deactivate flow and validation failures.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
+import services.itsm_service_catalog_service as service_catalog_service
+
+
+class _CatalogRepositoryStub:
+    def __init__(self):
+        self.list = MagicMock()
+        self.get_by_id = MagicMock()
+        self.upsert = MagicMock()
+        self.update = MagicMock()
+        self.deactivate = MagicMock()
+
+
+def _sample_catalog_record() -> dict:
+    return {
+        "service_id": "svc-001",
+        "id": "svc-001",
+        "name": "Operations Platform",
+        "category": "PLATFORM",
+        "owner_team": "SRE",
+        "tier": "Gold",
+        "service_tier": "Gold",
+        "criticality": "High",
+        "sla_target_minutes": 60,
+        "sla_minutes": 60,
+        "active": True,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+        "updated_by": "admin",
+    }
+
+
+class TestServiceCatalogService:
+    """Verify core Service Catalog service behaviors."""
+
+    def test_list_service_catalogs_returns_records(self):
+        repository = _CatalogRepositoryStub()
+        repository.list.return_value = [_sample_catalog_record()]
+
+        result = service_catalog_service.list_service_catalogs(repository=repository)
+
+        assert result == [_sample_catalog_record()]
+        repository.list.assert_called_once_with(limit=100)
+
+    def test_get_service_catalog_returns_404_when_missing(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = None
+
+        with pytest.raises(HTTPException) as exc:
+            service_catalog_service.get_service_catalog("missing", repository=repository)
+
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "Service catalog not found: missing"
+        repository.get_by_id.assert_called_once_with("missing")
+
+    def test_create_catalog_defaults_to_active_and_normalizes_aliases(self):
+        repository = _CatalogRepositoryStub()
+        repository.upsert.side_effect = lambda payload: payload.model_dump()
+
+        created = service_catalog_service.create_service_catalog(
+            {
+                "id": "svc-legacy",
+                "name": "Platform Core",
+                "service_tier": "Silver",
+                "sla_minutes": 45,
+            },
+            actor="admin",
+            repository=repository,
+        )
+
+        assert created["service_id"] == "svc-legacy"
+        assert created["id"] == "svc-legacy"
+        assert created["tier"] == "Silver"
+        assert created["sla_target_minutes"] == 45
+        assert created["sla_minutes"] == 45
+        assert created["active"] is True
+        repository.upsert.assert_called_once()
+        persisted_payload = repository.upsert.call_args.args[0]
+        assert isinstance(persisted_payload, ServiceCatalogCreate)
+        assert persisted_payload.service_id == "svc-legacy"
+        assert persisted_payload.id == "svc-legacy"
+        assert persisted_payload.updated_by == "admin"
+
+    def test_create_catalog_rejects_empty_name(self):
+        repository = _CatalogRepositoryStub()
+
+        with pytest.raises(HTTPException) as exc:
+            service_catalog_service.create_service_catalog(
+                {
+                    "service_id": "svc-empty",
+                    "name": "   ",
+                    "sla_target_minutes": 30,
+                },
+                repository=repository,
+            )
+
+        assert exc.value.status_code == 400
+        assert "name cannot be empty" in exc.value.detail.lower()
+        repository.upsert.assert_not_called()
+
+    def test_update_catalog_rejects_negative_sla(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = _sample_catalog_record()
+
+        with pytest.raises(HTTPException) as exc:
+            service_catalog_service.update_service_catalog(
+                "svc-001",
+                {
+                    "service_id": "svc-001",
+                    "sla_target_minutes": -1,
+                },
+                actor="admin",
+                repository=repository,
+            )
+
+        assert exc.value.status_code == 400
+        assert "sla_target_minutes" in exc.value.detail
+        repository.update.assert_not_called()
+
+    def test_update_allows_clearing_optional_fields(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = _sample_catalog_record()
+        repository.update.return_value = {**_sample_catalog_record(), "owner_team": None, "category": None}
+
+        service_catalog_service.update_service_catalog(
+            "svc-001",
+            {"owner_team": None, "category": None},
+            repository=repository,
+        )
+
+        update_payload = repository.update.call_args.args[1]
+        assert "owner_team" in update_payload.model_fields_set
+        assert "category" in update_payload.model_fields_set
+
+    def test_partial_update_with_no_fields_returns_current_record(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = _sample_catalog_record()
+
+        result = service_catalog_service.update_service_catalog(
+            "svc-001",
+            ServiceCatalogUpdate(),
+            repository=repository,
+        )
+
+        assert result == _sample_catalog_record()
+        repository.get_by_id.assert_called_once_with("svc-001")
+        repository.update.assert_not_called()
+
+    def test_deactivate_catalog_marks_catalog_inactive(self):
+        repository = _CatalogRepositoryStub()
+        repository.deactivate.return_value = {**_sample_catalog_record(), "active": False}
+
+        result = service_catalog_service.deactivate_service_catalog(
+            "svc-001",
+            actor="admin",
+            repository=repository,
+        )
+
+        assert result["service_id"] == "svc-001"
+        assert result["active"] is False
+        repository.deactivate.assert_called_once_with("svc-001", updated_by="admin")
+
+    def test_update_catalog_service_id_mismatch_is_rejected(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = _sample_catalog_record()
+
+        with pytest.raises(HTTPException) as exc:
+            service_catalog_service.update_service_catalog(
+                "svc-001",
+                {"service_id": "svc-other", "name": "Different"},
+                repository=repository,
+            )
+
+        assert exc.value.status_code == 400
+        assert "service_id" in exc.value.detail.lower()
+        repository.update.assert_not_called()

--- a/backend/tests/test_itsm_service_catalog_service.py
+++ b/backend/tests/test_itsm_service_catalog_service.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import HTTPException
-from pydantic import ValidationError
-
-from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
 import services.itsm_service_catalog_service as service_catalog_service
+from fastapi import HTTPException
+from models.itsm import ServiceCatalogCreate, ServiceCatalogUpdate
 
 
 class _CatalogRepositoryStub:

--- a/backend/tests/test_itsm_service_catalog_service.py
+++ b/backend/tests/test_itsm_service_catalog_service.py
@@ -131,7 +131,11 @@ class TestServiceCatalogService:
     def test_update_allows_clearing_optional_fields(self):
         repository = _CatalogRepositoryStub()
         repository.get_by_id.return_value = _sample_catalog_record()
-        repository.update.return_value = {**_sample_catalog_record(), "owner_team": None, "category": None}
+        repository.update.return_value = {
+            **_sample_catalog_record(),
+            "owner_team": None,
+            "category": None,
+        }
 
         service_catalog_service.update_service_catalog(
             "svc-001",

--- a/backend/tests/test_itsm_startup_checks.py
+++ b/backend/tests/test_itsm_startup_checks.py
@@ -107,3 +107,42 @@ def test_migration_file_documents_startup_conflict_policy():
     assert migration_path.exists(), f"Migration file not found at {migration_path}."
     migration_text = migration_path.read_text(encoding="utf-8")
     assert "fail-fast" in migration_text.lower()
+
+
+def test_startup_checks_continue_when_operational_backfill_fails(monkeypatch):
+    monkeypatch.setattr(
+        "services.itsm_bootstrap.run_service_catalog_compatibility_backfill",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("temporary Neo4j outage")),
+    )
+
+    assert run_service_catalog_startup_checks() is None
+
+
+def test_startup_checks_continue_when_idempotent_migration_fails(monkeypatch):
+    expected_report = object()
+    monkeypatch.setattr(
+        "services.itsm_bootstrap.run_service_catalog_compatibility_backfill", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "services.itsm_bootstrap.run_service_catalog_preflight", lambda **_: expected_report
+    )
+    monkeypatch.setattr(
+        "services.itsm_bootstrap.run_service_catalog_migration",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("constraint temporarily unavailable")),
+    )
+
+    assert run_service_catalog_startup_checks() is expected_report
+
+
+def test_startup_checks_preserve_actionable_identity_preflight_failures(monkeypatch):
+    expected_error = ItsmBootstrapPreflightError("duplicate identity values")
+    monkeypatch.setattr(
+        "services.itsm_bootstrap.run_service_catalog_compatibility_backfill", lambda **_: None
+    )
+    monkeypatch.setattr(
+        "services.itsm_bootstrap.run_service_catalog_preflight",
+        lambda **_: (_ for _ in ()).throw(expected_error),
+    )
+
+    with pytest.raises(ItsmBootstrapPreflightError, match="duplicate identity values"):
+        run_service_catalog_startup_checks()

--- a/backend/tests/test_itsm_startup_checks.py
+++ b/backend/tests/test_itsm_startup_checks.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-
 from unittest.mock import MagicMock
 
 import pytest
-
 from services.itsm_bootstrap import (
-    ITSM_SERVICE_ID_POLICY,
-    ItsmBootstrapPreflightError,
     _BACKFILL_COMPATIBILITY_QUERY,
     _PRECHECK_DUPLICATE_CANONICAL_ID_QUERY,
     _PRECHECK_INVALID_IDENTITY_QUERY,
+    ITSM_SERVICE_ID_POLICY,
+    ItsmBootstrapPreflightError,
     _migration_file_path,
     run_service_catalog_startup_checks,
 )

--- a/backend/tests/test_itsm_startup_checks.py
+++ b/backend/tests/test_itsm_startup_checks.py
@@ -104,10 +104,6 @@ def test_migration_file_documents_startup_conflict_policy():
     """Migration docs should keep startup policy consistent with runtime checks."""
 
     migration_path = _migration_file_path()
-    assert migration_path.exists(), (
-        f"Migration file not found at {migration_path}."
-    )
+    assert migration_path.exists(), f"Migration file not found at {migration_path}."
     migration_text = migration_path.read_text(encoding="utf-8")
     assert "fail-fast" in migration_text.lower()
-
-

--- a/backend/tests/test_itsm_startup_checks.py
+++ b/backend/tests/test_itsm_startup_checks.py
@@ -1,0 +1,115 @@
+"""Startup ordering and preflight policy tests for ITSM bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.itsm_bootstrap import (
+    ITSM_SERVICE_ID_POLICY,
+    ItsmBootstrapPreflightError,
+    _BACKFILL_COMPATIBILITY_QUERY,
+    _PRECHECK_DUPLICATE_CANONICAL_ID_QUERY,
+    _PRECHECK_INVALID_IDENTITY_QUERY,
+    _migration_file_path,
+    run_service_catalog_startup_checks,
+)
+
+
+class TestItsmServiceCatalogBootstrapPolicy:
+    """Startup policy should be explicit and fail fast before migration."""
+
+    def _mock_driver(self, query_responses: list[list[dict[str, Any]]]) -> MagicMock:
+        session = MagicMock()
+        session.run.side_effect = query_responses
+        driver = MagicMock()
+        session_ctx = MagicMock()
+        session_ctx.__enter__.return_value = session
+        session_ctx.__exit__.return_value = False
+        driver.session.return_value = session_ctx
+        return driver
+
+    def test_preflight_uses_fail_fast_policy_and_blocks_conflicts(self):
+        """When duplicates/legacy conflicts exist, startup must fail fast."""
+
+        driver = self._mock_driver(
+            [
+                [],
+                [{"canonical_id": "svc-alpha", "total": 2}],
+                [{"canonical_id": "svc-missing", "service_id": None, "legacy_id": "svc-missing"}],
+            ]
+        )
+
+        with pytest.raises(ItsmBootstrapPreflightError) as exc:
+            run_service_catalog_startup_checks(driver=driver)
+
+        message = str(exc.value).lower()
+        assert ITSM_SERVICE_ID_POLICY in str(exc.value)
+        assert "itsm catalog preflight failed" in message
+        assert "svc-alpha" in message
+        assert "svc-missing" in message
+
+    def test_startup_sequence_runs_preflight_before_migration(self, monkeypatch):
+        """Startup checks must verify data before executing migration statements."""
+
+        statements = [
+            "CREATE CONSTRAINT test_a IF NOT EXISTS FOR (s:ServiceCatalog) REQUIRE s.service_id IS UNIQUE",
+            "CREATE INDEX test_b IF NOT EXISTS FOR (s:ServiceCatalog) ON (s.active)",
+        ]
+        monkeypatch.setattr(
+            "services.itsm_bootstrap._load_service_catalog_migration_statements",
+            lambda: statements,
+        )
+
+        session = MagicMock()
+        session.run.side_effect = [
+            [],
+            [],
+            [],
+            [],
+            [],
+        ]
+        driver = MagicMock()
+        session_ctx = MagicMock()
+        session_ctx.__enter__.return_value = session
+        session_ctx.__exit__.return_value = False
+        driver.session.return_value = session_ctx
+
+        run_service_catalog_startup_checks(driver=driver, apply_migration=True)
+
+        calls = [str(call.args[0]) for call in session.run.call_args_list]
+        assert _BACKFILL_COMPATIBILITY_QUERY.strip() in calls[0]
+        assert _PRECHECK_DUPLICATE_CANONICAL_ID_QUERY.strip() in calls[1]
+        assert _PRECHECK_INVALID_IDENTITY_QUERY.strip() in calls[2]
+        assert calls[3] == statements[0]
+        assert calls[4] == statements[1]
+
+
+class TestItsmMainStartupOrdering:
+    """Existing startup flow must call bootstrap checks before Postgres migrations."""
+
+    def test_main_startup_event_calls_itsm_bootstrap_check_before_neo4j_schema_bootstrap(self):
+        source = Path(__file__).resolve().parents[1].joinpath("main.py").read_text(encoding="utf-8")
+        bootstrap_call_index = source.index("run_service_catalog_startup_checks")
+        neo4j_schema_index = source.index("Base.metadata.create_all")
+        assert bootstrap_call_index < neo4j_schema_index
+
+        # Keep the intended fail-fast policy discoverable in code.
+        assert "run_service_catalog_startup_checks" in source
+
+
+def test_migration_file_documents_startup_conflict_policy():
+    """Migration docs should keep startup policy consistent with runtime checks."""
+
+    migration_path = _migration_file_path()
+    assert migration_path.exists(), (
+        f"Migration file not found at {migration_path}."
+    )
+    migration_text = migration_path.read_text(encoding="utf-8")
+    assert "fail-fast" in migration_text.lower()
+
+

--- a/backend/tests/test_migration_itsm_catalog.py
+++ b/backend/tests/test_migration_itsm_catalog.py
@@ -1,0 +1,114 @@
+"""Static analysis tests for migration  - WU1 foundation."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+MIGRATION_FILE = (
+    Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "itsm_service_catalog.cypher"
+)
+
+
+def _read_migration() -> str:
+    if not MIGRATION_FILE.exists():
+        return ""
+    return MIGRATION_FILE.read_text(encoding="utf-8")
+
+
+class TestItsmCatalogMigrationFile:
+    """Validate migration presence and required directives."""
+
+    def test_migration_file_exists(self):
+        assert MIGRATION_FILE.exists(), (
+            f"Migration file not found at {MIGRATION_FILE}. "
+            "Task 1.7 requires backend/migrations/itsm_service_catalog.cypher."
+        )
+
+    def test_migration_file_is_non_empty(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration()
+        assert content.strip(), "Migration file is empty."
+
+    def test_migration_file_has_header_comment(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration()
+        assert "//" in content[:250] or "/*" in content[:250], (
+            "Migration file should start with comments describing intent."
+        )
+
+    def test_service_catalog_unique_constraint_present(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration()
+        assert re.search(
+            r"CREATE\s+CONSTRAINT\s+service_catalog_service_id\b",
+            content,
+            re.IGNORECASE,
+        ), "Missing CREATE CONSTRAINT service_catalog_service_id."
+        assert re.search(
+            r"CREATE\s+CONSTRAINT\s+service_catalog_service_id\b.*?FOR\s*\(\s*sc\s*:\s*ServiceCatalog\b",
+            content,
+            re.IGNORECASE | re.DOTALL,
+        ), "service_catalog_service_id must target :ServiceCatalog node."
+
+    def test_ticket_folio_unique_constraint_present(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration()
+        assert re.search(
+            r"CREATE\s+CONSTRAINT\s+ticket_folio_ticket_id\b",
+            content,
+            re.IGNORECASE,
+        ), "Missing CREATE CONSTRAINT ticket_folio_ticket_id."
+        assert re.search(
+            r"CREATE\s+CONSTRAINT\s+ticket_folio_ticket_id\b.*?FOR\s*\(\s*tf\s*:\s*TicketFolio\b",
+            content,
+            re.IGNORECASE | re.DOTALL,
+        ), "ticket_folio_ticket_id must target :TicketFolio node."
+
+    def test_required_indexes_exist(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration()
+        assert re.search(
+            r"CREATE\s+INDEX\s+service_catalog_active\b",
+            content,
+            re.IGNORECASE,
+        ), "Missing index service_catalog_active."
+        assert re.search(
+            r"CREATE\s+INDEX\s+ticket_folio_status\b",
+            content,
+            re.IGNORECASE,
+        ), "Missing index ticket_folio_status."
+        assert re.search(
+            r"CREATE\s+INDEX\s+ticket_folio_service_catalog_id\b",
+            content,
+            re.IGNORECASE,
+        ), "Missing index ticket_folio_service_catalog_id."
+
+    def test_idempotency_keywords_are_present(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration().upper().replace("\n", " ")
+        assert "IF NOT EXISTS" in content, "Migration statements must be idempotent."
+
+    def test_file_documents_backfill_and_compatibility(self):
+        if not MIGRATION_FILE.exists():
+            pytest.skip("Migration file does not exist yet (pre-implementation).")
+        content = _read_migration().lower()
+        assert (
+            "legacy" in content and "service_id" in content
+        ), "Backfill/legacy compatibility should be documented for legacy ServiceCatalog IDs."
+        assert (
+            "backfill" in content or "coalesce" in content
+        ), "Backfill logic must be documented explicitly."
+        assert (
+            "event snapshot" in content or "event" not in content or "snapshot" in content
+        ), "Compatibility notes should include that event snapshots are not mutated."

--- a/backend/tests/test_migration_itsm_catalog.py
+++ b/backend/tests/test_migration_itsm_catalog.py
@@ -8,9 +8,7 @@ from pathlib import Path
 import pytest
 
 MIGRATION_FILE = (
-    Path(__file__).resolve().parent.parent
-    / "migrations"
-    / "itsm_service_catalog.cypher"
+    Path(__file__).resolve().parent.parent / "migrations" / "itsm_service_catalog.cypher"
 )
 
 
@@ -39,9 +37,9 @@ class TestItsmCatalogMigrationFile:
         if not MIGRATION_FILE.exists():
             pytest.skip("Migration file does not exist yet (pre-implementation).")
         content = _read_migration()
-        assert "//" in content[:250] or "/*" in content[:250], (
-            "Migration file should start with comments describing intent."
-        )
+        assert (
+            "//" in content[:250] or "/*" in content[:250]
+        ), "Migration file should start with comments describing intent."
 
     def test_service_catalog_unique_constraint_present(self):
         if not MIGRATION_FILE.exists():

--- a/backend/tests/test_mqtt_permissions.py
+++ b/backend/tests/test_mqtt_permissions.py
@@ -116,6 +116,7 @@ class _SeedRoleSession:
     def __init__(self, existing_roles):
         self.existing_roles = existing_roles
         self.permission_updates = []
+        self.created_roles = []
 
     def __enter__(self):
         return self
@@ -133,6 +134,15 @@ class _SeedRoleSession:
 
         if "set r.permissions" in normalized:
             self.permission_updates.append(
+                {
+                    "name": role_name,
+                    "permissions": params["perms"],
+                    "query": normalized,
+                }
+            )
+
+        if normalized.startswith("create (r:role"):
+            self.created_roles.append(
                 {
                     "name": role_name,
                     "permissions": params["perms"],
@@ -315,3 +325,46 @@ async def test_reseed_existing_system_operator_does_not_overwrite_protected_role
     )
     assert "description" not in operator_update["query"]
     assert "is_system" not in operator_update["query"]
+
+
+@pytest.mark.asyncio
+async def test_reseed_existing_system_operator_adds_itsm_permissions_additively(monkeypatch):
+    existing_permissions = [UserPermission.EVENT_VIEW.value, "CUSTOM_KEEP"]
+    session = _SeedRoleSession(
+        {
+            "OPERATOR": {
+                "name": "OPERATOR",
+                "description": "Existing protected operator role",
+                "permissions": existing_permissions,
+                "is_system": True,
+            }
+        }
+    )
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    operator_update = next(
+        update for update in session.permission_updates if update["name"] == "OPERATOR"
+    )
+    assert UserPermission.ITSM_VIEW.value in operator_update["permissions"]
+    assert UserPermission.ITSM_EDIT.value in operator_update["permissions"]
+    assert "CUSTOM_KEEP" in operator_update["permissions"]
+
+
+@pytest.mark.asyncio
+async def test_seed_new_default_operator_includes_itsm_permissions(monkeypatch):
+    """Newly seeded OPERATOR roles must receive both ITSM permissions."""
+
+    session = _SeedRoleSession({})
+    monkeypatch.setattr(seed_roles, "get_db", lambda: _SeedRoleDriver(session))
+    monkeypatch.setattr(seed_roles, "close_db", lambda: None)
+
+    await seed_roles.seed_roles()
+
+    operator_create = next(
+        create for create in session.created_roles if create["name"] == "OPERATOR"
+    )
+    assert UserPermission.ITSM_VIEW.value in operator_create["permissions"]
+    assert UserPermission.ITSM_EDIT.value in operator_create["permissions"]

--- a/backend/tests/test_routers_itsm.py
+++ b/backend/tests/test_routers_itsm.py
@@ -7,12 +7,11 @@ Focus:
 
 from __future__ import annotations
 
-from fastapi import FastAPI
 from unittest.mock import patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
-
 from models.user import User, UserPermission
 from routers import itsm_service_catalog, ticket_folios
 from services.auth_service import get_current_active_user

--- a/backend/tests/test_routers_itsm.py
+++ b/backend/tests/test_routers_itsm.py
@@ -1,0 +1,302 @@
+"""Router-level tests for ITSM service catalog and ticket endpoints.
+
+Focus:
+- Explicit permission gates on read/write endpoints
+- Route wiring and payload pass-through for create/get/update/deactivate/transition
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from models.user import User, UserPermission
+from routers import itsm_service_catalog, ticket_folios
+from services.auth_service import get_current_active_user
+
+# ---------------------------------------------------------------------------
+# Build a focused FastAPI app containing only ITSM routers under test.
+# This avoids importing the full production app and unrelated legacy routers
+# that may require broader Python-version compatibility workarounds.
+# ---------------------------------------------------------------------------
+app = FastAPI()
+app.include_router(itsm_service_catalog.router, prefix="/api")
+app.include_router(ticket_folios.router, prefix="/api")
+
+
+# ---------------------------------------------------------------------------
+# TestClient
+# ---------------------------------------------------------------------------
+client = TestClient(app)
+
+READ_PERMISSION = UserPermission.ITSM_VIEW
+WRITE_PERMISSION = UserPermission.ITSM_EDIT
+
+
+def _make_pydantic_user(
+    username: str = "testuser",
+    role: str = "OPERATOR",
+    permissions: list[UserPermission] | None = None,
+) -> User:
+    return User(
+        username=username,
+        role=role,
+        permissions=[permission.value if isinstance(permission, UserPermission) else permission for permission in (permissions or [])],
+        allowed_locations=[],
+    )
+
+
+def _override_current_user(user: User) -> None:
+    async def override_get_current_active_user():
+        return user
+
+    app.dependency_overrides[get_current_active_user] = override_get_current_active_user
+
+
+@pytest.fixture(autouse=True)
+def clear_dependency_overrides():
+    original_overrides = app.dependency_overrides.copy()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(original_overrides)
+
+
+class TestItsmServiceCatalogRouter:
+    """Permissioned route coverage for /api/itsm/service-catalog."""
+
+    def test_list_catalogs_requires_authentication(self):
+        response = client.get("/api/itsm/service-catalog")
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize("method,url", [("get", "/api/itsm/service-catalog")])
+    def test_read_routes_require_read_permission(self, method, url):
+        _override_current_user(_make_pydantic_user())
+
+        response = client.request(method, url)
+        assert response.status_code == 403
+
+    def test_read_catalogs_with_read_permission_calls_service(self):
+        _override_current_user(_make_pydantic_user(permissions=[READ_PERMISSION]))
+
+        with patch("routers.itsm_service_catalog.service_catalog_service") as mock_service:
+            mock_service.list_service_catalogs.return_value = [
+                {"service_id": "svc-1", "name": "Ops"}
+            ]
+
+            response = client.get("/api/itsm/service-catalog")
+
+        assert response.status_code == 200
+        assert response.json() == [{"service_id": "svc-1", "name": "Ops"}]
+        mock_service.list_service_catalogs.assert_called_once_with(limit=100)
+
+    def test_write_catalog_routes_require_write_permission(self):
+        _override_current_user(_make_pydantic_user(permissions=[READ_PERMISSION]))
+
+        response = client.post(
+            "/api/itsm/service-catalog",
+            json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45},
+        )
+        assert response.status_code == 403
+
+        response = client.put(
+            "/api/itsm/service-catalog/svc-1",
+            json={"name": "Changed"},
+        )
+        assert response.status_code == 403
+
+        response = client.post("/api/itsm/service-catalog/svc-1/deactivate")
+        assert response.status_code == 403
+
+    def test_catalog_routes_reject_inventory_event_permissions(self):
+        for endpoint, method, permissions in [
+            ("/api/itsm/service-catalog", "get", [UserPermission.CI_VIEW]),
+            ("/api/itsm/service-catalog", "post", [UserPermission.CI_EDIT]),
+            ("/api/itsm/service-catalog/svc-1", "get", [UserPermission.CI_VIEW]),
+            ("/api/itsm/service-catalog/svc-1", "put", [UserPermission.CI_EDIT]),
+            ("/api/itsm/service-catalog/svc-1/deactivate", "post", [UserPermission.EVENT_VIEW]),
+        ]:
+            _override_current_user(_make_pydantic_user(permissions=permissions))
+            payload = {"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45}
+
+            if method == "get":
+                response = client.get(endpoint)
+            elif method == "post":
+                if endpoint.endswith("/deactivate"):
+                    response = client.post(endpoint)
+                else:
+                    response = client.post(endpoint, json=payload)
+            elif method == "put":
+                response = client.put(endpoint, json={"name": "Changed"})
+
+            assert response.status_code == 403
+
+    def test_create_catalog_with_write_permission_passes_payload(self):
+        _override_current_user(_make_pydantic_user(permissions=[WRITE_PERMISSION]))
+
+        with patch("routers.itsm_service_catalog.service_catalog_service") as mock_service:
+            mock_service.create_service_catalog.return_value = {
+                "service_id": "svc-new",
+                "name": "Core",
+                "active": True,
+            }
+
+            response = client.post(
+                "/api/itsm/service-catalog",
+                json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["service_id"] == "svc-new"
+        created_payload = mock_service.create_service_catalog.call_args.args[0]
+        assert created_payload.service_id == "svc-new"
+
+    def test_update_and_deactivate_catalog_with_write_permission(self):
+        _override_current_user(_make_pydantic_user(permissions=[WRITE_PERMISSION]))
+
+        with patch("routers.itsm_service_catalog.service_catalog_service") as mock_service:
+            mock_service.update_service_catalog.return_value = {
+                "service_id": "svc-1",
+                "name": "Updated",
+            }
+            mock_service.deactivate_service_catalog.return_value = {
+                "service_id": "svc-1",
+                "active": False,
+            }
+
+            put_response = client.put(
+                "/api/itsm/service-catalog/svc-1",
+                json={"name": "Updated"},
+            )
+            deactivate_response = client.post("/api/itsm/service-catalog/svc-1/deactivate")
+
+        assert put_response.status_code == 200
+        assert deactivate_response.status_code == 200
+        mock_service.update_service_catalog.assert_called_once()
+        mock_service.deactivate_service_catalog.assert_called_once_with("svc-1", actor="testuser")
+
+
+class TestItsmTicketRouter:
+    """Permissioned route coverage for /api/itsm/tickets."""
+
+    def test_ticket_read_routes_require_read_permission(self):
+        _override_current_user(_make_pydantic_user())
+        response = client.get("/api/itsm/tickets")
+        assert response.status_code == 403
+
+        response = client.get("/api/itsm/tickets/TK-1")
+        assert response.status_code == 403
+
+    def test_ticket_write_routes_require_write_permission(self):
+        _override_current_user(_make_pydantic_user(permissions=[READ_PERMISSION]))
+
+        response = client.post(
+            "/api/itsm/tickets",
+            json={"ticket_id": "TK-1", "type": "request", "title": "Access"},
+        )
+        assert response.status_code == 403
+
+        response = client.put(
+            "/api/itsm/tickets/TK-1",
+            json={"title": "Changed"},
+        )
+        assert response.status_code == 403
+
+        response = client.post(
+            "/api/itsm/tickets/TK-1/transition",
+            json={"next_status": "in_progress"},
+        )
+        assert response.status_code == 403
+
+    def test_ticket_routes_reject_catalog_or_event_permissions(self):
+        for endpoint, method, permissions in [
+            ("/api/itsm/tickets", "get", [UserPermission.CI_VIEW]),
+            ("/api/itsm/tickets/TK-1", "get", [UserPermission.EVENT_VIEW]),
+            ("/api/itsm/tickets", "post", [UserPermission.CI_EDIT]),
+            ("/api/itsm/tickets/TK-1", "put", [UserPermission.CI_EDIT]),
+            ("/api/itsm/tickets/TK-1/transition", "post", [UserPermission.EVENT_CLOSE]),
+        ]:
+            _override_current_user(_make_pydantic_user(permissions=permissions))
+
+            if method == "get":
+                response = client.get(endpoint)
+            elif method == "post":
+                if endpoint.endswith("/transition"):
+                    response = client.post(endpoint, json={"next_status": "in_progress"})
+                else:
+                    response = client.post(endpoint, json={"ticket_id": "TK-1", "type": "request", "title": "Access"})
+            elif method == "put":
+                response = client.put(endpoint, json={"title": "Changed"})
+
+            assert response.status_code == 403
+
+    def test_ticket_read_with_permission_calls_service(self):
+        _override_current_user(_make_pydantic_user(permissions=[READ_PERMISSION]))
+
+        with patch("routers.ticket_folios.ticket_folio_service") as mock_service:
+            mock_service.list_ticket_folios.return_value = [
+                {"ticket_id": "TK-1", "type": "request", "status": "open"}
+            ]
+
+            response = client.get("/api/itsm/tickets")
+
+        assert response.status_code == 200
+        assert response.json() == [{"ticket_id": "TK-1", "type": "request", "status": "open"}]
+        mock_service.list_ticket_folios.assert_called_once_with(
+            status=None,
+            service_catalog_id=None,
+            archived=None,
+            limit=100,
+        )
+
+    def test_ticket_mutations_pass_actor_and_payload(self):
+        _override_current_user(_make_pydantic_user(permissions=[WRITE_PERMISSION]))
+
+        with patch("routers.ticket_folios.ticket_folio_service") as mock_service:
+            mock_service.create_ticket_folio.return_value = {
+                "ticket_id": "TK-1",
+                "status": "open",
+            }
+            mock_service.update_ticket_folio.return_value = {
+                "ticket_id": "TK-1",
+                "title": "Escalated",
+            }
+            mock_service.transition_ticket_folio.return_value = {
+                "ticket_id": "TK-1",
+                "status": "in_progress",
+            }
+
+            response_create = client.post(
+                "/api/itsm/tickets",
+                json={"ticket_id": "TK-1", "type": "request", "title": "Access"},
+            )
+            response_update = client.put("/api/itsm/tickets/TK-1", json={"title": "Escalated"})
+            response_transition = client.post(
+                "/api/itsm/tickets/TK-1/transition",
+                json={"next_status": "in_progress"},
+            )
+
+        assert response_create.status_code == 200
+        assert response_update.status_code == 200
+        assert response_transition.status_code == 200
+        create_payload = mock_service.create_ticket_folio.call_args
+        assert create_payload.args[0].ticket_id == "TK-1"
+        assert create_payload.kwargs["actor"] == "testuser"
+
+        update_payload = mock_service.update_ticket_folio.call_args
+        assert update_payload.args[0] == "TK-1"
+        assert update_payload.args[1].title == "Escalated"
+        assert update_payload.kwargs["actor"] == "testuser"
+
+        transition_payload = mock_service.transition_ticket_folio.call_args
+        assert transition_payload.args[0] == "TK-1"
+        assert transition_payload.kwargs["next_status"] == "in_progress"
+        assert transition_payload.kwargs["actor"] == "testuser"
+
+        assert mock_service.create_ticket_folio.called
+        assert mock_service.update_ticket_folio.called
+        assert mock_service.transition_ticket_folio.called

--- a/backend/tests/test_routers_itsm.py
+++ b/backend/tests/test_routers_itsm.py
@@ -43,7 +43,10 @@ def _make_pydantic_user(
     return User(
         username=username,
         role=role,
-        permissions=[permission.value if isinstance(permission, UserPermission) else permission for permission in (permissions or [])],
+        permissions=[
+            permission.value if isinstance(permission, UserPermission) else permission
+            for permission in (permissions or [])
+        ],
         allowed_locations=[],
     )
 
@@ -227,7 +230,9 @@ class TestItsmTicketRouter:
                 if endpoint.endswith("/transition"):
                     response = client.post(endpoint, json={"next_status": "in_progress"})
                 else:
-                    response = client.post(endpoint, json={"ticket_id": "TK-1", "type": "request", "title": "Access"})
+                    response = client.post(
+                        endpoint, json={"ticket_id": "TK-1", "type": "request", "title": "Access"}
+                    )
             elif method == "put":
                 response = client.put(endpoint, json={"title": "Changed"})
 

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import HTTPException
-
 import services.ticket_folio_service as ticket_service
+from fastapi import HTTPException
 
 
 class _CatalogRepoStub:

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -16,7 +16,7 @@ class _CatalogRepoStub:
 
 class _TicketRepoStub:
     def __init__(self):
-        self.get = MagicMock()
+        self.get = MagicMock(return_value=None)
         self.list = MagicMock()
         self.upsert = MagicMock()
         self.update = MagicMock()
@@ -65,6 +65,32 @@ class TestTicketFolioService:
         assert created["status"] == "open"
         assert created["service_catalog_id"] == "svc-001"
         assert ticket_repo.sync_service_relationship.call_count == 1
+
+    def test_create_ticket_rejects_duplicate_without_mutating_closed_ticket(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = {
+            **_sample_ticket_record("closed"),
+            "archived": True,
+            "closed_reason": "Completed",
+        }
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                {
+                    "ticket_id": "TK-001",
+                    "type": "request",
+                    "title": "Retry request",
+                },
+                actor="admin",
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 409
+        assert "already exists" in exc.value.detail.lower()
+        ticket_repo.upsert.assert_not_called()
+        ticket_repo.sync_service_relationship.assert_not_called()
 
     def test_create_ticket_rejects_blank_title(self):
         catalog_repo = _CatalogRepoStub()

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -1,0 +1,264 @@
+"""Service-layer tests for ITSM ticket/folio lifecycle and transitions."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import services.ticket_folio_service as ticket_service
+
+
+class _CatalogRepoStub:
+    def __init__(self):
+        self.get_by_id = MagicMock()
+
+
+class _TicketRepoStub:
+    def __init__(self):
+        self.get = MagicMock()
+        self.list = MagicMock()
+        self.upsert = MagicMock()
+        self.update = MagicMock()
+        self.sync_service_relationship = MagicMock()
+
+
+def _sample_ticket_record(status: str = "open") -> dict:
+    return {
+        "ticket_id": "TK-001",
+        "type": "request",
+        "title": "Request access",
+        "description": "Please grant access",
+        "service_catalog_id": "svc-001",
+        "status": status,
+        "archived": False,
+        "closed_reason": None,
+        "created_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+        "updated_by": "admin",
+    }
+
+
+class TestTicketFolioService:
+    """Validate ticket lifecycle policy and no hard-delete semantics in service logic."""
+
+    def test_create_ticket_defaults_to_open_and_resolves_catalog_id(self):
+        catalog_repo = _CatalogRepoStub()
+        catalog_repo.get_by_id.return_value = {"service_id": "svc-001"}
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.upsert.return_value = _sample_ticket_record()
+
+        created = ticket_service.create_ticket_folio(
+            {
+                "ticket_id": "TK-001",
+                "type": "request",
+                "title": "Request access",
+                "description": "Please grant access",
+                "service_catalog_id": "svc-001",
+            },
+            actor="admin",
+            repository=ticket_repo,
+            catalog_repository=catalog_repo,
+        )
+
+        assert created["ticket_id"] == "TK-001"
+        assert created["status"] == "open"
+        assert created["service_catalog_id"] == "svc-001"
+        assert ticket_repo.sync_service_relationship.call_count == 1
+
+    def test_create_ticket_rejects_blank_title(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                {
+                    "ticket_id": "TK-blank",
+                    "type": "request",
+                    "title": "   ",
+                },
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 400
+        assert "title" in exc.value.detail.lower()
+        ticket_repo.upsert.assert_not_called()
+
+    def test_create_ticket_rejects_invalid_type(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                {
+                    "ticket_id": "TK-002",
+                    "type": "change",
+                    "title": "Change request",
+                },
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 400
+        ticket_repo.upsert.assert_not_called()
+        ticket_repo.sync_service_relationship.assert_not_called()
+
+    def test_create_ticket_requires_existing_catalog_when_catalog_id_provided(self):
+        catalog_repo = _CatalogRepoStub()
+        catalog_repo.get_by_id.return_value = None
+        ticket_repo = _TicketRepoStub()
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                {
+                    "ticket_id": "TK-003",
+                    "type": "incident",
+                    "title": "Production alarm",
+                    "service_catalog_id": "svc-missing",
+                },
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 404
+        assert "service_catalog" in exc.value.detail.lower()
+        ticket_repo.upsert.assert_not_called()
+
+    def test_transition_rejects_skip_and_regression(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("open")
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.transition_ticket_folio(
+                "TK-001",
+                next_status="resolved",
+                catalog_repository=catalog_repo,
+                repository=ticket_repo,
+                actor="admin",
+            )
+
+        assert exc.value.status_code == 409
+        assert "transition" in exc.value.detail.lower()
+        ticket_repo.update.assert_not_called()
+
+    def test_transition_to_closed_requires_closed_reason(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("resolved")
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.transition_ticket_folio(
+                "TK-001",
+                next_status="closed",
+                actor="admin",
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 400
+        assert "closed_reason" in exc.value.detail.lower()
+        ticket_repo.update.assert_not_called()
+
+    def test_transition_to_closed_archives_and_persists_reason(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("resolved")
+        ticket_repo.update.return_value = {
+            **_sample_ticket_record("resolved"),
+            "status": "closed",
+            "archived": True,
+            "closed_reason": "Incident resolved and verified",
+            "updated_by": "admin",
+        }
+
+        updated = ticket_service.transition_ticket_folio(
+            "TK-001",
+            next_status="closed",
+            closed_reason="Incident resolved and verified",
+            actor="admin",
+            repository=ticket_repo,
+            catalog_repository=catalog_repo,
+        )
+
+        assert updated["status"] == "closed"
+        assert updated["archived"] is True
+        assert updated["closed_reason"] == "Incident resolved and verified"
+        assert ticket_repo.update.called
+
+    def test_update_ticket_allows_clearing_optional_fields_and_syncs_relation(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("open")
+        ticket_repo.update.return_value = {
+            **_sample_ticket_record("open"),
+            "description": None,
+            "service_catalog_id": None,
+        }
+
+        ticket_service.update_ticket_folio(
+            "TK-001",
+            {"description": None, "service_catalog_id": None},
+            repository=ticket_repo,
+            catalog_repository=catalog_repo,
+        )
+
+        update_payload = ticket_repo.update.call_args.args[1]
+        assert "description" in update_payload.model_fields_set
+        assert "service_catalog_id" in update_payload.model_fields_set
+        ticket_repo.sync_service_relationship.assert_called_once_with("TK-001", None)
+
+    def test_closed_ticket_rejects_direct_updates(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("closed")
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.update_ticket_folio(
+                "TK-001",
+                {"title": "Should not change"},
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 409
+        assert "read-only" in exc.value.detail.lower()
+        ticket_repo.update.assert_not_called()
+
+    def test_archived_cannot_be_changed_without_closing_transition(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("open")
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.update_ticket_folio(
+                "TK-001",
+                {"archived": True},
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 409
+        assert "archived" in exc.value.detail.lower()
+        ticket_repo.update.assert_not_called()
+
+    def test_update_ticket_rejects_rollback_transition(self):
+        catalog_repo = _CatalogRepoStub()
+        ticket_repo = _TicketRepoStub()
+        ticket_repo.get.return_value = _sample_ticket_record("in_validation")
+
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.update_ticket_folio(
+                "TK-001",
+                {
+                    "status": "open",
+                },
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+        assert exc.value.status_code == 409
+        assert "transition" in exc.value.detail.lower()
+        ticket_repo.update.assert_not_called()

--- a/frontend/App.itsm-route.test.tsx
+++ b/frontend/App.itsm-route.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+
+const authMock = {
+  isAuthenticated: true,
+  loading: false,
+  user: {
+    username: "admin",
+    role: "ADMIN",
+    permissions: [],
+    allowed_locations: [],
+    tier: "T1",
+  },
+  hasPermission: vi.fn(() => true),
+  logout: vi.fn(),
+};
+
+vi.mock("./context/AuthContext", () => ({
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useAuth: () => authMock,
+}));
+
+vi.mock("./components/GraphCMDB", () => ({
+  default: () => <div>Graph CMDB</div>,
+}));
+vi.mock("./components/AIAgentConsole", () => ({
+  default: () => <div>AI Console</div>,
+}));
+vi.mock("./components/CIEditor", () => ({
+  default: () => <div>CI Editor</div>,
+}));
+vi.mock("./components/AdminPage", () => ({
+  default: () => <div>Administration</div>,
+}));
+vi.mock("./components/MonitoringConsole", () => ({
+  default: () => <div>Monitoring</div>,
+}));
+vi.mock("./components/SystemDashboard", () => ({
+  default: () => <div>System Dashboard</div>,
+}));
+vi.mock("./components/GlobalInventory", () => ({
+  default: () => <div>Inventory</div>,
+}));
+vi.mock("./components/ChangePasswordPage", () => ({
+  default: () => <div>Change Password</div>,
+}));
+vi.mock("./components/UserManager", () => ({
+  default: () => <div>User Manager</div>,
+}));
+vi.mock("./components/AuditLogPage", () => ({
+  default: () => <div>Audit Log</div>,
+}));
+vi.mock("./components/CIDetailModal", () => ({
+  default: () => <div>CI Detail Modal</div>,
+}));
+vi.mock("./components/MetricAnalytics", () => ({
+  default: () => <div>Metric Analytics</div>,
+}));
+vi.mock("./components/VisualRelationshipEditorPage", () => ({
+  default: () => <div>Visual Editor</div>,
+}));
+vi.mock("./components/LoginPage", () => ({
+  default: () => <div>Login Page</div>,
+}));
+vi.mock("./components/ItsmServiceCatalogPage", () => ({
+  default: () => <div>ITSM Service Catalog Page</div>,
+}));
+vi.mock("./components/ItsmTicketFolioPage", () => ({
+  default: () => <div>ITSM Ticket Folio Page</div>,
+}));
+
+const renderApp = (initialPath = "/itsm/service-catalog") => {
+  window.location.hash = `#${initialPath}`;
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>,
+  );
+};
+
+describe("App routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.hasPermission = vi.fn(() => true);
+  });
+
+  it("renders dedicated ITSM service catalog route", () => {
+    renderApp("/itsm/service-catalog");
+
+    expect(screen.getByText("ITSM Service Catalog Page")).toBeInTheDocument();
+  });
+
+  it("renders dedicated ITSM ticket folio route", () => {
+    renderApp("/itsm/tickets");
+
+    expect(screen.getByText("ITSM Ticket Folio Page")).toBeInTheDocument();
+  });
+
+  it("keeps existing inventory route intact", () => {
+    renderApp("/inventory");
+
+    expect(screen.getByText("Inventory")).toBeInTheDocument();
+  });
+});

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,14 +1,7 @@
 /* eslint-disable no-console */
 import type React from "react";
 import { useCallback, useState } from "react";
-import {
-	HashRouter as Router,
-	Routes,
-	Route,
-	Link,
-	useLocation,
-	Navigate,
-} from "react-router-dom";
+import { HashRouter as Router, Routes, Route, Link, useLocation, Navigate } from "react-router-dom";
 import { AuthProvider, useAuth } from "./context/AuthContext";
 import LoginPage from "./components/LoginPage";
 import type { GraphNode } from "./types";
@@ -35,332 +28,295 @@ import ItsmTicketFolioPage from "./components/ItsmTicketFolioPage";
 
 // --- Protected Route Helper ---
 const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
-	const { isAuthenticated, loading, user } = useAuth();
-	const location = useLocation();
+  const { isAuthenticated, loading, user } = useAuth();
+  const location = useLocation();
 
-	if (loading) {
-		return (
-			<div className="h-screen w-screen flex flex-col items-center justify-center bg-surface-950 font-sans text-neutral-200">
-				<div className="w-10 h-10 border-4 border-brand-600 border-t-transparent rounded-full animate-spin mb-4"></div>
-				<p className="text-xs font-bold uppercase tracking-widest text-neutral-400 animate-pulse">
-					Loading Session...
-				</p>
-			</div>
-		);
-	}
+  if (loading) {
+    return (
+      <div className="h-screen w-screen flex flex-col items-center justify-center bg-surface-950 font-sans text-neutral-200">
+        <div className="w-10 h-10 border-4 border-brand-600 border-t-transparent rounded-full animate-spin mb-4"></div>
+        <p className="text-xs font-bold uppercase tracking-widest text-neutral-400 animate-pulse">
+          Loading Session...
+        </p>
+      </div>
+    );
+  }
 
-	if (!isAuthenticated) {
-		return <Navigate to="/login" replace />;
-	}
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
 
-	if (user?.force_password_change && location.pathname !== "/change-password") {
-		return <Navigate to="/change-password" replace />;
-	}
+  if (user?.force_password_change && location.pathname !== "/change-password") {
+    return <Navigate to="/change-password" replace />;
+  }
 
-	return children;
+  return children;
 };
 
 // --- Main Layout (Authenticated) ---
 const MainLayout: React.FC = () => {
-	const { user, logout, hasPermission } = useAuth();
-	const queryClient = useQueryClient();
-	const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+  const { user, logout, hasPermission } = useAuth();
+  const queryClient = useQueryClient();
+  const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
 
-	const [isEditing, setIsEditing] = useState(false);
-	const [showDetailModal, setShowDetailModal] = useState(false);
-	const [showAIAgent, setShowAIAgent] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [showDetailModal, setShowDetailModal] = useState(false);
+  const [showAIAgent, setShowAIAgent] = useState(false);
 
-	// --- CRUD Functions ---
-	const refreshTopologyResources = async () => {
-		await Promise.all([
-			queryClient.invalidateQueries({
-				queryKey: queryKeys.graphTopologyRoot(),
-			}),
-			queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
-			queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
-		]);
-	};
+  // --- CRUD Functions ---
+  const refreshTopologyResources = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.graphTopologyRoot(),
+      }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.nodes() }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.links() }),
+    ]);
+  };
 
-	const handleSaveCI = async (newNode: GraphNode) => {
-		try {
-			await api.post("/nodes", newNode);
-			await refreshTopologyResources();
-			setIsEditing(false);
-			setSelectedNode(null);
-		} catch (err) {
-			console.error(err);
-		}
-	};
+  const handleSaveCI = async (newNode: GraphNode) => {
+    try {
+      await api.post("/nodes", newNode);
+      await refreshTopologyResources();
+      setIsEditing(false);
+      setSelectedNode(null);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
-	const handleDeleteCI = async (id: string) => {
-		try {
-			await api.delete(`/nodes/${id}`);
-			await refreshTopologyResources();
-			setIsEditing(false);
-			setSelectedNode(null);
-		} catch (err) {
-			console.error(err);
-		}
-	};
+  const handleDeleteCI = async (id: string) => {
+    try {
+      await api.delete(`/nodes/${id}`);
+      await refreshTopologyResources();
+      setIsEditing(false);
+      setSelectedNode(null);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
-	const handleGraphNodeClick = useCallback((node: GraphNode) => {
-		setSelectedNode(node);
-		setShowDetailModal(true);
-	}, []);
+  const handleGraphNodeClick = useCallback((node: GraphNode) => {
+    setSelectedNode(node);
+    setShowDetailModal(true);
+  }, []);
 
-	const exportToPythonAgent = async () => {
-		try {
-			const topology = await api.get<{ nodes: GraphNode[]; links: unknown[] }>(
-				"/graph/full",
-			);
-			const data = JSON.stringify(topology, null, 2);
-			const blob = new Blob([data], { type: "application/json" });
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement("a");
-			a.href = url;
-			a.download = "cmdb_inventory.json";
-			a.click();
-		} catch (err) {
-			console.error("Failed to export CMDB inventory for Python agent.", err);
-			alert(
-				"No se pudo exportar el inventario. Verificá tu conexion o volve a iniciar sesion.",
-			);
-		}
-	};
+  const exportToPythonAgent = async () => {
+    try {
+      const topology = await api.get<{ nodes: GraphNode[]; links: unknown[] }>("/graph/full");
+      const data = JSON.stringify(topology, null, 2);
+      const blob = new Blob([data], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "cmdb_inventory.json";
+      a.click();
+    } catch (err) {
+      console.error("Failed to export CMDB inventory for Python agent.", err);
+      alert("No se pudo exportar el inventario. Verificá tu conexion o volve a iniciar sesion.");
+    }
+  };
 
-	return (
-		<div className="flex h-screen w-full max-w-full overflow-hidden bg-surface-950 font-sans text-neutral-200">
-			{/* Sidebar Nav */}
-			<nav className="w-20 lg:w-64 border-r border-white/5 flex flex-col glass z-50">
-				<div className="p-6 flex items-center gap-3">
-					<div className="w-10 h-10 bg-brand-600 rounded-xl flex items-center justify-center text-white neon-glow">
-						<span className="material-symbols-outlined text-2xl">hub</span>
-					</div>
-					<span className="hidden lg:block font-black text-xl tracking-tighter text-white">
-						NEX-GEN
-					</span>
-				</div>
+  return (
+    <div className="flex h-screen w-full max-w-full overflow-hidden bg-surface-950 font-sans text-neutral-200">
+      {/* Sidebar Nav */}
+      <nav className="w-20 lg:w-64 border-r border-white/5 flex flex-col glass z-50">
+        <div className="p-6 flex items-center gap-3">
+          <div className="w-10 h-10 bg-brand-600 rounded-xl flex items-center justify-center text-white neon-glow">
+            <span className="material-symbols-outlined text-2xl">hub</span>
+          </div>
+          <span className="hidden lg:block font-black text-xl tracking-tighter text-white">
+            NEX-GEN
+          </span>
+        </div>
 
-				<div className="flex-1 flex flex-col py-6 space-y-2 px-3">
-					<NavItem to="/" icon="dashboard" label="Architecture" />
-					<NavItem to="/monitoring" icon="public" label="Monitoring" />
-					<NavItem to="/cmdb" icon="mediation" label="Graph CMDB" />
-					<NavItem to="/inventory" icon="inventory_2" label="CI Inventory" />
-					<NavItem to="/network" icon="hub" label="Network Topology" />
-					{(hasPermission("ITSM_VIEW") || hasPermission("ADMIN")) && (
-						<>
-							<NavItem
-								to="/itsm/service-catalog"
-								icon="support_agent"
-								label="ITSM Catalog"
-							/>
-							<NavItem
-								to="/itsm/tickets"
-								icon="confirmation_number"
-								label="ITSM Tickets"
-							/>
-						</>
-					)}
+        <div className="flex-1 flex flex-col py-6 space-y-2 px-3">
+          <NavItem to="/" icon="dashboard" label="Architecture" />
+          <NavItem to="/monitoring" icon="public" label="Monitoring" />
+          <NavItem to="/cmdb" icon="mediation" label="Graph CMDB" />
+          <NavItem to="/inventory" icon="inventory_2" label="CI Inventory" />
+          <NavItem to="/network" icon="hub" label="Network Topology" />
+          {(hasPermission("ITSM_VIEW") || hasPermission("ADMIN")) && (
+            <>
+              <NavItem to="/itsm/service-catalog" icon="support_agent" label="ITSM Catalog" />
+              <NavItem to="/itsm/tickets" icon="confirmation_number" label="ITSM Tickets" />
+            </>
+          )}
 
+          {(hasPermission("ADMIN") || hasPermission("METRICS_VIEW")) && (
+            <NavItem to="/analytics" icon="monitoring" label="Analytics" />
+          )}
 
-					{(hasPermission("ADMIN") || hasPermission("METRICS_VIEW")) && (
-						<NavItem to="/analytics" icon="monitoring" label="Analytics" />
-					)}
+          {(hasPermission("ADMIN") || hasPermission("USER_MANAGE")) && (
+            <NavItem to="/users" icon="manage_accounts" label="User Management" />
+          )}
+          {(hasPermission("AUDIT_VIEW") || hasPermission("ADMIN")) && (
+            <NavItem to="/audit" icon="history" label="Audit Log" />
+          )}
+          {(hasPermission("ADMIN") || hasPermission("USER_MANAGE")) && (
+            <NavItem to="/admin" icon="admin_panel_settings" label="Administration" />
+          )}
+        </div>
 
-					{(hasPermission("ADMIN") || hasPermission("USER_MANAGE")) && (
-						<NavItem
-							to="/users"
-							icon="manage_accounts"
-							label="User Management"
-						/>
-					)}
-					{(hasPermission("AUDIT_VIEW") || hasPermission("ADMIN")) && (
-						<NavItem
-							to="/audit"
-							icon="history"
-							label="Audit Log"
-						/>
-					)}
-					{(hasPermission("ADMIN") || hasPermission("USER_MANAGE")) && (
-						<NavItem
-							to="/admin"
-							icon="admin_panel_settings"
-							label="Administration"
-						/>
-					)}
-				</div>
+        <div className="p-6 space-y-4 border-t border-white/5">
+          <button
+            onClick={exportToPythonAgent}
+            className="w-full flex items-center gap-3 px-4 py-2 text-[10px] font-black uppercase text-neutral-500 hover:text-white transition-colors"
+          >
+            <span className="material-symbols-outlined text-sm">terminal</span>
+            Python Export
+          </button>
+          <div
+            className="flex items-center gap-3 group cursor-pointer"
+            onClick={logout}
+            title="Click to Logout"
+          >
+            <div className="w-10 h-10 rounded-full bg-neutral-800 border border-white/10 overflow-hidden flex items-center justify-center">
+              {/* Initials */}
+              <span className="font-bold text-lg">
+                {user?.username?.substring(0, 2).toUpperCase()}
+              </span>
+            </div>
+            <div className="hidden lg:block text-left">
+              <p className="text-xs font-bold text-white">{user?.username || "Guest"}</p>
+              <p className="text-[10px] text-neutral-500 uppercase tracking-widest">
+                {user?.role || "Viewer"}
+              </p>
+            </div>
+            <span className="material-symbols-outlined text-neutral-500 group-hover:text-red-500 ml-auto text-sm">
+              logout
+            </span>
+          </div>
+        </div>
+      </nav>
 
-				<div className="p-6 space-y-4 border-t border-white/5">
-					<button
-						onClick={exportToPythonAgent}
-						className="w-full flex items-center gap-3 px-4 py-2 text-[10px] font-black uppercase text-neutral-500 hover:text-white transition-colors"
-					>
-						<span className="material-symbols-outlined text-sm">terminal</span>
-						Python Export
-					</button>
-					<div
-						className="flex items-center gap-3 group cursor-pointer"
-						onClick={logout}
-						title="Click to Logout"
-					>
-						<div className="w-10 h-10 rounded-full bg-neutral-800 border border-white/10 overflow-hidden flex items-center justify-center">
-							{/* Initials */}
-							<span className="font-bold text-lg">
-								{user?.username?.substring(0, 2).toUpperCase()}
-							</span>
-						</div>
-						<div className="hidden lg:block text-left">
-							<p className="text-xs font-bold text-white">
-								{user?.username || "Guest"}
-							</p>
-							<p className="text-[10px] text-neutral-500 uppercase tracking-widest">
-								{user?.role || "Viewer"}
-							</p>
-						</div>
-						<span className="material-symbols-outlined text-neutral-500 group-hover:text-red-500 ml-auto text-sm">
-							logout
-						</span>
-					</div>
-				</div>
-			</nav>
+      {/* Main View Area */}
+      <div className="flex-1 min-w-0 flex flex-col relative overflow-hidden">
+        <header className="h-20 border-b border-white/5 flex items-center justify-between px-8 glass z-40">
+          <div className="flex items-center gap-4">
+            <h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">
+              Platform Engine v3.2
+            </h1>
+            <div className="hidden md:flex items-center gap-2 bg-neutral-900 border border-white/5 px-3 py-1 rounded-full text-[10px] font-black text-accent-cyan">
+              <span className="w-2 h-2 bg-accent-cyan rounded-full animate-pulse"></span>
+              SNMP Polling: ACTIVE
+            </div>
+          </div>
 
-			{/* Main View Area */}
-			<div className="flex-1 min-w-0 flex flex-col relative overflow-hidden">
-				<header className="h-20 border-b border-white/5 flex items-center justify-between px-8 glass z-40">
-					<div className="flex items-center gap-4">
-						<h1 className="text-lg font-bold text-white tracking-tight uppercase tracking-widest">
-							Platform Engine v3.2
-						</h1>
-						<div className="hidden md:flex items-center gap-2 bg-neutral-900 border border-white/5 px-3 py-1 rounded-full text-[10px] font-black text-accent-cyan">
-							<span className="w-2 h-2 bg-accent-cyan rounded-full animate-pulse"></span>
-							SNMP Polling: ACTIVE
-						</div>
-					</div>
+          <div className="flex items-center gap-4">
+            {/* Header Actions */}
+            <button
+              onClick={() => setShowAIAgent(!showAIAgent)}
+              className={`flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black transition-all border ${showAIAgent ? "bg-white/10 text-white border-white/20" : "bg-transparent text-neutral-500 border-white/5 hover:text-white"}`}
+            >
+              <span className="material-symbols-outlined text-sm">
+                {showAIAgent ? "chat" : "chat_bubble_outline"}
+              </span>
+              {showAIAgent ? "HIDE AI" : "SHOW AI"}
+            </button>
+          </div>
+        </header>
 
-					<div className="flex items-center gap-4">
-						{/* Header Actions */}
-						<button
-							onClick={() => setShowAIAgent(!showAIAgent)}
-							className={`flex items-center gap-2 px-5 py-2.5 rounded-xl text-xs font-black transition-all border ${showAIAgent ? "bg-white/10 text-white border-white/20" : "bg-transparent text-neutral-500 border-white/5 hover:text-white"}`}
-						>
-							<span className="material-symbols-outlined text-sm">
-								{showAIAgent ? "chat" : "chat_bubble_outline"}
-							</span>
-							{showAIAgent ? "HIDE AI" : "SHOW AI"}
-						</button>
-					</div>
-				</header>
+        <main className="flex-1 min-w-0 flex overflow-hidden relative">
+          <div className="flex-1 min-w-0 h-full relative overflow-hidden">
+            <Routes>
+              <Route index element={<SystemDashboard />} />
+              <Route path="monitoring" element={<MonitoringConsole />} />
+              <Route path="admin" element={<AdminPage />} />
+              <Route
+                path="admin/relationships/visual-editor"
+                element={<VisualRelationshipEditorPage />}
+              />
+              <Route path="users" element={<UserManager />} />
+              <Route path="audit" element={<AuditLogPage />} />
+              <Route path="cmdb" element={<GraphCMDB onNodeClick={handleGraphNodeClick} />} />
+              <Route path="analytics" element={<MetricAnalytics />} />
+              <Route path="inventory" element={<GlobalInventory />} />
+              <Route path="itsm/service-catalog" element={<ItsmServiceCatalogPage />} />
+              <Route path="itsm/tickets" element={<ItsmTicketFolioPage />} />
+            </Routes>
+          </div>
 
-				<main className="flex-1 min-w-0 flex overflow-hidden relative">
-					<div className="flex-1 min-w-0 h-full relative overflow-hidden">
-						<Routes>
-							<Route index element={<SystemDashboard />} />
-							<Route path="monitoring" element={<MonitoringConsole />} />
-							<Route path="admin" element={<AdminPage />} />
-							<Route
-								path="admin/relationships/visual-editor"
-								element={<VisualRelationshipEditorPage />}
-							/>
-							<Route path="users" element={<UserManager />} />
-							<Route path="audit" element={<AuditLogPage />} />
-							<Route
-								path="cmdb"
-								element={<GraphCMDB onNodeClick={handleGraphNodeClick} />}
-							/>
-							<Route path="analytics" element={<MetricAnalytics />} />
-							<Route path="inventory" element={<GlobalInventory />} />
-							<Route path="itsm/service-catalog" element={<ItsmServiceCatalogPage />} />
-							<Route path="itsm/tickets" element={<ItsmTicketFolioPage />} />
-						</Routes>
-					</div>
+          {isEditing && (
+            <CIEditor
+              node={selectedNode}
+              onSave={handleSaveCI}
+              onDelete={handleDeleteCI}
+              onClose={() => setIsEditing(false)}
+            />
+          )}
 
-					{isEditing && (
-						<CIEditor
-							node={selectedNode}
-							onSave={handleSaveCI}
-							onDelete={handleDeleteCI}
-							onClose={() => setIsEditing(false)}
-						/>
-					)}
+          {showDetailModal && (
+            <CIDetailModal node={selectedNode} onClose={() => setShowDetailModal(false)} />
+          )}
 
-					{showDetailModal && (
-						<CIDetailModal
-							node={selectedNode}
-							onClose={() => setShowDetailModal(false)}
-						/>
-					)}
-
-					<aside
-						className={`w-96 border-l border-white/5 glass flex flex-col transition-all duration-500 ${isEditing || !showAIAgent ? "opacity-0 translate-x-full absolute right-0" : "relative opacity-100 translate-x-0"}`}
-					>
-						<AIAgentConsole />
-					</aside>
-				</main>
-			</div>
-		</div>
-	);
+          <aside
+            className={`w-96 border-l border-white/5 glass flex flex-col transition-all duration-500 ${isEditing || !showAIAgent ? "opacity-0 translate-x-full absolute right-0" : "relative opacity-100 translate-x-0"}`}
+          >
+            <AIAgentConsole />
+          </aside>
+        </main>
+      </div>
+    </div>
+  );
 };
 
 // --- Helper Components ---
 const NavItem: React.FC<{
-	to: string;
-	icon: string;
-	label: string;
-	count?: number;
+  to: string;
+  icon: string;
+  label: string;
+  count?: number;
 }> = ({ to, icon, label, count }) => {
-	const location = useLocation();
-	const active = location.pathname === to;
-	return (
-		<Link
-			to={to}
-			className={`flex items-center gap-4 px-4 py-3.5 rounded-2xl transition-all duration-300 group ${
-				active
-					? "bg-brand-600/15 text-brand-400 border border-brand-600/20"
-					: "text-neutral-500 hover:text-neutral-200 hover:bg-white/5"
-			}`}
-		>
-			<span
-				className={`material-symbols-outlined text-2xl ${active ? "fill-1" : ""}`}
-			>
-				{icon}
-			</span>
-			<span className="hidden lg:block text-sm font-bold">{label}</span>
-			{count && (
-				<span className="ml-auto bg-red-500/20 text-red-500 text-[10px] px-1.5 py-0.5 rounded">
-					{count}
-				</span>
-			)}
-		</Link>
-	);
+  const location = useLocation();
+  const active = location.pathname === to;
+  return (
+    <Link
+      to={to}
+      className={`flex items-center gap-4 px-4 py-3.5 rounded-2xl transition-all duration-300 group ${
+        active
+          ? "bg-brand-600/15 text-brand-400 border border-brand-600/20"
+          : "text-neutral-500 hover:text-neutral-200 hover:bg-white/5"
+      }`}
+    >
+      <span className={`material-symbols-outlined text-2xl ${active ? "fill-1" : ""}`}>{icon}</span>
+      <span className="hidden lg:block text-sm font-bold">{label}</span>
+      {count && (
+        <span className="ml-auto bg-red-500/20 text-red-500 text-[10px] px-1.5 py-0.5 rounded">
+          {count}
+        </span>
+      )}
+    </Link>
+  );
 };
 
 // --- App Entry Point ---
 const App: React.FC = () => {
-	return (
-		<Router>
-			<AuthProvider>
-				<Routes>
-					<Route path="/login" element={<LoginPage />} />
-					<Route
-						path="/change-password"
-						element={
-							<ProtectedRoute>
-								<ChangePasswordPage />
-							</ProtectedRoute>
-						}
-					/>
-					<Route
-						path="/*"
-						element={
-							<ProtectedRoute>
-								<MainLayout />
-							</ProtectedRoute>
-						}
-					/>
-				</Routes>
-			</AuthProvider>
-		</Router>
-	);
+  return (
+    <Router>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/change-password"
+            element={
+              <ProtectedRoute>
+                <ChangePasswordPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/*"
+            element={
+              <ProtectedRoute>
+                <MainLayout />
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </AuthProvider>
+    </Router>
+  );
 };
 
 export default App;

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import type React from "react";
 import { useCallback, useState } from "react";
 import {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -29,6 +29,8 @@ import AuditLogPage from "./components/AuditLogPage";
 import CIDetailModal from "./components/CIDetailModal";
 import MetricAnalytics from "./components/MetricAnalytics";
 import VisualRelationshipEditorPage from "./components/VisualRelationshipEditorPage";
+import ItsmServiceCatalogPage from "./components/ItsmServiceCatalogPage";
+import ItsmTicketFolioPage from "./components/ItsmTicketFolioPage";
 
 // --- Protected Route Helper ---
 const ProtectedRoute = ({ children }: { children: React.ReactElement }) => {
@@ -144,6 +146,21 @@ const MainLayout: React.FC = () => {
 					<NavItem to="/cmdb" icon="mediation" label="Graph CMDB" />
 					<NavItem to="/inventory" icon="inventory_2" label="CI Inventory" />
 					<NavItem to="/network" icon="hub" label="Network Topology" />
+					{(hasPermission("ITSM_VIEW") || hasPermission("ADMIN")) && (
+						<>
+							<NavItem
+								to="/itsm/service-catalog"
+								icon="support_agent"
+								label="ITSM Catalog"
+							/>
+							<NavItem
+								to="/itsm/tickets"
+								icon="confirmation_number"
+								label="ITSM Tickets"
+							/>
+						</>
+					)}
+
 
 					{(hasPermission("ADMIN") || hasPermission("METRICS_VIEW")) && (
 						<NavItem to="/analytics" icon="monitoring" label="Analytics" />
@@ -251,6 +268,8 @@ const MainLayout: React.FC = () => {
 							/>
 							<Route path="analytics" element={<MetricAnalytics />} />
 							<Route path="inventory" element={<GlobalInventory />} />
+							<Route path="itsm/service-catalog" element={<ItsmServiceCatalogPage />} />
+							<Route path="itsm/tickets" element={<ItsmTicketFolioPage />} />
 						</Routes>
 					</div>
 

--- a/frontend/components/ItsmServiceCatalogPage.tsx
+++ b/frontend/components/ItsmServiceCatalogPage.tsx
@@ -1,0 +1,332 @@
+import React, { useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import {
+  createServiceCatalog,
+  deactivateServiceCatalog,
+  listServiceCatalog,
+  updateServiceCatalog,
+} from "../services/itsm";
+import type {
+  ServiceCatalogCreatePayload,
+  ServiceCatalogResponse,
+  ServiceCatalogUpdatePayload,
+} from "../types/itsm";
+
+type FormMode = "create" | "edit";
+
+type CatalogFormState = {
+  service_id: string;
+  name: string;
+  owner_team: string;
+  category: string;
+  tier: string;
+  criticality: string;
+  sla_target_minutes: string;
+};
+
+const emptyForm: CatalogFormState = {
+  service_id: "",
+  name: "",
+  owner_team: "",
+  category: "",
+  tier: "",
+  criticality: "",
+  sla_target_minutes: "0",
+};
+
+const normalizeString = (value: string) => value.trim();
+
+const toCreatePayload = (state: CatalogFormState): ServiceCatalogCreatePayload => ({
+  service_id: normalizeString(state.service_id),
+  name: normalizeString(state.name),
+  owner_team: normalizeString(state.owner_team) || null,
+  category: normalizeString(state.category) || null,
+  tier: normalizeString(state.tier) || null,
+  criticality: normalizeString(state.criticality) || null,
+  sla_target_minutes: Number(state.sla_target_minutes),
+});
+
+const toUpdatePayload = (state: CatalogFormState): ServiceCatalogUpdatePayload => ({
+  service_id: normalizeString(state.service_id),
+  name: normalizeString(state.name),
+  owner_team: normalizeString(state.owner_team) || null,
+  category: normalizeString(state.category) || null,
+  tier: normalizeString(state.tier) || null,
+  criticality: normalizeString(state.criticality) || null,
+  sla_target_minutes: Number(state.sla_target_minutes),
+});
+
+const ItsmServiceCatalogPage: React.FC = () => {
+  const [catalogs, setCatalogs] = useState<ServiceCatalogResponse[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<FormMode | null>(null);
+  const [selectedServiceId, setSelectedServiceId] = useState<string>("");
+  const [formState, setFormState] = useState<CatalogFormState>(emptyForm);
+
+  const hasCatalogs = useMemo(() => catalogs.length > 0, [catalogs]);
+
+  const loadCatalogs = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const catalogItems = await listServiceCatalog();
+      setCatalogs(catalogItems);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load service catalog.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadCatalogs();
+  }, []);
+
+  const onResetForm = () => {
+    setMode(null);
+    setSelectedServiceId("");
+    setFormState(emptyForm);
+  };
+
+  const onStartCreate = () => {
+    setMode("create");
+    setSelectedServiceId("");
+    setFormState(emptyForm);
+  };
+
+  const onStartEdit = (catalog: ServiceCatalogResponse) => {
+    setMode("edit");
+    setSelectedServiceId(catalog.service_id);
+    setFormState({
+      service_id: catalog.service_id,
+      name: catalog.name,
+      owner_team: catalog.owner_team ?? "",
+      category: catalog.category ?? "",
+      tier: catalog.tier ?? "",
+      criticality: catalog.criticality ?? "",
+      sla_target_minutes: String(catalog.sla_target_minutes),
+    });
+  };
+
+  const onChange = (field: keyof CatalogFormState, value: string) => {
+    setFormState(prev => ({ ...prev, [field]: value }));
+  };
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!formState.name.trim() || !formState.service_id.trim()) {
+      setError("Service ID and Name are required.");
+      return;
+    }
+
+    if (Number(formState.sla_target_minutes) < 0 || Number.isNaN(Number(formState.sla_target_minutes))) {
+      setError("SLA target minutes must be a non-negative number.");
+      return;
+    }
+
+    try {
+      if (mode === "edit" && selectedServiceId) {
+        await updateServiceCatalog(selectedServiceId, toUpdatePayload(formState));
+      } else {
+        await createServiceCatalog(toCreatePayload(formState));
+      }
+
+      await loadCatalogs();
+      onResetForm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save service catalog record.");
+    }
+  };
+
+  const onDeactivate = async (serviceId: string) => {
+    try {
+      await deactivateServiceCatalog(serviceId);
+      await loadCatalogs();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not deactivate service catalog record.");
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col p-6 gap-4 overflow-hidden">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-black text-white tracking-tighter uppercase">ITSM Service Catalog</h1>
+          <p className="text-xs font-black text-neutral-400 uppercase tracking-wider">
+            Manage operational service definitions and SLA targets in a dedicated ITSM surface.
+          </p>
+        </div>
+        <button
+          onClick={onStartCreate}
+          type="button"
+          className="px-4 py-2 rounded-lg font-bold bg-brand-600 hover:bg-brand-500 text-white text-sm"
+          aria-label="New Service Catalog"
+        >
+          New Service Catalog
+        </button>
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 p-3 text-sm" role="alert">
+          {error}
+        </div>
+      )}
+
+      {mode && (
+        <form className="grid gap-3 glass rounded-xl border border-white/5 p-4" onSubmit={onSubmit}>
+          <h2 className="text-sm font-black uppercase text-neutral-300">
+            {mode === "create" ? "Create Service Catalog" : `Edit Service ${selectedServiceId}`}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="text-xs text-neutral-300" htmlFor="service_id">
+              Service ID
+              <input
+                id="service_id"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.service_id}
+                onChange={event => onChange("service_id", event.target.value)}
+                disabled={mode === "edit"}
+                aria-label="Service ID"
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="name">
+              Name
+              <input
+                id="name"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.name}
+                onChange={event => onChange("name", event.target.value)}
+                aria-label="Name"
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="owner_team">
+              Owner Team
+              <input
+                id="owner_team"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.owner_team}
+                onChange={event => onChange("owner_team", event.target.value)}
+                aria-label="Owner Team"
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="category">
+              Category
+              <input
+                id="category"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.category}
+                onChange={event => onChange("category", event.target.value)}
+                aria-label="Category"
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="tier">
+              Tier
+              <input
+                id="tier"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.tier}
+                onChange={event => onChange("tier", event.target.value)}
+                aria-label="Tier"
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="criticality">
+              Criticality
+              <input
+                id="criticality"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.criticality}
+                onChange={event => onChange("criticality", event.target.value)}
+                aria-label="Criticality"
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="sla_target_minutes">
+              SLA Target Minutes
+              <input
+                id="sla_target_minutes"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.sla_target_minutes}
+                onChange={event => onChange("sla_target_minutes", event.target.value)}
+                inputMode="numeric"
+                aria-label="SLA Target Minutes"
+              />
+            </label>
+          </div>
+          <div className="flex gap-3 justify-end">
+            <button
+              type="button"
+              className="px-3 py-2 rounded-lg border border-white/20 text-white text-sm"
+              onClick={onResetForm}
+            >
+              Cancel
+            </button>
+            <button className="px-3 py-2 rounded-lg bg-brand-600 text-white font-bold text-sm" type="submit">
+              Save
+            </button>
+          </div>
+        </form>
+      )}
+
+      <section className="flex-1 min-h-0 glass rounded-xl border border-white/5 p-4 overflow-auto">
+        {loading ? (
+          <p className="text-sm text-neutral-400">Loading service catalog...</p>
+        ) : hasCatalogs ? (
+          <div className="space-y-3">
+            {catalogs.map(catalog => (
+              <article
+                key={catalog.service_id}
+                className={`p-4 rounded-lg border ${catalog.active ? "border-white/10" : "border-red-500/40"} bg-black/40 flex items-center justify-between gap-3`
+                }
+                aria-label={`service catalog ${catalog.service_id}`}
+              >
+                <div className="space-y-1">
+                  <p className="text-white font-bold">{catalog.name}</p>
+                  <p className="text-xs text-neutral-400">
+                    {catalog.service_id} · {catalog.category || "No category"} · {catalog.owner_team || "Unowned"}
+                  </p>
+                  <p className="text-xs text-neutral-500">SLA {catalog.sla_target_minutes} min · {catalog.criticality || "Unknown"} · {catalog.tier || "Unknown tier"}</p>
+                  <p className="text-[11px] text-neutral-500">
+                    {catalog.active ? "Status: Active" : "Status: Deactivated"}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className="px-3 py-2 rounded-lg bg-white/5 text-xs font-black text-white hover:bg-white/10"
+                    onClick={() => onStartEdit(catalog)}
+                    aria-label={`Edit ${catalog.service_id}`}
+                  >
+                    Edit
+                  </button>
+                  {catalog.active ? (
+                    <button
+                      type="button"
+                      className="px-3 py-2 rounded-lg bg-amber-500/20 border border-amber-300/40 text-xs font-black text-amber-200 hover:bg-amber-500/30"
+                      onClick={() => onDeactivate(catalog.service_id)}
+                      aria-label={`Deactivate ${catalog.service_id}`}
+                    >
+                      Deactivate
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      className="px-3 py-2 rounded-lg bg-white/5 text-xs font-black text-white/40 cursor-not-allowed"
+                      disabled
+                    >
+                      Deactivated
+                    </button>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-neutral-400">No service catalog entries yet. Create your first service above.</p>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default ItsmServiceCatalogPage;

--- a/frontend/components/ItsmServiceCatalogPage.tsx
+++ b/frontend/components/ItsmServiceCatalogPage.tsx
@@ -110,7 +110,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
   };
 
   const onChange = (field: keyof CatalogFormState, value: string) => {
-    setFormState(prev => ({ ...prev, [field]: value }));
+    setFormState((prev) => ({ ...prev, [field]: value }));
   };
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -121,7 +121,10 @@ const ItsmServiceCatalogPage: React.FC = () => {
       return;
     }
 
-    if (Number(formState.sla_target_minutes) < 0 || Number.isNaN(Number(formState.sla_target_minutes))) {
+    if (
+      Number(formState.sla_target_minutes) < 0 ||
+      Number.isNaN(Number(formState.sla_target_minutes))
+    ) {
       setError("SLA target minutes must be a non-negative number.");
       return;
     }
@@ -153,7 +156,9 @@ const ItsmServiceCatalogPage: React.FC = () => {
     <div className="h-full flex flex-col p-6 gap-4 overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-3xl font-black text-white tracking-tighter uppercase">ITSM Service Catalog</h1>
+          <h1 className="text-3xl font-black text-white tracking-tighter uppercase">
+            ITSM Service Catalog
+          </h1>
           <p className="text-xs font-black text-neutral-400 uppercase tracking-wider">
             Manage operational service definitions and SLA targets in a dedicated ITSM surface.
           </p>
@@ -169,7 +174,10 @@ const ItsmServiceCatalogPage: React.FC = () => {
       </header>
 
       {error && (
-        <div className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 p-3 text-sm" role="alert">
+        <div
+          className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 p-3 text-sm"
+          role="alert"
+        >
           {error}
         </div>
       )}
@@ -186,7 +194,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="service_id"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.service_id}
-                onChange={event => onChange("service_id", event.target.value)}
+                onChange={(event) => onChange("service_id", event.target.value)}
                 disabled={mode === "edit"}
                 aria-label="Service ID"
               />
@@ -197,7 +205,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="name"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.name}
-                onChange={event => onChange("name", event.target.value)}
+                onChange={(event) => onChange("name", event.target.value)}
                 aria-label="Name"
               />
             </label>
@@ -207,7 +215,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="owner_team"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.owner_team}
-                onChange={event => onChange("owner_team", event.target.value)}
+                onChange={(event) => onChange("owner_team", event.target.value)}
                 aria-label="Owner Team"
               />
             </label>
@@ -217,7 +225,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="category"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.category}
-                onChange={event => onChange("category", event.target.value)}
+                onChange={(event) => onChange("category", event.target.value)}
                 aria-label="Category"
               />
             </label>
@@ -227,7 +235,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="tier"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.tier}
-                onChange={event => onChange("tier", event.target.value)}
+                onChange={(event) => onChange("tier", event.target.value)}
                 aria-label="Tier"
               />
             </label>
@@ -237,7 +245,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="criticality"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.criticality}
-                onChange={event => onChange("criticality", event.target.value)}
+                onChange={(event) => onChange("criticality", event.target.value)}
                 aria-label="Criticality"
               />
             </label>
@@ -247,7 +255,7 @@ const ItsmServiceCatalogPage: React.FC = () => {
                 id="sla_target_minutes"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.sla_target_minutes}
-                onChange={event => onChange("sla_target_minutes", event.target.value)}
+                onChange={(event) => onChange("sla_target_minutes", event.target.value)}
                 inputMode="numeric"
                 aria-label="SLA Target Minutes"
               />
@@ -261,7 +269,10 @@ const ItsmServiceCatalogPage: React.FC = () => {
             >
               Cancel
             </button>
-            <button className="px-3 py-2 rounded-lg bg-brand-600 text-white font-bold text-sm" type="submit">
+            <button
+              className="px-3 py-2 rounded-lg bg-brand-600 text-white font-bold text-sm"
+              type="submit"
+            >
               Save
             </button>
           </div>
@@ -273,19 +284,22 @@ const ItsmServiceCatalogPage: React.FC = () => {
           <p className="text-sm text-neutral-400">Loading service catalog...</p>
         ) : hasCatalogs ? (
           <div className="space-y-3">
-            {catalogs.map(catalog => (
+            {catalogs.map((catalog) => (
               <article
                 key={catalog.service_id}
-                className={`p-4 rounded-lg border ${catalog.active ? "border-white/10" : "border-red-500/40"} bg-black/40 flex items-center justify-between gap-3`
-                }
+                className={`p-4 rounded-lg border ${catalog.active ? "border-white/10" : "border-red-500/40"} bg-black/40 flex items-center justify-between gap-3`}
                 aria-label={`service catalog ${catalog.service_id}`}
               >
                 <div className="space-y-1">
                   <p className="text-white font-bold">{catalog.name}</p>
                   <p className="text-xs text-neutral-400">
-                    {catalog.service_id} · {catalog.category || "No category"} · {catalog.owner_team || "Unowned"}
+                    {catalog.service_id} · {catalog.category || "No category"} ·{" "}
+                    {catalog.owner_team || "Unowned"}
                   </p>
-                  <p className="text-xs text-neutral-500">SLA {catalog.sla_target_minutes} min · {catalog.criticality || "Unknown"} · {catalog.tier || "Unknown tier"}</p>
+                  <p className="text-xs text-neutral-500">
+                    SLA {catalog.sla_target_minutes} min · {catalog.criticality || "Unknown"} ·{" "}
+                    {catalog.tier || "Unknown tier"}
+                  </p>
                   <p className="text-[11px] text-neutral-500">
                     {catalog.active ? "Status: Active" : "Status: Deactivated"}
                   </p>
@@ -322,7 +336,9 @@ const ItsmServiceCatalogPage: React.FC = () => {
             ))}
           </div>
         ) : (
-          <p className="text-sm text-neutral-400">No service catalog entries yet. Create your first service above.</p>
+          <p className="text-sm text-neutral-400">
+            No service catalog entries yet. Create your first service above.
+          </p>
         )}
       </section>
     </div>

--- a/frontend/components/ItsmTicketFolioPage.tsx
+++ b/frontend/components/ItsmTicketFolioPage.tsx
@@ -1,0 +1,285 @@
+import React, { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import {
+  createTicketFolio,
+  listTicketFolios,
+  transitionTicketFolio,
+  updateTicketFolio,
+} from "../services/itsm";
+import type {
+  TicketFolioCreatePayload,
+  TicketFolioResponse,
+  TicketFolioStatus,
+  TicketFolioType,
+} from "../types/itsm";
+import TicketStatusStepper from "./TicketStatusStepper";
+
+type TicketFormState = {
+  ticket_id: string;
+  type: TicketFolioType;
+  title: string;
+  description: string;
+  service_catalog_id: string;
+};
+
+const emptyForm: TicketFormState = {
+  ticket_id: "",
+  type: "request",
+  title: "",
+  description: "",
+  service_catalog_id: "",
+};
+
+const toCreatePayload = (state: TicketFormState): TicketFolioCreatePayload => ({
+  ticket_id: state.ticket_id.trim(),
+  type: state.type,
+  title: state.title.trim(),
+  description: state.description.trim() || null,
+  service_catalog_id: state.service_catalog_id.trim() || null,
+});
+
+const statusLabel = (status: TicketFolioStatus) => status.replace("_", " ");
+
+const ItsmTicketFolioPage: React.FC = () => {
+  const [tickets, setTickets] = useState<TicketFolioResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
+  const [formState, setFormState] = useState<TicketFormState>(emptyForm);
+
+  const loadTickets = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const items = await listTicketFolios({});
+      setTickets(items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load ITSM tickets.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadTickets();
+  }, []);
+
+  const onChange = (field: keyof TicketFormState, value: string) => {
+    setFormState(prev => ({ ...prev, [field]: value }));
+  };
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formState.ticket_id.trim() || !formState.title.trim()) {
+      setError("Ticket ID and Title are required.");
+      return;
+    }
+
+    try {
+      if (selectedTicketId) {
+        await updateTicketFolio(selectedTicketId, {
+          title: formState.title.trim(),
+          description: formState.description.trim() || null,
+          service_catalog_id: formState.service_catalog_id.trim() || null,
+        });
+      } else {
+        await createTicketFolio(toCreatePayload(formState));
+      }
+      await loadTickets();
+      setFormState(emptyForm);
+      setSelectedTicketId(null);
+      setShowForm(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not save ticket folio.");
+    }
+  };
+
+  const onStartEdit = (ticket: TicketFolioResponse) => {
+    setSelectedTicketId(ticket.ticket_id);
+    setFormState({
+      ticket_id: ticket.ticket_id,
+      type: ticket.type,
+      title: ticket.title,
+      description: ticket.description ?? "",
+      service_catalog_id: ticket.service_catalog_id ?? "",
+    });
+    setShowForm(true);
+  };
+
+  const onTransition = async (ticketId: string, nextStatus: TicketFolioStatus) => {
+    const closedReason = nextStatus === "closed" ? window.prompt("Close reason")?.trim() : undefined;
+    if (nextStatus === "closed" && !closedReason) {
+      setError("Closed tickets require a close reason.");
+      return;
+    }
+
+    try {
+      await transitionTicketFolio(ticketId, nextStatus, closedReason);
+      await loadTickets();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not transition ticket folio.");
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col p-6 gap-4 overflow-hidden">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-black text-white tracking-tighter uppercase">ITSM Tickets</h1>
+          <p className="text-xs font-black text-neutral-400 uppercase tracking-wider">
+            Manage request and incident folios independently from event workflows.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="px-4 py-2 rounded-lg font-bold bg-brand-600 hover:bg-brand-500 text-white text-sm"
+          onClick={() => {
+            setSelectedTicketId(null);
+            setFormState(emptyForm);
+            setShowForm(true);
+          }}
+        >
+          New Ticket
+        </button>
+      </header>
+
+      {error && (
+        <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 p-3 text-sm">
+          {error}
+        </div>
+      )}
+
+      {showForm && (
+        <form className="grid gap-3 glass rounded-xl border border-white/5 p-4" onSubmit={onSubmit}>
+          <h2 className="text-sm font-black uppercase text-neutral-300">
+            {selectedTicketId ? `Edit Ticket ${selectedTicketId}` : "Create Ticket Folio"}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="text-xs text-neutral-300" htmlFor="ticket_id">
+              Ticket ID
+              <input
+                id="ticket_id"
+                aria-label="Ticket ID"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.ticket_id}
+                onChange={event => onChange("ticket_id", event.target.value)}
+                disabled={Boolean(selectedTicketId)}
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="type">
+              Type
+              <select
+                id="type"
+                aria-label="Type"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.type}
+                onChange={event => onChange("type", event.target.value as TicketFolioType)}
+                disabled={Boolean(selectedTicketId)}
+              >
+                <option value="request">request</option>
+                <option value="incident">incident</option>
+              </select>
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="title">
+              Title
+              <input
+                id="title"
+                aria-label="Title"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.title}
+                onChange={event => onChange("title", event.target.value)}
+              />
+            </label>
+            <label className="text-xs text-neutral-300" htmlFor="service_catalog_id">
+              Service Catalog ID
+              <input
+                id="service_catalog_id"
+                aria-label="Service Catalog ID"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.service_catalog_id}
+                onChange={event => onChange("service_catalog_id", event.target.value)}
+              />
+            </label>
+            <label className="text-xs text-neutral-300 sm:col-span-2" htmlFor="description">
+              Description
+              <textarea
+                id="description"
+                aria-label="Description"
+                className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
+                value={formState.description}
+                onChange={event => onChange("description", event.target.value)}
+              />
+            </label>
+          </div>
+          <div className="flex gap-2">
+            <button type="submit" className="px-4 py-2 rounded-lg bg-brand-600 text-white font-bold">
+              Save Ticket
+            </button>
+            <button type="button" className="px-4 py-2 rounded-lg bg-white/10 text-neutral-200 font-bold" onClick={() => {
+              setShowForm(false);
+              setSelectedTicketId(null);
+              setFormState(emptyForm);
+            }}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      <section className="flex-1 overflow-auto rounded-xl border border-white/5 glass">
+        {loading ? (
+          <div className="p-4 text-sm text-neutral-400">Loading ITSM tickets...</div>
+        ) : tickets.length === 0 ? (
+          <div className="p-4 text-sm text-neutral-400">No ticket folios found.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="text-left text-neutral-400 uppercase text-xs">
+              <tr>
+                <th className="p-3">Ticket</th>
+                <th className="p-3">Type</th>
+                <th className="p-3">Service</th>
+                <th className="p-3">Status</th>
+                <th className="p-3">Next Step</th>
+                <th className="p-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tickets.map(ticket => (
+                <tr key={ticket.ticket_id} className="border-t border-white/5">
+                  <td className="p-3">
+                    <div className="font-bold text-white">{ticket.title}</div>
+                    <div className="text-xs text-neutral-500">{ticket.ticket_id}</div>
+                  </td>
+                  <td className="p-3 text-neutral-300">{ticket.type}</td>
+                  <td className="p-3 text-neutral-300">{ticket.service_catalog_id || "Unassigned"}</td>
+                  <td className="p-3 text-neutral-300">{statusLabel(ticket.status)}</td>
+                  <td className="p-3">
+                    <TicketStatusStepper
+                      ticketId={ticket.ticket_id}
+                      status={ticket.status}
+                      onTransition={nextStatus => onTransition(ticket.ticket_id, nextStatus)}
+                    />
+                  </td>
+                  <td className="p-3">
+                    <button
+                      type="button"
+                      className="px-3 py-1.5 rounded-lg text-xs font-bold bg-white/10 hover:bg-white/20 text-neutral-200 disabled:opacity-50"
+                      onClick={() => onStartEdit(ticket)}
+                      disabled={ticket.status === "closed"}
+                      aria-label={`Edit ${ticket.ticket_id}`}
+                    >
+                      Edit
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default ItsmTicketFolioPage;

--- a/frontend/components/ItsmTicketFolioPage.tsx
+++ b/frontend/components/ItsmTicketFolioPage.tsx
@@ -66,7 +66,7 @@ const ItsmTicketFolioPage: React.FC = () => {
   }, []);
 
   const onChange = (field: keyof TicketFormState, value: string) => {
-    setFormState(prev => ({ ...prev, [field]: value }));
+    setFormState((prev) => ({ ...prev, [field]: value }));
   };
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -108,7 +108,8 @@ const ItsmTicketFolioPage: React.FC = () => {
   };
 
   const onTransition = async (ticketId: string, nextStatus: TicketFolioStatus) => {
-    const closedReason = nextStatus === "closed" ? window.prompt("Close reason")?.trim() : undefined;
+    const closedReason =
+      nextStatus === "closed" ? window.prompt("Close reason")?.trim() : undefined;
     if (nextStatus === "closed" && !closedReason) {
       setError("Closed tickets require a close reason.");
       return;
@@ -126,7 +127,9 @@ const ItsmTicketFolioPage: React.FC = () => {
     <div className="h-full flex flex-col p-6 gap-4 overflow-hidden">
       <header className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-3xl font-black text-white tracking-tighter uppercase">ITSM Tickets</h1>
+          <h1 className="text-3xl font-black text-white tracking-tighter uppercase">
+            ITSM Tickets
+          </h1>
           <p className="text-xs font-black text-neutral-400 uppercase tracking-wider">
             Manage request and incident folios independently from event workflows.
           </p>
@@ -145,7 +148,10 @@ const ItsmTicketFolioPage: React.FC = () => {
       </header>
 
       {error && (
-        <div role="alert" className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 p-3 text-sm">
+        <div
+          role="alert"
+          className="rounded-lg border border-red-500/30 bg-red-500/10 text-red-300 p-3 text-sm"
+        >
           {error}
         </div>
       )}
@@ -163,7 +169,7 @@ const ItsmTicketFolioPage: React.FC = () => {
                 aria-label="Ticket ID"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.ticket_id}
-                onChange={event => onChange("ticket_id", event.target.value)}
+                onChange={(event) => onChange("ticket_id", event.target.value)}
                 disabled={Boolean(selectedTicketId)}
               />
             </label>
@@ -174,7 +180,7 @@ const ItsmTicketFolioPage: React.FC = () => {
                 aria-label="Type"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.type}
-                onChange={event => onChange("type", event.target.value as TicketFolioType)}
+                onChange={(event) => onChange("type", event.target.value as TicketFolioType)}
                 disabled={Boolean(selectedTicketId)}
               >
                 <option value="request">request</option>
@@ -188,7 +194,7 @@ const ItsmTicketFolioPage: React.FC = () => {
                 aria-label="Title"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.title}
-                onChange={event => onChange("title", event.target.value)}
+                onChange={(event) => onChange("title", event.target.value)}
               />
             </label>
             <label className="text-xs text-neutral-300" htmlFor="service_catalog_id">
@@ -198,7 +204,7 @@ const ItsmTicketFolioPage: React.FC = () => {
                 aria-label="Service Catalog ID"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.service_catalog_id}
-                onChange={event => onChange("service_catalog_id", event.target.value)}
+                onChange={(event) => onChange("service_catalog_id", event.target.value)}
               />
             </label>
             <label className="text-xs text-neutral-300 sm:col-span-2" htmlFor="description">
@@ -208,19 +214,26 @@ const ItsmTicketFolioPage: React.FC = () => {
                 aria-label="Description"
                 className="mt-1 w-full bg-black/40 border border-white/10 p-2 rounded text-white"
                 value={formState.description}
-                onChange={event => onChange("description", event.target.value)}
+                onChange={(event) => onChange("description", event.target.value)}
               />
             </label>
           </div>
           <div className="flex gap-2">
-            <button type="submit" className="px-4 py-2 rounded-lg bg-brand-600 text-white font-bold">
+            <button
+              type="submit"
+              className="px-4 py-2 rounded-lg bg-brand-600 text-white font-bold"
+            >
               Save Ticket
             </button>
-            <button type="button" className="px-4 py-2 rounded-lg bg-white/10 text-neutral-200 font-bold" onClick={() => {
-              setShowForm(false);
-              setSelectedTicketId(null);
-              setFormState(emptyForm);
-            }}>
+            <button
+              type="button"
+              className="px-4 py-2 rounded-lg bg-white/10 text-neutral-200 font-bold"
+              onClick={() => {
+                setShowForm(false);
+                setSelectedTicketId(null);
+                setFormState(emptyForm);
+              }}
+            >
               Cancel
             </button>
           </div>
@@ -245,20 +258,22 @@ const ItsmTicketFolioPage: React.FC = () => {
               </tr>
             </thead>
             <tbody>
-              {tickets.map(ticket => (
+              {tickets.map((ticket) => (
                 <tr key={ticket.ticket_id} className="border-t border-white/5">
                   <td className="p-3">
                     <div className="font-bold text-white">{ticket.title}</div>
                     <div className="text-xs text-neutral-500">{ticket.ticket_id}</div>
                   </td>
                   <td className="p-3 text-neutral-300">{ticket.type}</td>
-                  <td className="p-3 text-neutral-300">{ticket.service_catalog_id || "Unassigned"}</td>
+                  <td className="p-3 text-neutral-300">
+                    {ticket.service_catalog_id || "Unassigned"}
+                  </td>
                   <td className="p-3 text-neutral-300">{statusLabel(ticket.status)}</td>
                   <td className="p-3">
                     <TicketStatusStepper
                       ticketId={ticket.ticket_id}
                       status={ticket.status}
-                      onTransition={nextStatus => onTransition(ticket.ticket_id, nextStatus)}
+                      onTransition={(nextStatus) => onTransition(ticket.ticket_id, nextStatus)}
                     />
                   </td>
                   <td className="p-3">

--- a/frontend/components/TicketStatusStepper.tsx
+++ b/frontend/components/TicketStatusStepper.tsx
@@ -18,7 +18,11 @@ interface TicketStatusStepperProps {
   onTransition: TicketTransitionHandler;
 }
 
-const TicketStatusStepper: React.FC<TicketStatusStepperProps> = ({ ticketId, status, onTransition }) => {
+const TicketStatusStepper: React.FC<TicketStatusStepperProps> = ({
+  ticketId,
+  status,
+  onTransition,
+}) => {
   const currentIndex = statusOrder.indexOf(status);
   const nextStatus = currentIndex >= 0 ? statusOrder[currentIndex + 1] : undefined;
 

--- a/frontend/components/TicketStatusStepper.tsx
+++ b/frontend/components/TicketStatusStepper.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { TicketFolioStatus } from "../types/itsm";
+
+const statusOrder: TicketFolioStatus[] = [
+  "open",
+  "in_progress",
+  "in_validation",
+  "resolved",
+  "closed",
+];
+
+interface TicketStatusStepperProps {
+  ticketId: string;
+  status: TicketFolioStatus;
+  onTransition: (nextStatus: TicketFolioStatus) => void;
+}
+
+const TicketStatusStepper: React.FC<TicketStatusStepperProps> = ({ ticketId, status, onTransition }) => {
+  const currentIndex = statusOrder.indexOf(status);
+  const nextStatus = currentIndex >= 0 ? statusOrder[currentIndex + 1] : undefined;
+
+  if (!nextStatus) {
+    return <span className="text-xs font-bold uppercase text-neutral-400">Closed</span>;
+  }
+
+  return (
+    <button
+      type="button"
+      className="px-3 py-1.5 rounded-lg text-xs font-bold bg-brand-600 hover:bg-brand-500 text-white"
+      onClick={() => onTransition(nextStatus)}
+      aria-label={`Move ${ticketId} to ${nextStatus}`}
+    >
+      Move to {nextStatus.replace("_", " ")}
+    </button>
+  );
+};
+
+export default TicketStatusStepper;

--- a/frontend/components/TicketStatusStepper.tsx
+++ b/frontend/components/TicketStatusStepper.tsx
@@ -9,10 +9,13 @@ const statusOrder: TicketFolioStatus[] = [
   "closed",
 ];
 
+// eslint-disable-next-line no-unused-vars
+type TicketTransitionHandler = (status: TicketFolioStatus) => void;
+
 interface TicketStatusStepperProps {
   ticketId: string;
   status: TicketFolioStatus;
-  onTransition: (nextStatus: TicketFolioStatus) => void;
+  onTransition: TicketTransitionHandler;
 }
 
 const TicketStatusStepper: React.FC<TicketStatusStepperProps> = ({ ticketId, status, onTransition }) => {

--- a/frontend/components/__tests__/ItsmServiceCatalogPage.test.tsx
+++ b/frontend/components/__tests__/ItsmServiceCatalogPage.test.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import {
-  MemoryRouter,
-  Route,
-  Routes,
-} from "react-router-dom";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ItsmServiceCatalogPage from "../ItsmServiceCatalogPage";

--- a/frontend/components/__tests__/ItsmServiceCatalogPage.test.tsx
+++ b/frontend/components/__tests__/ItsmServiceCatalogPage.test.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+} from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ItsmServiceCatalogPage from "../ItsmServiceCatalogPage";
+
+const mocks = vi.hoisted(() => ({
+  listServiceCatalog: vi.fn(),
+  createServiceCatalog: vi.fn(),
+  updateServiceCatalog: vi.fn(),
+  deactivateServiceCatalog: vi.fn(),
+}));
+
+vi.mock("../../services/itsm", () => ({
+  listServiceCatalog: (...args: unknown[]) => mocks.listServiceCatalog(...args),
+  createServiceCatalog: (...args: unknown[]) => mocks.createServiceCatalog(...args),
+  updateServiceCatalog: (...args: unknown[]) => mocks.updateServiceCatalog(...args),
+  deactivateServiceCatalog: (...args: unknown[]) => mocks.deactivateServiceCatalog(...args),
+}));
+
+type ServiceCatalogFixture = {
+  service_id: string;
+  name: string;
+  owner_team: string | null;
+  category: string | null;
+  tier: string | null;
+  criticality: string | null;
+  sla_target_minutes: number;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+  updated_by: string | null;
+};
+
+const sampleCatalogs: ServiceCatalogFixture[] = [
+  {
+    service_id: "svc-auth",
+    name: "Auth API",
+    owner_team: "Platform",
+    category: "SaaS",
+    tier: "gold",
+    criticality: "high",
+    sla_target_minutes: 15,
+    active: true,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    updated_by: null,
+  },
+  {
+    service_id: "svc-billing",
+    name: "Billing API",
+    owner_team: "Finance",
+    category: "B2B",
+    tier: "silver",
+    criticality: "medium",
+    sla_target_minutes: 45,
+    active: true,
+    created_at: "2025-01-02T00:00:00Z",
+    updated_at: "2025-01-02T00:00:00Z",
+    updated_by: null,
+  },
+];
+
+const renderCatalogRoute = () =>
+  render(
+    <MemoryRouter initialEntries={["/itsm/service-catalog"]}>
+      <Routes>
+        <Route path="/itsm/service-catalog" element={<ItsmServiceCatalogPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("ItsmServiceCatalogPage", () => {
+  beforeEach(() => {
+    mocks.listServiceCatalog.mockReset();
+    mocks.createServiceCatalog.mockReset();
+    mocks.updateServiceCatalog.mockReset();
+    mocks.deactivateServiceCatalog.mockReset();
+  });
+
+  it("reads and renders /itsm/service-catalog route with list data", async () => {
+    mocks.listServiceCatalog.mockResolvedValueOnce(sampleCatalogs);
+
+    renderCatalogRoute();
+
+    expect(screen.getByRole("heading", { name: /itsm service catalog/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /new service catalog/i })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Auth API")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Billing API")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: `Edit ${"svc-auth"}` })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: `Deactivate ${"svc-auth"}` })).toBeInTheDocument();
+    expect(mocks.listServiceCatalog).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/SLA\s*15/)).toBeInTheDocument();
+  });
+
+  it("creates a service catalog through the API wrapper and refreshes the list", async () => {
+    const user = userEvent.setup();
+    const createdEntry = {
+      service_id: "svc-chat",
+      name: "Chat API",
+      owner_team: "Product",
+      category: "Microservice",
+      tier: "bronze",
+      criticality: "low",
+      sla_target_minutes: 20,
+      active: true,
+      created_at: "2025-01-03T00:00:00Z",
+      updated_at: "2025-01-03T00:00:00Z",
+      updated_by: null,
+    };
+
+    mocks.listServiceCatalog
+      .mockResolvedValueOnce(sampleCatalogs)
+      .mockResolvedValueOnce([...sampleCatalogs, createdEntry]);
+    mocks.createServiceCatalog.mockResolvedValueOnce(createdEntry);
+
+    renderCatalogRoute();
+
+    await waitFor(() => {
+      expect(screen.getByText("Auth API")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /new service catalog/i }));
+    expect(screen.getByRole("heading", { name: /create service catalog/i })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/service id/i), "svc-chat");
+    await user.type(screen.getByLabelText(/name/i), "Chat API");
+    await user.type(screen.getByLabelText(/sla target minutes/i), "20");
+    await user.type(screen.getByLabelText(/owner team/i), "Product");
+    await user.type(screen.getByLabelText(/category/i), "Microservice");
+    await user.type(screen.getByLabelText(/tier/i), "bronze");
+    await user.type(screen.getByLabelText(/criticality/i), "low");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mocks.createServiceCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.createServiceCatalog).toHaveBeenCalledWith({
+      service_id: "svc-chat",
+      name: "Chat API",
+      sla_target_minutes: 20,
+      owner_team: "Product",
+      category: "Microservice",
+      tier: "bronze",
+      criticality: "low",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Chat API")).toBeInTheDocument();
+    });
+    expect(mocks.listServiceCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it("edits an existing catalog and calls updateServiceCatalog", async () => {
+    const user = userEvent.setup();
+    const updatedEntry = {
+      ...sampleCatalogs[0],
+      name: "Auth API v2",
+      sla_target_minutes: 25,
+    };
+
+    mocks.listServiceCatalog
+      .mockResolvedValueOnce(sampleCatalogs)
+      .mockResolvedValueOnce([updatedEntry, sampleCatalogs[1]]);
+    mocks.updateServiceCatalog.mockResolvedValueOnce(updatedEntry);
+
+    renderCatalogRoute();
+
+    await waitFor(() => {
+      expect(screen.getByText("Auth API")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: `Edit ${"svc-auth"}` }));
+
+    const nameInput = screen.getByLabelText(/name/i) as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, "Auth API v2");
+
+    await user.clear(screen.getByLabelText(/sla target minutes/i));
+    await user.type(screen.getByLabelText(/sla target minutes/i), "25");
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mocks.updateServiceCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.updateServiceCatalog).toHaveBeenCalledWith("svc-auth", {
+      service_id: "svc-auth",
+      name: "Auth API v2",
+      sla_target_minutes: 25,
+      owner_team: "Platform",
+      category: "SaaS",
+      tier: "gold",
+      criticality: "high",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Auth API v2")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Auth API v2")).toBeInTheDocument();
+  });
+
+  it("deactivates a catalog entry and refreshes from /itsm/service-catalog", async () => {
+    const user = userEvent.setup();
+
+    mocks.listServiceCatalog
+      .mockResolvedValueOnce(sampleCatalogs)
+      .mockResolvedValueOnce(sampleCatalogs);
+    mocks.deactivateServiceCatalog.mockResolvedValueOnce({
+      ...sampleCatalogs[0],
+      active: false,
+    });
+
+    renderCatalogRoute();
+
+    await waitFor(() => {
+      expect(screen.getByText("Auth API")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: `Deactivate ${"svc-auth"}` }));
+
+    await waitFor(() => {
+      expect(mocks.deactivateServiceCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.deactivateServiceCatalog).toHaveBeenCalledWith("svc-auth");
+    expect(mocks.listServiceCatalog).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/components/__tests__/TicketFolioPage.test.tsx
+++ b/frontend/components/__tests__/TicketFolioPage.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ItsmTicketFolioPage from "../ItsmTicketFolioPage";
+
+const mocks = vi.hoisted(() => ({
+  listTicketFolios: vi.fn(),
+  createTicketFolio: vi.fn(),
+  updateTicketFolio: vi.fn(),
+  transitionTicketFolio: vi.fn(),
+}));
+
+vi.mock("../../services/itsm", () => ({
+  listTicketFolios: (...args: unknown[]) => mocks.listTicketFolios(...args),
+  createTicketFolio: (...args: unknown[]) => mocks.createTicketFolio(...args),
+  updateTicketFolio: (...args: unknown[]) => mocks.updateTicketFolio(...args),
+  transitionTicketFolio: (...args: unknown[]) => mocks.transitionTicketFolio(...args),
+}));
+
+const sampleTickets = [
+  {
+    ticket_id: "TK-001",
+    type: "request",
+    title: "Access request",
+    description: "Grant VPN access",
+    service_catalog_id: "svc-auth",
+    status: "open",
+    closed_reason: null,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    updated_by: "admin",
+  },
+  {
+    ticket_id: "TK-002",
+    type: "incident",
+    title: "API outage",
+    description: null,
+    service_catalog_id: null,
+    status: "in_validation",
+    closed_reason: null,
+    created_at: "2025-01-02T00:00:00Z",
+    updated_at: "2025-01-02T00:00:00Z",
+    updated_by: "admin",
+  },
+];
+
+describe("ItsmTicketFolioPage", () => {
+  beforeEach(() => {
+    mocks.listTicketFolios.mockReset();
+    mocks.createTicketFolio.mockReset();
+    mocks.updateTicketFolio.mockReset();
+    mocks.transitionTicketFolio.mockReset();
+  });
+
+  it("lists ticket folios and keeps UI independent from event endpoints", async () => {
+    mocks.listTicketFolios.mockResolvedValueOnce(sampleTickets);
+
+    render(<ItsmTicketFolioPage />);
+
+    expect(screen.getByRole("heading", { name: /itsm tickets/i })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
+    expect(screen.getByText("API outage")).toBeInTheDocument();
+    expect(mocks.listTicketFolios).toHaveBeenCalledWith({});
+  });
+
+  it("creates request and incident folios", async () => {
+    const user = userEvent.setup();
+    mocks.listTicketFolios
+      .mockResolvedValueOnce(sampleTickets)
+      .mockResolvedValueOnce([...sampleTickets, { ...sampleTickets[0], ticket_id: "TK-003", title: "New request" }]);
+    mocks.createTicketFolio.mockResolvedValueOnce({ ...sampleTickets[0], ticket_id: "TK-003", title: "New request" });
+
+    render(<ItsmTicketFolioPage />);
+    await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /new ticket/i }));
+    await user.type(screen.getByLabelText(/ticket id/i), "TK-003");
+    await user.selectOptions(screen.getByLabelText(/type/i), "incident");
+    await user.type(screen.getByLabelText(/title/i), "New request");
+    await user.type(screen.getByLabelText(/description/i), "Created outside events");
+    await user.type(screen.getByLabelText(/service catalog id/i), "svc-auth");
+    await user.click(screen.getByRole("button", { name: /save ticket/i }));
+
+    await waitFor(() => expect(mocks.createTicketFolio).toHaveBeenCalledTimes(1));
+    expect(mocks.createTicketFolio).toHaveBeenCalledWith({
+      ticket_id: "TK-003",
+      type: "incident",
+      title: "New request",
+      description: "Created outside events",
+      service_catalog_id: "svc-auth",
+    });
+  });
+
+  it("updates an existing ticket folio", async () => {
+    const user = userEvent.setup();
+    mocks.listTicketFolios.mockResolvedValueOnce(sampleTickets).mockResolvedValueOnce([
+      { ...sampleTickets[0], title: "Access request updated" },
+      sampleTickets[1],
+    ]);
+    mocks.updateTicketFolio.mockResolvedValueOnce({ ...sampleTickets[0], title: "Access request updated" });
+
+    render(<ItsmTicketFolioPage />);
+    await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /edit TK-001/i }));
+    const titleInput = screen.getByLabelText(/title/i);
+    await user.clear(titleInput);
+    await user.type(titleInput, "Access request updated");
+    await user.click(screen.getByRole("button", { name: /save ticket/i }));
+
+    await waitFor(() => expect(mocks.updateTicketFolio).toHaveBeenCalledWith("TK-001", {
+      title: "Access request updated",
+      description: "Grant VPN access",
+      service_catalog_id: "svc-auth",
+    }));
+  });
+
+  it("only exposes the next linear status transition", async () => {
+    const user = userEvent.setup();
+    mocks.listTicketFolios.mockResolvedValueOnce(sampleTickets).mockResolvedValueOnce(sampleTickets);
+    mocks.transitionTicketFolio.mockResolvedValueOnce({ ...sampleTickets[0], status: "in_progress" });
+
+    render(<ItsmTicketFolioPage />);
+    await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
+
+    expect(screen.queryByRole("button", { name: /move TK-001 to resolved/i })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /move TK-001 to in_progress/i }));
+
+    await waitFor(() => expect(mocks.transitionTicketFolio).toHaveBeenCalledWith("TK-001", "in_progress", undefined));
+  });
+
+  it("asks for a close reason when moving to closed", async () => {
+    const user = userEvent.setup();
+    const resolvedTicket = { ...sampleTickets[0], status: "resolved" };
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Validated by requester");
+    mocks.listTicketFolios.mockResolvedValueOnce([resolvedTicket]).mockResolvedValueOnce([{ ...resolvedTicket, status: "closed" }]);
+    mocks.transitionTicketFolio.mockResolvedValueOnce({ ...resolvedTicket, status: "closed", closed_reason: "Validated by requester" });
+
+    render(<ItsmTicketFolioPage />);
+    await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /move TK-001 to closed/i }));
+
+    await waitFor(() => expect(mocks.transitionTicketFolio).toHaveBeenCalledWith("TK-001", "closed", "Validated by requester"));
+    promptSpy.mockRestore();
+  });
+});

--- a/frontend/components/__tests__/TicketFolioPage.test.tsx
+++ b/frontend/components/__tests__/TicketFolioPage.test.tsx
@@ -69,8 +69,15 @@ describe("ItsmTicketFolioPage", () => {
     const user = userEvent.setup();
     mocks.listTicketFolios
       .mockResolvedValueOnce(sampleTickets)
-      .mockResolvedValueOnce([...sampleTickets, { ...sampleTickets[0], ticket_id: "TK-003", title: "New request" }]);
-    mocks.createTicketFolio.mockResolvedValueOnce({ ...sampleTickets[0], ticket_id: "TK-003", title: "New request" });
+      .mockResolvedValueOnce([
+        ...sampleTickets,
+        { ...sampleTickets[0], ticket_id: "TK-003", title: "New request" },
+      ]);
+    mocks.createTicketFolio.mockResolvedValueOnce({
+      ...sampleTickets[0],
+      ticket_id: "TK-003",
+      title: "New request",
+    });
 
     render(<ItsmTicketFolioPage />);
     await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
@@ -95,11 +102,16 @@ describe("ItsmTicketFolioPage", () => {
 
   it("updates an existing ticket folio", async () => {
     const user = userEvent.setup();
-    mocks.listTicketFolios.mockResolvedValueOnce(sampleTickets).mockResolvedValueOnce([
-      { ...sampleTickets[0], title: "Access request updated" },
-      sampleTickets[1],
-    ]);
-    mocks.updateTicketFolio.mockResolvedValueOnce({ ...sampleTickets[0], title: "Access request updated" });
+    mocks.listTicketFolios
+      .mockResolvedValueOnce(sampleTickets)
+      .mockResolvedValueOnce([
+        { ...sampleTickets[0], title: "Access request updated" },
+        sampleTickets[1],
+      ]);
+    mocks.updateTicketFolio.mockResolvedValueOnce({
+      ...sampleTickets[0],
+      title: "Access request updated",
+    });
 
     render(<ItsmTicketFolioPage />);
     await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
@@ -110,40 +122,63 @@ describe("ItsmTicketFolioPage", () => {
     await user.type(titleInput, "Access request updated");
     await user.click(screen.getByRole("button", { name: /save ticket/i }));
 
-    await waitFor(() => expect(mocks.updateTicketFolio).toHaveBeenCalledWith("TK-001", {
-      title: "Access request updated",
-      description: "Grant VPN access",
-      service_catalog_id: "svc-auth",
-    }));
+    await waitFor(() =>
+      expect(mocks.updateTicketFolio).toHaveBeenCalledWith("TK-001", {
+        title: "Access request updated",
+        description: "Grant VPN access",
+        service_catalog_id: "svc-auth",
+      }),
+    );
   });
 
   it("only exposes the next linear status transition", async () => {
     const user = userEvent.setup();
-    mocks.listTicketFolios.mockResolvedValueOnce(sampleTickets).mockResolvedValueOnce(sampleTickets);
-    mocks.transitionTicketFolio.mockResolvedValueOnce({ ...sampleTickets[0], status: "in_progress" });
+    mocks.listTicketFolios
+      .mockResolvedValueOnce(sampleTickets)
+      .mockResolvedValueOnce(sampleTickets);
+    mocks.transitionTicketFolio.mockResolvedValueOnce({
+      ...sampleTickets[0],
+      status: "in_progress",
+    });
 
     render(<ItsmTicketFolioPage />);
     await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
 
-    expect(screen.queryByRole("button", { name: /move TK-001 to resolved/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /move TK-001 to resolved/i }),
+    ).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /move TK-001 to in_progress/i }));
 
-    await waitFor(() => expect(mocks.transitionTicketFolio).toHaveBeenCalledWith("TK-001", "in_progress", undefined));
+    await waitFor(() =>
+      expect(mocks.transitionTicketFolio).toHaveBeenCalledWith("TK-001", "in_progress", undefined),
+    );
   });
 
   it("asks for a close reason when moving to closed", async () => {
     const user = userEvent.setup();
     const resolvedTicket = { ...sampleTickets[0], status: "resolved" };
     const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Validated by requester");
-    mocks.listTicketFolios.mockResolvedValueOnce([resolvedTicket]).mockResolvedValueOnce([{ ...resolvedTicket, status: "closed" }]);
-    mocks.transitionTicketFolio.mockResolvedValueOnce({ ...resolvedTicket, status: "closed", closed_reason: "Validated by requester" });
+    mocks.listTicketFolios
+      .mockResolvedValueOnce([resolvedTicket])
+      .mockResolvedValueOnce([{ ...resolvedTicket, status: "closed" }]);
+    mocks.transitionTicketFolio.mockResolvedValueOnce({
+      ...resolvedTicket,
+      status: "closed",
+      closed_reason: "Validated by requester",
+    });
 
     render(<ItsmTicketFolioPage />);
     await waitFor(() => expect(screen.getByText("Access request")).toBeInTheDocument());
 
     await user.click(screen.getByRole("button", { name: /move TK-001 to closed/i }));
 
-    await waitFor(() => expect(mocks.transitionTicketFolio).toHaveBeenCalledWith("TK-001", "closed", "Validated by requester"));
+    await waitFor(() =>
+      expect(mocks.transitionTicketFolio).toHaveBeenCalledWith(
+        "TK-001",
+        "closed",
+        "Validated by requester",
+      ),
+    );
     promptSpy.mockRestore();
   });
 });

--- a/frontend/components/__tests__/TicketStatusStepper.test.tsx
+++ b/frontend/components/__tests__/TicketStatusStepper.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import TicketStatusStepper from "../TicketStatusStepper";
+
+describe("TicketStatusStepper", () => {
+  it("shows only the next linear transition", () => {
+    render(<TicketStatusStepper ticketId="TK-001" status="in_progress" onTransition={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /move TK-001 to in_validation/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /move TK-001 to resolved/i })).not.toBeInTheDocument();
+  });
+
+  it("makes closed tickets read-only", () => {
+    render(<TicketStatusStepper ticketId="TK-002" status="closed" onTransition={vi.fn()} />);
+
+    expect(screen.getByText(/closed/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /move/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/components/__tests__/TicketStatusStepper.test.tsx
+++ b/frontend/components/__tests__/TicketStatusStepper.test.tsx
@@ -8,8 +8,12 @@ describe("TicketStatusStepper", () => {
   it("shows only the next linear transition", () => {
     render(<TicketStatusStepper ticketId="TK-001" status="in_progress" onTransition={vi.fn()} />);
 
-    expect(screen.getByRole("button", { name: /move TK-001 to in_validation/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /move TK-001 to resolved/i })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /move TK-001 to in_validation/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /move TK-001 to resolved/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("makes closed tickets read-only", () => {

--- a/frontend/services/__tests__/itsm_api.test.ts
+++ b/frontend/services/__tests__/itsm_api.test.ts
@@ -156,8 +156,12 @@ describe("ITSM service catalog API wrapper", () => {
     mocks.mockPost.mockResolvedValueOnce(created);
     mocks.mockPut.mockResolvedValueOnce({ ...created, title: "Alarm follow-up updated" });
 
-    await expect(createTicketFolio({ ticket_id: "TK-002", type: "incident", title: "Alarm follow-up" })).resolves.toEqual(created);
-    await expect(updateTicketFolio("TK-002", { title: "Alarm follow-up updated" })).resolves.toMatchObject({
+    await expect(
+      createTicketFolio({ ticket_id: "TK-002", type: "incident", title: "Alarm follow-up" }),
+    ).resolves.toEqual(created);
+    await expect(
+      updateTicketFolio("TK-002", { title: "Alarm follow-up updated" }),
+    ).resolves.toMatchObject({
       title: "Alarm follow-up updated",
     });
 

--- a/frontend/services/__tests__/itsm_api.test.ts
+++ b/frontend/services/__tests__/itsm_api.test.ts
@@ -1,0 +1,220 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import {
+  createServiceCatalog,
+  createTicketFolio,
+  deactivateServiceCatalog,
+  listServiceCatalog,
+  listTicketFolios,
+  transitionTicketFolio,
+  updateServiceCatalog,
+  updateTicketFolio,
+} from "../itsm";
+
+const mocks = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+  mockPut: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  api: {
+    get: mocks.mockGet,
+    post: mocks.mockPost,
+    put: mocks.mockPut,
+  },
+}));
+
+describe("ITSM service catalog API wrapper", () => {
+  beforeEach(() => {
+    mocks.mockGet.mockReset();
+    mocks.mockPost.mockReset();
+    mocks.mockPut.mockReset();
+  });
+
+  it("loads the catalog list from /api/itsm/service-catalog", async () => {
+    const catalog = {
+      service_id: "svc-auth",
+      name: "Auth Platform",
+      sla_target_minutes: 30,
+      active: true,
+      owner_team: "Platform",
+      category: "SaaS",
+      tier: "gold",
+      criticality: "high",
+      updated_by: "admin",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    mocks.mockGet.mockResolvedValue([catalog]);
+
+    const payload = await listServiceCatalog();
+
+    expect(payload).toEqual([catalog]);
+    expect(mocks.mockGet).toHaveBeenCalledTimes(1);
+    expect(mocks.mockGet).toHaveBeenCalledWith("/itsm/service-catalog", {});
+  });
+
+  it("creates service catalog entries using /api/itsm/service-catalog", async () => {
+    const requestPayload = {
+      service_id: "svc-billing",
+      name: "Billing Gateway",
+      sla_target_minutes: 45,
+      active: true,
+    };
+    const created = {
+      ...requestPayload,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      owner_team: null,
+      category: null,
+      tier: null,
+      criticality: null,
+      updated_by: null,
+    };
+
+    mocks.mockPost.mockResolvedValue(created);
+
+    const result = await createServiceCatalog(requestPayload);
+
+    expect(result).toEqual(created);
+    expect(mocks.mockPost).toHaveBeenCalledTimes(1);
+    expect(mocks.mockPost).toHaveBeenCalledWith("/itsm/service-catalog", requestPayload);
+  });
+
+  it("updates catalog entries using encoded /itsm/service-catalog/{id}", async () => {
+    const serviceId = "svc/network:core";
+    const requestPayload = {
+      name: "Network Core",
+      sla_target_minutes: 60,
+      category: "network",
+    };
+
+    const updated = {
+      service_id: serviceId,
+      name: requestPayload.name,
+      sla_target_minutes: 60,
+      active: true,
+      owner_team: null,
+      criticality: null,
+      tier: null,
+      category: requestPayload.category,
+      updated_by: "admin",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+
+    mocks.mockPut.mockResolvedValue(updated);
+
+    const result = await updateServiceCatalog(serviceId, requestPayload);
+
+    expect(result).toEqual(updated);
+    expect(mocks.mockPut).toHaveBeenCalledTimes(1);
+    expect(mocks.mockPut).toHaveBeenCalledWith(
+      "/itsm/service-catalog/svc%2Fnetwork%3Acore",
+      requestPayload,
+    );
+  });
+
+  it("lists ticket folios from /api/itsm/tickets", async () => {
+    const ticket = {
+      ticket_id: "TK-001",
+      type: "request",
+      title: "Access request",
+      description: null,
+      service_catalog_id: "svc-auth",
+      status: "open",
+      closed_reason: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      updated_by: "admin",
+    };
+
+    mocks.mockGet.mockResolvedValue([ticket]);
+
+    const result = await listTicketFolios({ status: "open", service_catalog_id: "svc-auth" });
+
+    expect(result).toEqual([ticket]);
+    expect(mocks.mockGet).toHaveBeenCalledWith("/itsm/tickets", {
+      params: { status: "open", service_catalog_id: "svc-auth" },
+    });
+  });
+
+  it("creates and updates ticket folios through /api/itsm/tickets", async () => {
+    const created = {
+      ticket_id: "TK-002",
+      type: "incident",
+      title: "Alarm follow-up",
+      description: "Check alarm",
+      service_catalog_id: null,
+      status: "open",
+      closed_reason: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      updated_by: "admin",
+    };
+    mocks.mockPost.mockResolvedValueOnce(created);
+    mocks.mockPut.mockResolvedValueOnce({ ...created, title: "Alarm follow-up updated" });
+
+    await expect(createTicketFolio({ ticket_id: "TK-002", type: "incident", title: "Alarm follow-up" })).resolves.toEqual(created);
+    await expect(updateTicketFolio("TK-002", { title: "Alarm follow-up updated" })).resolves.toMatchObject({
+      title: "Alarm follow-up updated",
+    });
+
+    expect(mocks.mockPost).toHaveBeenCalledWith("/itsm/tickets", {
+      ticket_id: "TK-002",
+      type: "incident",
+      title: "Alarm follow-up",
+    });
+    expect(mocks.mockPut).toHaveBeenCalledWith("/itsm/tickets/TK-002", {
+      title: "Alarm follow-up updated",
+    });
+  });
+
+  it("transitions ticket folios through /api/itsm/tickets/{id}/transition", async () => {
+    const transitioned = {
+      ticket_id: "TK-003",
+      type: "request",
+      title: "Validate access",
+      description: null,
+      service_catalog_id: null,
+      status: "in_validation",
+      closed_reason: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      updated_by: "admin",
+    };
+    mocks.mockPost.mockResolvedValueOnce(transitioned);
+
+    const result = await transitionTicketFolio("TK-003", "in_validation");
+
+    expect(result).toEqual(transitioned);
+    expect(mocks.mockPost).toHaveBeenCalledWith("/itsm/tickets/TK-003/transition", {
+      next_status: "in_validation",
+    });
+  });
+
+  it("deactivates catalog records through /api/itsm/service-catalog/{id}/deactivate", async () => {
+    const deactivated = {
+      service_id: "svc-auth",
+      name: "Auth Platform",
+      sla_target_minutes: 30,
+      active: false,
+      owner_team: "Platform",
+      category: "SaaS",
+      tier: "gold",
+      criticality: "high",
+      updated_by: "admin",
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-02T00:00:00Z",
+    };
+
+    mocks.mockPost.mockResolvedValue(deactivated);
+
+    const result = await deactivateServiceCatalog("svc-auth");
+
+    expect(result).toEqual(deactivated);
+    expect(mocks.mockPost).toHaveBeenCalledTimes(1);
+    expect(mocks.mockPost).toHaveBeenCalledWith("/itsm/service-catalog/svc-auth/deactivate", {});
+  });
+});

--- a/frontend/services/itsm.ts
+++ b/frontend/services/itsm.ts
@@ -19,17 +19,17 @@ export const listServiceCatalog = ({ signal }: ServiceCatalogListOptions = {}) =
 export const createServiceCatalog = (payload: ServiceCatalogCreatePayload) =>
   api.post<ServiceCatalogResponse>("/itsm/service-catalog", payload);
 
-export const updateServiceCatalog = (
-  serviceId: string,
-  payload: ServiceCatalogUpdatePayload,
-) =>
+export const updateServiceCatalog = (serviceId: string, payload: ServiceCatalogUpdatePayload) =>
   api.put<ServiceCatalogResponse>(
     `/itsm/service-catalog/${encodeURIComponent(serviceId)}`,
     payload,
   );
 
 export const deactivateServiceCatalog = (serviceId: string) =>
-  api.post<ServiceCatalogResponse>(`/itsm/service-catalog/${encodeURIComponent(serviceId)}/deactivate`, {});
+  api.post<ServiceCatalogResponse>(
+    `/itsm/service-catalog/${encodeURIComponent(serviceId)}/deactivate`,
+    {},
+  );
 
 export interface TicketFolioListOptions {
   status?: TicketFolioStatus;

--- a/frontend/services/itsm.ts
+++ b/frontend/services/itsm.ts
@@ -1,0 +1,58 @@
+import { api } from "./api";
+import type {
+  ServiceCatalogCreatePayload,
+  ServiceCatalogResponse,
+  ServiceCatalogUpdatePayload,
+  TicketFolioCreatePayload,
+  TicketFolioResponse,
+  TicketFolioStatus,
+  TicketFolioUpdatePayload,
+} from "../types/itsm";
+
+export interface ServiceCatalogListOptions {
+  signal?: AbortSignal;
+}
+
+export const listServiceCatalog = ({ signal }: ServiceCatalogListOptions = {}) =>
+  api.get<ServiceCatalogResponse[]>("/itsm/service-catalog", { signal });
+
+export const createServiceCatalog = (payload: ServiceCatalogCreatePayload) =>
+  api.post<ServiceCatalogResponse>("/itsm/service-catalog", payload);
+
+export const updateServiceCatalog = (
+  serviceId: string,
+  payload: ServiceCatalogUpdatePayload,
+) =>
+  api.put<ServiceCatalogResponse>(
+    `/itsm/service-catalog/${encodeURIComponent(serviceId)}`,
+    payload,
+  );
+
+export const deactivateServiceCatalog = (serviceId: string) =>
+  api.post<ServiceCatalogResponse>(`/itsm/service-catalog/${encodeURIComponent(serviceId)}/deactivate`, {});
+
+export interface TicketFolioListOptions {
+  status?: TicketFolioStatus;
+  service_catalog_id?: string;
+  archived?: boolean;
+  signal?: AbortSignal;
+}
+
+export const listTicketFolios = ({ signal, ...params }: TicketFolioListOptions = {}) =>
+  api.get<TicketFolioResponse[]>("/itsm/tickets", { signal, params });
+
+export const createTicketFolio = (payload: TicketFolioCreatePayload) =>
+  api.post<TicketFolioResponse>("/itsm/tickets", payload);
+
+export const updateTicketFolio = (ticketId: string, payload: TicketFolioUpdatePayload) =>
+  api.put<TicketFolioResponse>(`/itsm/tickets/${encodeURIComponent(ticketId)}`, payload);
+
+export const transitionTicketFolio = (
+  ticketId: string,
+  nextStatus: TicketFolioStatus,
+  closedReason?: string,
+) =>
+  api.post<TicketFolioResponse>(`/itsm/tickets/${encodeURIComponent(ticketId)}/transition`, {
+    next_status: nextStatus,
+    ...(closedReason ? { closed_reason: closedReason } : {}),
+  });

--- a/frontend/types/itsm.ts
+++ b/frontend/types/itsm.ts
@@ -1,0 +1,78 @@
+export type TicketFolioStatus =
+  | "open"
+  | "in_progress"
+  | "in_validation"
+  | "resolved"
+  | "closed";
+
+export type TicketFolioType = "request" | "incident";
+
+export interface ServiceCatalogBase {
+  service_id: string;
+  name: string;
+  owner_team: string | null;
+  category: string | null;
+  tier: string | null;
+  criticality: string | null;
+  sla_target_minutes: number;
+  active: boolean;
+}
+
+export interface ServiceCatalogResponse extends ServiceCatalogBase {
+  created_at: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export interface ServiceCatalogCreatePayload {
+  service_id: string;
+  name: string;
+  owner_team?: string | null;
+  category?: string | null;
+  tier?: string | null;
+  criticality?: string | null;
+  sla_target_minutes: number;
+  active?: boolean;
+}
+
+export interface ServiceCatalogUpdatePayload {
+  service_id?: string;
+  name?: string;
+  owner_team?: string | null;
+  category?: string | null;
+  tier?: string | null;
+  criticality?: string | null;
+  sla_target_minutes?: number;
+  active?: boolean;
+}
+
+export interface TicketFolioResponse {
+  ticket_id: string;
+  type: TicketFolioType;
+  title: string;
+  description: string | null;
+  service_catalog_id: string | null;
+  status: TicketFolioStatus;
+  closed_reason: string | null;
+  created_at: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export interface TicketFolioCreatePayload {
+  ticket_id: string;
+  type: TicketFolioType;
+  title: string;
+  description?: string | null;
+  service_catalog_id?: string | null;
+  status?: TicketFolioStatus;
+  closed_reason?: string | null;
+}
+
+export interface TicketFolioUpdatePayload {
+  title?: string;
+  description?: string | null;
+  service_catalog_id?: string | null;
+  status?: TicketFolioStatus;
+  closed_reason?: string | null;
+}

--- a/frontend/types/itsm.ts
+++ b/frontend/types/itsm.ts
@@ -1,9 +1,4 @@
-export type TicketFolioStatus =
-  | "open"
-  | "in_progress"
-  | "in_validation"
-  | "resolved"
-  | "closed";
+export type TicketFolioStatus = "open" | "in_progress" | "in_validation" | "resolved" | "closed";
 
 export type TicketFolioType = "request" | "incident";
 

--- a/openspec/changes/itsm-service-catalog/apply-progress.md
+++ b/openspec/changes/itsm-service-catalog/apply-progress.md
@@ -1,0 +1,255 @@
+# Apply Progress — ITSM Service Catalog + Ticket/Folio
+
+## Apply Progress — Work Unit 1
+
+## Status
+- change: `itsm-service-catalog`
+- unit: `Work Unit 1 — Backend domain contracts + migration preflight`
+- executed: with strict TDD (RED → GREEN → TRIANGULATE → REFACTOR)
+
+## Files changed
+- Added
+  - `backend/tests/test_itsm_domain_contracts.py`
+  - `backend/tests/test_migration_itsm_catalog.py`
+  - `backend/models/itsm.py`
+  - `backend/repositories/itsm_service_catalog_repo.py`
+  - `backend/repositories/ticket_folio_repo.py`
+  - `backend/services/itsm_bootstrap.py`
+  - `backend/migrations/itsm_service_catalog.cypher`
+  - `backend/tests/test_itsm_startup_checks.py`
+- Updated
+  - `backend/main.py` (startup bootstrap checks and migration application call)
+  - `openspec/changes/itsm-service-catalog/tasks.md` (completed Work Unit 1 checkbox items)
+
+## Completed Work Unit 1 tasks
+- [x] 1.1 Add alias/domain contracts tests
+- [x] 1.2 Add migration contract tests
+- [x] 1.3 Create `backend/models/itsm.py`
+- [x] 1.4 Add `backend/repositories/itsm_service_catalog_repo.py`
+- [x] 1.5 Add `backend/repositories/ticket_folio_repo.py`
+- [x] 1.6 Add startup bootstrap preflight service
+- [x] 1.7 Add migration for constraints/indexes/compatibility
+- [x] 1.8 Register bootstrap in `backend/main.py`
+- [x] 1.9 Validate ordering and event-flow unchanged
+- [x] 1.10 Define startup fail-fast policy
+- [x] 1.11 Clean naming/docs in models/migration
+
+## TDD Cycle Evidence (WU1)
+- RED: added domain contract and migration migration tests
+- GREEN: implemented models/repos/bootstrap/migration wiring
+- TRIANGULATE: startup/order and event-path checks
+- REFACTOR: docs and contract cleanup
+
+## Verification commands run (WU1)
+- `cd backend && python3 -m compileall backend/models/itsm.py ...` — PASS
+- `cd backend && python3 -m pytest backend/tests/test_itsm_domain_contracts.py backend/tests/test_migration_itsm_catalog.py` — PASS
+- `cd backend && python3 -m pytest backend/tests/test_itsm_startup_checks.py` — PASS
+
+---
+
+## Apply Progress — Work Unit 2
+
+## Status
+- change: `itsm-service-catalog`
+- unit: `Work Unit 2 — Backend API services + routers + permissions + event compatibility`
+- executed: with strict TDD (RED → GREEN → TRIANGULATE → REFACTOR)
+
+## Files changed
+- Added
+  - `backend/tests/test_itsm_service_catalog_service.py`
+  - `backend/tests/test_ticket_folio_service.py`
+  - `backend/tests/test_routers_itsm.py`
+  - `backend/routers/itsm_service_catalog.py`
+  - `backend/routers/ticket_folios.py`
+  - `backend/services/itsm_service_catalog_service.py`
+  - `backend/services/ticket_folio_service.py`
+- Updated
+  - `backend/tests/test_event_service_smoke.py`
+  - `backend/models/user.py`
+  - `backend/models/itsm.py`
+  - `backend/repositories/ticket_folio_repo.py`
+  - `backend/main.py`
+
+## Completed Work Unit 2 tasks
+- [x] 2.1 Add `backend/tests/test_itsm_service_catalog_service.py`
+- [x] 2.2 Add `backend/tests/test_ticket_folio_service.py`
+- [x] 2.3 Add `backend/tests/test_routers_itsm.py`
+- [x] 2.4 Add/extend event compatibility tests in `backend/tests/test_event_service_smoke.py`
+- [x] 2.5 Create `backend/services/itsm_service_catalog_service.py`
+- [x] 2.6 Create `backend/services/ticket_folio_service.py`
+- [x] 2.7 Add `backend/routers/itsm_service_catalog.py`
+- [x] 2.8 Add `backend/routers/ticket_folios.py`
+- [x] 2.9 Register routers in `backend/main.py`
+- [x] 2.10 `backend/models/core.py` unchanged (not required for this backend slice)
+- [x] 2.11 Run endpoint permission audit against `routers/catalog.py` and `routers/events.py`
+- [x] 2.12 Validate service-catalog/ticket reference behavior (property + relationship sync)
+- [x] 2.13 Refactor for explicit 400/409 vs 404 error semantics
+- [x] 2.14 Add router docstring contract note for explicit event-flow separation
+
+## TDD Cycle Evidence (WU2)
+
+| Task(s) | RED (test-first) | GREEN (implementation) | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|
+| WU2 backend services + routers + permission gates | Added tests for service validation, transitions, router permission enforcement, and event compatibility before implementation | Implemented service/route layers, added ITSM permission enums, router registration, and repository relationship-sync support | Added compatibility event test to verify no event-to-folio write/mutation references in event detail path | Kept logic tight; no further refactor in this cycle |
+
+## Verification commands run
+- `cd backend && python3 -m py_compile models/user.py models/itsm.py repositories/ticket_folio_repo.py services/itsm_service_catalog_service.py services/ticket_folio_service.py routers/itsm_service_catalog.py routers/ticket_folios.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py tests/test_event_service_smoke.py main.py`
+  - Result: PASS
+- `cd backend && /tmp/next-gen-it-sm-venv/bin/python -m pytest tests/test_itsm_domain_contracts.py tests/test_migration_itsm_catalog.py tests/test_itsm_startup_checks.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py tests/test_event_service_smoke.py -q`
+  - Result: PASS (97 passed, 0 warnings)
+
+## Remaining backend risks
+- None for WU2 focused backend scope.
+
+## Workload / PR boundary
+- Review workload forecast remains high.
+- Delivery PR boundary this batch: **PR 2**.
+
+---
+
+## Apply Progress — Work Unit 3
+
+## Status
+- change: `itsm-service-catalog`
+- unit: `Work Unit 3 — Frontend ITSM catalog surface + routes/navigation isolation`
+- executed: with strict TDD (RED → GREEN → TRIANGULATE → REFACTOR)
+
+## Files changed
+- Added
+  - `frontend/types/itsm.ts`
+  - `frontend/services/itsm.ts`
+  - `frontend/services/__tests__/itsm_api.test.ts`
+  - `frontend/components/ItsmServiceCatalogPage.tsx`
+  - `frontend/components/__tests__/ItsmServiceCatalogPage.test.tsx`
+  - `frontend/App.itsm-route.test.tsx`
+- Updated
+  - `frontend/App.tsx`
+  - `openspec/changes/itsm-service-catalog/tasks.md`
+
+## Completed Work Unit 3 tasks
+- [x] 3.1 Add Service Catalog page tests
+- [x] 3.2 Add ITSM API wrapper tests
+- [x] 3.3 Add frontend ITSM types
+- [x] 3.4 Add Service Catalog API client functions
+- [x] 3.5 Add Service Catalog page/form flow
+- [x] 3.6 Add dedicated `/itsm/service-catalog` route/navigation
+- [x] 3.7 Keep inventory catalog navigation untouched
+- [x] 3.8 Verify route isolation with routing test
+- [x] 3.9 Refactor loading/error UI and English labels
+
+## TDD Cycle Evidence (WU3)
+- RED: frontend route/page/API tests were added before passing implementation.
+- GREEN: Service Catalog types, API client, page, and route/navigation were implemented.
+- TRIANGULATE: route isolation test verifies `/itsm/service-catalog` and existing `/inventory` remain separate.
+- REFACTOR: App route test was corrected to use `HashRouter` behavior directly and not nest routers.
+
+## Verification commands run
+- `cd frontend && corepack pnpm install --frozen-lockfile`
+  - Result: PASS (installed missing dependency links, including `sonner`, from existing lockfile)
+- `cd frontend && corepack pnpm exec vitest run App.itsm-route.test.tsx components/__tests__/ItsmServiceCatalogPage.test.tsx services/__tests__/itsm_api.test.ts`
+  - Result: PASS (3 files, 10 tests)
+
+## Remaining frontend WU3 risks
+- None for focused WU3 scope.
+
+---
+
+## Apply Progress — Work Unit 4
+
+## Status
+- change: `itsm-service-catalog`
+- unit: `Work Unit 4 — Frontend ticket/folio UX + lifecycle controls`
+- executed: with strict TDD (RED → GREEN → TRIANGULATE → REFACTOR)
+
+## Files changed
+- Added
+  - `frontend/components/ItsmTicketFolioPage.tsx`
+  - `frontend/components/TicketStatusStepper.tsx`
+  - `frontend/components/__tests__/TicketFolioPage.test.tsx`
+  - `frontend/components/__tests__/TicketStatusStepper.test.tsx`
+- Updated
+  - `frontend/types/itsm.ts`
+  - `frontend/services/itsm.ts`
+  - `frontend/services/__tests__/itsm_api.test.ts`
+  - `frontend/App.tsx`
+  - `frontend/App.itsm-route.test.tsx`
+  - `openspec/changes/itsm-service-catalog/tasks.md`
+
+## Completed Work Unit 4 tasks
+- [x] 4.1 Add Ticket/Folio page and status stepper tests
+- [x] 4.2 Add ticket endpoint and transition API client functions
+- [x] 4.3 Add Ticket/Folio page and status stepper components
+- [x] 4.4 Add `/itsm/tickets` route/navigation entry
+- [x] 4.5 Add API/client/component sanity coverage ensuring no event endpoints are used
+- [x] 4.6 Keep ITSM UI labels distinguishable from inventory wording
+
+## TDD Cycle Evidence (WU4)
+- RED: Ticket/Folio page, status stepper, API wrapper, and route tests were added/extended before implementation passed.
+- GREEN: Ticket/Folio client functions, page, status stepper, and `/itsm/tickets` route were implemented.
+- TRIANGULATE: UI exposes only next linear status transition and uses `/api/itsm/tickets` wrappers, not event endpoints.
+- REFACTOR: Shared ITSM API wrapper now owns both Service Catalog and Ticket/Folio endpoints.
+
+## Verification commands run
+- `cd frontend && corepack pnpm exec vitest run App.itsm-route.test.tsx components/__tests__/ItsmServiceCatalogPage.test.tsx components/__tests__/TicketFolioPage.test.tsx components/__tests__/TicketStatusStepper.test.tsx services/__tests__/itsm_api.test.ts`
+  - Result: PASS (5 files, 19 tests)
+- `cd backend && /tmp/next-gen-it-sm-venv/bin/python -m pytest tests/test_itsm_domain_contracts.py tests/test_migration_itsm_catalog.py tests/test_itsm_startup_checks.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py tests/test_event_service_smoke.py -q`
+  - Result: PASS (97 passed, 0 warnings)
+
+## Remaining apply risks
+- None for focused ITSM backend/frontend scope.
+
+---
+
+## Apply Progress — Verify Remediation
+
+## Status
+- change: `itsm-service-catalog`
+- unit: `Verify remediation — Ticket/Folio update + close flow`
+
+## Files changed
+- Updated
+  - `frontend/components/ItsmTicketFolioPage.tsx`
+  - `frontend/components/__tests__/TicketFolioPage.test.tsx`
+
+## Remediated verification blockers
+- Ticket/Folio UI now supports editing existing folios through `updateTicketFolio`.
+- Closing a resolved ticket prompts for a close reason and sends it to `transitionTicketFolio`.
+- Closed tickets remain read-only for edit actions.
+
+## Verification commands run
+- `cd frontend && corepack pnpm exec vitest run components/__tests__/TicketFolioPage.test.tsx components/__tests__/TicketStatusStepper.test.tsx services/__tests__/itsm_api.test.ts App.itsm-route.test.tsx`
+  - Result: PASS (4 files, 17 tests)
+- `cd frontend && corepack pnpm test:run`
+  - Result: PASS (69 files, 571 tests)
+
+---
+
+## Delivery Strategy Exception
+
+The user explicitly accepted delivering this change as a single oversized PR despite the 400-line review budget forecast. This is recorded as a `size:exception` for `itsm-service-catalog`.
+
+---
+
+## Apply Progress — 4R Remediation
+
+## Status
+- change: `itsm-service-catalog`
+- unit: `Review remediation — risk/resilience/reliability`
+
+## Remediated review findings
+- Backend now treats closed tickets as read-only and rejects direct updates after closure.
+- Backend rejects blank Ticket/Folio titles.
+- Backend rejects direct `archived` updates unless they are produced by the `closed` transition.
+- Service/repository update paths preserve explicit `null` clears for optional fields.
+- Clearing `service_catalog_id` now synchronizes/removes the derived `FOR_SERVICE` relationship.
+- Ticket/Folio list endpoint now has bounded pagination via `limit` with default 100/max 500.
+- Startup bootstrap now runs an additive ServiceCatalog compatibility backfill before strict duplicate/conflict preflight and constraints.
+- Accidental unrelated Python 3.9 compatibility edits were reverted from non-ITSM files.
+
+## Verification commands run
+- `cd backend && /tmp/next-gen-backend-py311/bin/python -m pytest tests/test_itsm_startup_checks.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py -q`
+  - Result: PASS (36 passed; one third-party passlib deprecation warning from auth import path)
+- `cd backend && /tmp/next-gen-backend-py311/bin/python -m pytest tests/test_itsm_domain_contracts.py tests/test_migration_itsm_catalog.py tests/test_itsm_startup_checks.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py tests/test_event_service_smoke.py tests/test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness -q`
+  - Result: PASS (103 passed; one third-party passlib deprecation warning from auth import path)
+- `cd frontend && corepack pnpm test:run`
+  - Result: PASS (69 files, 571 tests)

--- a/openspec/changes/itsm-service-catalog/design.md
+++ b/openspec/changes/itsm-service-catalog/design.md
@@ -1,0 +1,309 @@
+# Design: ITSM Service Catalog Foundation + Ticket/Folio CRUD
+
+This first slice adds two independent ITSM domains: a dedicated Service Catalog for operational service/SLA metadata and a Ticket/Folio workflow for `request` and `incident` records. Event response behavior remains unchanged; the design keeps stable identifiers and boundaries so future work can associate events to folios without retrofitting this slice.
+
+## Discovery note
+
+CodeGraph was required first for structural exploration, but this delegated environment exposes only file read/search tools and no shell or CodeGraph MCP tool. I could not run `git rev-parse`, inspect `.codegraph/`, or initialize/explore CodeGraph from here. Fallback was limited to targeted reads/searches of known artifacts and concrete project files referenced by the exploration/proposal: `backend/models/core.py`, `backend/services/event_service.py`, `backend/routers/*`, `backend/database.py`, `backend/postgres_db.py`, `frontend/App.tsx`, `frontend/services/api.ts`, and existing test conventions.
+
+## Architecture decisions
+
+| Area | Decision | Rationale |
+|---|---|---|
+| Service Catalog persistence | Extend the existing Neo4j `ServiceCatalog` node as the ITSM source of truth. | Current event SLA fallback already reads `(:ServiceCatalog)` through `BusinessService -> USES_SLA -> ServiceCatalog`; using the same graph label avoids dual-write and keeps event compatibility. |
+| Service Catalog field compatibility | Store new fields (`service_id`, `name`, `owner_team`, `category`, `tier`, `criticality`, `sla_target_minutes`, `active`, audit fields) and keep compatibility aliases (`id`, `service_tier`, `sla_minutes`) synchronized. | Existing Pydantic/event response contracts expose `id`, `service_tier`, and `sla_minutes`; additive fields avoid breaking current SLA behavior. |
+| Ticket/Folio persistence | Store `TicketFolio` nodes in Neo4j, independent from events. | Folios will later relate naturally to events and catalog services; first-slice CRUD remains independent by not creating event relationships. |
+| Postgres boundary | Do not add ITSM tables to Postgres in this slice. | Current Postgres usage is auth/session/audit/runtime locking oriented; Neo4j already owns operational topology/events/SLA relationships. Avoid cross-store transactions. |
+| API boundary | Add new routers under explicit ITSM paths: `/api/itsm/service-catalog` and `/api/itsm/tickets`. | Prevents collision with existing inventory endpoints such as `/api/categories`, `/api/hardware`, and the frontend “CI Inventory”/Catalog manager. |
+| Validation | Put Pydantic request/response schemas in `backend/models/itsm.py`; enforce domain rules in services before repository writes. | Keeps routers thin, makes RED tests deterministic, and prevents partial writes on invalid payloads. |
+| Lifecycle | Centralize status transitions in a pure state machine: `open -> in_progress -> in_validation -> resolved -> closed`. | The lifecycle must reject skips, regressions, and reopening closed folios consistently across API and service tests. |
+| Permissions | Use existing admin-level authorization for the first slice, preferably `ADMIN` or `CI_EDIT` for writes and `EVENT_VIEW`/authenticated user for reads until dedicated `ITSM_*` permissions are introduced. | Proposal allows existing admin-level auth; adding a role migration can be a follow-up if product needs finer-grained ITSM permissions. |
+| Frontend placement | Add a separate “ITSM” module/nav section, not a tab inside existing inventory/admin catalog UI. | The spec requires users to distinguish ITSM Service Catalog from inventory catalog/CI management. |
+
+## Backend design
+
+### Modules and files
+
+| File | Action | Purpose |
+|---|---|---|
+| `backend/models/itsm.py` | Create | Pydantic enums, create/update schemas, response schemas for Service Catalog and Ticket/Folio. |
+| `backend/repositories/itsm_service_catalog_repo.py` | Create | Neo4j Cypher for catalog CRUD, constraints/bootstrap helpers if needed, and compatibility field mapping. |
+| `backend/repositories/ticket_folio_repo.py` | Create | Neo4j Cypher for folio CRUD and list/detail queries. No event relationship writes. |
+| `backend/services/itsm_service_catalog_service.py` | Create | Validation orchestration, deterministic defaults, active/deactivate semantics, audit attribution. |
+| `backend/services/ticket_folio_service.py` | Create | Ticket validation, lifecycle transition enforcement, service reference validation, close behavior. |
+| `backend/routers/itsm_service_catalog.py` | Create | REST endpoints for catalog CRUD. |
+| `backend/routers/ticket_folios.py` | Create | REST endpoints for ticket/folio CRUD and status transitions. |
+| `backend/main.py` | Modify | Include the two routers with the existing `/api` prefix convention. |
+| `backend/models/core.py` | Minimal modify if needed | Keep existing event response models stable; avoid renaming current `ServiceCatalog`/`BusinessContextCatalog`. |
+
+### API contracts
+
+Use no trailing slashes, matching the convention documented in `backend/main.py`.
+
+```text
+GET    /api/itsm/service-catalog
+POST   /api/itsm/service-catalog
+GET    /api/itsm/service-catalog/{service_id}
+PUT    /api/itsm/service-catalog/{service_id}
+POST   /api/itsm/service-catalog/{service_id}/deactivate
+
+GET    /api/itsm/tickets
+POST   /api/itsm/tickets
+GET    /api/itsm/tickets/{ticket_id}
+PUT    /api/itsm/tickets/{ticket_id}
+POST   /api/itsm/tickets/{ticket_id}/transition
+```
+
+Deletion should be logical for Service Catalog (`active=false`) to preserve historical SLA references. For tickets, prefer no hard delete in the first slice; if CRUD acceptance requires delete, implement it only as `archived=true` or keep it out of first PR and document the product decision before apply.
+
+### Domain schemas
+
+Service Catalog response fields:
+
+```python
+service_id: str
+name: str
+owner_team: str | None
+category: str | None
+tier: str | None
+criticality: str | None
+sla_target_minutes: int
+active: bool
+created_at: str
+updated_at: str
+updated_by: str | None
+```
+
+Neo4j compatibility properties on the same node:
+
+```text
+id = service_id
+service_tier = tier
+sla_minutes = sla_target_minutes
+```
+
+Ticket/Folio response fields:
+
+```python
+ticket_id: str
+type: Literal["request", "incident"]
+title: str
+description: str | None
+service_catalog_id: str | None
+status: Literal["open", "in_progress", "in_validation", "resolved", "closed"]
+closed_reason: str | None
+created_at: str
+updated_at: str
+updated_by: str | None
+```
+
+`service_catalog_id` is an optional reference in this slice. If provided, validate that the target Service Catalog exists; do not require an event context.
+
+### Neo4j data model
+
+```text
+(:ServiceCatalog {
+  service_id,
+  id,
+  name,
+  owner_team,
+  category,
+  tier,
+  service_tier,
+  criticality,
+  sla_target_minutes,
+  sla_minutes,
+  active,
+  created_at,
+  updated_at,
+  updated_by
+})
+
+(:TicketFolio {
+  ticket_id,
+  type,
+  title,
+  description,
+  service_catalog_id,
+  status,
+  closed_reason,
+  created_at,
+  updated_at,
+  updated_by
+})
+```
+
+Optional first-slice relationship:
+
+```text
+(:TicketFolio)-[:FOR_SERVICE]->(:ServiceCatalog)
+```
+
+This relationship is allowed only when a ticket explicitly references a service. Do not create any relationship between events and folios in this slice.
+
+### Validation and state machine
+
+Implement the transition rule as a pure function in `ticket_folio_service.py`:
+
+```python
+TICKET_STATUS_ORDER = ["open", "in_progress", "in_validation", "resolved", "closed"]
+
+def validate_ticket_transition(current: str, next_status: str) -> None:
+    # accepts only current_index + 1
+```
+
+Rules:
+
+- New tickets always start as `open`; client-provided create status is ignored or rejected consistently.
+- `type` must be exactly `request` or `incident`.
+- `sla_target_minutes` must be numeric and non-negative.
+- Empty `name`/`title` is rejected.
+- Invalid writes return deterministic 4xx errors and do not write partial data.
+- `closed_reason` is required when transitioning to `closed` if product wants closure audit; otherwise keep optional but persist it when provided.
+
+## Frontend design
+
+### Module placement
+
+Add a top-level sidebar item labeled `ITSM` (or `Service Management`) routed separately from inventory:
+
+```text
+/itsm/service-catalog
+/itsm/tickets
+```
+
+Do not add these screens under the current `AdminPage` Catalog tab, because that tab is CI/inventory oriented (`HardwareCatalog`, categories, owners). The implementation can still require admin-level permissions to render write actions.
+
+### Frontend files
+
+| File | Action | Purpose |
+|---|---|---|
+| `frontend/types/itsm.ts` | Create | Shared TS types/enums matching backend response contracts. |
+| `frontend/services/itsm.ts` | Create | API client functions using existing `api` wrapper. |
+| `frontend/hooks/queries/useItsmServiceCatalogQuery.ts` | Create | React Query list/detail hooks and mutations for Service Catalog. |
+| `frontend/hooks/queries/useTicketFoliosQuery.ts` | Create | React Query list/detail hooks and mutations for folios/transitions. |
+| `frontend/components/itsm/ItsmServiceCatalogPage.tsx` | Create | List + create/edit/deactivate UI. |
+| `frontend/components/itsm/TicketFolioPage.tsx` | Create | List + create/edit + transition UI. |
+| `frontend/components/itsm/TicketStatusStepper.tsx` | Create | Linear status display/actions. |
+| `frontend/App.tsx` | Modify | Add nav item and routes. |
+
+### UX behavior
+
+- Service Catalog list shows `name`, `category`, `tier`, `criticality`, `sla_target_minutes`, and `active`.
+- Deactivation is explicit and reversible only if update API permits setting `active=true`; no hard delete by default.
+- Ticket/Folio list filters by `type` and `status`.
+- Ticket form allows `request`/`incident`, title/description, and optional Service Catalog selection.
+- Status transition UX shows only the next valid action. For example, an `open` ticket only offers “Move to in progress”; it must not offer “Resolve”.
+- Closed tickets render read-only lifecycle controls.
+- Error messages from 4xx validation responses are displayed inline and do not mutate local optimistic state unless the mutation succeeds.
+
+## Event SLA compatibility
+
+Existing event detail behavior must remain stable:
+
+- Do not change `backend/services/event_service.py` event-to-business-context queries for this slice unless tests prove compatibility is preserved.
+- Do not mutate historical event SLA snapshots when Service Catalog entries change.
+- Existing `BusinessContextCatalog` response fields (`id`, `category`, `service_tier`, `sla_minutes`) remain available.
+- New catalog writes keep `id/service_tier/sla_minutes` aliases synchronized so current fallback queries still resolve.
+- No event ingestion, acknowledgement, close, recovery, or modal behavior creates or updates `TicketFolio` nodes.
+
+## Future extension point: event manager association
+
+Reserve the following boundary without implementing behavior now:
+
+```text
+(:Event)-[:HAS_FOLIO]->(:TicketFolio)
+(:TicketFolio)-[:FOR_SERVICE]->(:ServiceCatalog)
+```
+
+Future implementation can add an `EventFolioAssociationService` that owns event-driven creation/linking. This first slice must not call that service, register event hooks, or add event router endpoints that link folios. Keep the extension documented through stable IDs (`event.id`, `ticket_id`, `service_id`) and independent service methods:
+
+```python
+def create_ticket_folio(payload, *, actor: str | None = None) -> TicketFolioResponse: ...
+def get_ticket_folio(ticket_id: str) -> TicketFolioResponse: ...
+def transition_ticket_folio(ticket_id: str, next_status: str, *, actor: str | None = None) -> TicketFolioResponse: ...
+```
+
+A future association service should consume these APIs rather than bypassing lifecycle validation.
+
+## Migration and data backfill
+
+### Required migration/bootstrap
+
+Add Neo4j constraints/indexes during startup or via a small idempotent migration script:
+
+```cypher
+CREATE CONSTRAINT service_catalog_service_id IF NOT EXISTS
+FOR (s:ServiceCatalog) REQUIRE s.service_id IS UNIQUE;
+
+CREATE INDEX service_catalog_active IF NOT EXISTS
+FOR (s:ServiceCatalog) ON (s.active);
+
+CREATE CONSTRAINT ticket_folio_ticket_id IF NOT EXISTS
+FOR (t:TicketFolio) REQUIRE t.ticket_id IS UNIQUE;
+
+CREATE INDEX ticket_folio_status IF NOT EXISTS
+FOR (t:TicketFolio) ON (t.status);
+```
+
+### Backfill for existing `ServiceCatalog` nodes
+
+If existing nodes have only legacy fields (`id`, `service_tier`, `sla_minutes`), backfill additively:
+
+```cypher
+MATCH (s:ServiceCatalog)
+SET s.service_id = coalesce(s.service_id, s.id),
+    s.name = coalesce(s.name, s.category, s.id),
+    s.tier = coalesce(s.tier, s.service_tier),
+    s.sla_target_minutes = coalesce(s.sla_target_minutes, s.sla_minutes, 0),
+    s.active = coalesce(s.active, true)
+```
+
+Do not rewrite event nodes or historical event snapshots. Backfill only Service Catalog node properties required by the new admin CRUD surface.
+
+## Testing strategy under strict TDD
+
+Strict TDD applies. Implementation should produce RED evidence before code and GREEN evidence after code for each slice.
+
+| Layer | RED evidence | GREEN evidence |
+|---|---|---|
+| Backend service catalog model/service | Tests fail for negative SLA, empty name, default `active=true`, alias mapping, and no partial write. | `pytest backend/tests/test_itsm_service_catalog_service.py` passes with mocked repository/driver. |
+| Backend service catalog router | Tests fail for create/list/update/deactivate auth and response shape. | FastAPI TestClient tests pass with service mocked, following existing router test style. |
+| Backend ticket lifecycle | Tests fail for invalid type, skipped transition, regression, closed reopening, and valid full sequence. | `pytest backend/tests/test_ticket_folio_service.py` passes with pure state machine and mocked repository. |
+| Backend event compatibility | Tests fail if event detail creates folios or changes SLA snapshot/fallback response fields. | Existing `test_event_service_smoke.py` / `test_routers_metrics_events.py` SLA cases still pass plus one no-folio-regression test. |
+| Frontend hooks | Tests fail until ITSM hooks call `/itsm/service-catalog` and `/itsm/tickets` through `api`. | Vitest hook tests pass with mocked `api` and QueryClient. |
+| Frontend pages | Tests fail until pages render separate ITSM labels, CRUD forms, validation errors, and next-only status transition actions. | Testing Library tests pass for Service Catalog page, Ticket/Folio page, and `TicketStatusStepper`. |
+
+Recommended commands once implementation exists:
+
+```bash
+cd backend && pytest backend/tests/test_itsm_service_catalog_service.py backend/tests/test_ticket_folio_service.py
+cd backend && pytest backend/tests/test_routers_itsm.py backend/tests/test_event_service_smoke.py
+cd frontend && pnpm test:run frontend/components/itsm frontend/hooks/queries
+```
+
+Adjust exact paths to match the repository’s test invocation conventions if the test runner expects execution from inside each package.
+
+## Implementation slicing recommendation
+
+This scope is likely to exceed the 400-line review budget if implemented as one PR. Recommended chained slices:
+
+1. **Backend domain foundation**: schemas, repositories, services, state machine, Neo4j constraints/backfill helper, unit tests. No frontend.
+2. **Backend API surface**: routers, auth checks, main router registration, router tests, event compatibility regression tests.
+3. **Frontend ITSM Service Catalog**: types, service client, query hooks, Service Catalog page, route/nav, tests.
+4. **Frontend Ticket/Folio workflow**: ticket hooks, page, status stepper, transition UX, tests.
+
+If the team insists on a single PR, record a review-budget exception before apply and keep commits grouped by the same boundaries.
+
+## Rollout and rollback
+
+- Roll out additively: constraints/indexes first, backend APIs second, frontend routes last.
+- Keep new routes isolated under `/api/itsm/*` and `/itsm/*` so disabling the UI does not affect monitoring/event flows.
+- Rollback frontend by removing the ITSM nav/routes.
+- Rollback backend APIs by unregistering routers while leaving additive Neo4j properties/constraints in place.
+- Never roll back by deleting or rewriting existing event SLA snapshot data.
+
+## Open questions before apply
+
+- Should dedicated permissions (`ITSM_VIEW`, `ITSM_EDIT`, `ITSM_DELETE`) be introduced now, or should first slice explicitly use `ADMIN`/existing permissions and defer a permission migration?
+- Does CRUD require hard delete for Ticket/Folio, or is archive/close sufficient for auditability?

--- a/openspec/changes/itsm-service-catalog/exploration.md
+++ b/openspec/changes/itsm-service-catalog/exploration.md
@@ -1,0 +1,99 @@
+# Exploration: ITSM Service Catalog
+
+## Issue / Intent
+
+Issue #14 requests a `ServiceCatalog` entity in Neo4j to enable `SLA Restante` in the event modal. The maintainer comment correctly reframes it: this should not be solved as an isolated node/field. The product needs a dedicated ITSM Service Catalog / Service Management foundation where operational services are registered, associated to categories, tier/criticality, and configured with operational SLA values consumed by event response flows.
+
+Initial target concepts from the user:
+
+- Service catalog for all business/system services.
+- Ticket/folio types: `request` and `incident`.
+- Later integration with "respuesta al evento", where events receive folios based on administrator-defined configurations.
+- CRUD for tickets/folios independent of events.
+
+## Current State
+
+### Existing Event and SLA Context
+
+- Domain models already include `BusinessService`, `ServiceCatalog`, `BusinessContext`, `ItsmContext`, and `ExternalTicketRef` in `backend/models/core.py`.
+- Event detail resolution in `backend/services/event_service.py` uses event snapshot data first, then can resolve/fallback through `BusinessService -> ServiceCatalog` when needed.
+- Event responses expose SLA context such as service catalog/category/SLA and `sla_remaining_minutes`.
+- Frontend types and monitoring UI already consume the business context for event detail display.
+
+### Existing Catalog Meaning
+
+- Current admin/catalog surfaces are inventory/CI-oriented: categories, hardware, owners.
+- These are not an ITSM Service Catalog management module.
+- Naming collision risk is high if the new module is called only "Catalog" in routes/UI.
+
+### Ticket / Folio State
+
+- A first-class ticket/folio lifecycle was not found.
+- Existing external ticket support appears passive: event-level external ticket references can be returned, but there is no dedicated writer, workflow, assignment, or CRUD surface for ITSM folios.
+
+## Issue #14 Assessment
+
+Issue #14 is valid but too narrow as the implementation unit.
+
+Partially covered already:
+
+- Event SLA context and modal contract have foundation pieces.
+- Snapshot/fallback behavior exists for event details.
+
+Still missing:
+
+- Dedicated Service Catalog CRUD/admin module.
+- Clear source of truth for service categories, tiers, criticality, and SLA policies.
+- Ticket/folio domain for request and incident lifecycle.
+- Event-response configuration that decides when and how to create/assign a folio.
+
+Recommendation: keep #14 as the tactical event-SLA issue, but create/use a parent change for the broader ITSM Service Catalog foundation.
+
+## Recommended First Slice
+
+First slice should focus on the catalog foundation, not the whole ITSM workflow.
+
+Include:
+
+1. Dedicated Service Catalog domain/API/admin UI for managing business/system services and operational SLA metadata.
+2. Clear separation from the existing hardware/inventory catalog.
+3. Compatibility with existing event SLA snapshot/fallback behavior.
+4. Tests around catalog CRUD and event detail compatibility.
+
+Defer:
+
+- Full ticket/folio lifecycle.
+- Automatic folio assignment from events.
+- External ITSM sync with tools like Jira/ServiceNow.
+- SLA recalculation for historical events unless explicitly required.
+
+## Initial Domain Vocabulary
+
+- `ServiceCatalog`: existing graph/domain concept, source of operational SLA metadata.
+- `BusinessService`: business-facing service related to CIs and SLA catalog entries.
+- `ServiceOffering` or `Service`: candidate naming for admin-managed service records; must be decided before implementation.
+- `SlaPolicy`: candidate abstraction if SLA becomes more complex than `sla_minutes`.
+- `Ticket` / `Folio`: future workflow entity.
+- `Request`: service request ticket type.
+- `Incident`: incident ticket type.
+- `EventResponseConfiguration`: future admin configuration deciding folio creation/assignment from events.
+
+## Key Risks
+
+- Naming collision between inventory catalog and ITSM Service Catalog.
+- Scope creep: tickets, incidents, event automation, and external sync can quickly exceed the 400-line review budget.
+- Permission model may need new ITSM permissions instead of reusing broad CI edit/delete permissions.
+- Historical event snapshots should not silently change if Service Catalog configuration changes later.
+- Existing issue #14 may be closed incorrectly if only a graph node is added without admin/product flow.
+
+## Open Product Questions for Proposal
+
+1. Is the first release only Service Catalog administration, or must it include ticket/folio CRUD too?
+2. Should the user-facing term be "Service Catalog", "Service Management", or "ITSM" in navigation?
+3. Are `request` and `incident` enough as initial folio types, or do we also need states/priorities/assignment from day one?
+4. Should event-created folios be immutable historical records, or can admin rule changes update them retroactively?
+5. Should SLA remain a single `sla_minutes` field initially, or do we need tier/priority calendars and working-hours policies?
+
+## Next Recommended Phase
+
+Proceed to proposal for `itsm-service-catalog`, using this exploration as the scope guard.

--- a/openspec/changes/itsm-service-catalog/proposal.md
+++ b/openspec/changes/itsm-service-catalog/proposal.md
@@ -1,0 +1,108 @@
+# Proposal: ITSM Service Catalog Foundation + Ticket/Folio CRUD
+
+Status: Draft  
+Change ID: `itsm-service-catalog`
+
+## Executive Summary
+Implement a first-slice ITSM foundation that adds:
+1) dedicated Service Catalog CRUD for operational service definitions and SLA metadata, and 2) independent Ticket/Folio CRUD with an initial `request`/`incident` lifecycle. The first delivery intentionally excludes automatic event-to-folio association; that will be implemented later as a controlled extension point.
+
+## Problem and business outcome
+**Problem:** The current codebase has fragments (service metadata references, event SLA snapshots, external ticket references) but no coherent ITSM product surface for teams to define services and manage request/incident folios. This creates fragmented behavior, unclear ownership of SLAs, and inconsistent service operations.
+
+**Business outcome:** Define a clear operational domain that teams can use immediately to:
+- register/manage services and SLA expectations centrally,
+- create and track request/incident folios independently,
+- keep event-response paths untouched and simple while preparing for future automation.
+
+## Proposal question round (assumptions captured)
+Based on your provided decisions:
+1. First slice MUST include both **Service Catalog CRUD** and **Ticket/Folio CRUD**.
+2. Ticket/Folio CRUD is **independent of events** in this delivery.
+3. Event-response association is a **future extension**.
+4. Initial ticket/folio types are only `request` and `incident`.
+5. Workflow is linear and includes `in_validation`.
+6. Recommended linear lifecycle is: `open -> in_progress -> in_validation -> resolved -> closed`.
+
+If any assumption should change, or if you want a second question round, say so before moving to spec.
+
+## Scope (first slice)
+### In scope
+- Service Catalog domain CRUD and admin-facing management flow.
+- Ticket/Folio domain CRUD and linear lifecycle transitions (initial types: `request`, `incident`).
+- API and data model groundwork that keeps ticket/folio and catalog independent.
+- Boundary/interface design for future event-response association.
+- Minimal tests around lifecycle, CRUD boundaries, and validation rules.
+
+### Out of scope (non-goals)
+- Automatic event-to-folio association from event-response workflows.
+- Event routing/reassignment from catalog/business rules for initial delivery.
+- External ITSM connector workflows (e.g., Jira/ServiceNow sync).
+- SLA recalculation retroactively mutating already-created event artifacts.
+- Advanced ITSM policies (priorities/escalation matrices/SLAs by priority calendars) beyond first-slice metadata.
+
+## Proposed domain boundaries
+1. **Service Catalog**
+   - Canonical operational service registry used by operations workflows.
+   - Separate name/meaning from existing inventory/catalog concepts.
+   - Own fields: identification, owner/context references, category/tier/criticality, base SLA configuration, active/disabled state.
+
+2. **Ticket/Folio**
+   - Dedicated ITSM entities with types `request` and `incident`.
+   - Independent lifecycle and CRUD in this slice.
+   - Status lifecycle is linear and must include: `open` → `in_progress` → `in_validation` → `resolved` → `closed`.
+
+3. **Future Event Response association**
+   - No functional association in first slice.
+   - Keep explicit extension points (service reference and lifecycle compatibility) so event workflows can create/attach folios in later iterations without major migration.
+
+## Minimal data/behavior expectations
+- **Service Catalog** should include required identity and SLA fields with deterministic defaults and validation.
+- **Ticket/Folio** should enforce valid type + status transitions in linear order only.
+- **Separation of concerns:** catalog management and folio operations must not be coupled in a way that prevents running either feature independently.
+- **Auditability:** create/update timestamps and user attribution are expected for both domains.
+- **Permissions:** use existing admin-level authorization model unless a dedicated ITSM permission needs to be introduced as a follow-up.
+
+## Affected areas (expected)
+- Backend domain/API work for Service Catalog and Ticket/Folio persistence and endpoints.
+- Frontend admin and operational UI surfaces for both CRUD areas.
+- Shared models/schemas, validations, and tests.
+- Initial routing/navigation labels/sections to avoid inventory catalog confusion.
+
+## Proposed design direction
+- Introduce/solidify Service Catalog as its own bounded domain with explicit naming in API and UI.
+- Implement Ticket/Folio lifecycle with explicit status enum and linear state validation.
+- Keep event-response code unchanged for now; introduce clean hooks/interfaces for later association.
+- Keep models and services additive to avoid breaking existing event SLA snapshot behavior.
+
+## Acceptance criteria
+1. Service Catalog can be created, read, updated, and deactivated via API/admin flow.
+2. Ticket/Folio can be created, read, updated, and closed via API/admin flow.
+3. Ticket/Folio supports exactly initial `request` and `incident` types.
+4. Ticket/Folio status transitions only allow linear progression through: `open` → `in_progress` → `in_validation` → `resolved` → `closed`.
+5. No event-to-folio association behavior is introduced in this slice.
+6. Existing issue/feature behaviors around event SLA snapshots remain stable.
+7. Existing users can distinguish Service Catalog (ITSM) from inventory catalog areas.
+
+## Risks
+1. **Naming collision risk:** confusion between new ITSM catalog and existing inventory catalog; require explicit module naming and route labels.
+2. **Scope creep:** adding full ITSM parity too early can exceed delivery intent and review budget.
+3. **Permission misalignment:** existing roles may not map cleanly to new domains.
+4. **Workflow migration risk:** adding status values later could require backward-compatible transition strategy.
+
+## Rollback plan
+- Feature-flag where practical and keep domain changes additive.
+- If needed, disable/remove new catalog/folio modules independently without impacting existing event/SLA logic.
+- Revert API/controller surfaces if behavior coupling breaks existing flows.
+
+## Review workload note
+This is likely to cross the **400 changed lines** threshold (especially if both domains plus frontend screens are included). Plan for slicing (recommended: separate PRs or batches) based on `delivery_strategy` and review capacity.
+
+## Success criteria
+- Service Catalog and Ticket/Folio first-slice capabilities are usable end-to-end by operators.
+- Ticket/Folio lifecycle is strictly linear with `in_validation` in sequence.
+- No regressions in existing event SLA retrieval/usage.
+- Future event association can be implemented without breaking current ticket/folio and catalog data contracts.
+
+## Next recommended phase
+Proceed to **spec**.

--- a/openspec/changes/itsm-service-catalog/specs/itsm-service-catalog/spec.md
+++ b/openspec/changes/itsm-service-catalog/specs/itsm-service-catalog/spec.md
@@ -1,0 +1,129 @@
+# ITSM Service Catalog Specification
+
+## Purpose
+
+The first slice SHALL provide a dedicated ITSM Service Catalog domain and an independent Ticket/Folio domain so teams can manage services and request/incident records without coupling to existing inventory catalog behavior or event-response automation.
+
+## Requirements
+
+### Requirement: Service Catalog is the ITSM source of truth
+
+The system SHALL provide full CRUD for a dedicated Service Catalog domain that is independent of inventory catalog entities.
+
+The Service Catalog record SHALL include, at minimum, English-named technical fields such as `service_id`, `name`, `owner_team`, `category`, `tier`, `criticality`, `sla_target_minutes`, `active`, `created_at`, `updated_at`, and `updated_by`.
+
+#### Scenario: Create, read, update, and deactivate a catalog service
+
+- GIVEN an authorized user provides a valid Service Catalog payload
+- WHEN the service is created
+- THEN the system SHALL persist it with `active=true`.
+- WHEN the same service is updated with valid fields
+- THEN the system SHALL persist the new values and update `updated_at`.
+- WHEN the service is marked inactive
+- THEN it SHALL remain queryable for historical consistency with `active=false`.
+
+### Requirement: Service Catalog values are validated with deterministic defaults
+
+The system SHALL validate Service Catalog inputs at create/update time and apply deterministic defaults where fields are optional.
+
+The system SHALL require a non-empty `name` and a non-negative numeric `sla_target_minutes`.
+
+The system SHALL reject invalid payloads with a deterministic validation error and MUST NOT partially persist changes.
+
+#### Scenario: Invalid SLA target is rejected
+
+- GIVEN a Service Catalog payload with negative `sla_target_minutes`
+- WHEN an upsert operation is executed
+- THEN the system SHALL return a validation failure
+- AND no catalog changes SHALL be saved.
+
+### Requirement: Ticket/Folio records support independent CRUD
+
+The system SHALL provide independent CRUD for Ticket/Folio records with initial types limited to `request` and `incident`.
+
+Ticket/Folio records SHALL include English-named technical fields such as `ticket_id`, `type`, `title`, `description`, `service_catalog_id`, `status`, `closed_reason`, `created_at`, `updated_at`, and `updated_by`.
+
+#### Scenario: Create/read/update/close a ticket folio
+
+- GIVEN an authorized user creates a `request` folio with valid payload
+- WHEN the create API is called
+- THEN the system SHALL persist the folio with initial `status=open`.
+- WHEN the folio is read or updated
+- THEN the system SHALL return current persisted values without requiring an event context.
+- WHEN the folio is closed through the status lifecycle and updated to `closed`
+- THEN the system SHALL persist the closure and preserve created history.
+
+### Requirement: Ticket/Folio lifecycle is linear and validated
+
+The system SHALL accept only the following status state machine for Ticket/Folio records in this slice: `open -> in_progress -> in_validation -> resolved -> closed`.
+
+The system SHALL reject status updates that skip steps, regress (move backward), or transition from `closed` to any other status.
+
+#### Scenario: Valid linear transition sequence
+
+- GIVEN a ticket with status `open`
+- WHEN status is updated to `in_progress`
+- THEN the transition SHALL be accepted.
+- WHEN status is updated to `resolved` directly from `open`
+- THEN the transition SHALL be rejected.
+
+### Requirement: Ticket/Folio and Service Catalog are decoupled from inventory catalog
+
+The system SHALL keep ITSM domains separate from inventory catalog data models and surfaces.
+
+A Service Catalog service SHALL NOT be a rebranded alias of inventory `Category`/CI catalog entities, and Ticket/Folio SHALL NOT depend on inventory catalog CRUD for lifecycle operations.
+
+#### Scenario: Inventory operations do not drive ITSM CRUD
+
+- GIVEN an inventory catalog item is created, updated, or deleted
+- WHEN no explicit Service Catalog API call is made
+- THEN no Ticket/Folio record SHALL be auto-created, auto-updated, or auto-deleted.
+- WHEN an ITSM operator uses Service Catalog APIs
+- THEN the result SHALL reflect ITSM data regardless of inventory catalog operations.
+
+### Requirement: Event-to-folio association remains a future extension point
+
+The system SHALL NOT implement automatic event-to-folio creation, linking, or mutation in this first slice.
+
+The system SHALL preserve extension points (stable identifiers, documented boundaries, and explicit API version compatibility) so future work can add event-driven association without breaking existing Ticket/Folio records.
+
+#### Scenario: Event ingestion stays behaviorally unchanged for folios
+
+- GIVEN an event is processed under existing workflows
+- WHEN the event engine runs
+- THEN it SHALL NOT create, update, or close any Ticket/Folio record implicitly.
+- WHEN an existing event arrives with the same payload as before this change
+- THEN event response behavior SHALL remain unchanged.
+
+### Requirement: Existing event SLA behavior remains compatible
+
+The system SHALL maintain current event SLA behavior for snapshots and fallback resolution.
+
+The system SHALL NOT mutate existing event SLA snapshots when Service Catalog entries are edited.
+
+#### Scenario: SLA retrieval remains stable after catalog changes
+
+- GIVEN an event record already contains SLA snapshot data
+- WHEN the related Service Catalog service is updated in this change
+- THEN subsequent reads of that historical event SHALL return the same snapshot values as before the update.
+- WHEN the event path relies on existing fallback behavior
+- THEN it SHALL continue to resolve SLA context using existing rules when snapshot data is present or when service lookups fail.
+
+### Requirement: First-slice implementation scope remains bounded
+
+The system SHALL not include event-response configuration, automatic routing, or external ITSM connector behavior in this slice.
+
+The system SHALL include only capabilities directly required for independent Service Catalog CRUD, independent Ticket/Folio CRUD, and linear lifecycle validation.
+
+#### Scenario: Out-of-scope features are not shipped in this slice
+
+- GIVEN the implementation of this slice
+- WHEN a consumer tests ticket/folio and catalog behavior
+- THEN no new endpoints SHALL automatically connect events to folios.
+- AND no external workflow connectors for third-party ITSM tools SHALL be introduced.
+
+## Risks
+
+- The proposal does not contain a `Capabilities` section, so domain boundaries are inferred from proposal and exploration text; this assumption should be reviewed before implementation.
+- The first slice combines two CRUD domains plus lifecycle validation and is likely to be large; if implementation exceeds the review budget, split into stacked PR slices.
+- Permissions and route naming need explicit follow-up design decisions to avoid overlap with existing inventory catalog authorization and navigation.

--- a/openspec/changes/itsm-service-catalog/tasks.md
+++ b/openspec/changes/itsm-service-catalog/tasks.md
@@ -1,0 +1,179 @@
+# Tasks: ITSM Service Catalog + Ticket/Folio CRUD
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~640-900 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 foundation/domain contracts; PR 2 backend API/services/repositories; PR 3 frontend service-catalog module; PR 4 frontend ticket/folio module |
+| Delivery strategy | single-pr size exception accepted by user |
+| Chain strategy | not applicable — single oversized PR accepted |
+
+Decision needed before apply: No — user accepted single oversized PR
+Chained PRs recommended: Yes, but overridden by accepted size exception
+Chain strategy: not applicable
+400-line budget risk: High — accepted by user
+
+> Forecast rationale: cross-domain backend migration/bootstrap + 4 backend routers/repos/services + 2 UI modules and route wiring will likely exceed 400 lines and couples two domains plus extension-point safeguards.
+
+## TDD ordering (strict TDD)
+- Backend behavior changes: **RED → GREEN → TRIANGULATE → REFACTOR** per work unit.
+- Backend tests must be added/updated before implementation in the same work unit.
+- Frontend behavior changes: **frontend tests first**, then component/service implementation in the same work unit.
+
+## Global in-slice constraints (must remain true)
+1. No event-to-folio auto-association in this slice.
+2. Service catalog stays separate from inventory catalog/domain routes and UI.
+3. Ticket/Folio delete semantics are LOGICAL (archive/close-oriented) only unless a follow-up explicit hard-delete task is approved.
+4. ITSM read/write endpoints must have explicit permission gates.
+5. `service_catalog_id` reference for Ticket/Folio is the authoritative identifier; any `FOR_SERVICE` relationship is kept in sync and is non-authoritative.
+6. Migration/bootstrap MUST preflight existing `ServiceCatalog` data (duplicates/invalid legacy IDs) before enabling uniqueness constraints.
+
+## Suggested work units and verification boundaries
+
+### Work Unit 1 — Backend domain contracts + migration preflight (PR 1)
+Dependencies: proposal + design only.
+Finish state: domain entities, migration script, and startup preflight are in place and test-covered.
+
+- **RED**
+  - [x] 1.1 Add `backend/tests/test_itsm_domain_contracts.py` covering:
+    - `ServiceCatalog` alias compatibility (`id`/`service_id`, `service_tier`/`tier`, `sla_minutes`/`sla_target_minutes`) and non-negative SLA validation.
+    - Ticket/Folio type enum (`request`, `incident`) and required linear lifecycle order.
+    - no hard-delete behavior expectation for ticket updates (`archived`/`closed` path only; physical delete absent).
+  - [x] 1.2 Add `backend/tests/test_migration_itsm_catalog.py` asserting `backend/migrations/itsm_service_catalog.cypher` contains:
+    - `service_catalog_service_id` unique constraint with `IF NOT EXISTS`,
+    - ticket folio constraint/indexes,
+    - additive/compatibility comments for legacy data.
+
+- **GREEN**
+  - [x] 1.3 Create `backend/models/itsm.py` with Pydantic payload/response models:
+    - service catalog fields (`service_id`, `name`, `owner_team`, `category`, `tier`, `criticality`, `sla_target_minutes`, `active`, timestamps, `updated_by`, optional compatibility fields as needed),
+    - ticket/folio fields (`ticket_id`, `type`, `title`, `description`, `service_catalog_id`, `status`, `archived`, `closed_reason`, `created_at`, `updated_at`, `updated_by`).
+  - [x] 1.4 Add `backend/repositories/itsm_service_catalog_repo.py` with additive Neo4j write/read queries:
+    - list/get by `service_id`,
+    - create/update with deterministic defaults and optional compatibility aliases,
+    - logical deactivate (`active=false`).
+  - [x] 1.5 Add `backend/repositories/ticket_folio_repo.py` with query patterns for ticket CRUD and status-based list filtering.
+  - [x] 1.6 Add `backend/services/itsm_bootstrap.py` with preflight:
+    - detect duplicate/collision risks in candidate `(service_id/id)` keys,
+    - detect invalid legacy `ServiceCatalog` nodes lacking resolvable canonical identity,
+    - emit startup-failing exception if preflight blockers exist.
+  - [x] 1.7 Add `backend/migrations/itsm_service_catalog.cypher` with:
+    - `ServiceCatalog`/`TicketFolio` constraints/indexes,
+    - a safe backfill block mapping legacy `id/service_tier/sla_minutes` into new fields when present,
+    - explicit additive behavior comments (no event snapshot mutation).
+  - [x] 1.8 Register startup preflight in `backend/main.py` startup path (before Neo4j writes for catalog constraints).
+
+- **TRIANGULATE**
+  - [x] 1.9 Verify migration/application ordering against existing startup flow (`backend/main.py` startup path) and confirm no change to event snapshot usage (`main.startup_event`) and confirm no change to event snapshot usage paths.
+  - [x] 1.10 Reconcile whether `service_catalog_id` conflicts are resolved pre-migration or blocked with startup error (document chosen behavior in task notes).
+
+- **REFACTOR**
+  - [x] 1.11 Clean naming/docs in `backend/models/itsm.py` and migration file comments; keep backward-compatible aliases explicit.
+
+### Work Unit 2 — Backend API services + routers + permissions + event compatibility (PR 2)
+Dependencies: Work Unit 1 complete.
+Finish state: all backend endpoints are implemented and validated; event compatibility is proven unchanged.
+
+- **RED**
+  - [x] 2.1 Add `backend/tests/test_itsm_service_catalog_service.py`:
+    - create/list/update/deactivate catalog semantics,
+    - validation failures (empty name, negative SLA,
+      partial write safety).
+  - [x] 2.2 Add `backend/tests/test_ticket_folio_service.py`:
+    - create defaults (`open`),
+    - transition validator rejects skip/rollback,
+    - close transition preserves history and requires closed state handling.
+  - [x] 2.3 Add `backend/tests/test_routers_itsm.py` for ITSM auth + route behavior:
+    - catalog/ticket reads require read permission,
+    - writes require explicit write permission,
+    - CRUD endpoints return expected models.
+  - [x] 2.4 Add/extend event compatibility tests in `backend/tests/test_event_service_smoke.py` or `backend/tests/test_routers_events.py` to assert no event-path creates/updates/deletes folios and existing snapshot/fallback reads remain unchanged.
+
+- **GREEN**
+  - [x] 2.5 Create `backend/services/itsm_service_catalog_service.py`:
+    - catalog defaults + validation + compatibility sync,
+    - no hard-delete semantics (logical deactivate only).
+  - [x] 2.6 Create `backend/services/ticket_folio_service.py`:
+    - enforce pure state machine `open -> in_progress -> in_validation -> resolved -> closed`,
+    - define authoritative `service_catalog_id` contract and synchronize optional `FOR_SERVICE` relationship.
+  - [x] 2.7 Add `backend/routers/itsm_service_catalog.py` with explicit permission checks:
+    - list/get/create/update/deactivate routes under `/api/itsm/service-catalog`.
+  - [x] 2.8 Add `backend/routers/ticket_folios.py` with explicit permission checks:
+    - list/get/create/update/transition under `/api/itsm/tickets`.
+    - if delete is present, document `archived=true` only and route name accordingly.
+  - [x] 2.9 Register routers in `backend/main.py` with `/api` prefix and ensure naming/tag isolation from inventory routes.
+  - [x] 2.10 Add/update `backend/models/core.py` if needed for backward-compatible `BusinessContextCatalog` alias exposure only (no breaking rename).
+
+- **TRIANGULATE**
+  - [x] 2.11 Run endpoint permission audit against `routers/catalog.py` and `routers/events.py` to prevent overlap/ambiguity with inventory permission model.
+  - [x] 2.12 Validate service-catalog/ticket reference behavior:
+    - service relation and property both accepted on writes,
+    - repository writes keep property/relationship in sync,
+    - reads remain deterministic when relation missing but property present.
+
+- **REFACTOR**
+  - [x] 2.13 Refactor router/service wiring for pure transition function and explicit error messages (400/409 vs 404 semantics).
+  - [x] 2.14 Add short API contract note in code docstring for both routers: explicit separation from event flows.
+
+### Work Unit 3 — Frontend ITSM catalog surface + routes/navigation isolation (PR 3)
+Dependencies: Work Unit 2 completed enough for mocked service wiring.
+Finish state: users can manage Service Catalog in a dedicated ITSM route (not inside inventory UI).
+
+- **RED**
+  - [x] 3.1 Add `frontend/components/__tests__/ItsmServiceCatalogPage.test.tsx`:
+    - reads and renders `/itsm/service-catalog` route,
+    - list/create/edit/deactivate behavior,
+    - read/write API calls hit `/api/itsm/service-catalog`.
+  - [x] 3.2 Add `frontend/services/__tests__/itsm_api.test.ts` (or inline vitest mock test file in same folder convention): API client method tests for catalog endpoints.
+
+- **GREEN**
+  - [x] 3.3 Add `frontend/types/itsm.ts` with TicketFolio and ServiceCatalog response/input types.
+  - [x] 3.4 Add `frontend/services/itsm.ts` client wrapper functions:
+    - `listServiceCatalog`, `createServiceCatalog`, `updateServiceCatalog`, `deactivateServiceCatalog`.
+  - [x] 3.5 Add `frontend/components/ItsmServiceCatalogPage.tsx` and optional `frontend/components/ItsmServiceCatalogForm.tsx` for CRUD flow.
+  - [x] 3.6 Add dedicated ITSM navigation in `frontend/App.tsx`:
+    - new route `/itsm/service-catalog`,
+    - sidebar item under ITSM.
+  - [x] 3.7 Ensure no shared navigation path with inventory catalog tabs (keep Inventory/Hardware catalogs untouched).
+
+- **TRIANGULATE**
+  - [x] 3.8 Verify route isolation by end-to-end route test + manual smoke plan:
+    - `/inventory` behavior unchanged,
+    - ITSM screens visible only under `/itsm/*`.
+
+- **REFACTOR**
+  - [x] 3.9 Refactor shared query/loading/error UI patterns for catalog page; keep labels concise and user-facing English.
+
+### Work Unit 4 — Frontend ticket/folio UX + lifecycle controls (PR 4)
+Dependencies: Work Units 1–3 complete (backend APIs and auth contract stable).
+Finish state: operators can manage request/incident folios and enforce linear transitions from UI.
+
+- **RED**
+  - [x] 4.1 Add `frontend/components/__tests__/TicketFolioPage.test.tsx` and `frontend/components/__tests__/TicketStatusStepper.test.tsx`:
+    - list/filter by type/status,
+    - create/update/transition controls only allow next-step transitions,
+    - closed items are read-only,
+    - endpoint calls go through `/api/itsm/tickets` and `/api/itsm/tickets/{id}/transition`.
+
+- **GREEN**
+  - [x] 4.2 Add/extend `frontend/services/itsm.ts` for ticket endpoints and transition calls.
+  - [x] 4.3 Add `frontend/components/ItsmTicketFolioPage.tsx` and `frontend/components/TicketStatusStepper.tsx`.
+  - [x] 4.4 Update `frontend/App.tsx` with `/itsm/tickets` route and ITSM nav entry (if not already covered in Work Unit 3).
+
+- **TRIANGULATE**
+  - [x] 4.5 Add contract sanity test for API client + component using `api` mock to ensure no event endpoints are called by Ticket/Folio UI.
+
+- **REFACTOR**
+  - [x] 4.6 Rename/add UI strings and action labels so ITSM is distinguishable from catalog/inventory wording.
+
+## Acceptance / completion checklist before apply
+- [x] All work units in PR 1 and PR 2 pass backend tests (unit + router + migration contract).
+- [x] PR 3 and PR 4 include frontend tests for the changed screens.
+- [x] Event path behavior remains unchanged (existing event tests still pass).
+- [x] Navigation/UI separation from inventory/catalog routes is demonstrable by route checks.
+- [x] Deletion policy for Ticket/Folio is documented in code/test assertions as logical/archival-first.
+- [x] Migration preflight behavior for legacy/duplicate catalog IDs is implemented and documented.
+- [x] Rollback playbook: remove ITSM routers from `backend/main.py` + remove `/itsm/*` routes from `frontend/App.tsx` without touching event or inventory modules.

--- a/openspec/changes/itsm-service-catalog/verify-report.md
+++ b/openspec/changes/itsm-service-catalog/verify-report.md
@@ -1,0 +1,131 @@
+# Verify Report — ITSM Service Catalog
+
+## Status
+
+PASS — final verification refresh is clean for the in-scope ITSM Service Catalog and Ticket/Folio slice. All implementation tasks are complete, strict-TDD evidence is present, focused backend and frontend ITSM suites are green, the frontend full suite is green on rerun, the accepted `size:exception` is recorded, and final 4R focused re-review is PASS across risk, resilience, reliability, and readability.
+
+## Structured status and action context findings
+
+```yaml
+schemaName: spec-driven
+changeName: itsm-service-catalog
+artifactStore: openspec
+planningHome:
+  root: /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/openspec
+  changesDir: openspec/changes
+changeRoot: openspec/changes/itsm-service-catalog
+artifactPaths:
+  specs:
+    - openspec/changes/itsm-service-catalog/specs/itsm-service-catalog/spec.md
+  design:
+    - openspec/changes/itsm-service-catalog/design.md
+  tasks:
+    - openspec/changes/itsm-service-catalog/tasks.md
+  applyProgress:
+    - openspec/changes/itsm-service-catalog/apply-progress.md
+  verifyReport:
+    - openspec/changes/itsm-service-catalog/verify-report.md
+artifacts:
+  specs: done
+  design: done
+  tasks: done
+  applyProgress: done
+  verifyReport: done
+taskProgress:
+  unchecked: []
+applyState: all_done
+dependencies:
+  apply: all_done
+  verify: all_done
+  archive: ready
+actionContext:
+  mode: repo-local
+  workspaceRoot: /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen
+  allowedEditRoots:
+    - /Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen
+  warnings: []
+nextRecommended: archive
+isNonAuthoritative: false
+```
+
+- Active change selection: explicit `itsm-service-catalog`.
+- Artifact store: OpenSpec file backend.
+- Implementation ownership/workspace: verified artifacts and referenced implementation/test files are under the repository workspace.
+- Status blocker check: none.
+
+## Spec coverage
+
+| Requirement | Verification | Status |
+|---|---|---|
+| Service Catalog CRUD independent of inventory | Backend models/services/repos/routers implement create/list/get/update/deactivate under `/api/itsm/service-catalog`; frontend has dedicated `/itsm/service-catalog`; inventory routes remain separate. | PASS |
+| Service Catalog validation/defaults | Tests cover non-empty name, non-negative SLA, default `active=true`, compatibility alias sync, and partial write safety. | PASS |
+| Ticket/Folio independent CRUD with `request`/`incident` | Backend supports list/get/create/update/transition under `/api/itsm/tickets`; frontend supports create and update; types are limited to `request` and `incident`. | PASS |
+| Ticket/Folio linear lifecycle | Backend validates `open -> in_progress -> in_validation -> resolved -> closed`; frontend stepper exposes only the next transition; closed tickets are read-only. | PASS |
+| Ticket/Folio close flow | UI prompts for close reason and sends `closed_reason`; backend persists the reason and archives on close. | PASS |
+| No event-to-folio association | Event compatibility coverage remains green; Ticket/Folio behavior stays isolated from event paths. | PASS |
+| Existing event SLA behavior compatible | Focused backend ITSM/event smoke suite passes; event snapshot/fallback behavior remains covered. | PASS |
+| Service Catalog distinguishable from inventory catalog | Dedicated ITSM nav/routes (`/itsm/service-catalog`, `/itsm/tickets`) with route isolation tests. | PASS |
+| Bounded first-slice scope | No external connector or automatic event-response association endpoint is included in this slice. | PASS |
+
+## Task completion status
+
+- Unchecked implementation task markers matching `^\s*- \[ \]`: none found.
+- `tasks.md` marks all work units and the acceptance checklist complete.
+- Archive completeness blocker from task checkboxes: none.
+
+## Strict TDD compliance
+
+Strict TDD is active in `openspec/config.yaml` and the parent prompt. Project-local strict-TDD verify guidance was not present; global guidance was read from `/Users/macbook/.pi/agent/gentle-ai/support/strict-tdd-verify.md`.
+
+| Check | Result | Details |
+|---|---:|---|
+| TDD evidence reported | PASS | `apply-progress.md` contains `TDD Cycle Evidence` sections for WU1, WU2, WU3, and WU4, including a table for WU2. |
+| Reported test files exist | PASS | Referenced backend and frontend test files were cross-referenced in the workspace. |
+| GREEN confirmed | PASS | Backend focused suite, frontend focused ITSM suite, and frontend full suite are green after final refresh. |
+| Remediation regression coverage | PASS | Ticket/Folio update, close reason, closed read-only behavior, bounded pagination, explicit-null preservation, relationship clearing, and closed-ticket backend restrictions are covered by focused tests. |
+| Assertion quality | PASS | No tautology, ghost-loop, type-only-only, smoke-only, or implementation-detail assertion issues remain in changed ITSM test scope based on the prior assertion-quality audit and final PASS reviews. |
+
+## Test layer distribution
+
+| Layer | Tests/files | Evidence |
+|---|---:|---|
+| Backend unit/service/router integration | 103 focused backend tests | `test_itsm_domain_contracts.py`, `test_migration_itsm_catalog.py`, `test_itsm_startup_checks.py`, `test_itsm_service_catalog_service.py`, `test_ticket_folio_service.py`, `test_routers_itsm.py`, `test_event_service_smoke.py`, `test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness` |
+| Frontend component/service integration | 21 focused frontend ITSM tests | `App.itsm-route.test.tsx`, `ItsmServiceCatalogPage.test.tsx`, `TicketFolioPage.test.tsx`, `TicketStatusStepper.test.tsx`, `itsm_api.test.ts` |
+| Frontend full regression | 571 tests | Full Vitest suite |
+
+## Test / validation commands
+
+- `cd backend && /tmp/next-gen-backend-py311/bin/python -m pytest tests/test_itsm_domain_contracts.py tests/test_migration_itsm_catalog.py tests/test_itsm_startup_checks.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py tests/test_event_service_smoke.py tests/test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness -q`
+  - Result: PASS — 103 passed, 1 warning.
+  - Warning: one third-party `passlib` deprecation warning from auth import path; not introduced by ITSM.
+
+- `cd frontend && corepack pnpm exec vitest run App.itsm-route.test.tsx components/__tests__/ItsmServiceCatalogPage.test.tsx components/__tests__/TicketFolioPage.test.tsx components/__tests__/TicketStatusStepper.test.tsx services/__tests__/itsm_api.test.ts`
+  - Result: PASS — 5 files, 21 tests.
+
+- `cd frontend && corepack pnpm test:run`
+  - First run result: FAIL — 1 failed, 570 passed, 69 files. Failure was `components/MetricsManager.test.tsx > shows delete pending state, guards duplicate deletion, clears stale selection, and refetches metrics and nodes`: expected `mocks.apiGet` to be called 1 time, got 2.
+  - Focused rerun: `cd frontend && corepack pnpm exec vitest run components/MetricsManager.test.tsx -t "shows delete pending state, guards duplicate deletion, clears stale selection, and refetches metrics and nodes"` — PASS, 1 passed / 23 skipped.
+  - Final full rerun result: PASS — 69 files, 571 tests.
+  - Finding: the transient failure is outside the ITSM scope and passed on isolated and final full-suite rerun; no in-scope ITSM warning/blocker remains.
+
+## 4R final focused re-review
+
+PASS — final focused re-review after remediation reported clean results across all four lenses:
+
+| Lens | Result | Finding |
+|---|---:|---|
+| Risk | PASS | No remaining in-scope security/permission/data-loss/architecture blocker. |
+| Resilience | PASS | No remaining in-scope partial-failure, pagination, null-clear, relationship-sync, or startup-order blocker. |
+| Reliability | PASS | No remaining in-scope lifecycle, validation, determinism, or regression blocker. |
+| Readability | PASS | No remaining in-scope maintainability/naming/structure blocker. |
+
+## Review workload / PR boundary findings
+
+- `tasks.md` forecasted high review-budget risk and recommended chained PRs.
+- The user accepted a single oversized PR and the `size:exception` is recorded in both `tasks.md` and `apply-progress.md`.
+- The implementation completed the full accepted slice and no scope creep beyond the specified Service Catalog + Ticket/Folio first slice was found.
+- In-scope review workload blockers: none.
+
+## Exact blockers before archive
+
+None for the ITSM change.


### PR DESCRIPTION
Closes #14

## Descripción del Cambio

Implementa la base del módulo ITSM:

- Service Catalog CRUD como fuente de verdad operativa separada del catálogo de inventario.
- Ticket/Folio CRUD independiente para tipos `request` e `incident`.
- Flujo lineal de folios: `open → in_progress → in_validation → resolved → closed`.
- Preparación para asociación futura con eventos, sin crear asociación evento→folio en este PR.
- Artefactos SDD/OpenSpec incluidos en `openspec/changes/itsm-service-catalog/`.

> Size exception: el cambio supera el presupuesto recomendado de 400 líneas y fue aceptado explícitamente como PR único.

## Tipo de Cambio
- [x] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios principales

| Área | Cambio |
|------|--------|
| `backend/models/itsm.py` | Modelos, enums y validaciones ITSM para Service Catalog y Ticket/Folio. |
| `backend/repositories/*itsm*`, `backend/repositories/ticket_folio_repo.py` | Persistencia Neo4j para catálogo y folios. |
| `backend/services/*itsm*`, `backend/services/ticket_folio_service.py` | Reglas de negocio, lifecycle lineal, preflight/backfill y validaciones. |
| `backend/routers/itsm_service_catalog.py`, `backend/routers/ticket_folios.py` | Endpoints `/api/itsm/service-catalog` y `/api/itsm/tickets`. |
| `frontend/components/ItsmServiceCatalogPage.tsx` | UI CRUD para Service Catalog. |
| `frontend/components/ItsmTicketFolioPage.tsx` | UI CRUD y transición lineal para folios. |
| `frontend/services/itsm.ts`, `frontend/types/itsm.ts` | Cliente API y tipos ITSM. |
| `openspec/changes/itsm-service-catalog/` | Proposal, spec, design, tasks, apply progress y verify report. |

## ¿Cómo se probó?

- [x] Backend focused ITSM: `cd backend && /tmp/next-gen-backend-py311/bin/python -m pytest tests/test_itsm_domain_contracts.py tests/test_migration_itsm_catalog.py tests/test_itsm_startup_checks.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py tests/test_event_service_smoke.py tests/test_auth_extended.py::TestPermissionSecurity::test_permission_enum_completeness -q`
  - Resultado: `103 passed`.
- [x] Frontend full: `cd frontend && corepack pnpm test:run`
  - Resultado: `69 files / 571 tests passed`.
- [x] SDD verify final: PASS, sin riesgos/warnings/blockers in-scope ITSM.
- [x] 4R final review: PASS en risk, resilience, reliability y readability.
- [x] Shell scripts: N/A, no se modificaron scripts.

Nota: el backend full suite en entorno local requiere Python 3.11 y Docker disponible para tests con testcontainers. Las fallas restantes observadas fuera del scope ITSM fueron por Docker/testcontainers no disponible y checks legacy de entorno auth; no fueron introducidas por este cambio.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label: `type:feature`.
- [x] Ran shellcheck or confirmed N/A for scripts.
- [x] Tests executed for backend/frontend affected scope.
- [x] Docs/SDD artifacts updated for behavior change.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` trailers.

---
*Generado por Alex*
