### PR TITLE
feat(service-management): enforce ticket service contracts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,7 +143,7 @@ jobs:
           python-version: "3.11"
       - name: Install ruff and black
         if: steps.changed.outputs.any_changed == 'true'
-        run: pip install --quiet ruff==0.15.18 black==26.5.1
+        run: pip install --quiet ruff==0.15.18 black==25.11.0
       - name: Run Ruff
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: backend
@@ -268,7 +268,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install yamllint + ruff + black
-        run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==26.5.1
+        run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==25.11.0
       - name: yamllint must pass
         run: yamllint -c .yamllint.yml .github/
       - name: ruff must parse config

--- a/backend/migrations/itsm_service_catalog.cypher
+++ b/backend/migrations/itsm_service_catalog.cypher
@@ -35,6 +35,12 @@ FOR (sc:ServiceCatalog) ON (sc.id);
 CREATE CONSTRAINT ticket_folio_ticket_id IF NOT EXISTS
 FOR (tf:TicketFolio) REQUIRE tf.ticket_id IS UNIQUE;
 
+CREATE CONSTRAINT ticket_sequence_name IF NOT EXISTS
+FOR (seq:TicketSequence) REQUIRE seq.name IS UNIQUE;
+
+MERGE (seq:TicketSequence {name: 'ticket_folio'})
+ON CREATE SET seq.next_value = 0;
+
 CREATE INDEX ticket_folio_status IF NOT EXISTS
 FOR (tf:TicketFolio) ON (tf.status);
 

--- a/backend/models/itsm.py
+++ b/backend/models/itsm.py
@@ -19,7 +19,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 ServiceCatalogId = str
-TicketId = str
+TicketId = int
 
 
 TICKET_STATUS_ORDER = (
@@ -40,8 +40,8 @@ class TicketStatus:
 
 
 class TicketFolioType:
-    REQUEST = "request"
     INCIDENT = "incident"
+    SERVICE_REQUEST = "service_request"
 
 
 class ServiceCatalogCreate(BaseModel):
@@ -59,6 +59,7 @@ class ServiceCatalogCreate(BaseModel):
     tier: str | None = None
     criticality: str | None = None
     sla_target_minutes: int = Field(ge=0)
+    service_type: str
     active: bool = True
     updated_by: str | None = None
 
@@ -88,6 +89,13 @@ class ServiceCatalogCreate(BaseModel):
     def _validate_sla_target_minutes(cls, value: int) -> int:
         if value < 0:
             raise ValueError("sla_target_minutes must be >= 0")
+        return value
+
+    @field_validator("service_type")
+    @classmethod
+    def _validate_service_type(cls, value: str) -> str:
+        if value not in (TicketFolioType.INCIDENT, TicketFolioType.SERVICE_REQUEST):
+            raise ValueError("service_type must be either 'incident' or 'service_request'")
         return value
 
     @field_validator("sla_minutes")
@@ -164,6 +172,7 @@ class ServiceCatalogUpdate(BaseModel):
     tier: str | None = None
     criticality: str | None = None
     sla_target_minutes: int | None = None
+    service_type: str | None = None
     active: bool | None = None
     updated_by: str | None = None
 
@@ -231,6 +240,14 @@ class ServiceCatalogUpdate(BaseModel):
         return self
 
 
+    @field_validator("service_type")
+    @classmethod
+    def _validate_service_type(cls, value: str) -> str:
+        if value not in (TicketFolioType.INCIDENT, TicketFolioType.SERVICE_REQUEST):
+            raise ValueError("service_type must be either 'incident' or 'service_request'")
+        return value
+
+
 class ServiceCatalogResponse(ServiceCatalogCreate):
     """Response contract for ServiceCatalog domain reads."""
 
@@ -238,13 +255,14 @@ class ServiceCatalogResponse(ServiceCatalogCreate):
 
 
 class TicketFolioCreate(BaseModel):
-    """Input contract for creating a ticket/folio."""
+    """Input contract for creating a ticket; the server allocates its ID."""
 
-    ticket_id: str
+    model_config = {"extra": "forbid"}
+
     type: str
     title: str
     description: str | None = None
-    service_catalog_id: str | None = None
+    service_catalog_id: str
     status: str = TicketStatus.OPEN
     archived: bool = False
     closed_reason: str | None = None
@@ -255,8 +273,8 @@ class TicketFolioCreate(BaseModel):
     @field_validator("type")
     @classmethod
     def _validate_type(cls, value: str) -> str:
-        if value not in (TicketFolioType.REQUEST, TicketFolioType.INCIDENT):
-            raise ValueError("type must be either 'request' or 'incident'")
+        if value not in (TicketFolioType.INCIDENT, TicketFolioType.SERVICE_REQUEST):
+            raise ValueError("type must be either 'incident' or 'service_request'")
         return value
 
     @field_validator("title")
@@ -277,9 +295,30 @@ class TicketFolioCreate(BaseModel):
     def _normalize_defaults(self):
         if self.status != TicketStatus.OPEN:
             raise ValueError("New folios must start as 'open'")
-        if self.ticket_id is None or not str(self.ticket_id).strip():
-            raise ValueError("ticket_id is required")
         return self
+
+
+class TicketFolioResponse(BaseModel):
+    """Response contract exposing the server-generated numeric ticket ID."""
+
+    ticket_id: int
+    type: str
+    title: str
+    description: str | None = None
+    service_catalog_id: str | None = None
+    status: str = TicketStatus.OPEN
+    archived: bool = False
+    closed_reason: str | None = None
+    updated_by: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+    @field_validator("type")
+    @classmethod
+    def _validate_type(cls, value: str) -> str:
+        if value not in (TicketFolioType.INCIDENT, TicketFolioType.SERVICE_REQUEST):
+            raise ValueError("type must be either 'incident' or 'service_request'")
+        return value
 
 
 class TicketFolioUpdate(BaseModel):

--- a/backend/models/itsm.py
+++ b/backend/models/itsm.py
@@ -239,7 +239,6 @@ class ServiceCatalogUpdate(BaseModel):
             self.sla_minutes = self.sla_target_minutes
         return self
 
-
     @field_validator("service_type")
     @classmethod
     def _validate_service_type(cls, value: str) -> str:

--- a/backend/repositories/itsm_service_catalog_repo.py
+++ b/backend/repositories/itsm_service_catalog_repo.py
@@ -24,6 +24,7 @@ ON CREATE SET
   sc.criticality = $criticality,
   sc.sla_target_minutes = $sla_target_minutes,
   sc.sla_minutes = $sla_target_minutes,
+  sc.service_type = $service_type,
   sc.active = $active,
   sc.created_at = datetime($created_at),
   sc.updated_at = datetime($updated_at),
@@ -50,6 +51,7 @@ RETURN
   sc.criticality AS criticality,
   sc.sla_target_minutes AS sla_target_minutes,
   sc.sla_minutes AS sla_minutes,
+  sc.service_type AS service_type,
   sc.active AS active,
   sc.created_at AS created_at,
   sc.updated_at AS updated_at,
@@ -70,6 +72,7 @@ RETURN
   sc.criticality AS criticality,
   sc.sla_target_minutes AS sla_target_minutes,
   sc.sla_minutes AS sla_minutes,
+  sc.service_type AS service_type,
   sc.active AS active,
   sc.created_at AS created_at,
   sc.updated_at AS updated_at,
@@ -89,6 +92,7 @@ RETURN
   sc.criticality AS criticality,
   sc.sla_target_minutes AS sla_target_minutes,
   sc.sla_minutes AS sla_minutes,
+  sc.service_type AS service_type,
   sc.active AS active,
   sc.created_at AS created_at,
   sc.updated_at AS updated_at,
@@ -130,6 +134,7 @@ class ServiceCatalogRepository:
                 row.get("sla_target_minutes") if hasattr(row, "get") else row["sla_target_minutes"]
             ),
             "sla_minutes": row.get("sla_minutes") if hasattr(row, "get") else row["sla_minutes"],
+            "service_type": row.get("service_type") if hasattr(row, "get") else row["service_type"],
             "active": row.get("active") if hasattr(row, "get") else row["active"],
             "created_at": row.get("created_at") if hasattr(row, "get") else row["created_at"],
             "updated_at": row.get("updated_at") if hasattr(row, "get") else row["updated_at"],
@@ -167,6 +172,7 @@ class ServiceCatalogRepository:
                 tier=payload.tier,
                 criticality=payload.criticality,
                 sla_target_minutes=payload.sla_target_minutes,
+                service_type=payload.service_type,
                 active=payload.active,
                 created_at=payload.created_at or now,
                 updated_at=now,
@@ -212,6 +218,8 @@ class ServiceCatalogRepository:
         if "sla_target_minutes" in updates:
             set_clauses.append("sc.sla_target_minutes = $sla_target_minutes")
             set_clauses.append("sc.sla_minutes = $sla_target_minutes")
+        if "service_type" in updates:
+            raise ValueError("service_type is immutable after catalog creation")
         if "active" in updates:
             set_clauses.append("sc.active = $active")
 
@@ -229,6 +237,7 @@ class ServiceCatalogRepository:
           sc.criticality AS criticality,
           sc.sla_target_minutes AS sla_target_minutes,
           sc.sla_minutes AS sla_minutes,
+          sc.service_type AS service_type,
           sc.active AS active,
           sc.created_at AS created_at,
           sc.updated_at AS updated_at,

--- a/backend/repositories/itsm_service_catalog_repo.py
+++ b/backend/repositories/itsm_service_catalog_repo.py
@@ -242,7 +242,9 @@ class ServiceCatalogRepository:
           sc.created_at AS created_at,
           sc.updated_at AS updated_at,
           sc.updated_by AS updated_by
-        """.replace("__SET_CLAUSES__", ",\n  ".join(set_clauses))
+        """.replace(
+            "__SET_CLAUSES__", ",\n  ".join(set_clauses)
+        )
 
         with self._driver.session() as session:
             row = session.run(

--- a/backend/repositories/ticket_folio_repo.py
+++ b/backend/repositories/ticket_folio_repo.py
@@ -13,28 +13,26 @@ from database import get_db
 from models.itsm import TicketFolioCreate, TicketFolioUpdate
 
 _CREATE_TICKET_FOLIO_QUERY = """
-MERGE (tf:TicketFolio {ticket_id: $ticket_id})
-ON CREATE SET
-  tf.type = $type,
-  tf.title = $title,
-  tf.description = $description,
-  tf.service_catalog_id = $service_catalog_id,
-  tf.status = $status,
-  tf.archived = $archived,
-  tf.closed_reason = $closed_reason,
-  tf.created_at = datetime($created_at),
-  tf.updated_at = datetime($updated_at),
-  tf.updated_by = $updated_by
-ON MATCH SET
-  tf.type = coalesce($type, tf.type),
-  tf.title = coalesce($title, tf.title),
-  tf.description = coalesce($description, tf.description),
-  tf.service_catalog_id = coalesce($service_catalog_id, tf.service_catalog_id),
-  tf.status = coalesce($status, tf.status),
-  tf.archived = coalesce($archived, tf.archived),
-  tf.closed_reason = coalesce($closed_reason, tf.closed_reason),
-  tf.updated_at = datetime($updated_at),
-  tf.updated_by = coalesce($updated_by, tf.updated_by)
+MATCH (seq:TicketSequence {name: 'ticket_folio'})
+MATCH (sc:ServiceCatalog {service_id: $service_catalog_id})
+WHERE coalesce(sc.active, true) = true AND sc.service_type = $type
+SET seq.next_value = seq.next_value + 1
+WITH seq.next_value AS ticket_id, sc
+CREATE (tf:TicketFolio {
+  ticket_id: ticket_id,
+  type: $type,
+  title: $title,
+  description: $description,
+  service_catalog_id: $service_catalog_id,
+  status: $status,
+  archived: $archived,
+  closed_reason: $closed_reason,
+  created_at: datetime($created_at),
+  updated_at: datetime($updated_at),
+  updated_by: $updated_by
+})
+WITH tf, sc
+MERGE (tf)-[:FOR_SERVICE]->(sc)
 RETURN
   tf.ticket_id AS ticket_id,
   tf.type AS type,
@@ -141,15 +139,14 @@ class TicketFolioRepository:
             )
             return [self._record(row) for row in result if self._record(row) is not None]
 
-    def upsert(self, payload: TicketFolioCreate) -> dict[str, Any]:
-        payload = (
-            payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
-        )
+    def create_with_generated_id(self, payload: TicketFolioCreate) -> dict[str, Any]:
+        """Allocate, create, and synchronize the service relation atomically."""
+        payload = payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
         now = self._now()
-        with self._driver.session() as session:
-            row = session.run(
+
+        def write_transaction(tx):
+            row = tx.run(
                 _CREATE_TICKET_FOLIO_QUERY,
-                ticket_id=payload.ticket_id,
                 type=payload.type,
                 title=payload.title,
                 description=payload.description,
@@ -161,7 +158,12 @@ class TicketFolioRepository:
                 updated_at=now,
                 updated_by=payload.updated_by,
             ).single()
-        return self._record(row) or {}
+            if row is None:
+                raise RuntimeError("TicketSequence 'ticket_folio' or referenced ServiceCatalog is missing")
+            return self._record(row) or {}
+
+        with self._driver.session() as session:
+            return session.execute_write(write_transaction)
 
     def update(self, ticket_id: str, payload: TicketFolioUpdate) -> dict[str, Any] | None:
         payload = (

--- a/backend/repositories/ticket_folio_repo.py
+++ b/backend/repositories/ticket_folio_repo.py
@@ -141,7 +141,9 @@ class TicketFolioRepository:
 
     def create_with_generated_id(self, payload: TicketFolioCreate) -> dict[str, Any]:
         """Allocate, create, and synchronize the service relation atomically."""
-        payload = payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
+        payload = (
+            payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
+        )
         now = self._now()
 
         def write_transaction(tx):
@@ -159,7 +161,9 @@ class TicketFolioRepository:
                 updated_by=payload.updated_by,
             ).single()
             if row is None:
-                raise RuntimeError("TicketSequence 'ticket_folio' or referenced ServiceCatalog is missing")
+                raise RuntimeError(
+                    "TicketSequence 'ticket_folio' or referenced ServiceCatalog is missing"
+                )
             return self._record(row) or {}
 
         with self._driver.session() as session:
@@ -205,7 +209,9 @@ class TicketFolioRepository:
           tf.created_at AS created_at,
           tf.updated_at AS updated_at,
           tf.updated_by AS updated_by
-        """.replace("__SET_CLAUSES__", ",\n  ".join(set_clauses))
+        """.replace(
+            "__SET_CLAUSES__", ",\n  ".join(set_clauses)
+        )
 
         with self._driver.session() as session:
             row = session.run(

--- a/backend/routers/ticket_folios.py
+++ b/backend/routers/ticket_folios.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any
 
 import services.ticket_folio_service as ticket_folio_service
 from fastapi import APIRouter, Depends, HTTPException, Query
-from models.itsm import TicketFolioCreate, TicketFolioUpdate
+from models.itsm import TicketFolioCreate, TicketFolioResponse, TicketFolioUpdate
 from models.user import User, UserPermission
 from pydantic import BaseModel
 from services.auth_service import check_permission, get_current_active_user
@@ -46,9 +46,9 @@ async def list_ticket_folios(
     )
 
 
-@router.get("/{ticket_id}", response_model=dict[str, Any])
+@router.get("/{ticket_id}", response_model=TicketFolioResponse)
 async def get_ticket_folio(
-    ticket_id: str,
+    ticket_id: int,
     current_user: CurrentUserDep,
 ):
     if not check_permission(UserPermission.ITSM_VIEW, current_user):
@@ -56,7 +56,7 @@ async def get_ticket_folio(
     return ticket_folio_service.get_ticket_folio(ticket_id)
 
 
-@router.post("", response_model=dict[str, Any])
+@router.post("", response_model=TicketFolioResponse)
 async def create_ticket_folio(
     payload: TicketFolioCreate,
     current_user: CurrentUserDep,
@@ -69,9 +69,9 @@ async def create_ticket_folio(
     )
 
 
-@router.put("/{ticket_id}", response_model=dict[str, Any])
+@router.put("/{ticket_id}", response_model=TicketFolioResponse)
 async def update_ticket_folio(
-    ticket_id: str,
+    ticket_id: int,
     payload: TicketFolioUpdate,
     current_user: CurrentUserDep,
 ):
@@ -84,9 +84,9 @@ async def update_ticket_folio(
     )
 
 
-@router.post("/{ticket_id}/transition", response_model=dict[str, Any])
+@router.post("/{ticket_id}/transition", response_model=TicketFolioResponse)
 async def transition_ticket_folio(
-    ticket_id: str,
+    ticket_id: int,
     payload: TicketTransitionRequest,
     current_user: CurrentUserDep,
 ):

--- a/backend/services/itsm_service_catalog_service.py
+++ b/backend/services/itsm_service_catalog_service.py
@@ -93,6 +93,14 @@ def update_service_catalog(
 
     update_values = update_model.model_dump(exclude_unset=True)
 
+    if "service_type" in update_values:
+        if update_values["service_type"] != current.get("service_type"):
+            _http_bad_request("service_type is immutable after catalog creation")
+        # An unchanged immutable field is accepted, but must not reach the
+        # repository's mutation guard alongside mutable updates.
+        update_values.pop("service_type")
+        update_model = ServiceCatalogUpdate(**update_values)
+
     # Authoritative path is service_id in URL.
     path_fields = {"service_id", "id"}
     for key in path_fields:

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -39,17 +39,22 @@ def _raise_conflict(message: str) -> None:
 
 
 def _check_catalog_exists(
-    service_catalog_id: str | None,
+    service_catalog_id: str,
+    ticket_type: str,
     *,
     catalog_repository: ServiceCatalogRepository | None = None,
 ) -> None:
     if not service_catalog_id:
-        return
+        _raise_bad_request("service_catalog_id is required")
 
     catalog_repository = catalog_repository or ServiceCatalogRepository()
     catalog = catalog_repository.get_by_id(service_catalog_id)
     if not catalog:
         _raise_not_found(f"service_catalog not found: {service_catalog_id}")
+    if catalog.get("active") is False:
+        _raise_bad_request("service_catalog_id references an inactive service")
+    if catalog.get("service_type") != ticket_type:
+        _raise_bad_request("service_catalog_id must reference a compatible service_type")
 
 
 def _sync_relation(
@@ -99,18 +104,18 @@ def create_ticket_folio(
     except ValidationError as exc:
         _raise_bad_request(str(exc))
 
-    existing = repository.get(payload_model.ticket_id)
-    if existing:
-        _raise_conflict(f"Ticket folio already exists: {payload_model.ticket_id}")
-
-    _check_catalog_exists(payload_model.service_catalog_id, catalog_repository=catalog_repository)
+    _check_catalog_exists(
+        payload_model.service_catalog_id, payload_model.type, catalog_repository=catalog_repository
+    )
 
     payload_model = payload_model.model_copy(update={"updated_by": actor})
-    created = repository.upsert(payload_model)
+    try:
+        created = repository.create_with_generated_id(payload_model)
+    except RuntimeError as exc:
+        _raise_conflict(str(exc))
 
-    # Keep legacy relationship up to date for read compatibility; property is
-    # authoritative.
-    _sync_relation(created["ticket_id"], created.get("service_catalog_id"), repository)
+    # Creation and relation synchronization are committed by the repository as one
+    # Neo4j transaction; a relation failure therefore rolls back the ticket and ID.
     return created
 
 
@@ -156,7 +161,9 @@ def update_ticket_folio(
     has_service_catalog_update = "service_catalog_id" in updates
     new_service_catalog_id = updates.get("service_catalog_id")
     if has_service_catalog_update:
-        _check_catalog_exists(new_service_catalog_id, catalog_repository=catalog_repository)
+        _check_catalog_exists(
+            new_service_catalog_id, current.get("type"), catalog_repository=catalog_repository
+        )
 
     normalized_updates = {**updates, "updated_by": actor}
     if next_status == "closed":

--- a/backend/tests/test_itsm_domain_contracts.py
+++ b/backend/tests/test_itsm_domain_contracts.py
@@ -92,7 +92,7 @@ class TestTicketFolioTypeAndLifecycle:
                 type=ticket_type,
                 title="Reset password",
                 description="Request access reset",
-                    service_catalog_id="svc-request",
+                service_catalog_id="svc-request",
             )
             assert payload.type == ticket_type
 

--- a/backend/tests/test_itsm_domain_contracts.py
+++ b/backend/tests/test_itsm_domain_contracts.py
@@ -31,6 +31,7 @@ class TestServiceCatalogDomainContract:
             sla_target_minutes=45,
             owner_team="NetOps",
             criticality="High",
+            service_type="incident",
         )
 
         assert payload.service_id == "svc-net-01"
@@ -47,6 +48,7 @@ class TestServiceCatalogDomainContract:
             category="CORE",
             service_tier="Silver",
             sla_minutes=60,
+            service_type="service_request",
         )
 
         assert payload.service_id == "svc-legacy-01"
@@ -84,22 +86,24 @@ class TestServiceCatalogDomainContract:
 class TestTicketFolioTypeAndLifecycle:
     """Contract expectations for Ticket/Folio type and linear lifecycle order."""
 
-    def test_ticket_folio_type_is_limited_to_request_and_incident(self):
-        for ticket_type in (TicketFolioType.REQUEST, TicketFolioType.INCIDENT):
+    def test_ticket_folio_type_is_limited_to_incident_and_service_request(self):
+        for ticket_type in (TicketFolioType.SERVICE_REQUEST, TicketFolioType.INCIDENT):
             payload = TicketFolioCreate(
                 type=ticket_type,
                 title="Reset password",
                 description="Request access reset",
-                ticket_id="T-001",
+                    service_catalog_id="svc-request",
             )
             assert payload.type == ticket_type
 
         with pytest.raises(ValidationError):
-            TicketFolioCreate(
-                type="change",  # invalid
-                title="Change request",
-                ticket_id="T-002",
-            )
+            TicketFolioCreate(type="request", title="Legacy request")
+
+        with pytest.raises(ValidationError):
+            TicketFolioCreate(type="change", title="Change request")
+
+        with pytest.raises(ValidationError, match="ticket_id"):
+            TicketFolioCreate(type="incident", title="Client supplied ID", ticket_id=2)
 
     def test_ticket_transition_only_allows_linear_progression(self):
         assert validate_ticket_transition(TicketStatus.OPEN, TicketStatus.IN_PROGRESS)

--- a/backend/tests/test_itsm_service_catalog_service.py
+++ b/backend/tests/test_itsm_service_catalog_service.py
@@ -74,6 +74,7 @@ class TestServiceCatalogService:
                 "name": "Platform Core",
                 "service_tier": "Silver",
                 "sla_minutes": 45,
+                "service_type": "incident",
             },
             actor="admin",
             repository=repository,
@@ -188,4 +189,35 @@ class TestServiceCatalogService:
 
         assert exc.value.status_code == 400
         assert "service_id" in exc.value.detail.lower()
+        repository.update.assert_not_called()
+
+    def test_update_catalog_accepts_unchanged_service_type_with_mutable_fields(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = {**_sample_catalog_record(), "service_type": "incident"}
+        repository.update.return_value = {**_sample_catalog_record(), "name": "Updated"}
+
+        result = service_catalog_service.update_service_catalog(
+            "svc-001",
+            {"service_type": "incident", "name": "Updated"},
+            repository=repository,
+        )
+
+        assert result["name"] == "Updated"
+        update_payload = repository.update.call_args.args[1]
+        assert update_payload.service_type is None
+        assert update_payload.name == "Updated"
+
+    def test_update_catalog_rejects_changed_service_type_with_controlled_error(self):
+        repository = _CatalogRepositoryStub()
+        repository.get_by_id.return_value = {**_sample_catalog_record(), "service_type": "incident"}
+
+        with pytest.raises(HTTPException) as exc:
+            service_catalog_service.update_service_catalog(
+                "svc-001",
+                {"service_type": "service_request", "name": "Updated"},
+                repository=repository,
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "service_type is immutable after catalog creation"
         repository.update.assert_not_called()

--- a/backend/tests/test_routers_itsm.py
+++ b/backend/tests/test_routers_itsm.py
@@ -101,7 +101,12 @@ class TestItsmServiceCatalogRouter:
 
         response = client.post(
             "/api/itsm/service-catalog",
-            json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45, "service_type": "incident"},
+            json={
+                "service_id": "svc-new",
+                "name": "Core",
+                "sla_target_minutes": 45,
+                "service_type": "incident",
+            },
         )
         assert response.status_code == 403
 
@@ -123,7 +128,12 @@ class TestItsmServiceCatalogRouter:
             ("/api/itsm/service-catalog/svc-1/deactivate", "post", [UserPermission.EVENT_VIEW]),
         ]:
             _override_current_user(_make_pydantic_user(permissions=permissions))
-            payload = {"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45, "service_type": "incident"}
+            payload = {
+                "service_id": "svc-new",
+                "name": "Core",
+                "sla_target_minutes": 45,
+                "service_type": "incident",
+            }
 
             if method == "get":
                 response = client.get(endpoint)
@@ -149,7 +159,12 @@ class TestItsmServiceCatalogRouter:
 
             response = client.post(
                 "/api/itsm/service-catalog",
-                json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45, "service_type": "incident"},
+                json={
+                    "service_id": "svc-new",
+                    "name": "Core",
+                    "sla_target_minutes": 45,
+                    "service_type": "incident",
+                },
             )
 
         assert response.status_code == 200
@@ -264,7 +279,12 @@ class TestItsmTicketRouter:
                     response = client.post(endpoint, json={"next_status": "in_progress"})
                 else:
                     response = client.post(
-                        endpoint, json={"type": "service_request", "title": "Access", "service_catalog_id": "svc-001"}
+                        endpoint,
+                        json={
+                            "type": "service_request",
+                            "title": "Access",
+                            "service_catalog_id": "svc-001",
+                        },
                     )
             elif method == "put":
                 response = client.put(endpoint, json={"title": "Changed"})
@@ -314,7 +334,11 @@ class TestItsmTicketRouter:
 
             response_create = client.post(
                 "/api/itsm/tickets",
-                json={"type": "service_request", "title": "Access", "service_catalog_id": "svc-001"},
+                json={
+                    "type": "service_request",
+                    "title": "Access",
+                    "service_catalog_id": "svc-001",
+                },
             )
             response_update = client.put("/api/itsm/tickets/1", json={"title": "Escalated"})
             response_transition = client.post(

--- a/backend/tests/test_routers_itsm.py
+++ b/backend/tests/test_routers_itsm.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from models.user import User, UserPermission
 from routers import itsm_service_catalog, ticket_folios
@@ -101,7 +101,7 @@ class TestItsmServiceCatalogRouter:
 
         response = client.post(
             "/api/itsm/service-catalog",
-            json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45},
+            json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45, "service_type": "incident"},
         )
         assert response.status_code == 403
 
@@ -123,7 +123,7 @@ class TestItsmServiceCatalogRouter:
             ("/api/itsm/service-catalog/svc-1/deactivate", "post", [UserPermission.EVENT_VIEW]),
         ]:
             _override_current_user(_make_pydantic_user(permissions=permissions))
-            payload = {"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45}
+            payload = {"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45, "service_type": "incident"}
 
             if method == "get":
                 response = client.get(endpoint)
@@ -149,7 +149,7 @@ class TestItsmServiceCatalogRouter:
 
             response = client.post(
                 "/api/itsm/service-catalog",
-                json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45},
+                json={"service_id": "svc-new", "name": "Core", "sla_target_minutes": 45, "service_type": "incident"},
             )
 
         assert response.status_code == 200
@@ -181,6 +181,39 @@ class TestItsmServiceCatalogRouter:
         mock_service.update_service_catalog.assert_called_once()
         mock_service.deactivate_service_catalog.assert_called_once_with("svc-1", actor="testuser")
 
+    def test_update_catalog_with_unchanged_service_type_is_accepted(self):
+        _override_current_user(_make_pydantic_user(permissions=[WRITE_PERMISSION]))
+        with patch("routers.itsm_service_catalog.service_catalog_service") as mock_service:
+            mock_service.update_service_catalog.return_value = {
+                "service_id": "svc-1",
+                "service_type": "incident",
+                "name": "Updated",
+            }
+
+            response = client.put(
+                "/api/itsm/service-catalog/svc-1",
+                json={"service_type": "incident", "name": "Updated"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["service_type"] == "incident"
+
+    def test_update_catalog_with_changed_service_type_returns_controlled_400(self):
+        _override_current_user(_make_pydantic_user(permissions=[WRITE_PERMISSION]))
+        with patch("routers.itsm_service_catalog.service_catalog_service") as mock_service:
+            mock_service.update_service_catalog.side_effect = HTTPException(
+                status_code=400,
+                detail="service_type is immutable after catalog creation",
+            )
+
+            response = client.put(
+                "/api/itsm/service-catalog/svc-1",
+                json={"service_type": "service_request", "name": "Updated"},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "service_type is immutable after catalog creation"
+
 
 class TestItsmTicketRouter:
     """Permissioned route coverage for /api/itsm/tickets."""
@@ -190,7 +223,7 @@ class TestItsmTicketRouter:
         response = client.get("/api/itsm/tickets")
         assert response.status_code == 403
 
-        response = client.get("/api/itsm/tickets/TK-1")
+        response = client.get("/api/itsm/tickets/1")
         assert response.status_code == 403
 
     def test_ticket_write_routes_require_write_permission(self):
@@ -198,18 +231,18 @@ class TestItsmTicketRouter:
 
         response = client.post(
             "/api/itsm/tickets",
-            json={"ticket_id": "TK-1", "type": "request", "title": "Access"},
+            json={"type": "service_request", "title": "Access", "service_catalog_id": "svc-001"},
         )
         assert response.status_code == 403
 
         response = client.put(
-            "/api/itsm/tickets/TK-1",
+            "/api/itsm/tickets/1",
             json={"title": "Changed"},
         )
         assert response.status_code == 403
 
         response = client.post(
-            "/api/itsm/tickets/TK-1/transition",
+            "/api/itsm/tickets/1/transition",
             json={"next_status": "in_progress"},
         )
         assert response.status_code == 403
@@ -217,10 +250,10 @@ class TestItsmTicketRouter:
     def test_ticket_routes_reject_catalog_or_event_permissions(self):
         for endpoint, method, permissions in [
             ("/api/itsm/tickets", "get", [UserPermission.CI_VIEW]),
-            ("/api/itsm/tickets/TK-1", "get", [UserPermission.EVENT_VIEW]),
+            ("/api/itsm/tickets/1", "get", [UserPermission.EVENT_VIEW]),
             ("/api/itsm/tickets", "post", [UserPermission.CI_EDIT]),
-            ("/api/itsm/tickets/TK-1", "put", [UserPermission.CI_EDIT]),
-            ("/api/itsm/tickets/TK-1/transition", "post", [UserPermission.EVENT_CLOSE]),
+            ("/api/itsm/tickets/1", "put", [UserPermission.CI_EDIT]),
+            ("/api/itsm/tickets/1/transition", "post", [UserPermission.EVENT_CLOSE]),
         ]:
             _override_current_user(_make_pydantic_user(permissions=permissions))
 
@@ -231,7 +264,7 @@ class TestItsmTicketRouter:
                     response = client.post(endpoint, json={"next_status": "in_progress"})
                 else:
                     response = client.post(
-                        endpoint, json={"ticket_id": "TK-1", "type": "request", "title": "Access"}
+                        endpoint, json={"type": "service_request", "title": "Access", "service_catalog_id": "svc-001"}
                     )
             elif method == "put":
                 response = client.put(endpoint, json={"title": "Changed"})
@@ -243,13 +276,13 @@ class TestItsmTicketRouter:
 
         with patch("routers.ticket_folios.ticket_folio_service") as mock_service:
             mock_service.list_ticket_folios.return_value = [
-                {"ticket_id": "TK-1", "type": "request", "status": "open"}
+                {"ticket_id": 1, "type": "service_request", "status": "open"}
             ]
 
             response = client.get("/api/itsm/tickets")
 
         assert response.status_code == 200
-        assert response.json() == [{"ticket_id": "TK-1", "type": "request", "status": "open"}]
+        assert response.json() == [{"ticket_id": 1, "type": "service_request", "status": "open"}]
         mock_service.list_ticket_folios.assert_called_once_with(
             status=None,
             service_catalog_id=None,
@@ -262,25 +295,30 @@ class TestItsmTicketRouter:
 
         with patch("routers.ticket_folios.ticket_folio_service") as mock_service:
             mock_service.create_ticket_folio.return_value = {
-                "ticket_id": "TK-1",
+                "ticket_id": 1,
+                "type": "service_request",
+                "title": "Access",
                 "status": "open",
             }
             mock_service.update_ticket_folio.return_value = {
-                "ticket_id": "TK-1",
+                "ticket_id": 1,
+                "type": "service_request",
                 "title": "Escalated",
             }
             mock_service.transition_ticket_folio.return_value = {
-                "ticket_id": "TK-1",
+                "ticket_id": 1,
+                "type": "service_request",
+                "title": "Access",
                 "status": "in_progress",
             }
 
             response_create = client.post(
                 "/api/itsm/tickets",
-                json={"ticket_id": "TK-1", "type": "request", "title": "Access"},
+                json={"type": "service_request", "title": "Access", "service_catalog_id": "svc-001"},
             )
-            response_update = client.put("/api/itsm/tickets/TK-1", json={"title": "Escalated"})
+            response_update = client.put("/api/itsm/tickets/1", json={"title": "Escalated"})
             response_transition = client.post(
-                "/api/itsm/tickets/TK-1/transition",
+                "/api/itsm/tickets/1/transition",
                 json={"next_status": "in_progress"},
             )
 
@@ -288,16 +326,16 @@ class TestItsmTicketRouter:
         assert response_update.status_code == 200
         assert response_transition.status_code == 200
         create_payload = mock_service.create_ticket_folio.call_args
-        assert create_payload.args[0].ticket_id == "TK-1"
+        assert "ticket_id" not in create_payload.args[0].model_fields_set
         assert create_payload.kwargs["actor"] == "testuser"
 
         update_payload = mock_service.update_ticket_folio.call_args
-        assert update_payload.args[0] == "TK-1"
+        assert update_payload.args[0] == 1
         assert update_payload.args[1].title == "Escalated"
         assert update_payload.kwargs["actor"] == "testuser"
 
         transition_payload = mock_service.transition_ticket_folio.call_args
-        assert transition_payload.args[0] == "TK-1"
+        assert transition_payload.args[0] == 1
         assert transition_payload.kwargs["next_status"] == "in_progress"
         assert transition_payload.kwargs["actor"] == "testuser"
 

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -1,4 +1,5 @@
 """RED tests for PR1 server-generated ticket identity contracts."""
+
 # ruff: noqa: I001
 
 from unittest.mock import MagicMock

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -1,4 +1,5 @@
 """RED tests for PR1 server-generated ticket identity contracts."""
+# ruff: noqa: I001
 
 from unittest.mock import MagicMock
 

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -70,7 +70,10 @@ def test_repository_rolls_back_ticket_and_sequence_when_relation_sync_fails():
             self.query = ""
 
         def execute_write(self, callback):
-            snapshot = {"next_value": self.state["next_value"], "tickets": list(self.state["tickets"])}
+            snapshot = {
+                "next_value": self.state["next_value"],
+                "tickets": list(self.state["tickets"]),
+            }
             try:
                 return callback(self)
             except Exception:
@@ -129,7 +132,9 @@ def test_repository_rejects_missing_sequence_without_persisting_ticket():
     repository = TicketFolioRepository(driver=driver)
     with pytest.raises(RuntimeError, match="TicketSequence"):
         repository.create_with_generated_id(
-            TicketFolioCreate(type="incident", title="Router down", service_catalog_id="svc-incident")
+            TicketFolioCreate(
+                type="incident", title="Router down", service_catalog_id="svc-incident"
+            )
         )
 
 
@@ -204,7 +209,9 @@ def test_catalog_api_then_same_type_ticket_uses_persisted_type_and_active_status
         "service_type": payload.service_type,
         "active": payload.active,
     }
-    catalog_repository.get_by_id.side_effect = lambda service_id: catalog_repository.upsert.call_args.args[0].model_dump()
+    catalog_repository.get_by_id.side_effect = (
+        lambda service_id: catalog_repository.upsert.call_args.args[0].model_dump()
+    )
     ticket_repository = MagicMock()
     ticket_repository.create_with_generated_id.return_value = {
         "ticket_id": 19,

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -1,0 +1,298 @@
+"""RED tests for PR1 server-generated ticket identity contracts."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from models.itsm import TicketFolioCreate, TicketFolioResponse
+from repositories.ticket_folio_repo import TicketFolioRepository
+from services.itsm_service_catalog_service import create_service_catalog
+from services.ticket_folio_service import create_ticket_folio
+
+
+def test_create_payload_rejects_client_ticket_id_and_uses_canonical_types():
+    with pytest.raises(ValidationError, match="ticket_id"):
+        TicketFolioCreate(
+            ticket_id=42,
+            type="incident",
+            title="Router down",
+            description="Core router unreachable",
+        )
+
+    payload = TicketFolioCreate(
+        type="service_request",
+        title="Access request",
+        description="Grant access",
+        service_catalog_id="svc-request",
+    )
+    assert payload.type == "service_request"
+
+    with pytest.raises(ValidationError, match="service_request"):
+        TicketFolioCreate(type="request", title="Legacy type")
+
+
+def test_ticket_response_contract_exposes_numeric_generated_id():
+    response = TicketFolioResponse(
+        ticket_id=123,
+        type="incident",
+        title="Router down",
+        description="Core router unreachable",
+    )
+    assert response.ticket_id == 123
+    assert isinstance(response.ticket_id, int)
+
+
+def test_repository_allocates_id_and_creates_ticket_in_one_write_transaction():
+    session = MagicMock()
+    session.execute_write.side_effect = lambda callback: callback(session)
+    session.run.return_value.single.return_value = {"ticket_id": 17}
+    driver = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+
+    repository = TicketFolioRepository(driver=driver)
+    created = repository.create_with_generated_id(
+        TicketFolioCreate(type="incident", title="Router down", service_catalog_id="svc-incident")
+    )
+
+    assert created["ticket_id"] == 17
+    session.execute_write.assert_called_once()
+    session.run.assert_called_once()
+    assert "TicketSequence" in session.run.call_args.args[0]
+    assert "CREATE (tf:TicketFolio" in session.run.call_args.args[0]
+
+
+def test_repository_rolls_back_ticket_and_sequence_when_relation_sync_fails():
+    class TransactionalSession:
+        def __init__(self):
+            self.state = {"next_value": 0, "tickets": []}
+            self.query = ""
+
+        def execute_write(self, callback):
+            snapshot = {"next_value": self.state["next_value"], "tickets": list(self.state["tickets"])}
+            try:
+                return callback(self)
+            except Exception:
+                self.state = snapshot
+                raise
+
+        def run(self, query, **params):
+            self.query = query
+            self.state["next_value"] += 1
+            self.state["tickets"].append(params)
+            raise RuntimeError("service relation synchronization failed")
+
+    session = TransactionalSession()
+    driver = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+
+    repository = TicketFolioRepository(driver=driver)
+    with pytest.raises(RuntimeError, match="relation synchronization"):
+        repository.create_with_generated_id(
+            TicketFolioCreate(type="incident", title="Router down", service_catalog_id="svc-1")
+        )
+
+    assert session.state == {"next_value": 0, "tickets": []}
+    assert "FOR_SERVICE" in session.query
+
+
+def test_repository_rejects_missing_catalog_in_write_transaction_without_persisting_ticket():
+    session = MagicMock()
+    session.execute_write.side_effect = lambda callback: callback(session)
+    session.run.return_value.single.return_value = None
+    driver = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+
+    repository = TicketFolioRepository(driver=driver)
+    with pytest.raises(RuntimeError, match="ServiceCatalog"):
+        repository.create_with_generated_id(
+            TicketFolioCreate(
+                type="incident", title="Router down", service_catalog_id="svc-deleted"
+            )
+        )
+
+    query = session.run.call_args.args[0]
+    assert "MATCH (sc:ServiceCatalog {service_id: $service_catalog_id})" in query
+    assert "sc.service_type = $type" in query
+    assert "coalesce(sc.active, true) = true" in query
+    assert "OPTIONAL MATCH (sc:ServiceCatalog" not in query
+
+
+def test_repository_rejects_missing_sequence_without_persisting_ticket():
+    session = MagicMock()
+    session.execute_write.side_effect = lambda callback: callback(session)
+    session.run.return_value.single.return_value = None
+    driver = MagicMock()
+    driver.session.return_value.__enter__.return_value = session
+
+    repository = TicketFolioRepository(driver=driver)
+    with pytest.raises(RuntimeError, match="TicketSequence"):
+        repository.create_with_generated_id(
+            TicketFolioCreate(type="incident", title="Router down", service_catalog_id="svc-incident")
+        )
+
+
+def test_create_service_rejects_omitted_service_catalog_id_before_persistence():
+    repository = MagicMock()
+
+    with pytest.raises(ValidationError, match="service_catalog_id"):
+        TicketFolioCreate(type="incident", title="Router down")
+
+    with pytest.raises(Exception):
+        create_ticket_folio(
+            {"type": "incident", "title": "Router down"},
+            actor="admin",
+            repository=repository,
+        )
+    repository.create_with_generated_id.assert_not_called()
+
+
+def test_create_service_rejects_missing_catalog_without_persistence():
+    repository = MagicMock()
+    catalog_repository = MagicMock()
+    catalog_repository.get_by_id.return_value = None
+
+    with pytest.raises(Exception, match="service_catalog"):
+        create_ticket_folio(
+            {
+                "type": "incident",
+                "title": "Router down",
+                "service_catalog_id": "svc-missing",
+            },
+            repository=repository,
+            catalog_repository=catalog_repository,
+        )
+    repository.create_with_generated_id.assert_not_called()
+
+
+def test_create_service_accepts_existing_compatible_catalog():
+    repository = MagicMock()
+    repository.create_with_generated_id.return_value = {
+        "ticket_id": 18,
+        "type": "incident",
+        "title": "Router down",
+        "service_catalog_id": "svc-incident",
+    }
+    catalog_repository = MagicMock()
+    catalog_repository.get_by_id.return_value = {
+        "service_id": "svc-incident",
+        "service_type": "incident",
+        "active": True,
+    }
+
+    created = create_ticket_folio(
+        {
+            "type": "incident",
+            "title": "Router down",
+            "service_catalog_id": "svc-incident",
+        },
+        actor="admin",
+        repository=repository,
+        catalog_repository=catalog_repository,
+    )
+
+    assert created["ticket_id"] == 18
+    repository.create_with_generated_id.assert_called_once()
+
+
+def test_catalog_api_then_same_type_ticket_uses_persisted_type_and_active_status():
+    catalog_repository = MagicMock()
+    catalog_repository.upsert.side_effect = lambda payload: {
+        **payload.model_dump(),
+        "service_id": payload.service_id,
+        "service_type": payload.service_type,
+        "active": payload.active,
+    }
+    catalog_repository.get_by_id.side_effect = lambda service_id: catalog_repository.upsert.call_args.args[0].model_dump()
+    ticket_repository = MagicMock()
+    ticket_repository.create_with_generated_id.return_value = {
+        "ticket_id": 19,
+        "type": "incident",
+        "service_catalog_id": "svc-incident",
+    }
+
+    catalog = create_service_catalog(
+        {"service_id": "svc-incident", "name": "Network Incident", "service_type": "incident"},
+        actor="admin",
+        repository=catalog_repository,
+    )
+    ticket = create_ticket_folio(
+        {
+            "type": "incident",
+            "title": "Router down",
+            "service_catalog_id": catalog["service_id"],
+        },
+        repository=ticket_repository,
+        catalog_repository=catalog_repository,
+    )
+
+    assert catalog["service_type"] == "incident"
+    assert catalog["active"] is True
+    assert ticket["ticket_id"] == 19
+    ticket_repository.create_with_generated_id.assert_called_once()
+
+
+def test_ticket_rejects_incompatible_persisted_catalog_type():
+    catalog_repository = MagicMock()
+    catalog_repository.get_by_id.return_value = {
+        "service_id": "svc-request",
+        "service_type": "service_request",
+        "active": True,
+    }
+    ticket_repository = MagicMock()
+
+    with pytest.raises(Exception, match="compatible service_type"):
+        create_ticket_folio(
+            {
+                "type": "incident",
+                "title": "Router down",
+                "service_catalog_id": "svc-request",
+            },
+            repository=ticket_repository,
+            catalog_repository=catalog_repository,
+        )
+
+    ticket_repository.create_with_generated_id.assert_not_called()
+
+
+def test_ticket_rejects_inactive_persisted_catalog():
+    catalog_repository = MagicMock()
+    catalog_repository.get_by_id.return_value = {
+        "service_id": "svc-inactive",
+        "service_type": "incident",
+        "active": False,
+    }
+    ticket_repository = MagicMock()
+
+    with pytest.raises(Exception, match="inactive"):
+        create_ticket_folio(
+            {
+                "type": "incident",
+                "title": "Router down",
+                "service_catalog_id": "svc-inactive",
+            },
+            repository=ticket_repository,
+            catalog_repository=catalog_repository,
+        )
+
+    ticket_repository.create_with_generated_id.assert_not_called()
+
+
+def test_catalog_service_type_is_immutable_on_update():
+    catalog_repository = MagicMock()
+    catalog_repository.get_by_id.return_value = {
+        "service_id": "svc-incident",
+        "service_type": "incident",
+        "active": True,
+    }
+
+    with pytest.raises(Exception, match="service_type"):
+        from services.itsm_service_catalog_service import update_service_catalog
+
+        update_service_catalog(
+            "svc-incident",
+            {"service_type": "service_request"},
+            repository=catalog_repository,
+        )
+
+    catalog_repository.update.assert_not_called()

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from models.itsm import TicketFolioCreate, TicketFolioResponse
@@ -138,7 +139,7 @@ def test_create_service_rejects_omitted_service_catalog_id_before_persistence():
     with pytest.raises(ValidationError, match="service_catalog_id"):
         TicketFolioCreate(type="incident", title="Router down")
 
-    with pytest.raises(Exception):
+    with pytest.raises(HTTPException):
         create_ticket_folio(
             {"type": "incident", "title": "Router down"},
             actor="admin",
@@ -152,7 +153,7 @@ def test_create_service_rejects_missing_catalog_without_persistence():
     catalog_repository = MagicMock()
     catalog_repository.get_by_id.return_value = None
 
-    with pytest.raises(Exception, match="service_catalog"):
+    with pytest.raises(HTTPException, match="service_catalog"):
         create_ticket_folio(
             {
                 "type": "incident",
@@ -241,7 +242,7 @@ def test_ticket_rejects_incompatible_persisted_catalog_type():
     }
     ticket_repository = MagicMock()
 
-    with pytest.raises(Exception, match="compatible service_type"):
+    with pytest.raises(HTTPException, match="compatible service_type"):
         create_ticket_folio(
             {
                 "type": "incident",
@@ -264,7 +265,7 @@ def test_ticket_rejects_inactive_persisted_catalog():
     }
     ticket_repository = MagicMock()
 
-    with pytest.raises(Exception, match="inactive"):
+    with pytest.raises(HTTPException, match="inactive"):
         create_ticket_folio(
             {
                 "type": "incident",
@@ -286,7 +287,7 @@ def test_catalog_service_type_is_immutable_on_update():
         "active": True,
     }
 
-    with pytest.raises(Exception, match="service_type"):
+    with pytest.raises(HTTPException, match="service_type"):
         from services.itsm_service_catalog_service import update_service_catalog
 
         update_service_catalog(

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -45,7 +45,11 @@ class TestTicketFolioService:
 
     def test_create_ticket_defaults_to_open_and_resolves_catalog_id(self):
         catalog_repo = _CatalogRepoStub()
-        catalog_repo.get_by_id.return_value = {"service_id": "svc-001", "service_type": "service_request", "active": True}
+        catalog_repo.get_by_id.return_value = {
+            "service_id": "svc-001",
+            "service_type": "service_request",
+            "active": True,
+        }
         ticket_repo = _TicketRepoStub()
         ticket_repo.create_with_generated_id.return_value = _sample_ticket_record()
 
@@ -101,7 +105,11 @@ class TestTicketFolioService:
 
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {"type": "incident", "title": "Production alarm", "service_catalog_id": "svc-missing"},
+                {
+                    "type": "incident",
+                    "title": "Production alarm",
+                    "service_catalog_id": "svc-missing",
+                },
                 repository=ticket_repo,
                 catalog_repository=catalog_repo,
             )

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -19,14 +19,15 @@ class _TicketRepoStub:
         self.get = MagicMock(return_value=None)
         self.list = MagicMock()
         self.upsert = MagicMock()
+        self.create_with_generated_id = MagicMock()
         self.update = MagicMock()
         self.sync_service_relationship = MagicMock()
 
 
 def _sample_ticket_record(status: str = "open") -> dict:
     return {
-        "ticket_id": "TK-001",
-        "type": "request",
+        "ticket_id": 1,
+        "type": "service_request",
         "title": "Request access",
         "description": "Please grant access",
         "service_catalog_id": "svc-001",
@@ -44,14 +45,13 @@ class TestTicketFolioService:
 
     def test_create_ticket_defaults_to_open_and_resolves_catalog_id(self):
         catalog_repo = _CatalogRepoStub()
-        catalog_repo.get_by_id.return_value = {"service_id": "svc-001"}
+        catalog_repo.get_by_id.return_value = {"service_id": "svc-001", "service_type": "service_request", "active": True}
         ticket_repo = _TicketRepoStub()
-        ticket_repo.upsert.return_value = _sample_ticket_record()
+        ticket_repo.create_with_generated_id.return_value = _sample_ticket_record()
 
         created = ticket_service.create_ticket_folio(
             {
-                "ticket_id": "TK-001",
-                "type": "request",
+                "type": "service_request",
                 "title": "Request access",
                 "description": "Please grant access",
                 "service_catalog_id": "svc-001",
@@ -61,74 +61,38 @@ class TestTicketFolioService:
             catalog_repository=catalog_repo,
         )
 
-        assert created["ticket_id"] == "TK-001"
+        assert created["ticket_id"] == 1
         assert created["status"] == "open"
-        assert created["service_catalog_id"] == "svc-001"
-        assert ticket_repo.sync_service_relationship.call_count == 1
+        ticket_repo.create_with_generated_id.assert_called_once()
+        ticket_repo.sync_service_relationship.assert_not_called()
 
-    def test_create_ticket_rejects_duplicate_without_mutating_closed_ticket(self):
-        catalog_repo = _CatalogRepoStub()
+    def test_create_ticket_rejects_client_supplied_id(self):
         ticket_repo = _TicketRepoStub()
-        ticket_repo.get.return_value = {
-            **_sample_ticket_record("closed"),
-            "archived": True,
-            "closed_reason": "Completed",
-        }
-
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {
-                    "ticket_id": "TK-001",
-                    "type": "request",
-                    "title": "Retry request",
-                },
-                actor="admin",
+                {"ticket_id": 1, "type": "incident", "title": "Router down"},
                 repository=ticket_repo,
-                catalog_repository=catalog_repo,
             )
-
-        assert exc.value.status_code == 409
-        assert "already exists" in exc.value.detail.lower()
-        ticket_repo.upsert.assert_not_called()
-        ticket_repo.sync_service_relationship.assert_not_called()
+        assert exc.value.status_code == 400
+        ticket_repo.create_with_generated_id.assert_not_called()
 
     def test_create_ticket_rejects_blank_title(self):
-        catalog_repo = _CatalogRepoStub()
         ticket_repo = _TicketRepoStub()
-
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {
-                    "ticket_id": "TK-blank",
-                    "type": "request",
-                    "title": "   ",
-                },
-                repository=ticket_repo,
-                catalog_repository=catalog_repo,
+                {"type": "incident", "title": "   "}, repository=ticket_repo
             )
-
         assert exc.value.status_code == 400
-        assert "title" in exc.value.detail.lower()
-        ticket_repo.upsert.assert_not_called()
+        ticket_repo.create_with_generated_id.assert_not_called()
 
     def test_create_ticket_rejects_invalid_type(self):
-        catalog_repo = _CatalogRepoStub()
         ticket_repo = _TicketRepoStub()
-
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {
-                    "ticket_id": "TK-002",
-                    "type": "change",
-                    "title": "Change request",
-                },
-                repository=ticket_repo,
-                catalog_repository=catalog_repo,
+                {"type": "request", "title": "Legacy request"}, repository=ticket_repo
             )
-
         assert exc.value.status_code == 400
-        ticket_repo.upsert.assert_not_called()
-        ticket_repo.sync_service_relationship.assert_not_called()
+        ticket_repo.create_with_generated_id.assert_not_called()
 
     def test_create_ticket_requires_existing_catalog_when_catalog_id_provided(self):
         catalog_repo = _CatalogRepoStub()
@@ -137,19 +101,13 @@ class TestTicketFolioService:
 
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {
-                    "ticket_id": "TK-003",
-                    "type": "incident",
-                    "title": "Production alarm",
-                    "service_catalog_id": "svc-missing",
-                },
+                {"type": "incident", "title": "Production alarm", "service_catalog_id": "svc-missing"},
                 repository=ticket_repo,
                 catalog_repository=catalog_repo,
             )
 
         assert exc.value.status_code == 404
-        assert "service_catalog" in exc.value.detail.lower()
-        ticket_repo.upsert.assert_not_called()
+        ticket_repo.create_with_generated_id.assert_not_called()
 
     def test_transition_rejects_skip_and_regression(self):
         catalog_repo = _CatalogRepoStub()
@@ -213,27 +171,22 @@ class TestTicketFolioService:
         assert updated["closed_reason"] == "Incident resolved and verified"
         assert ticket_repo.update.called
 
-    def test_update_ticket_allows_clearing_optional_fields_and_syncs_relation(self):
+    def test_update_ticket_rejects_clearing_required_service_catalog_id(self):
         catalog_repo = _CatalogRepoStub()
         ticket_repo = _TicketRepoStub()
         ticket_repo.get.return_value = _sample_ticket_record("open")
-        ticket_repo.update.return_value = {
-            **_sample_ticket_record("open"),
-            "description": None,
-            "service_catalog_id": None,
-        }
 
-        ticket_service.update_ticket_folio(
-            "TK-001",
-            {"description": None, "service_catalog_id": None},
-            repository=ticket_repo,
-            catalog_repository=catalog_repo,
-        )
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.update_ticket_folio(
+                "TK-001",
+                {"service_catalog_id": None},
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
 
-        update_payload = ticket_repo.update.call_args.args[1]
-        assert "description" in update_payload.model_fields_set
-        assert "service_catalog_id" in update_payload.model_fields_set
-        ticket_repo.sync_service_relationship.assert_called_once_with("TK-001", None)
+        assert exc.value.status_code == 400
+        ticket_repo.update.assert_not_called()
+        ticket_repo.sync_service_relationship.assert_not_called()
 
     def test_closed_ticket_rejects_direct_updates(self):
         catalog_repo = _CatalogRepoStub()

--- a/openspec/changes/service-management-catalog/apply-progress.md
+++ b/openspec/changes/service-management-catalog/apply-progress.md
@@ -1,0 +1,216 @@
+# Apply Progress: service-management-catalog
+
+## Status
+
+- Slice: PR 1 backend ticket identity/core contract (`feature-branch-chain`, child targets tracker `feat/service-management-catalog`, issue #401)
+- Workload boundary: ~76 production changed lines plus focused tests; intentionally excludes catalog governance, compatibility enforcement beyond existing lookup, assignee locking/lifecycle, XLSX, and frontend work.
+- Structured status consumed: `change=service-management-catalog`, `artifactStore=openspec`, `apply=ready`, `nextRecommended=apply`, `allowedEditRoots` limited to this worktree, 5 tasks pending.
+- Action-context warning: native status was supplied by the parent; all operations were executed from the isolated worktree.
+
+## Completed tasks
+
+- [x] Work Unit 1 — backend ticket domain contracts and clean-slate identity model. Persisted checkbox updated in `tasks.md`.
+- [x] Work Unit 2 — backend sequence allocator and single-ticket generated-ID persistence. Persisted checkbox updated in `tasks.md`.
+
+## Files changed
+
+- `backend/models/itsm.py`
+- `backend/repositories/ticket_folio_repo.py`
+- `backend/services/ticket_folio_service.py`
+- `backend/routers/ticket_folios.py`
+- `backend/migrations/itsm_service_catalog.cypher`
+- `backend/tests/test_service_management_pr1.py`
+- `openspec/changes/service-management-catalog/tasks.md`
+
+## TDD Cycle Evidence
+
+| Task | Test file | Layer | Safety net | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|---|---|---|
+| Work Unit 1 | `backend/tests/test_service_management_pr1.py` | Unit | Not executable: `python` unavailable; `python3` has no pytest | Written first; initially referenced missing response/allocator contracts | Not executable: `python3 -m pytest ...` failed with `No module named pytest` | Added canonical enum negative case and numeric response case | `python3 -m compileall` passed; no behavior refactor run |
+| Work Unit 2 | `backend/tests/test_service_management_pr1.py` | Unit/repository seam | Not executable: `python` unavailable; `python3` has no pytest | Written first for generated allocation and missing sequence | Not executable: `python3 -m pytest ...` failed with `No module named pytest` | Covered successful allocation and missing-sequence rollback guard | `python3 -m compileall` and `git diff --check` passed |
+
+## Verification evidence
+
+- `python -m pytest ...`: blocked by environment (`python: command not found`).
+- `python3 -m pytest tests/test_service_management_pr1.py -q`: blocked by environment (`No module named pytest`).
+- `python3 -m compileall -q ...`: passed.
+- `git diff --check`: passed.
+
+## Deviations
+
+- The repository did not provide the configured Python test runtime, so GREEN test execution could not be demonstrated. No dependency installation was performed.
+- The focused RED tests were added as a new PR1 test module rather than rewriting the broader legacy lifecycle tests, which remain outside this slice and require contract migration in a later compatibility/test cleanup pass.
+
+## Remaining tasks
+
+- [ ] Work Unit 3 — backend shared active-user locking and logical deactivation.
+- [ ] Work Unit 4 — catalog governance and value streams.
+- [ ] Work Unit 5 — compatibility enforcement in single-ticket flows.
+- [ ] Work Unit 6 — atomic XLSX catalog import stack.
+- [ ] Work Unit 7 — atomic XLSX ticket import.
+- [ ] Work Unit 8 — frontend Service Management UI.
+- [ ] Work Unit 9 — end-to-end compatibility checks and release verification.
+
+## Next recommendation
+
+`verify` after the backend test environment is available. Then continue PR 2 (catalog/value-stream domain) on the tracker chain.
+
+## Environment blocker resolution (continuation)
+
+- Created the ignored local virtual environment `.venv/` with Python 3.11.15; no tracked source files were changed.
+- Installed `backend/requirements.txt` and `backend/requirements-dev.txt` successfully into `.venv/`.
+- Python 3.9.6 is insufficient for the current backend model annotations: focused collection failed with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` for `str | None` in `backend/models/itsm.py`. The repository Dockerfile specifies Python 3.11, which is the minimum runtime used here.
+- RED evidence: prior focused run was blocked before collection because the test environment lacked pytest; after environment setup, the Python 3.9 compatibility attempt still failed during collection.
+- GREEN evidence: `cd backend && ../.venv/bin/python -m pytest tests/test_service_management_pr1.py -q` passed: 5 tests passed in 3.45s.
+- No implementation scope was added, and no commit, push, or PR was created.
+
+## Continuation status
+
+- Persisted task checkboxes unchanged: Work Units 1–2 remain `[x]`; Work Units 3–9 remain `[ ]`.
+- Files changed by this continuation: `openspec/changes/service-management-catalog/apply-progress.md` only; ignored `.venv/` is a local environment artifact.
+- Remaining tasks are the exact unchecked Work Unit lines listed above.
+- Workload / PR boundary: PR1 backend ticket identity/core contract only; this continuation resolved test-environment setup and did not expand the slice.
+- Structured status consumed: `changeName=service-management-catalog`, `artifactStore=openspec`, `applyState=ready`, `nextRecommended=apply`, `actionContext.mode=repo-local`, workspace is the isolated PR1 worktree, with no edit-root warning.
+- `skill_resolution=paths-injected` (`work-unit-commits` loaded from the parent-provided path).
+
+## PR1 review remediation
+
+- **JD-PR1-001 fixed:** moved `FOR_SERVICE` relation synchronization into the same Neo4j `execute_write` query as sequence allocation and ticket creation. A relation-write exception now rolls back the ticket and sequence increment; no separate post-create synchronization call remains.
+- **JD-PR1-002 fixed:** migrated the current PR1 domain, service, and router consumers/tests to numeric response IDs and canonical `incident`/`service_request` values. Client-supplied ticket IDs remain forbidden; deprecated `REQUEST` is not restored.
+- Persisted task checkboxes: Work Units 1–2 remain `[x]`; no later catalog, assignment, XLSX, or frontend task was marked complete.
+
+## TDD Cycle Evidence — review remediation
+
+| Finding | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|
+| JD-PR1-001 | Added failure test asserting transactional rollback and relation query participation; it failed because the create query lacked `FOR_SERVICE`. | Added relation merge inside `_CREATE_TICKET_FOLIO_QUERY`; focused failure test passed. | Confirmed sequence/ticket/relation are inside one repository `execute_write`; service no longer invokes a second create-time sync. | Added repository docstring and clarified service transaction comment. |
+| JD-PR1-002 | Existing focused consumer/contract suites exposed stale `REQUEST` and client-ID assumptions. | Updated only PR1 ticket consumers/tests/contracts; focused suite passed. | Verified route IDs and response fixtures are numeric and create model fields exclude `ticket_id`. | Kept later catalog/assignment/import/frontend slices untouched. |
+
+## Verification evidence — review remediation
+
+- RED: `cd backend && ../.venv/bin/python3.11 -m pytest tests/test_service_management_pr1.py -q` — 1 failed, 5 passed (expected missing atomic relation assertion).
+- GREEN/triangulation: `cd backend && ../.venv/bin/python3.11 -m pytest tests/test_service_management_pr1.py tests/test_itsm_domain_contracts.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py -q` — **43 passed**, 1 deprecation warning.
+- Review ledger statuses updated: `JD-PR1-001=fixed`, `JD-PR1-002=fixed` after the passing focused suite.
+
+## Current status after remediation
+
+- Structured status consumed: `schemaName=spec-driven`, `changeName=service-management-catalog`, `artifactStore=openspec`, `applyState=ready`, `dependencies.apply=ready`, `nextRecommended=verify`, `actionContext.mode=repo-local`, workspace is the isolated PR1 worktree, and allowed edit scope is this worktree only.
+- Remaining tasks (exact unchecked lines):
+  - [ ] Work Unit 3 — backend shared active-user locking and logical deactivation.
+  - [ ] Work Unit 4 — catalog governance and value streams.
+  - [ ] Work Unit 5 — compatibility enforcement in single-ticket flows.
+  - [ ] Work Unit 6 — atomic XLSX catalog import stack.
+  - [ ] Work Unit 7 — atomic XLSX ticket import.
+  - [ ] Work Unit 8 — frontend Service Management UI.
+  - [ ] Work Unit 9 — end-to-end compatibility checks and release verification.
+- No commit, push, or PR was created.
+
+## Defensive fix — JD-PR1-001
+
+- **Completed:** Required the referenced `ServiceCatalog` via `MATCH` inside `_CREATE_TICKET_FOLIO_QUERY` before sequence allocation and `TicketFolio` creation; `FOR_SERVICE` is merged in that same Neo4j write transaction.
+- **Test added:** `backend/tests/test_service_management_pr1.py::test_repository_rejects_missing_catalog_in_write_transaction_without_persisting_ticket` covers the no-match/race-equivalent path and asserts the query does not use `OPTIONAL MATCH`.
+- **TDD evidence:** RED failed against the prior optional-match/error behavior; GREEN passed after the query guard; TRIANGULATE passed with the existing relation-failure rollback test and the full focused PR1 consumer suite; REFACTOR limited to the deterministic combined missing-sequence/catalog error.
+- **Persisted task checkboxes:** Work Units 1–2 remain `[x]`; no later work unit is complete or marked.
+- **Files changed for this fix:** `backend/repositories/ticket_folio_repo.py`, `backend/tests/test_service_management_pr1.py`, `openspec/changes/service-management-catalog/review-ledger.md`, this file.
+- **Verification:** `cd backend && ../.venv/bin/python -m pytest tests/test_service_management_pr1.py tests/test_itsm_domain_contracts.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py -q` — **44 passed**, 1 deprecation warning; `git diff --check` passed.
+- **Ledger update:** `JD-PR1-001` updated from `open` to `fixed` only after the passing focused evidence.
+
+
+## Confirmed product decision — PR1 contract remediation
+
+- **Decision applied:** every ticket must reference an existing active compatible service catalog record; omitted `service_catalog_id` is invalid.
+- **Completed implementation:** made `service_catalog_id` required in `TicketFolioCreate`; service validation now rejects missing/inactive/incompatible records; repository matching requires active compatible catalog in the same write transaction before sequence/ticket persistence and relation linking.
+- **Tests added/updated:** omitted service ID rejection, missing catalog rejection with no repository call/persistence, valid compatible service creation, same-transaction active/type match assertion, and stale PR1 consumer fixtures.
+- **Persisted task checkboxes:** Work Units 1–2 remain `[x]`; no later work unit marked complete.
+
+### TDD Cycle Evidence
+
+| Cycle | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|
+| Required catalog create contract | `backend/tests/test_service_management_pr1.py` failed: omitted `service_catalog_id` did not raise (`1 failed, 8 passed`). | `.venv/bin/python -m pytest backend/tests/test_service_management_pr1.py -q` — 9 passed. | Full focused backend suite — 46 passed; query assertions verify active/type match and no optional catalog match. | Updated domain/router/service fixtures and rejected clearing the required catalog reference on update. |
+
+### Verification evidence
+
+- `cd backend && ../.venv/bin/python -m pytest tests/test_service_management_pr1.py -q` — **9 passed**.
+- `cd backend && ../.venv/bin/python -m pytest tests/test_service_management_pr1.py tests/test_itsm_domain_contracts.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py -q` — **46 passed**, 1 deprecation warning.
+- `cd backend && ../.venv/bin/python -m compileall -q models repositories services routers tests/test_service_management_pr1.py` — passed.
+- `git diff --check` — passed.
+
+### Files changed in this continuation
+
+- `backend/models/itsm.py`
+- `backend/services/ticket_folio_service.py`
+- `backend/repositories/ticket_folio_repo.py`
+- `backend/tests/test_service_management_pr1.py`
+- `backend/tests/test_itsm_domain_contracts.py`
+- `backend/tests/test_ticket_folio_service.py`
+- `backend/tests/test_routers_itsm.py`
+- `openspec/changes/service-management-catalog/specs/service-management-catalog/spec.md`
+- `openspec/changes/service-management-catalog/design.md`
+- `openspec/changes/service-management-catalog/tasks.md`
+- `openspec/changes/service-management-catalog/review-ledger.md`
+
+### Scope and remaining work
+
+- Workload / PR boundary remains PR1 backend contract and persistence guard only; no later scope was started.
+- Remaining exact unchecked tasks are unchanged: Work Units 3, 4, 5, 6, 7, 8, and 9 in `tasks.md`.
+- No commit, push, or PR was created.
+- Structured status consumed/produced: `schemaName=spec-driven`, `changeName=service-management-catalog`, `artifactStore=openspec`, `applyState=ready`, `dependencies.apply=ready`, `nextRecommended=verify`, `actionContext.mode=repo-local`, workspace is the isolated PR1 worktree, allowed edit scope is this worktree, warnings none.
+- `skill_resolution=paths-injected` (`work-unit-commits` loaded from the parent-provided path).
+
+## Approved PR1 boundary adjustment — completed
+
+- **Boundary:** PR1 now includes only the minimum catalog backend contract required for independently usable compatible ticket creation: persisted/returned immutable `service_type` (`incident` or `service_request`) and `active` status. No value streams, catalog UI, XLSX import, user locking/lifecycle, or frontend work was added.
+- **Completed implementation tasks and persisted checkboxes:**
+  - [x] PR1 boundary extension — minimum persisted catalog compatibility contract (added to `tasks.md`).
+  - Work Units 1–2 remain [x]. Work Units 3–9 remain unchecked.
+- **Files changed:** `backend/models/itsm.py`, `backend/repositories/itsm_service_catalog_repo.py`, `backend/services/itsm_service_catalog_service.py`, `backend/tests/test_service_management_pr1.py`, `backend/tests/test_itsm_domain_contracts.py`, `backend/tests/test_itsm_service_catalog_service.py`, `backend/tests/test_routers_itsm.py`, `openspec/changes/service-management-catalog/tasks.md`, `openspec/changes/service-management-catalog/design.md`.
+- **Behavior:** catalog create/read/update contracts carry `service_type`; only canonical values validate; update attempts cannot mutate it; catalog `active` is persisted and returned; ticket preflight and same-transaction Neo4j `MATCH` require active compatible persisted catalog data.
+
+### TDD Cycle Evidence
+
+| Boundary task | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|
+| Minimum catalog compatibility contract | Added service/API flow test for catalog creation followed by same-type ticket creation, plus incompatible-type and immutable-type negatives; focused run failed 2 tests before implementation. | Implemented model validation, repository persistence/return fields, immutable update guard, and retained active/type write query; boundary tests passed. | Focused backend suites passed with catalog consumers, ticket service, router contracts, and same-transaction query assertions. | Kept later value-stream, import, locking, and frontend seams untouched; updated existing contract fixtures to canonical service types. |
+
+### Verification evidence
+
+- RED: `cd backend && ../.venv/bin/python3.11 -m pytest tests/test_service_management_pr1.py -q` — **10 passed, 2 failed** before implementation.
+- GREEN/triangulation: `cd backend && ../.venv/bin/python3.11 -m pytest tests/test_service_management_pr1.py tests/test_itsm_domain_contracts.py tests/test_itsm_service_catalog_service.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py -q` — **59 passed**, 1 deprecation warning.
+- No commit, push, or PR was created.
+
+### Structured status consumed/produced
+
+- `schemaName=spec-driven`; `changeName=service-management-catalog`; `artifactStore=openspec`; authoritative workspace is isolated worktree `/Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/service-management-catalog-pr1`; `actionContext.mode=repo-local`; allowed edit root is this worktree; warnings none.
+- `applyState=ready`; `dependencies.apply=ready`; `nextRecommended=verify`.
+- Workload boundary is the approved feature-branch-chain PR1 extension; the overall change remains high-risk and later tasks remain separate PR slices.
+
+## Remaining tasks
+
+- [ ] Work Unit 3 — backend shared active-user locking and logical deactivation.
+- [ ] Work Unit 4 — catalog governance and value streams.
+- [ ] Work Unit 5 — compatibility enforcement in single-ticket flows beyond this minimum contract.
+- [ ] Work Unit 6 — atomic XLSX catalog import stack.
+- [ ] Work Unit 7 — atomic XLSX ticket import.
+- [ ] Work Unit 8 — frontend Service Management UI.
+- [ ] Work Unit 9 — end-to-end compatibility checks and release verification.
+
+## PR1 review remediation — JD-PR1-003
+
+- **Completed:** Catalog updates now accept an unchanged immutable `service_type` alongside mutable fields by removing it before repository mutation. Changed `service_type` values still return the existing controlled HTTP 400 validation error.
+- **Tests added:** Service-layer positive/negative tests and router-level positive/negative tests cover unchanged and changed values.
+- **Files changed:** `backend/services/itsm_service_catalog_service.py`, `backend/tests/test_itsm_service_catalog_service.py`, `backend/tests/test_routers_itsm.py`, `openspec/changes/service-management-catalog/review-ledger.md`, this file.
+
+### TDD Cycle Evidence
+
+| Finding | RED | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|
+| JD-PR1-003 | New service test failed with the uncaught immutable-field rejection for unchanged `service_type`; router test initially exposed missing controlled-error test import. | Implemented unchanged-field stripping; focused service/router tests passed. | Full PR1 focused backend suite passed with changed-type rejection preserved and no repository call for the changed case. | Kept the fix in the service boundary; repository guard remains defensive and later catalog scope is untouched. |
+
+### Verification evidence
+
+- RED: focused service/router tests — 2 failed, 2 passed before implementation/import correction.
+- GREEN: focused service/router tests — **4 passed**, 1 deprecation warning.
+- TRIANGULATE: `cd backend && ../.venv/bin/python -m pytest tests/test_service_management_pr1.py tests/test_itsm_service_catalog_service.py tests/test_itsm_domain_contracts.py tests/test_ticket_folio_service.py tests/test_routers_itsm.py -q` — **63 passed**, 1 deprecation warning.
+- Review ledger `JD-PR1-003` updated from `open` to `fixed` after passing evidence.
+- No commit, push, or PR was created.

--- a/openspec/changes/service-management-catalog/design.md
+++ b/openspec/changes/service-management-catalog/design.md
@@ -17,6 +17,10 @@ This design defines the initial target state for Service Management in a confirm
 | CI bulk reuse | Reuse CI import interaction shape and route ergonomics where useful, but Service Management imports are atomic and never partially successful. |
 | Strict TDD | Implementation must begin with failing tests for every requirement seam before production changes. |
 
+## Approved PR1 boundary adjustment
+
+PR1 includes the minimum catalog backend contract required for an independently usable ticket create flow. The catalog API/repository now persists and returns immutable `service_type` (`incident` or `service_request`) plus `active` status. Ticket selection and the same Neo4j write transaction require an existing active catalog whose persisted `service_type` matches the ticket `type`; incompatible or inactive references create no ticket. This slice does not include value streams, catalog UI, XLSX import, user locking/lifecycle, or frontend changes.
+
 ## Current code anchors
 
 | Concern | Current anchor | Required change |
@@ -44,7 +48,7 @@ Create the Service Management ticket model in the target form:
 | `type` | Required enum: `incident` or `service_request`. |
 | `title` | Required non-empty string. |
 | `description` | Required for imports; single create follows product validation and should reject blank values unless explicitly relaxed. |
-| `service_catalog_id` | Required for catalog-linked workflows; must point to an active compatible service. |
+| `service_catalog_id` | Required for every ticket; must point to an existing active compatible service. |
 | `assignee_username` | Required; exactly one active user. |
 | `assignee_display_name` | Snapshot at assignment time for stable display. |
 | `assignee_active_at_assignment` | `true` at create time. Current active state may be shown as enrichment later. |
@@ -158,7 +162,7 @@ Validation:
 - If request body contains `ticket_id`, return `400` or `422` with a deterministic field error and create nothing.
 - `type` must be `incident` or `service_request`.
 - `assignee_username` is required and must resolve to exactly one active user.
-- `service_catalog_id` must resolve to an active service with matching `service_type`.
+- `service_catalog_id` is required and must resolve to an existing active service with matching `service_type`.
 - Preflight validation may provide early feedback, but is not authoritative for persistence.
 - The ticket write transaction must re-read the catalog service, confirm that it is active and type-compatible, then create the ticket, store assignment snapshot fields, and link the selected catalog service. PostgreSQL user state cannot be re-read in that Neo4j transaction.
 - Active-assignee revalidation uses the cross-store serialization protocol below. It is authoritative at persistence time; preflight is not.

--- a/openspec/changes/service-management-catalog/review-ledger.md
+++ b/openspec/changes/service-management-catalog/review-ledger.md
@@ -1,24 +1,13 @@
-# Judgment Day Review Ledger
-
-## Superseded migration findings
-
-| id | lens | severity | status | evidence |
-|---|---|---|---|---|
-| JD-001 (prior) | judgment-day | CRITICAL | wont-fix | Superseded by the confirmed clean-slate scope: no historical catalog migration is required. |
-| JD-003 (prior) | judgment-day | CRITICAL | wont-fix | Superseded by the confirmed clean-slate scope: no mixed legacy ticket-ID migration is required. |
-| JD-002 (prior) | judgment-day | WARNING | info | The clean-slate design now makes service type immutable. |
-| JD-004 (prior) | judgment-day | WARNING | info | The clean-slate design now requires unique normalized name within a service type. |
-
-## Clean-slate design review
+# Judgment Day Review Ledger — PR1
 
 | id | lens | location | severity | status | evidence |
 |---|---|---|---|---|---|
-| JD-005 | judgment-day | `openspec/changes/service-management-catalog/design.md:159-181,311-313,323-329,418-444` | CRITICAL | verified | Both scoped re-judges verified shared PostgreSQL per-user locking across ticket creation/import and deactivation, held through the Neo4j commit with ordering, timeout/retry, and interleaving acceptance tests. |
-| JD-006 | judgment-day | `openspec/changes/service-management-catalog/design.md:228-252,397-401` | CRITICAL | verified | Both scoped re-judges verified the external `SLA` workbook header maps deterministically to internal `sla_target_minutes`, with template/parser/rejection coverage. |
+| JD-PR1-001 | judgment-day | `backend/models/itsm.py`, `backend/services/ticket_folio_service.py`, `backend/repositories/ticket_folio_repo.py` | CRITICAL | verified | Required existing compatible catalog matching occurs before ticket/sequence mutation; client IDs remain forbidden. |
+| JD-PR1-002 | judgment-day | `backend/models/itsm.py`, `backend/routers/ticket_folios.py` | CRITICAL | verified | Numeric ticket IDs and canonical ticket types are enforced across API contracts. |
+| JD-PR1-003 | judgment-day | `backend/services/itsm_service_catalog_service.py:96-115` | CRITICAL | verified | Both scoped re-judges verified unchanged `service_type` is stripped before mutable update, while changed type returns controlled HTTP 400; regression tests cover both paths. |
 
 ## Verdict
 
-- Verified CRITICAL findings: 2
+- Verified CRITICAL findings: 3
 - Open CRITICAL findings: 0
-- Informational warnings: 2
 - **JUDGMENT: APPROVED**

--- a/openspec/changes/service-management-catalog/specs/service-management-catalog/spec.md
+++ b/openspec/changes/service-management-catalog/specs/service-management-catalog/spec.md
@@ -70,7 +70,7 @@ The service catalog SHALL require and persist each record with:
 
 ### Requirement: Ticket and catalog compatibility SHALL be enforced in both UI and backend
 
-The system SHALL ensure that ticket workflows only allow catalog services with matching `service_type` at both UI interaction time and backend validation time.
+Every ticket SHALL reference an existing active service catalog record. Ticket workflows SHALL only allow catalog services with matching `service_type` at both UI interaction time and backend validation time.
 
 #### Scenario: Backend rejects incompatible service mapping
 

--- a/openspec/changes/service-management-catalog/tasks.md
+++ b/openspec/changes/service-management-catalog/tasks.md
@@ -26,6 +26,8 @@ Chain strategy: feature-branch-chain (tracker; child PRs merge sequentially to t
 - Excel catalog header for SLA must be `SLA` (external workbook), mapped to internal `sla_target_minutes`.
 - Ticket template must include service reference worksheets.
 - Maintain backend/frontend contract compatibility for shared types/endpoints.
+- **Approved PR1 boundary adjustment:** include only the catalog backend `service_type`/`active` contract needed for independently usable required compatible-ticket creation. Exclude value streams, catalog UI, XLSX, user locking/lifecycle, and frontend work.
+    - Every ticket create contract requires `service_catalog_id`; the referenced catalog must exist, be active, and match the ticket type.
 
 ## Strict TDD loop (per work unit)
 **RED -> GREEN -> TRIANGULATE -> REFACTOR**
@@ -44,7 +46,7 @@ Chain strategy: feature-branch-chain (tracker; child PRs merge sequentially to t
 - **REQ-07**: Ticket import is atomic, template-based, reference-driven, compatibility- and assignee-safe.
 - **REQ-08**: Strict TDD evidence for all requirements.
 
-## Work Unit 1 — backend: ticket domain contracts and clean-slate identity model (foundational)
+## [x] Work Unit 1 — backend: ticket domain contracts and clean-slate identity model (foundational)
 Dependencies: proposal, design, spec complete.
 
 - **Target areas**: `backend/models/itsm.py`, `backend/tests/test_itsm_domain_contracts.py`
@@ -65,7 +67,7 @@ Dependencies: proposal, design, spec complete.
 - **REFACTOR evidence**:
   - Normalize naming and validation messages to keep API error shapes deterministic across tests and UI clients.
 
-## Work Unit 2 — backend: sequence allocator + single-ticket create persistence with shared lock semantics
+## [x] Work Unit 2 — backend: sequence allocator + single-ticket create persistence with shared lock semantics
 Dependencies: Work Unit 1 complete.
 
 - **Target areas**:
@@ -91,6 +93,14 @@ Dependencies: Work Unit 1 complete.
   - Validate transaction boundary: sequence increment and ticket create are atomic and rollback-safe.
 - **REFACTOR evidence**:
   - Extract allocation + mapping helpers for easier lock/transaction testing.
+
+## [x] PR1 boundary extension — minimum persisted catalog compatibility contract
+Dependencies: Work Units 1–2 complete.
+
+- **Completed scope:** `ServiceCatalogCreate`/update validation accepts only immutable `service_type` values (`incident`, `service_request`); repository create/read/update responses persist and return `service_type` and `active`; ticket preflight and same-transaction Neo4j write require active type compatibility.
+- **RED/GREEN evidence:** integration/service coverage creates a catalog through the supported catalog service, creates a same-type ticket, rejects an incompatible persisted type, and rejects service-type mutation; focused backend suite passes.
+- **Explicit exclusions:** value streams, catalog UI, XLSX import, user locking/lifecycle, and frontend work remain later work units.
+- **Acceptance linkage:** REQ-02 and REQ-03 (minimum backend contract only).
 
 ## Work Unit 3 — backend: shared active-user locking + logical deactivation contract
 Dependencies: Work Unit 2 complete.


### PR DESCRIPTION
Closes #401

## Summary
- Generates numeric ticket IDs server-side and rejects client-provided IDs.
- Requires active, compatible catalog services in the same ticket write transaction.
- Adds the minimal typed catalog backend contract required for this independent slice.

## Chain context
Tracker: #403

```text
main <- #403 tracker <- 📍 this PR (PR1)
```

## Review size
`size:exception` — 477 changed lines. Tests and contract updates stay with the behavior they verify.

## Test plan
- [x] Strict TDD RED/GREEN/TRIANGULATE evidence recorded.
- [x] 63 focused backend tests passed with local Python 3.11 `.venv`.
- [x] `git diff --check` and compileall passed.
- [x] Judgment Day approved.