### PR TITLE
chore(release): prepare v1.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.2] — 2026-07-11
+
+### Fixed
+
+- **Availability MTBF now measures completed operating intervals** (PR #402, closes #400): MTBF is calculated from an incident recovery to the next failure, and each outage cycle retains its own immutable event record.
+- **Event-service lint is reproducible** (PRs #406 and #409, closes #399): clears the inherited Ruff baseline and pins CI Black to the published `25.11.0` version.
+
 ## [1.14.0] — 2026-07-10
 
 ### Added


### PR DESCRIPTION
## Descripción del Cambio

Closes #410

- Registra v1.14.2 en el changelog.
- Documenta la corrección de MTBF y la remediación del lint reproducible.

## Tipo de Cambio
- [ ] Feat (Nueva funcionalidad)
- [ ] Fix (Reparación de error)
- [ ] Docs (Documentación)
- [ ] Performance (Optimización)

## ¿Cómo se probó?

- [x] `git diff --check`.
- [x] Verificación de que `v1.14.1` ya existe y no contiene #402.
- [x] Los checks de #409 que corrigen el lint están verdes.

## Checklist de Seguridad
- [x] He verificado que NO hay secretos ni llaves API en el código.
- [x] Los cambios respetan el `.gitignore`.
- [x] El código sigue la estructura de carpetas definida.
