### PR TITLE
fix(ci): pin published Black version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,7 +143,7 @@ jobs:
           python-version: "3.11"
       - name: Install ruff and black
         if: steps.changed.outputs.any_changed == 'true'
-        run: pip install --quiet ruff==0.15.18 black==26.5.1
+        run: pip install --quiet ruff==0.15.18 black==25.11.0
       - name: Run Ruff
         if: steps.changed.outputs.any_changed == 'true'
         working-directory: backend
@@ -268,7 +268,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install yamllint + ruff + black
-        run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==26.5.1
+        run: pip install --quiet yamllint==1.38.0 ruff==0.15.18 black==25.11.0
       - name: yamllint must pass
         run: yamllint -c .yamllint.yml .github/
       - name: ruff must parse config


### PR DESCRIPTION
## Descripción del Cambio

Closes #399

- Reemplaza `black==26.5.1`, que no está publicado en PyPI, por `black==25.11.0`.
- Mantiene la validación Black reproducible tanto en CI como en el entorno local aislado.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [x] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?

- [x] Revisión de riesgo sin hallazgos.
- [x] El cambio se limita a dos pins del workflow.
- [x] `git diff --check`.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
