### PR TITLE
fix(availability): calculate MTBF from completed outage intervals

### DIFF
--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -547,7 +547,7 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
             MATCH (n:CI {id: row.node_id})
             MATCH (m:MetricDef {id: row.metric_id})
             OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
-            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+            WHERE existing.status IN ['OPEN', 'ACK']
               AND existing.event_type = 'AVAILABILITY'
               AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
               AND existing.availability_source IN ['PING', 'ICMP']
@@ -592,7 +592,7 @@ def _refresh_icmp_availability_events(session, updates, cache=None, lock_db=None
             MATCH (n:CI {id: row.node_id})
             MATCH (m:MetricDef {id: row.metric_id})
             OPTIONAL MATCH (existing:Event {ci_id: row.node_id, metric_id: row.metric_id})
-            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+            WHERE existing.status IN ['OPEN', 'ACK']
               AND existing.event_type = 'AVAILABILITY'
               AND coalesce(existing.correlation_type, 'ROOT') = 'ROOT'
               AND existing.availability_source IN ['PING', 'ICMP']

--- a/backend/polling/event_writer.py
+++ b/backend/polling/event_writer.py
@@ -437,7 +437,7 @@ def batch_update_events(driver, envelopes: Iterable[Mapping[str, Any]], lock_db=
             MATCH (n:CI {id: row.ci_id})
             MATCH (m:MetricDef {id: row.metric_id})
             OPTIONAL MATCH (existing:Event {ci_id: row.ci_id, metric_id: row.metric_id})
-            WHERE existing.status IN ['OPEN', 'ACK', 'RECOVERED']
+            WHERE existing.status IN ['OPEN', 'ACK']
               AND (
                 existing.event_type = row.event_type
                 OR (existing.event_type IS NULL AND existing.message STARTS WITH 'Metric Collection Failed:')

--- a/backend/services/event_service.py
+++ b/backend/services/event_service.py
@@ -634,8 +634,9 @@ def get_availability_report(
     """Return MTTR/MTBF availability metrics grouped by CI + event type.
 
     MTTR uses technical recovery (`recovered_at - created_at`). MTBF uses the
-    average interval between consecutive failure starts in the report window,
-    including valid currently open/acknowledged starts. Incomplete legacy events
+    average completed operating interval: an eligible failure start minus the
+    prior eligible failure's recovery. Active incidents never complete an interval.
+        Incomplete legacy events
     are excluded from MTTR; active events are reported separately as current
     downtime where possible.
     """
@@ -660,6 +661,7 @@ def get_availability_report(
                 "ci_name": ci_name,
                 "event_type": key[1],
                 "failure_starts": [],
+                    "completed_incidents": [],
                 "repair_seconds": [],
                 "downtime_seconds": 0.0,
                 "active_events": 0,
@@ -683,7 +685,6 @@ def get_availability_report(
               AND e.availability_source IN ['PING', 'ICMP']
               AND toUpper(coalesce(e.correlation_type, 'ROOT')) <> 'PROPAGATED'
               AND NOT e.status IN ['OPEN', 'ACK']
-              AND e.created_at >= $window_start
               AND e.created_at <= $window_end
               AND e.recovered_at <= $window_end
             OPTIONAL MATCH (ci)-[:CATEGORIZED_AS]->(cat:Category)
@@ -704,7 +705,7 @@ def get_availability_report(
             recovered_at = _parse_datetime(event_data.get("recovered_at"))
             if created_at is None or recovered_at is None:
                 continue
-            if created_at < window_start or created_at > window_end:
+            if created_at > window_end:
                 continue
             if recovered_at < created_at or recovered_at > window_end:
                 continue
@@ -713,6 +714,9 @@ def get_availability_report(
                 ci_data, _record_value(record, "category")
             )
             row = ensure_group(key, ci_data.get("name"), ci_metadata)
+            row["completed_incidents"].append((created_at, recovered_at))
+            if created_at < window_start:
+                continue
             repair_seconds = (recovered_at - created_at).total_seconds()
             row["failure_starts"].append(created_at)
             row["repair_seconds"].append(repair_seconds)
@@ -786,10 +790,23 @@ def get_availability_report(
         mttr_seconds = (
             sum(repair_seconds) / len(repair_seconds) if repair_seconds else None
         )
-        intervals = [
-            (failure_starts[index] - failure_starts[index - 1]).total_seconds()
-            for index in range(1, len(failure_starts))
-        ]
+        intervals = []
+        effective_outage_end = None
+        seen_incidents = set()
+        for created_at, recovered_at in sorted(row["completed_incidents"]):
+            incident_key = (created_at, recovered_at)
+            if incident_key in seen_incidents:
+                continue
+            seen_incidents.add(incident_key)
+            if effective_outage_end is None:
+                effective_outage_end = recovered_at
+                continue
+            if created_at < effective_outage_end:
+                effective_outage_end = max(effective_outage_end, recovered_at)
+                continue
+            if created_at >= window_start:
+                intervals.append((created_at - effective_outage_end).total_seconds())
+            effective_outage_end = recovered_at
         mtbf_seconds = sum(intervals) / len(intervals) if intervals else None
         total_downtime = row["downtime_seconds"] + row["active_downtime_seconds"]
         availability_percentage = None

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -841,7 +841,7 @@ class TestEventServiceSmoke:
             "window_start": start,
             "window_end": end,
         }
-        assert "e.created_at >= $window_start" in recovered_query["query"]
+        assert "e.created_at >= $window_start" not in recovered_query["query"]
         assert "e.created_at <= $window_end" in recovered_query["query"]
         assert "e.recovered_at <= $window_end" in recovered_query["query"]
 

--- a/backend/tests/test_event_service_smoke.py
+++ b/backend/tests/test_event_service_smoke.py
@@ -186,7 +186,7 @@ class TestEventServiceSmoke:
         assert row["event_type"] == "AVAILABILITY"
         assert row["recovered_incidents"] == 2
         assert row["mttr_seconds"] == 900
-        assert row["mtbf_seconds"] == 7200
+        assert row["mtbf_seconds"] == 6600
         assert row["downtime_seconds"] == 1800
         assert row["active_events"] == 1
         assert row["active_downtime_seconds"] == 3600
@@ -317,7 +317,7 @@ class TestEventServiceSmoke:
         assert report["offset"] == 0
         assert mock_neo4j_session.queries[1]["params"] == {"limit": 100, "offset": 0}
 
-    def test_get_availability_report_includes_active_failure_starts_in_mtbf(
+    def test_get_availability_report_excludes_active_incidents_from_mtbf(
         self, mock_neo4j_session
     ):
         get_availability_report = _load_event_service_module().get_availability_report
@@ -362,8 +362,78 @@ class TestEventServiceSmoke:
         row = report["rows"][0]
         assert row["recovered_incidents"] == 1
         assert row["mttr_seconds"] == 600
-        assert row["mtbf_seconds"] == 10800
+        assert row["mtbf_seconds"] is None
         assert row["active_events"] == 1
+
+    def test_get_availability_report_calculates_completed_intervals_across_window_boundaries(
+            self, mock_neo4j_session
+        ):
+            get_availability_report = _load_event_service_module().get_availability_report
+            start = datetime(2026, 1, 2, 0, 0, tzinfo=UTC)
+            end = datetime(2026, 1, 3, 0, 0, tzinfo=UTC)
+            mock_neo4j_session.set_response(
+                "not e.status in ['open', 'ack']",
+                [
+                    {
+                        "e": {
+                            "id": "before-window", "ci_id": "ci-1", "status": "RECOVERED",
+                            "event_type": "AVAILABILITY", "availability_source": "PING",
+                            "created_at": datetime(2026, 1, 1, 20, 0, tzinfo=UTC),
+                            "recovered_at": datetime(2026, 1, 1, 21, 0, tzinfo=UTC),
+                        }, "ci": {"id": "ci-1", "name": "Router-01"},
+                    },
+                    {
+                        "e": {
+                            "id": "inside-window", "ci_id": "ci-1", "status": "RECOVERED",
+                            "event_type": "AVAILABILITY", "availability_source": "PING",
+                            "created_at": datetime(2026, 1, 2, 4, 0, tzinfo=UTC),
+                            "recovered_at": datetime(2026, 1, 2, 5, 0, tzinfo=UTC),
+                        }, "ci": {"id": "ci-1", "name": "Router-01"},
+                    },
+                    {
+                        "e": {
+                            "id": "duplicate-candidate", "ci_id": "ci-1", "status": "RECOVERED",
+                            "event_type": "AVAILABILITY", "availability_source": "PING",
+                            "created_at": datetime(2026, 1, 2, 4, 0, tzinfo=UTC),
+                            "recovered_at": datetime(2026, 1, 2, 5, 0, tzinfo=UTC),
+                        }, "ci": {"id": "ci-1", "name": "Router-01"},
+                    },
+                    {
+                        "e": {
+                            "id": "overlapping-candidate", "ci_id": "ci-1", "status": "RECOVERED",
+                            "event_type": "AVAILABILITY", "availability_source": "PING",
+                            "created_at": datetime(2026, 1, 2, 4, 30, tzinfo=UTC),
+                            "recovered_at": datetime(2026, 1, 2, 6, 0, tzinfo=UTC),
+                        }, "ci": {"id": "ci-1", "name": "Router-01"},
+                    },
+                    {
+                        "e": {
+                            "id": "subsequent-failure", "ci_id": "ci-1", "status": "RECOVERED",
+                            "event_type": "AVAILABILITY", "availability_source": "PING",
+                            "created_at": datetime(2026, 1, 2, 8, 0, tzinfo=UTC),
+                            "recovered_at": datetime(2026, 1, 2, 8, 10, tzinfo=UTC),
+                        }, "ci": {"id": "ci-1", "name": "Router-01"},
+                    },
+                    {
+                        "e": {
+                            "id": "propagated", "ci_id": "ci-1", "status": "RECOVERED",
+                            "event_type": "AVAILABILITY", "availability_source": "PING",
+                            "correlation_type": "PROPAGATED",
+                            "created_at": datetime(2026, 1, 2, 9, 0, tzinfo=UTC),
+                            "recovered_at": datetime(2026, 1, 2, 9, 10, tzinfo=UTC),
+                        }, "ci": {"id": "ci-1", "name": "Router-01"},
+                    },
+                ],
+            )
+
+            report = get_availability_report(start=start, end=end, now=end)
+
+            row = report["rows"][0]
+            assert row["mtbf_seconds"] == 4.5 * 3600
+            assert row["recovered_incidents"] == 4
+            recovered_query = mock_neo4j_session.queries[0]["query"]
+            assert "e.created_at <= $window_end" in recovered_query
+            assert "e.created_at >= $window_start" not in recovered_query
 
     def test_get_availability_report_enriches_rows_with_sanitized_ci_metadata(
         self, mock_neo4j_session

--- a/backend/tests/test_polling_event_writer.py
+++ b/backend/tests/test_polling_event_writer.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from tests.conftest import MockNeo4jDriver
 
@@ -204,9 +204,105 @@ def test_event_writer_uses_unwind_for_latest_breach_and_recovery_updates():
     assert "id: randomUUID()" in queries
     assert "e.id = coalesce(e.id, randomUUID())" not in queries
     assert "RECOVERED" in queries
+    assert "existing.status IN ['OPEN', 'ACK', 'RECOVERED']" not in queries
     assert "correlation_type" in queries
     assert "root_cause_ci_id" in queries
     assert "PROPAGATED" in queries
+
+
+def test_event_writer_creates_a_new_incident_after_availability_recovery():
+    from polling.event_writer import batch_update_events
+
+    class LifecycleSession:
+        def __init__(self):
+            self.events = []
+            self.queries = []
+            self._clock = datetime(2026, 1, 1, tzinfo=UTC)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def run(self, query, **params):
+            self.queries.append({"query": query, "params": params})
+            rows = params.get("rows", [])
+            if "WITH row WHERE row.is_breach AND row.event_type <> 'COLLECTION_FAILURE'" in query:
+                eligible_statuses = {"OPEN", "ACK"}
+                if "'RECOVERED'" in query:
+                    eligible_statuses.add("RECOVERED")
+                for row in rows:
+                    if not row["is_breach"]:
+                        continue
+                    existing = next(
+                        (
+                            event
+                            for event in self.events
+                            if event["ci_id"] == row["ci_id"]
+                            and event["metric_id"] == row["metric_id"]
+                            and event["event_type"] == row["event_type"]
+                            and event["status"] in eligible_statuses
+                        ),
+                        None,
+                    )
+                    if existing is None:
+                        self._clock += timedelta(minutes=1)
+                        self.events.append(
+                            {
+                                "ci_id": row["ci_id"],
+                                "metric_id": row["metric_id"],
+                                "event_type": row["event_type"],
+                                "status": "OPEN",
+                                "created_at": self._clock,
+                                "recovered_at": None,
+                            }
+                        )
+                    else:
+                        existing["status"] = "OPEN"
+                        existing["recovered_at"] = None
+            elif "WITH row WHERE row.recover_non_collection_event" in query:
+                for row in rows:
+                    if not row["recover_non_collection_event"]:
+                        continue
+                    for event in self.events:
+                        if (
+                            event["ci_id"] == row["ci_id"]
+                            and event["metric_id"] == row["metric_id"]
+                            and event["status"] in {"OPEN", "ACK"}
+                        ):
+                            self._clock += timedelta(minutes=1)
+                            event["status"] = "RECOVERED"
+                            event["recovered_at"] = self._clock
+            return []
+
+    class LifecycleDriver:
+        def __init__(self):
+            self.session_obj = LifecycleSession()
+
+        def session(self):
+            return self.session_obj
+
+    driver = LifecycleDriver()
+    failed_ping = {
+        **_event_row(0.0),
+        "protocol": "ICMP",
+        "metric_id": "PING-CHECK",
+        "metadata": {"availability_source": "PING", "criticality": 3},
+    }
+    recovered_ping = {**failed_ping, "value": {"numeric": 1.0, "raw": 1.0}}
+
+    batch_update_events(driver, [failed_ping])
+    batch_update_events(driver, [recovered_ping])
+    first_incident = driver.session_obj.events[0].copy()
+    batch_update_events(driver, [failed_ping])
+
+    assert first_incident["status"] == "RECOVERED"
+    assert first_incident["recovered_at"] is not None
+    assert len(driver.session_obj.events) == 2
+    next_incident = driver.session_obj.events[1]
+    assert next_incident["status"] == "OPEN"
+    assert next_incident["created_at"] > first_incident["created_at"]
 
 
 def test_event_writer_deduplicates_idempotent_payload_rows_before_metric_result_write():

--- a/backend/tests/test_snmp_worker.py
+++ b/backend/tests/test_snmp_worker.py
@@ -759,6 +759,8 @@ class TestICMPDebounce:
         assert availability_queries, mock_session.queries
         availability_query = "\n".join(q["query"] for q in availability_queries)
         assert "source_protocol" in availability_query
+        assert "existing.status IN ['OPEN', 'ACK', 'RECOVERED']" not in availability_query
+        assert "existing.status IN ['OPEN', 'ACK']" in availability_query
         assert (
             "MERGE (created)-[:TRIGGERED_BY]->(m)" in availability_query
             or "MERGE (existing)-[:TRIGGERED_BY]->(m)" in availability_query


### PR DESCRIPTION
## Descripción del Cambio

Closes #400

- Calcula MTBF desde la recuperación del incidente anterior hasta el inicio de la siguiente falla.
- Evita reutilizar incidentes `RECOVERED`, preservando un registro por ciclo de caída.
- Cubre límites de ventana, eventos solapados y el ciclo falla → recuperación → nueva falla.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?

- [x] Revisión de confiabilidad y re-revisión focalizada de los hallazgos críticos.
- [x] `python3 -m py_compile` sobre los archivos modificados.
- [x] `git diff --check`.
- [ ] Pytest local: no disponible en el entorno; se valida mediante CI del repositorio.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
