### PR TITLE
fix(events): clean recovered events with comments

### DIFF
--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -1142,7 +1142,6 @@ def prune_recovered_events(user: str) -> Dict[str, Any]:
             MATCH (e:Event)
             WHERE e.status = 'RECOVERED'
               AND (e.ack IS NULL OR e.ack = false)
-              AND (e.comments IS NULL OR size(e.comments) = 0)
             SET e.status = 'CLOSED', e.closed_at = datetime(), e.closed_by = $user
             RETURN count(e) as closed_count
         """,
@@ -1333,7 +1332,6 @@ async def event_batch_pruner(
             MATCH (e:Event)
             WHERE e.status = 'RECOVERED'
               AND (e.ack IS NULL OR e.ack = false)
-              AND (e.comments IS NULL OR size(e.comments) = 0)
             RETURN count(e) as total
             """
         ).single()
@@ -1362,7 +1360,6 @@ async def event_batch_pruner(
                     MATCH (e:Event)
                     WHERE e.status = 'RECOVERED'
                       AND (e.ack IS NULL OR e.ack = false)
-                      AND (e.comments IS NULL OR size(e.comments) = 0)
                       {cursor_filter}
                     RETURN e.id as event_id, e.status, e.created_at as created_at
                     ORDER BY e.created_at ASC
@@ -1394,7 +1391,6 @@ async def event_batch_pruner(
                                 MATCH (e:Event {id: $eid})
                                 WHERE e.status = 'RECOVERED'
                                   AND (e.ack IS NULL OR e.ack = false)
-                                  AND (e.comments IS NULL OR size(e.comments) = 0)
                                 SET e.status = 'CLOSED', e.closed_at = datetime(), e.closed_by = $user
                                 RETURN e.id AS closed_id
                                 """,

--- a/backend/tests/test_event_batch_pruner.py
+++ b/backend/tests/test_event_batch_pruner.py
@@ -376,35 +376,47 @@ class TestEventBatchPrunerTimeout:
 
 
 class TestEventBatchPrunerSafetyGuards:
-    """Verify streaming prune preserves ACK/comment safeguards at close time."""
+    """Verify streaming prune only requires recovered, unacknowledged events."""
 
-    def test_close_query_rechecks_ack_and_comments_after_selection(self, mock_driver):
-        """Events ACKed or commented after selection must not be closed by prune."""
+    def test_commented_recovered_unacknowledged_event_is_closed(self, mock_driver):
+        """Non-ACK comments do not make a recovered event ineligible for pruning."""
         event_service = _load_event_service_module()
         session = mock_driver.session()
         session.set_response("return count(e) as total", [{"total": 1}])
         session.set_response(
             "return e.id as event_id, e.status",
-            [{"event_id": "evt-1", "status": "RECOVERED"}],
+            [
+                {
+                    "event_id": "evt-commented",
+                    "status": "RECOVERED",
+                    "comments": [{"text": "operator note"}],
+                }
+            ],
         )
 
         original_driver, original_get_db = _patch_get_db(mock_driver, event_service)
         try:
+            progress_list = []
 
             async def consume():
-                async for _ in event_service.event_batch_pruner(user="system", batch_delay_ms=0):
-                    pass
+                async for progress in event_service.event_batch_pruner(
+                    user="system", batch_delay_ms=0
+                ):
+                    progress_list.append(progress)
 
             _run_async(consume())
 
             close_queries = [
-                q["query"] for q in session.queries if "RETURN e.id AS closed_id" in q["query"]
+                q for q in session.queries if "RETURN e.id AS closed_id" in q["query"]
             ]
-            assert close_queries, "Expected guarded close query to run"
-            close_query = close_queries[0]
+            assert close_queries, "Expected commented recovered event to be closed"
+            assert close_queries[0]["params"]["eid"] == "evt-commented"
+            assert progress_list[-1]["processed"] == 1
+
+            close_query = close_queries[0]["query"]
             assert "WHERE e.status = 'RECOVERED'" in close_query
             assert "AND (e.ack IS NULL OR e.ack = false)" in close_query
-            assert "AND (e.comments IS NULL OR size(e.comments) = 0)" in close_query
+            assert "comments" not in close_query.lower()
         finally:
             _restore_get_db(original_driver, original_get_db, event_service)
 

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -1023,6 +1023,20 @@ class TestEventServiceSmoke:
         assert result["count"] == 3
         assert "Cleaned up" in result["message"]
 
+    def test_prune_recovered_events_does_not_require_comment_state(self, mock_neo4j_session):
+        """Recovered event cleanup eligibility ignores comment state when selecting events."""
+        prune_recovered_events = _load_event_service_module().prune_recovered_events
+
+        mock_neo4j_session.set_response("recovered", [{"closed_count": 1}])
+
+        prune_recovered_events("system")
+
+        assert len(mock_neo4j_session.queries) >= 1
+        query = mock_neo4j_session.queries[0]["query"].lower()
+        assert "where e.status = 'recovered'" in query
+        assert "and (e.ack is null or e.ack = false)" in query
+        assert "comments" not in query
+
     def test_build_event_detail_prefers_snapshot_values_and_sla_math(self):
         event_service = _load_event_service_module()
         now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -1099,10 +1099,8 @@ const MonitoringConsole: React.FC = () => {
   const kpiCritical = openEvents.filter((e) => e.severity === "CRITICAL").length;
   const kpiWarning = openEvents.filter((e) => e.severity === "WARNING").length;
   const kpiAck = ackEvents.length;
-  // Helper for Cleanup Button Logic
-  // Note: summary feed doesn't include comments, so count is best-effort.
-  // Backend may skip events with comments during prune.
-  const cleanableCount = events.filter((e) => e.status === "RECOVERED" && !e.ack).length;
+      // Eligibility matches backend policy: RECOVERED + not acknowledged.
+      const cleanableCount = events.filter((e) => e.status === "RECOVERED" && !e.ack).length;
 
   // Streaming prune state
   const pruneState = eventMutations.usePruneRecovered();
@@ -1217,7 +1215,7 @@ const MonitoringConsole: React.FC = () => {
               if (cleanableCount === 0) return;
               if (
                 !window.confirm(
-                  `About to close ${cleanableCount} RECOVERED events that have no Acks or Comments. Proceed?`,
+                      `About to close ${cleanableCount} RECOVERED events that are not acknowledged. Proceed?`,
                 )
               )
                 return;

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -1099,8 +1099,8 @@ const MonitoringConsole: React.FC = () => {
   const kpiCritical = openEvents.filter((e) => e.severity === "CRITICAL").length;
   const kpiWarning = openEvents.filter((e) => e.severity === "WARNING").length;
   const kpiAck = ackEvents.length;
-      // Eligibility matches backend policy: RECOVERED + not acknowledged.
-      const cleanableCount = events.filter((e) => e.status === "RECOVERED" && !e.ack).length;
+  // Eligibility matches backend policy: RECOVERED + not acknowledged.
+  const cleanableCount = events.filter((e) => e.status === "RECOVERED" && !e.ack).length;
 
   // Streaming prune state
   const pruneState = eventMutations.usePruneRecovered();

--- a/frontend/components/MonitoringConsole.tsx
+++ b/frontend/components/MonitoringConsole.tsx
@@ -1215,7 +1215,7 @@ const MonitoringConsole: React.FC = () => {
               if (cleanableCount === 0) return;
               if (
                 !window.confirm(
-                      `About to close ${cleanableCount} RECOVERED events that are not acknowledged. Proceed?`,
+                  `About to close ${cleanableCount} RECOVERED events that are not acknowledged. Proceed?`,
                 )
               )
                 return;


### PR DESCRIPTION
Closes #397

## Descripción del Cambio
- Alinea la elegibilidad de **Clean recovered**: todo evento `RECOVERED` sin ACK puede cerrarse aunque tenga comentarios no-ACK.
- Evita que eventos recuperados correlacionados, anidados o restaurados queden reportados como limpiables pero sin cerrar.
- Añade cobertura para el flujo síncrono y el flujo de streaming.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## Cambios
| Archivo | Cambio |
| --- | --- |
| `backend/services/event_service.py` | Elimina el filtro obsoleto por comentarios de las consultas de cleanup. |
| `backend/tests/test_event_batch_pruner.py` | Cubre el cierre streaming de recuperados sin ACK con comentarios. |
| `backend/tests/test_event_service_smoke.py` | Cubre la elegibilidad del cleanup síncrono. |
| `frontend/components/MonitoringConsole.tsx` | Alinea el texto/contador del control con la elegibilidad. |

## ¿Cómo se probó?
- [x] `git diff --check`
- [x] `python3 -m py_compile` para los cambios backend
- [ ] Pytest/Vitest locales: no disponibles en este worktree; la validación queda a cargo del CI de la PR.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
