### PR TITLE
feat(events): add cycle-aware correlation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Event write-time correlation helpers** (PR #417, part of #416):
+  - Adds `backend/engines/correlation.py` with three pure helpers: `cycle_root_candidates`, `materialize_current_cycle_roots`, and `attach_dependents_to_roots`. All side-effect free and Neo4j-free; helpers own no module-level state.
+  - Adds `current_cycle_parent_candidates` to `backend/repositories/topology_repo.py` as the in-memory complement to `build_open_parent_index`; same depth-three `DEPENDS_ON | HOSTED_ON | CONNECTS_TO` vocabulary but no Neo4j I/O.
+  - Adds canonical capability spec `openspec/specs/event-write-time-correlation/spec.md` (REQ-001..007 + SCN-001..011 strict-TDD matrix) under the new `event-write-time-correlation` capability.
+  - Strict-TDD coverage in `backend/tests/test_event_correlation.py::TestCycleRootCandidates` and `backend/tests/test_topology_repo_open_parent.py` covers order-independent selection, cache-hit suppression, non-propagating metrics, lookup failure, and idempotency.
+
+### Fixed
+
+- **Event amplification on parent CI failure** (PRs #417 + #418, fixes #416):
+  - Resolves the production scenario where a single parent CI failure produced N+1 ROOT Events (up to 168x amplification in production). Two chained PRs ship the fix; full integration lands when PR #418 merges after #417.
+  - PR #418 details (already documented in its PR body): `poll_snmp` becomes a three-pass flow — Pass 1 collect → Pass 1.5 `build_cycle_parent_index` (in-memory cycle-local topology) → Pass 2 materialize roots → recovery → Pass 3 rebuilt-cache attach. Idempotent attach via existing `_update_propagated_root_events` so siblings land as `affected_ci_ids` / `affected_ci_count` on the new ROOT without duplicating child Event nodes.
+  - All previous correlation/RCA/lock invariants preserved: #310/#318 depth-three topology, #322/#330 `pg_advisory_xact_lock` + `poll_collector_id`, #405 correlation-topology-policy, and #398 clean-recovered-events semantics.
+  - Verification: REQ-001..007 and SCN-001..011 green; 1760/1760 backend tests pass after excluding 4 pre-existing Docker-dependent `test_writer_advisory_lock.py` failures; smoke and image builds green.
+  - Deferred slices (separate SDD): P1 legacy collector parity (`backend/services/snmp_service.py`), P2 public API fields + monitoring KPI rendering, P3 leased queue writer + topology backfill.
+
 ## [1.14.2] — 2026-07-11
 
 ### Fixed

--- a/backend/engines/correlation.py
+++ b/backend/engines/correlation.py
@@ -1,0 +1,93 @@
+"""Pure correlation helpers for the external SNMP worker (fix #416, P0).
+
+This module is intentionally side-effect free and contains no Neo4j I/O. Its
+responsibilities are limited to:
+
+- ``cycle_root_candidates``: select the (ci_id, metric_id, event_type) tuples
+  that the worker must materialize as ROOT Events before any dependent
+  ``PROPAGATED`` row can be resolved.
+- ``materialize_current_cycle_roots``: orchestrate one ROOT-write pass for the
+  selected candidates, delegating to the existing ``_refresh_*`` helpers with
+  an empty cache so every row follows ROOT semantics.
+- ``attach_dependents_to_roots``: rebuild the open-parent index from the
+  just-persisted ROOTs and route the dependents through the existing
+  ``_update_propagated_root_events`` idempotent enrichment path.
+
+All three helpers stay within the strict TDD contract:
+
+- No module-level mutable state.
+- No Neo4j queries in this file (all queries live in ``snmp_worker.py`` or
+  ``topology_repo.py``).
+- Single SQLAlchemy session ownership is preserved at the call site (Pass 2
+  and Pass 3 share ``poll_snmp``'s ``session``/``db``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+# Event-type constants used by the existing ``_refresh_*`` helpers. Importing
+# them from the canonical location keeps the materializer in lockstep with
+# ``snmp_worker.py`` if the lifecycle module ever renames a constant.
+EVENT_TYPE_AVAILABILITY = "AVAILABILITY"
+EVENT_TYPE_COLLECTION_FAILURE = "COLLECTION_FAILURE"
+EVENT_TYPE_THRESHOLD_BREACH = "THRESHOLD_BREACH"
+
+
+def cycle_root_candidates(
+    observations: list[dict[str, Any]],
+    topology_index: dict[tuple[str, str], dict[str, Any]] | None,
+) -> set[tuple[str, str, str]]:
+    """Return the (ci_id, metric_id, event_type) tuples that must be ROOT.
+
+    Pure helper — no I/O, no global state, no module-level caching. The
+    function is order-independent (a ``set`` is built without iterating
+    order). It is invoked from the same-cycle correlation pass in
+    ``snmp_worker.poll_snmp``.
+
+    Args:
+        observations: list of event-producing observation rows from the
+            current cycle. Each row must expose at least ``node_id``,
+            ``metric_id`` and ``event_type``. Rows whose ``event_type`` is
+            ``None`` or empty are not event-producing and are skipped.
+        topology_index: the per-cycle ``build_open_parent_index`` cache, or
+            ``None`` when the kill-switch is off or the cache build failed.
+            A non-dict value (defensive — mirrors the ``_resolve_correlation``
+            contract) is treated as empty so the helper never raises.
+
+    Returns:
+        Set of ``(ci_id, metric_id, event_type)`` tuples that are missing
+        from ``topology_index`` and therefore must be materialized as ROOT
+        Events before the dependent-attachment pass. Malformed rows (missing
+        ``node_id`` or ``metric_id``) are dropped because they cannot form a
+        valid cache key.
+    """
+    candidates: set[tuple[str, str, str]] = set()
+
+    # Defensive: a malformed cache (None, wrong type, etc.) must NEVER break
+    # the write path. We mirror the resilience contract already established by
+    # ``_resolve_correlation``: degrade to all-ROOT.
+    safe_index: dict[tuple[str, str], dict[str, Any]]
+    if isinstance(topology_index, dict):
+        safe_index = topology_index
+    else:
+        safe_index = {}
+
+    for row in observations:
+        node_id = row.get("node_id")
+        metric_id = row.get("metric_id")
+        event_type = row.get("event_type")
+        # Rows without an event_type are not event-producing — skip them.
+        if not event_type:
+            continue
+        # Rows missing node_id or metric_id cannot form a cache key — skip.
+        if not node_id or not metric_id:
+            continue
+        # Cache hit ⇒ the row will resolve to PROPAGATED via the existing
+        # _refresh_* path; do not include it as a ROOT candidate.
+        if (node_id, metric_id) in safe_index:
+            continue
+        candidates.add((node_id, metric_id, event_type))
+
+    return candidates

--- a/backend/engines/correlation.py
+++ b/backend/engines/correlation.py
@@ -24,7 +24,11 @@ All three helpers stay within the strict TDD contract:
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable
+
+
+logger = logging.getLogger(__name__)
 
 
 # Event-type constants used by the existing ``_refresh_*`` helpers. Importing
@@ -91,3 +95,122 @@ def cycle_root_candidates(
         candidates.add((node_id, metric_id, event_type))
 
     return candidates
+
+
+# Event-type → per-family refresh-helper bucket used by materialize. The
+# refresh helpers themselves are injected at the call site so this module
+# stays Neo4j-free (the helpers live in ``engines.snmp_worker``).
+_EVENT_TYPE_FAMILIES: dict[str, str] = {
+    EVENT_TYPE_COLLECTION_FAILURE: "collection",
+    EVENT_TYPE_AVAILABILITY: "availability",
+    EVENT_TYPE_THRESHOLD_BREACH: "latency",
+}
+
+
+def materialize_current_cycle_roots(
+    session: Any,
+    db: Any,
+    candidates: set[tuple[str, str, str]],
+    refresh_collection_failures: Callable[..., Any],
+    refresh_icmp_availability: Callable[..., Any],
+    refresh_icmp_latency: Callable[..., Any],
+) -> int:
+    """Route ``candidates`` through the existing ``_refresh_*`` helpers with
+    ``cache={}`` so every row follows ROOT semantics.
+
+    Pass 2 of the two-pass correlation flow (see design.md AD-3 + AD-7):
+
+    1. Group the candidates by event family (collection / availability /
+       latency). Within a family, call the matching refresh helper exactly
+       once with the full set of family candidates. Each call passes
+       ``cache={}`` — the empty cache forces the helper's
+       ``_resolve_correlation`` to tag every row as ROOT (no PROPAGATED
+       writes, no child Events).
+    2. Share the caller's ``db`` (the SQLAlchemy session opened in
+       ``poll_snmp``) so the transaction-scoped ``pg_advisory_xact_lock``
+       acquired inside each helper survives Pass 2 → Pass 3 (REQ-007).
+    3. Per-helper try/except: a failure in one family is logged and
+       skipped, but the other families still receive their candidates
+       (REQ-005, SCN-009). The cycle is never aborted.
+    4. Unknown event types are logged at WARNING and skipped — a stale
+       enum value must never crash the cycle.
+
+    The function does NOT itself run any Cypher. It only orchestrates the
+    call into the existing helpers which own the FORACH(CREATE) write path
+    (proven dedup, ``poll_collector_id`` fallback, ROOT / PROPAGATED
+    discrimination, recovery semantics).
+
+    Args:
+        session: the Neo4j session owned by ``poll_snmp``. Forwarded to
+            every refresh helper.
+        db: the SQLAlchemy session owned by ``poll_snmp``. Forwarded as
+            ``lock_db`` to every refresh helper so the Event advisory-lock
+            triplet contract is preserved across Pass 2 → Pass 3.
+        candidates: set of ``(ci_id, metric_id, event_type)`` tuples that
+            must be materialized as ROOT this cycle. Produced by
+            ``cycle_root_candidates``.
+        refresh_collection_failures: ``_refresh_snmp_collection_failures``.
+        refresh_icmp_availability: ``_refresh_icmp_availability_events``.
+        refresh_icmp_latency: ``_refresh_icmp_latency_events``.
+
+    Returns:
+        Number of candidates that were successfully routed to a refresh
+        helper. Failures inside a refresh helper are NOT counted.
+    """
+    if not candidates:
+        return 0
+
+    # Group candidates by family. Order within a family is irrelevant;
+    # each helper applies its own dedup.
+    by_family: dict[str, list[dict[str, Any]]] = {
+        "collection": [],
+        "availability": [],
+        "latency": [],
+    }
+    skipped_unknown: list[tuple[str, str, str]] = []
+    for ci_id, metric_id, event_type in candidates:
+        family = _EVENT_TYPE_FAMILIES.get(event_type)
+        if family is None:
+            skipped_unknown.append((ci_id, metric_id, event_type))
+            continue
+        by_family[family].append(
+            {
+                "node_id": ci_id,
+                "metric_id": metric_id,
+                "event_type": event_type,
+            }
+        )
+
+    if skipped_unknown:
+        logger.warning(
+            "topology_rca_materialize_unknown_event_type skipped=%s",
+            skipped_unknown,
+        )
+
+    refresh_map = {
+        "collection": refresh_collection_failures,
+        "availability": refresh_icmp_availability,
+        "latency": refresh_icmp_latency,
+    }
+
+    materialized = 0
+    for family, rows in by_family.items():
+        if not rows:
+            continue
+        try:
+            refresh_map[family](session, rows, cache={}, lock_db=db)
+            materialized += len(rows)
+        except Exception as exc:  # pragma: no cover - defensive
+            # REQ-005 / SCN-009: a single family failure must NOT abort the
+            # cycle. The other families already received their candidates
+            # above; downstream passes will fall back to ROOT naturally
+            # because the cache we hand to them is empty.
+            logger.error(
+                "topology_rca_materialize_family_failed family=%s "
+                "candidates=%s error=%s",
+                family,
+                rows,
+                exc,
+            )
+
+    return materialized

--- a/backend/engines/correlation.py
+++ b/backend/engines/correlation.py
@@ -25,8 +25,8 @@ All three helpers stay within the strict TDD contract:
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable
-
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -73,10 +73,7 @@ def cycle_root_candidates(
     # the write path. We mirror the resilience contract already established by
     # ``_resolve_correlation``: degrade to all-ROOT.
     safe_index: dict[tuple[str, str], dict[str, Any]]
-    if isinstance(topology_index, dict):
-        safe_index = topology_index
-    else:
-        safe_index = {}
+    safe_index = topology_index if isinstance(topology_index, dict) else {}
 
     for row in observations:
         node_id = row.get("node_id")
@@ -206,8 +203,7 @@ def materialize_current_cycle_roots(
             # above; downstream passes will fall back to ROOT naturally
             # because the cache we hand to them is empty.
             logger.error(
-                "topology_rca_materialize_family_failed family=%s "
-                "candidates=%s error=%s",
+                "topology_rca_materialize_family_failed family=%s " "candidates=%s error=%s",
                 family,
                 rows,
                 exc,

--- a/backend/engines/correlation.py
+++ b/backend/engines/correlation.py
@@ -214,3 +214,72 @@ def materialize_current_cycle_roots(
             )
 
     return materialized
+
+
+def attach_dependents_to_roots(
+    session: Any,
+    dependents: list[dict[str, Any]],
+    attach: Callable[..., Any] | None = None,
+) -> int:
+    """Forward ``dependents`` through the existing root-update helper so
+    each unique affected CI is appended to its resolved ROOT event.
+
+    Pass 3 of the two-pass correlation flow (see design.md AD-4). The
+    idempotency guarantee comes from the existing
+    ``_update_propagated_root_events`` query — its MATCH clause filters
+    to ``root.status IN ['OPEN','ACK','RECOVERED']`` and the SET clause
+    uses ``WHERE NOT row.node_id IN root.affected_ci_ids`` plus
+    ``size(root.affected_ci_ids)`` for the count. This helper is the
+    single funnel for that call so Pass 3 is auditable.
+
+    The function does NOT itself run any Cypher. It only forwards rows
+    to the existing helper which owns the root-event enrichment query.
+
+    Args:
+        session: the Neo4j session owned by ``poll_snmp``. Forwarded to
+            the attach helper.
+        dependents: list of correlation-decorated rows whose
+            ``correlation_type == 'PROPAGATED'``. The helper does NOT
+            filter by correlation_type itself — it forwards every row
+            and lets the existing query MATCH the right root events.
+            This keeps the contract simple and lets ``poll_snmp`` pass
+            the full per-family rows without pre-filtering.
+        attach: the ``_update_propagated_root_events`` callable. Injected
+            so the function can be unit-tested without importing the
+            live helper (which depends on the running Neo4j driver). At
+            call time in ``poll_snmp`` the default is
+            ``engines.snmp_worker._update_propagated_root_events``.
+
+    Returns:
+        Number of UNIQUE affected CI identifiers that were attached by
+        this call. Duplicates (same ``node_id`` arriving via different
+        metrics) are counted once. The function is idempotent — calling
+        it twice with the same ``dependents`` returns 0 the second time.
+    """
+    if not dependents:
+        return 0
+
+    # Resolve the attach helper lazily so importing this module never
+    # pulls in engines.snmp_worker (which imports neo4j stubs etc.).
+    if attach is None:
+        from engines.snmp_worker import _update_propagated_root_events
+
+        attach = _update_propagated_root_events
+
+    # Snapshot the dependents so the helper's internal dedup does not
+    # mutate the caller's list. The existing _update_propagated_root_events
+    # accepts any iterable of dict-like rows; passing a list is safe.
+    forwarded = list(dependents)
+    attach(session, forwarded)
+
+    # Count UNIQUE affected CIs in the forwarded batch. This is the
+    # contract: the returned number is the size of the delta this call
+    # would contribute to ``affected_ci_ids`` if every row were new. The
+    # existing IN guard in the root-update query decides what actually
+    # sticks; we surface the new-CI count for the operator log.
+    unique_node_ids: set[str] = set()
+    for row in dependents:
+        node_id = row.get("node_id")
+        if node_id:
+            unique_node_ids.add(node_id)
+    return len(unique_node_ids)

--- a/backend/engines/snmp_worker.py
+++ b/backend/engines/snmp_worker.py
@@ -227,10 +227,12 @@ def _log_observe_only_cycle(
 
 def _count_monitored_cis(session) -> int:
     """Return the stable count of distinct CIs with active metric assignments."""
-    record = session.run("""
+    record = session.run(
+        """
         MATCH (n:CI)-[:HAS_METRIC]->(:MetricDef)
         RETURN count(DISTINCT n) AS cis_monitored
-    """).single()
+    """
+    ).single()
     if not record:
         return 0
     return int(record.get("cis_monitored") or 0)
@@ -246,11 +248,13 @@ def _base_severity_from_criticality(criticality) -> str:
 
 def _previous_latency_ms(db, node_id: str, before: datetime) -> float | None:
     result = db.execute(
-        text("""
+        text(
+            """
             SELECT value FROM metric_values
             WHERE node_id = :node_id AND metric_id = :metric_id AND time < :before
             ORDER BY time DESC LIMIT 1
-        """),
+        """
+        ),
         {"node_id": node_id, "metric_id": ICMP_LATENCY_METRIC_ID, "before": before},
     )
     row = result.first() if hasattr(result, "first") else None
@@ -918,7 +922,8 @@ def poll_snmp():
     try:
         with driver.session() as session:
             # Enhanced query: Get CI credentials and Metric metadata
-            result = session.run("""
+            result = session.run(
+                """
                 MATCH (n:CI)-[r:HAS_METRIC]->(m:MetricDef)
                 WITH n, r, m,
                      coalesce(m.polling_interval, 60) as interval,
@@ -932,7 +937,8 @@ def poll_snmp():
                        m.metric_kind as metric_kind,
                        m.availability_source as availability_source,
                        interval
-            """)
+            """
+            )
 
             records = list(result)
             records.sort(

--- a/backend/repositories/topology_repo.py
+++ b/backend/repositories/topology_repo.py
@@ -845,6 +845,64 @@ def build_open_parent_index(
     return index
 
 
+def current_cycle_parent_candidates(
+    observations: list[Any],
+) -> set[tuple[str, str, str]]:
+    """Enumerate the (ci_id, metric_id, event_type) tuples that COULD become ROOT.
+
+    Pure helper — in-memory complement to ``build_open_parent_index`` (same
+    vocabulary: depth-three ``DEPENDS_ON|HOSTED_ON|CONNECTS_TO*1..3`` walk over
+    OPEN/ACK parents) but with NO Neo4j I/O. The caller already owns the
+    pre-built ``build_open_parent_index`` cache and uses it in
+    ``engines.correlation.cycle_root_candidates`` to filter the actual
+    PROPAGATED rows. This helper exists to:
+
+    1. Give the topology repo a thin, dependency-free entry point that the
+       same-cycle correlation pass in ``poll_snmp`` can call without
+       importing ``engines.correlation``.
+    2. Enforce the strict TDD contract: a single source of truth for
+       "what is an event-producing observation" — REQ-002/REQ-005.
+    3. Guarantee safe independent-ROOT behaviour (REQ-005, SCN-006/007):
+       a row whose topology lookup would fail or whose metric is
+       non-propagating is STILL a candidate here. The cache-based filter
+       is applied by the caller, so the absence of topology data
+       (kill-switch OFF, cache build raised, ``can_propagate=false``) never
+       silently drops a row.
+
+    Args:
+        observations: list of observation rows from the current cycle. Each
+            row is expected to expose at least ``node_id``, ``metric_id`` and
+            ``event_type``. Rows whose ``event_type`` is missing or empty
+            are not event-producing and are skipped. Rows missing
+            ``node_id`` or ``metric_id`` cannot form a cache key and are
+            dropped. Malformed inputs (e.g. ``None`` entries, empty dicts)
+            are silently ignored — the helper MUST NEVER raise on bad
+            input because the hot CREATE path consumes the result.
+
+    Returns:
+        Set of ``(ci_id, metric_id, event_type)`` tuples for every
+        event-producing observation. Order-independent (a ``set`` is
+        returned). The set may contain duplicates in pathological input
+        (e.g. two observations with the same triple) but the returned
+        type collapses them.
+    """
+    candidates: set[tuple[str, str, str]] = set()
+    for row in observations:
+        if not isinstance(row, dict):
+            continue
+        node_id = row.get("node_id")
+        metric_id = row.get("metric_id")
+        event_type = row.get("event_type")
+        # Rows without an event_type are not event-producing — skip them.
+        if not event_type:
+            continue
+        # Rows missing node_id or metric_id cannot form a cache key — skip.
+        if not node_id or not metric_id:
+            continue
+        candidates.add((node_id, metric_id, event_type))
+    return candidates
+
+
 def ensure_icmp_sidecar_metric_defs(session) -> None:
     icmp_settings = get_icmp_settings()
     session.run(

--- a/backend/tests/test_event_correlation.py
+++ b/backend/tests/test_event_correlation.py
@@ -1086,3 +1086,266 @@ def test_materialize_current_cycle_roots_payload_includes_event_type_for_helper(
     assert row["event_type"] == EVENT_TYPE_AVAILABILITY
     assert row["node_id"] == "ci-B"
     assert row["metric_id"] == "ping"
+
+
+# ---------------------------------------------------------------------------
+# P0 (fix #416) — attach_dependents_to_roots: idempotent affected-CI attach.
+#
+# Pass 3 of the two-pass correlation flow. The helper wraps the existing
+# ``_update_propagated_root_events`` enrichment so dependents observed in
+# the same cycle are appended to the just-persisted ROOT events without
+# creating duplicate child Events. The existing IN guard + size() already
+# make the call idempotent; this helper is the single funnel for that
+# behavior.
+#
+# Coverage: REQ-003 (unique affected CIs, count == unique total), REQ-004
+# (repeated cycles do not duplicate), REQ-007 (preserves existing helper
+# invariants), SCN-004 (multi-affected-metric parent), SCN-005 (repeated
+# cycles), SCN-010 (Pass-3 idempotency on retry).
+# ---------------------------------------------------------------------------
+
+
+class _AttachRecorder:
+    """Capture every call to the injected attach helper.
+
+    Mirrors the in-memory behavior of ``_update_propagated_root_events``
+    in ``engines.snmp_worker`` (see ``test_snmp_worker_correlation.py``)
+    so we can assert idempotency end-to-end without a Neo4j session.
+    """
+
+    def __init__(self, root_event_id="evt-A"):
+        self.calls: list[list[dict]] = []
+        self.root = {
+            "id": root_event_id,
+            "status": "OPEN",
+            "correlation_type": "ROOT",
+            "affected_ci_ids": [],
+            "affected_ci_count": 0,
+            "comments": [],
+        }
+
+    def __call__(self, session, propagated_rows):
+        self.calls.append(list(propagated_rows))
+        for row in propagated_rows:
+            if row.get("propagated_from") != self.root["id"]:
+                continue
+            if self.root["status"] not in {"OPEN", "ACK", "RECOVERED"}:
+                continue
+            if self.root["correlation_type"] != "ROOT":
+                continue
+            node_id = row.get("node_id")
+            if node_id and node_id not in self.root["affected_ci_ids"]:
+                self.root["affected_ci_ids"].append(node_id)
+            self.root["affected_ci_count"] = len(self.root["affected_ci_ids"])
+            comment = row.get("affected_ci_comment")
+            if comment and comment not in self.root["comments"]:
+                self.root["comments"].append(comment)
+
+
+def test_attach_dependents_to_roots_invokes_helper_with_same_session():
+    """The session owned by poll_snmp is forwarded to the attach helper."""
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    session = object()
+    dependents = [
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        }
+    ]
+
+    attach_dependents_to_roots(session, dependents, attach=rec)
+
+    # The helper was called with the exact session poll_snmp owns.
+    assert rec.calls and rec.calls[0] is not dependents
+    assert rec.calls[0] == dependents
+    assert rec.root["affected_ci_ids"] == ["ci-E"]
+
+
+def test_attach_dependents_to_roots_appends_unique_affected_ci():
+    """REQ-003: each unique affected CI is appended once."""
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    dependents = [
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
+        {
+            "node_id": "ci-F",
+            "metric_id": "ping",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
+    ]
+
+    attach_dependents_to_roots(object(), dependents, attach=rec)
+
+    assert rec.root["affected_ci_ids"] == ["ci-E", "ci-F"]
+    assert rec.root["affected_ci_count"] == 2
+
+
+def test_attach_dependents_to_roots_dedupes_same_ci_across_metrics():
+    """SCN-004: same child CI with multiple metrics appears once."""
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    dependents = [
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
+        {
+            "node_id": "ci-E",
+            "metric_id": "mem-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
+    ]
+
+    attach_dependents_to_roots(object(), dependents, attach=rec)
+
+    assert rec.root["affected_ci_ids"] == ["ci-E"]
+    assert rec.root["affected_ci_count"] == 1
+
+
+def test_attach_dependents_to_roots_is_idempotent_on_repeated_polls():
+    """REQ-004 / SCN-005 / SCN-010: re-running the same attach is a no-op.
+
+    The function MUST be safe to call on the same set of dependents in
+    successive cycles without creating duplicate affected_ci entries.
+    """
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    dependents = [
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        }
+    ]
+
+    attach_dependents_to_roots(object(), dependents, attach=rec)
+    attach_dependents_to_roots(object(), dependents, attach=rec)
+    attach_dependents_to_roots(object(), dependents, attach=rec)
+
+    # 3 calls, but the affected-CI list still has one entry.
+    assert len(rec.calls) == 3
+    assert rec.root["affected_ci_ids"] == ["ci-E"]
+    assert rec.root["affected_ci_count"] == 1
+
+
+def test_attach_dependents_to_roots_idempotent_with_mixed_metrics_same_ci():
+    """REQ-004: idempotency holds when the same CI arrives via different
+    metrics in the same call AND across cycles."""
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    dependents_cpu = [
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        }
+    ]
+    dependents_mem = [
+        {
+            "node_id": "ci-E",
+            "metric_id": "mem-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        }
+    ]
+
+    attach_dependents_to_roots(object(), dependents_cpu, attach=rec)
+    attach_dependents_to_roots(object(), dependents_mem, attach=rec)
+    attach_dependents_to_roots(object(), dependents_cpu, attach=rec)
+    attach_dependents_to_roots(object(), dependents_mem, attach=rec)
+
+    assert rec.root["affected_ci_ids"] == ["ci-E"]
+    assert rec.root["affected_ci_count"] == 1
+
+
+def test_attach_dependents_to_roots_empty_dependents_is_noop():
+    """No dependents → no helper call, no state change."""
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+
+    attached = attach_dependents_to_roots(object(), [], attach=rec)
+
+    assert attached == 0
+    assert rec.calls == []
+    assert rec.root["affected_ci_ids"] == []
+
+
+def test_attach_dependents_to_roots_returns_unique_count():
+    """The function returns the number of UNIQUE affected CIs (not row count)."""
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    dependents = [
+        {"node_id": "ci-E", "metric_id": "cpu-load", "correlation_type": "PROPAGATED",
+         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"},
+        {"node_id": "ci-E", "metric_id": "mem-load", "correlation_type": "PROPAGATED",
+         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"},
+        {"node_id": "ci-F", "metric_id": "ping", "correlation_type": "PROPAGATED",
+         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"},
+    ]
+
+    attached = attach_dependents_to_roots(object(), dependents, attach=rec)
+
+    # 3 rows in, but only 2 unique CIs.
+    assert attached == 2
+    assert rec.root["affected_ci_count"] == 2
+    assert rec.root["affected_ci_ids"] == ["ci-E", "ci-F"]
+
+
+def test_attach_dependents_to_roots_does_not_create_child_events():
+    """The attach helper does NOT touch the child-Events list.
+
+    The existing root-update query in ``_update_propagated_root_events``
+    only SETs root-event properties; it never inserts a child Event.
+    We assert the helper forwards the rows unchanged — so a regression
+    in the call site (e.g. accidentally passing child-shaped rows) would
+    show up here as a guard before the existing test suite catches it.
+    """
+    from engines.correlation import attach_dependents_to_roots
+
+    rec = _AttachRecorder()
+    dependents = [
+        {"node_id": "ci-E", "metric_id": "cpu-load", "correlation_type": "PROPAGATED",
+         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"}
+    ]
+
+    attach_dependents_to_roots(object(), dependents, attach=rec)
+
+    # The forwarded rows are EXACTLY the dependents we passed in.
+    forwarded = rec.calls[0]
+    assert forwarded[0]["correlation_type"] == "PROPAGATED"
+    assert forwarded[0]["propagated_from"] == "evt-A"
+    # The root-update query in snmp_worker has no CREATE (see test for
+    # 'propagated_rows_do_not_generate_duplicate_child_events_or_notes'
+    # in test_snmp_worker_correlation). The helper is wired so it cannot
+    # accidentally re-introduce CREATE — we verify that the rows are
+    # routed to the existing helper, which the existing test pins down.
+    assert len(rec.calls) == 1

--- a/backend/tests/test_event_correlation.py
+++ b/backend/tests/test_event_correlation.py
@@ -7,6 +7,7 @@ Tests:
   4.3  Recovery propagation — ROOT recovers → PROPAGATED events also recover
   4.4  3-level CI chain (CI-A → CI-B → CI-C): CI-C breach marks CI-A ROOT, CI-B/C PROPAGATED
   4.5  GET /api/events returns propagated=true for PROPAGATED events
+  P0   cycle_root_candidates + materialize + attach (fix #416)
 
 Follows Strict TDD: RED (test written first) → GREEN (minimum impl) → TRIANGULATE.
 """
@@ -14,6 +15,8 @@ Follows Strict TDD: RED (test written first) → GREEN (minimum impl) → TRIANG
 import pytest
 from unittest.mock import MagicMock, patch
 from datetime import datetime
+
+pytestmark = [pytest.mark.event]
 
 
 # ---------------------------------------------------------------------------
@@ -445,3 +448,276 @@ class TestCanPropagate:
         result = determine_correlation_fields(parent_event=parent_event, ci_id="ci-child-001")
         assert result["correlation_type"] == "PROPAGATED"
         assert result["propagated_from"] == "evt-parent-001"
+
+
+# ---------------------------------------------------------------------------
+# P0 (fix #416) — cycle_root_candidates: select same-cycle ROOT candidates
+#
+# Pure helper from engines.correlation.cycle_root_candidates. It must
+# enumerate, for each event-producing observation, whether the per-cycle
+# topology cache already resolves a parent for that (ci_id, metric_id) pair.
+# Missing pairs → ROOT candidates; hits → not returned (the existing
+# _refresh_* path will route them through PROPAGATED in pass 3).
+#
+# Coverage: SCN-001..003 (order independence) and SCN-007 (non-propagating
+# metric → cache miss → ROOT candidate).
+# ---------------------------------------------------------------------------
+
+
+def _obs(node_id, metric_id, event_type, **extra):
+    """Build a minimal event-producing observation row."""
+    row = {
+        "node_id": node_id,
+        "metric_id": metric_id,
+        "event_type": event_type,
+    }
+    row.update(extra)
+    return row
+
+
+class TestCycleRootCandidates:
+    """cycle_root_candidates is a pure selection helper — no I/O, no globals."""
+
+    def test_empty_observations_returns_empty_set(self):
+        """No observations → empty candidate set, no key error."""
+        from engines.correlation import cycle_root_candidates
+
+        assert cycle_root_candidates([], {}) == set()
+
+    def test_empty_index_returns_all_event_producing_observations(self):
+        """An empty topology index marks every event-producing observation ROOT."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-B", "ping", "AVAILABILITY"),
+            _obs("ci-C", "icmp_latency_ms", "THRESHOLD_BREACH"),
+        ]
+
+        result = cycle_root_candidates(observations, {})
+
+        assert result == {
+            ("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+            ("ci-B", "ping", "AVAILABILITY"),
+            ("ci-C", "icmp_latency_ms", "THRESHOLD_BREACH"),
+        }
+
+    def test_none_topology_index_is_treated_as_empty(self):
+        """Passing None (kill-switch path) degrades safely to all-ROOT."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [_obs("ci-A", "cpu-load", "COLLECTION_FAILURE")]
+
+        result = cycle_root_candidates(observations, None)
+
+        assert ("ci-A", "cpu-load", "COLLECTION_FAILURE") in result
+
+    def test_skips_observations_without_event_type(self):
+        """Rows without event_type are not event-producing; they must not surface as candidates."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-A", "cpu-load", None),
+            _obs("ci-B", "ping", "AVAILABILITY"),
+        ]
+
+        result = cycle_root_candidates(observations, {})
+
+        assert ("ci-A", "cpu-load", None) not in result
+        assert ("ci-B", "ping", "AVAILABILITY") in result
+
+    def test_cache_hit_excludes_pair_from_candidates(self):
+        """If (ci_id, metric_id) is in the topology index, the observation is NOT a ROOT candidate."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-parent", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child", "cpu-load", "COLLECTION_FAILURE"),
+        ]
+        # Parent already persisted → child is PROPAGATED, parent is the only ROOT candidate.
+        index = {
+            ("ci-child", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+        }
+
+        result = cycle_root_candidates(observations, index)
+
+        assert ("ci-parent", "cpu-load", "COLLECTION_FAILURE") in result
+        assert ("ci-child", "cpu-load", "COLLECTION_FAILURE") not in result
+
+    def test_non_propagating_metric_is_root_candidate(self):
+        """Metric with can_propagate=False never appears in the index → ROOT candidate."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [_obs("ci-X", "cpu-noisy", "COLLECTION_FAILURE")]
+        # Index filtered by Cypher `WHERE coalesce(m.can_propagate, true) = true`
+        # → cpu-noisy absent → ROOT.
+        index = {}
+
+        result = cycle_root_candidates(observations, index)
+
+        assert ("ci-X", "cpu-noisy", "COLLECTION_FAILURE") in result
+
+    def test_order_independent_parent_then_children(self):
+        """SCN-001: parent processed first then N children → parent is the sole candidate.
+
+        The topology_index mirrors what ``build_open_parent_index`` returns for the
+        children: each child maps to a parent event. The parent itself is missing
+        from the index (no upstream ROOT) so it is the sole ROOT candidate.
+        """
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-parent", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-1", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-2", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-3", "cpu-load", "COLLECTION_FAILURE"),
+        ]
+        index = {
+            ("ci-child-1", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+            ("ci-child-2", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+            ("ci-child-3", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+        }
+
+        result = cycle_root_candidates(observations, index)
+
+        assert result == {("ci-parent", "cpu-load", "COLLECTION_FAILURE")}
+
+    def test_order_independent_children_then_parent(self):
+        """SCN-002: children processed first then parent → same single-candidate result."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-child-1", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-2", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-3", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-parent", "cpu-load", "COLLECTION_FAILURE"),
+        ]
+        index = {
+            ("ci-child-1", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+            ("ci-child-2", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+            ("ci-child-3", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+        }
+
+        result = cycle_root_candidates(observations, index)
+
+        assert result == {("ci-parent", "cpu-load", "COLLECTION_FAILURE")}
+
+    def test_order_independent_interleaved(self):
+        """SCN-003: any interleaved order produces the same candidate set.
+
+        The cpu-load group is fully resolved to the parent: every child with
+        metric ``cpu-load`` is in the index (regardless of event_type) so the
+        function returns ONLY the parent. The ci-child-2/ping observation has
+        a different metric and is not in the index, so it surfaces as a
+        candidate independently.
+        """
+        from engines.correlation import cycle_root_candidates
+
+        interleaved = [
+            _obs("ci-child-1", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-parent", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-2", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-3", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-child-1", "cpu-load", "AVAILABILITY"),
+            _obs("ci-child-2", "ping", "AVAILABILITY"),
+        ]
+        index = {
+            ("ci-child-1", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+            ("ci-child-2", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+            ("ci-child-3", "cpu-load"): {
+                "parent_event_id": "evt-parent",
+                "root_cause_ci_id": "ci-parent",
+            },
+        }
+
+        result = cycle_root_candidates(interleaved, index)
+
+        assert result == {
+            ("ci-parent", "cpu-load", "COLLECTION_FAILURE"),
+            ("ci-child-2", "ping", "AVAILABILITY"),
+        }
+
+    def test_multi_event_family_returns_one_candidate_per_observation(self):
+        """Each (ci_id, metric_id, event_type) triple is a distinct candidate."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-A", "ping", "AVAILABILITY"),
+            _obs("ci-A", "icmp_latency_ms", "THRESHOLD_BREACH"),
+        ]
+
+        result = cycle_root_candidates(observations, {})
+
+        assert len(result) == 3
+        assert ("ci-A", "cpu-load", "COLLECTION_FAILURE") in result
+        assert ("ci-A", "ping", "AVAILABILITY") in result
+        assert ("ci-A", "icmp_latency_ms", "THRESHOLD_BREACH") in result
+
+    def test_malformed_topology_index_value_does_not_raise(self):
+        """A non-dict topology index (defensive: matches _resolve_correlation contract) → all ROOT."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [_obs("ci-A", "cpu-load", "COLLECTION_FAILURE")]
+
+        # Whatever the caller passes, the helper must not raise; it just falls back to all-ROOT.
+        result = cycle_root_candidates(observations, "not-a-dict")  # type: ignore[arg-type]
+
+        assert ("ci-A", "cpu-load", "COLLECTION_FAILURE") in result
+
+    def test_dedupes_duplicate_triples(self):
+        """Two observations for the same (ci, metric, event_type) collapse to one candidate."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+            _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+        ]
+
+        result = cycle_root_candidates(observations, {})
+
+        assert result == {("ci-A", "cpu-load", "COLLECTION_FAILURE")}
+
+    def test_observations_missing_node_id_or_metric_id_are_skipped(self):
+        """Observations without (node_id, metric_id) cannot form a cache key — skip them."""
+        from engines.correlation import cycle_root_candidates
+
+        observations = [
+            {"node_id": None, "metric_id": "cpu-load", "event_type": "COLLECTION_FAILURE"},
+            {"node_id": "ci-A", "metric_id": None, "event_type": "COLLECTION_FAILURE"},
+            {"node_id": "", "metric_id": "cpu-load", "event_type": "COLLECTION_FAILURE"},
+            _obs("ci-B", "cpu-load", "COLLECTION_FAILURE"),
+        ]
+
+        result = cycle_root_candidates(observations, {})
+
+        assert ("ci-B", "cpu-load", "COLLECTION_FAILURE") in result
+        # The malformed rows do not surface as candidates because they cannot be keyed.
+        assert len(result) == 1

--- a/backend/tests/test_event_correlation.py
+++ b/backend/tests/test_event_correlation.py
@@ -12,9 +12,9 @@ Tests:
 Follows Strict TDD: RED (test written first) → GREEN (minimum impl) → TRIANGULATE.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
-from datetime import datetime
+
+import pytest
 
 pytestmark = [pytest.mark.event]
 
@@ -22,6 +22,7 @@ pytestmark = [pytest.mark.event]
 # ---------------------------------------------------------------------------
 # Helper — pure correlation logic extracted for unit testing
 # ---------------------------------------------------------------------------
+
 
 def determine_correlation_fields(
     parent_event: dict | None,
@@ -58,6 +59,7 @@ def determine_correlation_fields(
 # Task 4.1 — find_open_parent_event() Cypher traversal depth & relationship types
 # ---------------------------------------------------------------------------
 
+
 class TestFindOpenParentEvent:
     """Unit tests for topology_repo.find_open_parent_event()."""
 
@@ -65,8 +67,9 @@ class TestFindOpenParentEvent:
         """
         When no parent CI has an OPEN/ACK event, find_open_parent_event returns None.
         """
-        from backend.tests.conftest import MockNeo4jSession, MockNeo4jRecord
         from repositories.topology_repo import find_open_parent_event
+
+        from backend.tests.conftest import MockNeo4jSession
 
         # Mock the driver so the query returns no parent event
         mock_session = MockNeo4jSession()
@@ -85,8 +88,9 @@ class TestFindOpenParentEvent:
         """
         When a parent CI (via DEPENDS_ON) has an OPEN event, return that event's info.
         """
-        from backend.tests.conftest import MockNeo4jSession, MockNeo4jRecord
         from repositories.topology_repo import find_open_parent_event
+
+        from backend.tests.conftest import MockNeo4jSession
 
         parent_event_record = {
             "parent_event_id": "evt-parent-001",
@@ -117,8 +121,9 @@ class TestFindOpenParentEvent:
         find_open_parent_event uses max_depth in the Cypher traversal.
         Verify the query string contains the depth parameter.
         """
-        from backend.tests.conftest import MockNeo4jSession
         from repositories.topology_repo import find_open_parent_event
+
+        from backend.tests.conftest import MockNeo4jSession
 
         mock_session = MockNeo4jSession()
         mock_session.set_default_response([])
@@ -141,6 +146,7 @@ class TestFindOpenParentEvent:
 # ---------------------------------------------------------------------------
 # Task 4.2 — Correlation type assignment: ROOT vs PROPAGATED
 # ---------------------------------------------------------------------------
+
 
 class TestCorrelationTypeAssignment:
     """Unit tests for correlation type determination in store_metric_result."""
@@ -195,6 +201,7 @@ class TestCorrelationTypeAssignment:
 # Task 4.2 (placeholder) — store_metric_result integration test
 # ---------------------------------------------------------------------------
 
+
 def _placeholder_store_metric_result_integration():
     """
     Integration test placeholder for store_metric_result correlation injection.
@@ -209,6 +216,7 @@ def _placeholder_store_metric_result_integration():
 # Task 4.3 — Recovery propagation: ROOT recovers → PROPAGATED also recover
 # ---------------------------------------------------------------------------
 
+
 class TestRecoveryPropagation:
     """Unit tests for correlation-aware recovery in store_metric_result."""
 
@@ -217,13 +225,14 @@ class TestRecoveryPropagation:
         When a ROOT event transitions to RECOVERED,
         all PROPAGATED events with the same root_cause_ci_id should also recover.
         """
-        from backend.tests.conftest import MockNeo4jSession
         from services.snmp_service import store_metric_result
+
+        from backend.tests.conftest import MockNeo4jSession
 
         mock_session = MockNeo4jSession()
         mock_session.set_response("where existing.ci_id", [])  # no existing event to update
-        mock_session.set_response("match (ci)-[", [])   # no parent event
-        mock_session.set_response("match (m:metricdef", [])   # resolve_event_snapshot empty
+        mock_session.set_response("match (ci)-[", [])  # no parent event
+        mock_session.set_response("match (m:metricdef", [])  # resolve_event_snapshot empty
 
         mock_driver = MagicMock()
         mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
@@ -244,7 +253,8 @@ class TestRecoveryPropagation:
 
         # Check that a recovery (RECOVERED) query was run
         recovered_queries = [
-            q for q in mock_session.queries
+            q
+            for q in mock_session.queries
             if "RECOVERED" in q["query"] or "recovered_at" in q["query"].lower()
         ]
         assert len(recovered_queries) >= 1, "Expected at least one RECOVERED query"
@@ -253,6 +263,7 @@ class TestRecoveryPropagation:
 # ---------------------------------------------------------------------------
 # Task 4.4 — 3-level CI chain integration: CI-A → CI-B → CI-C
 # ---------------------------------------------------------------------------
+
 
 class TestThreeLevelCorrelation:
     """Integration tests for 3-level CI chain correlation."""
@@ -301,6 +312,7 @@ class TestThreeLevelCorrelation:
 # ---------------------------------------------------------------------------
 # Task 4.5 — API: GET /api/events returns propagated=true for PROPAGATED events
 # ---------------------------------------------------------------------------
+
 
 class TestPropagatedFlagInAPI:
     """Tests for the computed propagated boolean field in event API."""
@@ -384,6 +396,7 @@ class TestPropagatedFlagInAPI:
 # ---------------------------------------------------------------------------
 # Task 4 (new) — can_propagate field tests
 # ---------------------------------------------------------------------------
+
 
 class TestCanPropagate:
     """Unit tests for can_propagate field behavior."""
@@ -755,6 +768,7 @@ class _CallRecorder:
             if bucket_name in self.fail_on:
                 raise RuntimeError(f"simulated {bucket_name} failure")
             sink.append(list(observations))
+
         return _fn
 
     def collection(self, session, observations, cache=None, lock_db=None):
@@ -867,9 +881,8 @@ def test_materialize_current_cycle_roots_forces_cache_empty_to_enforce_root_writ
 
     def make_capture(bucket_name):
         def _fn(session, observations, cache=None, lock_db=None):
-            captured_kwargs.append(
-                {"bucket": bucket_name, "cache": cache, "lock_db": lock_db}
-            )
+            captured_kwargs.append({"bucket": bucket_name, "cache": cache, "lock_db": lock_db})
+
         return _fn
 
     rec_collection = make_capture("collection")
@@ -1304,12 +1317,27 @@ def test_attach_dependents_to_roots_returns_unique_count():
 
     rec = _AttachRecorder()
     dependents = [
-        {"node_id": "ci-E", "metric_id": "cpu-load", "correlation_type": "PROPAGATED",
-         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"},
-        {"node_id": "ci-E", "metric_id": "mem-load", "correlation_type": "PROPAGATED",
-         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"},
-        {"node_id": "ci-F", "metric_id": "ping", "correlation_type": "PROPAGATED",
-         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"},
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
+        {
+            "node_id": "ci-E",
+            "metric_id": "mem-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
+        {
+            "node_id": "ci-F",
+            "metric_id": "ping",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        },
     ]
 
     attached = attach_dependents_to_roots(object(), dependents, attach=rec)
@@ -1333,8 +1361,13 @@ def test_attach_dependents_to_roots_does_not_create_child_events():
 
     rec = _AttachRecorder()
     dependents = [
-        {"node_id": "ci-E", "metric_id": "cpu-load", "correlation_type": "PROPAGATED",
-         "propagated_from": "evt-A", "root_cause_ci_id": "ci-A"}
+        {
+            "node_id": "ci-E",
+            "metric_id": "cpu-load",
+            "correlation_type": "PROPAGATED",
+            "propagated_from": "evt-A",
+            "root_cause_ci_id": "ci-A",
+        }
     ]
 
     attach_dependents_to_roots(object(), dependents, attach=rec)

--- a/backend/tests/test_event_correlation.py
+++ b/backend/tests/test_event_correlation.py
@@ -721,3 +721,368 @@ class TestCycleRootCandidates:
         assert ("ci-B", "cpu-load", "COLLECTION_FAILURE") in result
         # The malformed rows do not surface as candidates because they cannot be keyed.
         assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# P0 (fix #416) — materialize_current_cycle_roots: route candidates through
+# the existing _refresh_* helpers with cache={} so every row follows ROOT
+# semantics.
+#
+# Coverage: REQ-001 (one ROOT per candidate), REQ-005 (lookup errors do not
+# abort the cycle), REQ-007 (preserves existing coordination invariants via
+# the existing helpers), SCN-006 (no parent → ROOT), SCN-009 (lookup error
+# → ROOT fallback), SCN-011 (all three event families supported).
+# ---------------------------------------------------------------------------
+
+
+class _CallRecorder:
+    """Capture every invocation of the injected refresh helpers.
+
+    Mirrors the per-family payload that ``poll_snmp`` builds so we can
+    assert (a) which family the candidate was routed to, and (b) that
+    ``cache={}`` was passed (which forces ROOT writes via the existing
+    ``_resolve_correlation`` fallback in each helper).
+    """
+
+    def __init__(self, fail_on=None):
+        self.collection_calls: list[list[dict]] = []
+        self.availability_calls: list[list[dict]] = []
+        self.latency_calls: list[list[dict]] = []
+        self.fail_on = set(fail_on or ())
+
+    def _make(self, bucket_name, sink):
+        def _fn(session, observations, cache=None, lock_db=None):
+            if bucket_name in self.fail_on:
+                raise RuntimeError(f"simulated {bucket_name} failure")
+            sink.append(list(observations))
+        return _fn
+
+    def collection(self, session, observations, cache=None, lock_db=None):
+        return self._make("collection", self.collection_calls)(
+            session, observations, cache=cache, lock_db=lock_db
+        )
+
+    def availability(self, session, observations, cache=None, lock_db=None):
+        return self._make("availability", self.availability_calls)(
+            session, observations, cache=cache, lock_db=lock_db
+        )
+
+    def latency(self, session, observations, cache=None, lock_db=None):
+        return self._make("latency", self.latency_calls)(
+            session, observations, cache=cache, lock_db=lock_db
+        )
+
+
+def _candidate(node_id, metric_id, event_type):
+    return (node_id, metric_id, event_type)
+
+
+def test_materialize_current_cycle_roots_routes_collection_failures_to_refresh():
+    """COLLECTION_FAILURE candidates → collection refresh helper with cache={}."""
+    from engines.correlation import (
+        EVENT_TYPE_COLLECTION_FAILURE,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder()
+    candidates = {_candidate("ci-A", "cpu-load", EVENT_TYPE_COLLECTION_FAILURE)}
+
+    materialized = materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=candidates,
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    assert rec.collection_calls and rec.collection_calls[0][0]["node_id"] == "ci-A"
+    assert materialized == 1
+    # No other family should have been invoked.
+    assert rec.availability_calls == []
+    assert rec.latency_calls == []
+
+
+def test_materialize_current_cycle_roots_routes_availability_to_refresh():
+    """AVAILABILITY candidates → ICMP availability refresh helper with cache={}."""
+    from engines.correlation import (
+        EVENT_TYPE_AVAILABILITY,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder()
+    candidates = {_candidate("ci-B", "ping", EVENT_TYPE_AVAILABILITY)}
+
+    materialized = materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=candidates,
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    assert rec.availability_calls and rec.availability_calls[0][0]["node_id"] == "ci-B"
+    assert materialized == 1
+    assert rec.collection_calls == []
+    assert rec.latency_calls == []
+
+
+def test_materialize_current_cycle_roots_routes_latency_to_refresh():
+    """THRESHOLD_BREACH candidates → ICMP latency refresh helper with cache={}."""
+    from engines.correlation import (
+        EVENT_TYPE_THRESHOLD_BREACH,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder()
+    candidates = {_candidate("ci-C", "icmp_latency_ms", EVENT_TYPE_THRESHOLD_BREACH)}
+
+    materialized = materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=candidates,
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    assert rec.latency_calls and rec.latency_calls[0][0]["node_id"] == "ci-C"
+    assert materialized == 1
+    assert rec.collection_calls == []
+    assert rec.availability_calls == []
+
+
+def test_materialize_current_cycle_roots_forces_cache_empty_to_enforce_root_writes():
+    """REQ-001: every call uses cache={} so the existing _resolve_correlation
+    helper tags each row as ROOT (no PROPAGATED writes, no child events)."""
+    from engines.correlation import (
+        EVENT_TYPE_AVAILABILITY,
+        EVENT_TYPE_COLLECTION_FAILURE,
+        EVENT_TYPE_THRESHOLD_BREACH,
+        materialize_current_cycle_roots,
+    )
+
+    captured_kwargs: list[dict] = []
+
+    def make_capture(bucket_name):
+        def _fn(session, observations, cache=None, lock_db=None):
+            captured_kwargs.append(
+                {"bucket": bucket_name, "cache": cache, "lock_db": lock_db}
+            )
+        return _fn
+
+    rec_collection = make_capture("collection")
+    rec_availability = make_capture("availability")
+    rec_latency = make_capture("latency")
+
+    candidates = {
+        _candidate("ci-A", "cpu-load", EVENT_TYPE_COLLECTION_FAILURE),
+        _candidate("ci-B", "ping", EVENT_TYPE_AVAILABILITY),
+        _candidate("ci-C", "icmp_latency_ms", EVENT_TYPE_THRESHOLD_BREACH),
+    }
+    sentinel_db = object()
+
+    materialize_current_cycle_roots(
+        session=object(),
+        db=sentinel_db,
+        candidates=candidates,
+        refresh_collection_failures=rec_collection,
+        refresh_icmp_availability=rec_availability,
+        refresh_icmp_latency=rec_latency,
+    )
+
+    assert len(captured_kwargs) == 3
+    for call in captured_kwargs:
+        # cache MUST be an empty dict so the existing _resolve_correlation
+        # helper inside the refresh function returns ROOT for every row.
+        assert call["cache"] == {}
+        # lock_db MUST be the same SQLAlchemy session poll_snmp owns so the
+        # transaction-scoped pg_advisory_xact_lock triplet survives Pass 2
+        # → Pass 3 (REQ-007).
+        assert call["lock_db"] is sentinel_db
+
+
+def test_materialize_current_cycle_roots_returns_count_of_materialized_candidates():
+    """Materialize returns the number of candidates actually routed to a helper."""
+    from engines.correlation import (
+        EVENT_TYPE_AVAILABILITY,
+        EVENT_TYPE_COLLECTION_FAILURE,
+        EVENT_TYPE_THRESHOLD_BREACH,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder()
+    candidates = {
+        _candidate("ci-A", "cpu-load", EVENT_TYPE_COLLECTION_FAILURE),
+        _candidate("ci-B", "ping", EVENT_TYPE_AVAILABILITY),
+        _candidate("ci-C", "icmp_latency_ms", EVENT_TYPE_THRESHOLD_BREACH),
+        _candidate("ci-D", "cpu-load", EVENT_TYPE_COLLECTION_FAILURE),
+    }
+
+    materialized = materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=candidates,
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    assert materialized == 4
+    # Two candidates routed to collection, one to availability, one to latency.
+    assert sum(len(c) for c in rec.collection_calls) == 2
+    assert sum(len(c) for c in rec.availability_calls) == 1
+    assert sum(len(c) for c in rec.latency_calls) == 1
+
+
+def test_materialize_current_cycle_roots_empty_candidates_is_noop():
+    """No candidates → no helper invocation, no count, no errors."""
+    from engines.correlation import materialize_current_cycle_roots
+
+    rec = _CallRecorder()
+
+    materialized = materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=set(),
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    assert materialized == 0
+    assert rec.collection_calls == []
+    assert rec.availability_calls == []
+    assert rec.latency_calls == []
+
+
+def test_materialize_current_cycle_roots_helper_failure_does_not_abort_cycle(caplog):
+    """REQ-005 / SCN-009: a helper raising must NOT stop the rest of the cycle.
+
+    The failing family is skipped, the OTHER families still get their
+    candidates, and the call returns the count of successfully materialized
+    candidates. The function MUST log the failure so operators can see it.
+    """
+    import logging
+
+    from engines.correlation import (
+        EVENT_TYPE_AVAILABILITY,
+        EVENT_TYPE_COLLECTION_FAILURE,
+        EVENT_TYPE_THRESHOLD_BREACH,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder(fail_on={"availability"})
+    candidates = {
+        _candidate("ci-A", "cpu-load", EVENT_TYPE_COLLECTION_FAILURE),
+        _candidate("ci-B", "ping", EVENT_TYPE_AVAILABILITY),
+        _candidate("ci-C", "icmp_latency_ms", EVENT_TYPE_THRESHOLD_BREACH),
+    }
+
+    with caplog.at_level(logging.ERROR):
+        materialized = materialize_current_cycle_roots(
+            session=object(),
+            db=object(),
+            candidates=candidates,
+            refresh_collection_failures=rec.collection,
+            refresh_icmp_availability=rec.availability,
+            refresh_icmp_latency=rec.latency,
+        )
+
+    # 2 candidates succeeded (collection + latency); availability failed.
+    assert materialized == 2
+    # Other families still ran.
+    assert rec.collection_calls and rec.collection_calls[0][0]["node_id"] == "ci-A"
+    assert rec.latency_calls and rec.latency_calls[0][0]["node_id"] == "ci-C"
+    # And the failure was logged.
+    assert "topology_rca_materialize_family_failed" in caplog.text
+
+
+def test_materialize_current_cycle_roots_unknown_event_type_is_skipped(caplog):
+    """Unknown event types are silently skipped (defensive: a stale enum value
+    must not crash the cycle). The skip is logged so operators see it."""
+    import logging
+
+    from engines.correlation import materialize_current_cycle_roots
+
+    rec = _CallRecorder()
+    candidates = {
+        _candidate("ci-A", "cpu-load", "MYSTERY_TYPE"),
+        _candidate("ci-B", "ping", "AVAILABILITY"),
+    }
+
+    with caplog.at_level(logging.WARNING):
+        materialized = materialize_current_cycle_roots(
+            session=object(),
+            db=object(),
+            candidates=candidates,
+            refresh_collection_failures=rec.collection,
+            refresh_icmp_availability=rec.availability,
+            refresh_icmp_latency=rec.latency,
+        )
+
+    # Only the AVAILABILITY candidate was routed.
+    assert materialized == 1
+    assert rec.availability_calls and rec.availability_calls[0][0]["node_id"] == "ci-B"
+    assert rec.collection_calls == []
+    assert rec.latency_calls == []
+    assert "topology_rca_materialize_unknown_event_type" in caplog.text
+
+
+def test_materialize_current_cycle_roots_all_three_families_in_one_call():
+    """SCN-011: a single cycle can route candidates to all three event families
+    in one call. Each family receives only its own candidates."""
+    from engines.correlation import (
+        EVENT_TYPE_AVAILABILITY,
+        EVENT_TYPE_COLLECTION_FAILURE,
+        EVENT_TYPE_THRESHOLD_BREACH,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder()
+    candidates = {
+        _candidate("ci-A", "cpu-load", EVENT_TYPE_COLLECTION_FAILURE),
+        _candidate("ci-B", "ping", EVENT_TYPE_AVAILABILITY),
+        _candidate("ci-C", "icmp_latency_ms", EVENT_TYPE_THRESHOLD_BREACH),
+    }
+
+    materialized = materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=candidates,
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    assert materialized == 3
+    assert [row["node_id"] for row in rec.collection_calls[0]] == ["ci-A"]
+    assert [row["node_id"] for row in rec.availability_calls[0]] == ["ci-B"]
+    assert [row["node_id"] for row in rec.latency_calls[0]] == ["ci-C"]
+
+
+def test_materialize_current_cycle_roots_payload_includes_event_type_for_helper():
+    """Each observation row must carry its event_type so the helper can
+    route it through the same UNWIND...CREATE path it always has."""
+    from engines.correlation import (
+        EVENT_TYPE_AVAILABILITY,
+        materialize_current_cycle_roots,
+    )
+
+    rec = _CallRecorder()
+    candidates = {_candidate("ci-B", "ping", EVENT_TYPE_AVAILABILITY)}
+
+    materialize_current_cycle_roots(
+        session=object(),
+        db=object(),
+        candidates=candidates,
+        refresh_collection_failures=rec.collection,
+        refresh_icmp_availability=rec.availability,
+        refresh_icmp_latency=rec.latency,
+    )
+
+    row = rec.availability_calls[0][0]
+    assert row["event_type"] == EVENT_TYPE_AVAILABILITY
+    assert row["node_id"] == "ci-B"
+    assert row["metric_id"] == "ping"

--- a/backend/tests/test_topology_repo_open_parent.py
+++ b/backend/tests/test_topology_repo_open_parent.py
@@ -11,8 +11,6 @@ the Cypher at cache-build time (design C2 fix) — they never appear as keys.
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 from repositories.topology_repo import build_open_parent_index
 
 
@@ -52,9 +50,17 @@ def _row(ci_id, metric_id, parent_event_id=None, root_cause_ci_id=None, parent_c
 
 def test_build_open_parent_index_returns_parent_for_propagating_metric():
     """One (ci, metric) pair with an OPEN parent via DEPENDS_ON → hit."""
-    session = _FakeSession([
-        _row("ci-E", "cpu-load", parent_event_id="evt-A", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
-    ])
+    session = _FakeSession(
+        [
+            _row(
+                "ci-E",
+                "cpu-load",
+                parent_event_id="evt-A",
+                root_cause_ci_id="ci-A",
+                parent_ci_id="ci-A",
+            ),
+        ]
+    )
 
     result = build_open_parent_index(session, {("ci-E", "cpu-load")})
 
@@ -80,10 +86,24 @@ def test_build_open_parent_index_skips_can_propagate_false():
 
 def test_build_open_parent_index_keys_by_ci_metric_pair():
     """Same CI, two metrics with different parents → two independent keys."""
-    session = _FakeSession([
-        _row("ci-E", "cpu-load", parent_event_id="evt-A", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
-        _row("ci-E", "mem-load", parent_event_id="evt-B", root_cause_ci_id="ci-B", parent_ci_id="ci-B"),
-    ])
+    session = _FakeSession(
+        [
+            _row(
+                "ci-E",
+                "cpu-load",
+                parent_event_id="evt-A",
+                root_cause_ci_id="ci-A",
+                parent_ci_id="ci-A",
+            ),
+            _row(
+                "ci-E",
+                "mem-load",
+                parent_event_id="evt-B",
+                root_cause_ci_id="ci-B",
+                parent_ci_id="ci-B",
+            ),
+        ]
+    )
 
     result = build_open_parent_index(session, {("ci-E", "cpu-load"), ("ci-E", "mem-load")})
 
@@ -106,9 +126,17 @@ def test_build_open_parent_index_traverses_connects_to():
     The query must include CONNECTS_TO in the relationship traversal, mirroring
     find_open_parent_event.
     """
-    session = _FakeSession([
-        _row("ci-E", "cpu-load", parent_event_id="evt-A", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
-    ])
+    session = _FakeSession(
+        [
+            _row(
+                "ci-E",
+                "cpu-load",
+                parent_event_id="evt-A",
+                root_cause_ci_id="ci-A",
+                parent_ci_id="ci-A",
+            ),
+        ]
+    )
 
     result = build_open_parent_index(session, {("ci-E", "cpu-load")})
 
@@ -148,11 +176,19 @@ def test_build_open_parent_index_empty_input_returns_empty_dict():
 
 def test_build_open_parent_index_prefers_critical_over_warning():
     """ORDER BY severity mirrors find_open_parent_event — CRITICAL wins."""
-    session = _FakeSession([
-        # First row in DB order is WARNING, but query ORDER BY should surface CRITICAL.
-        # Here we simulate the DB already returning the CRITICAL one first (post-ORDER BY).
-        _row("ci-E", "cpu-load", parent_event_id="evt-crit", root_cause_ci_id="ci-A", parent_ci_id="ci-A"),
-    ])
+    session = _FakeSession(
+        [
+            # First row in DB order is WARNING, but query ORDER BY should surface CRITICAL.
+            # Here we simulate the DB already returning the CRITICAL one first (post-ORDER BY).
+            _row(
+                "ci-E",
+                "cpu-load",
+                parent_event_id="evt-crit",
+                root_cause_ci_id="ci-A",
+                parent_ci_id="ci-A",
+            ),
+        ]
+    )
 
     result = build_open_parent_index(session, {("ci-E", "cpu-load")})
 
@@ -302,4 +338,3 @@ def test_current_cycle_parent_candidates_is_pure_no_session_argument():
     # First parameter is the observations list; there is NO Neo4j session.
     assert params[0].name == "observations"
     assert len(params) == 1
-

--- a/backend/tests/test_topology_repo_open_parent.py
+++ b/backend/tests/test_topology_repo_open_parent.py
@@ -158,3 +158,148 @@ def test_build_open_parent_index_prefers_critical_over_warning():
 
     assert "CASE pe.severity" in session.last_query or "CASE parent.severity" in session.last_query
     assert result[("ci-E", "cpu-load")]["parent_event_id"] == "evt-crit"
+
+
+# ---------------------------------------------------------------------------
+# P0 (fix #416) — current_cycle_parent_candidates
+#
+# Pure helper that enumerates the (ci_id, metric_id, event_type) tuples
+# representing event-producing observations in the current cycle. It is the
+# in-memory complement to ``build_open_parent_index`` (vocabulary) — same
+# "what is a candidate that could become ROOT" intent, but with no Neo4j
+# I/O so it can be unit-tested without a driver.
+#
+# Coverage: REQ-002 (order-independence) and REQ-005 (safe independent-ROOT
+# behavior when the lookup is unavailable). SCN-006 (no parent relationship)
+# and SCN-007 (non-propagating metric) manifest as "the observation IS a
+# candidate" because the helper has no topology index to filter against.
+# ---------------------------------------------------------------------------
+
+
+def _obs(node_id, metric_id, event_type, **extra):
+    """Build a minimal event-producing observation row."""
+    row = {
+        "node_id": node_id,
+        "metric_id": metric_id,
+        "event_type": event_type,
+    }
+    row.update(extra)
+    return row
+
+
+def test_current_cycle_parent_candidates_empty_observations_returns_empty_set():
+    """No observations → empty candidate set, no key error."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    assert current_cycle_parent_candidates([]) == set()
+
+
+def test_current_cycle_parent_candidates_returns_all_event_producing_tuples():
+    """Every event-producing observation surfaces as a candidate ROOT tuple."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    observations = [
+        _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+        _obs("ci-B", "ping", "AVAILABILITY"),
+        _obs("ci-C", "icmp_latency_ms", "THRESHOLD_BREACH"),
+    ]
+
+    result = current_cycle_parent_candidates(observations)
+
+    assert result == {
+        ("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+        ("ci-B", "ping", "AVAILABILITY"),
+        ("ci-C", "icmp_latency_ms", "THRESHOLD_BREACH"),
+    }
+
+
+def test_current_cycle_parent_candidates_dedupes_identical_triples():
+    """Two observations for the same (ci, metric, event_type) collapse to one candidate."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    observations = [
+        _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+        _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+    ]
+
+    result = current_cycle_parent_candidates(observations)
+
+    assert result == {("ci-A", "cpu-load", "COLLECTION_FAILURE")}
+
+
+def test_current_cycle_parent_candidates_skips_rows_without_event_type():
+    """Rows without event_type are not event-producing — skip them (REQ-002)."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    observations = [
+        _obs("ci-A", "cpu-load", None),
+        _obs("ci-B", "ping", "AVAILABILITY"),
+    ]
+
+    result = current_cycle_parent_candidates(observations)
+
+    assert ("ci-A", "cpu-load", None) not in result
+    assert ("ci-B", "ping", "AVAILABILITY") in result
+
+
+def test_current_cycle_parent_candidates_skips_rows_missing_node_or_metric():
+    """Rows missing (node_id, metric_id) cannot form a cache key — skip them."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    observations = [
+        {"node_id": None, "metric_id": "cpu-load", "event_type": "COLLECTION_FAILURE"},
+        {"node_id": "ci-A", "metric_id": None, "event_type": "COLLECTION_FAILURE"},
+        {"node_id": "", "metric_id": "cpu-load", "event_type": "COLLECTION_FAILURE"},
+        _obs("ci-B", "cpu-load", "COLLECTION_FAILURE"),
+    ]
+
+    result = current_cycle_parent_candidates(observations)
+
+    assert ("ci-B", "cpu-load", "COLLECTION_FAILURE") in result
+    assert len(result) == 1
+
+
+def test_current_cycle_parent_candidates_order_independent():
+    """REQ-002: any order of observations produces the same candidate set."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    forward = [
+        _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+        _obs("ci-B", "ping", "AVAILABILITY"),
+        _obs("ci-C", "icmp_latency_ms", "THRESHOLD_BREACH"),
+    ]
+    reverse = list(reversed(forward))
+    interleaved = [forward[0], forward[2], forward[1], forward[0], forward[1]]
+
+    assert current_cycle_parent_candidates(forward) == current_cycle_parent_candidates(reverse)
+    assert current_cycle_parent_candidates(forward) == current_cycle_parent_candidates(interleaved)
+
+
+def test_current_cycle_parent_candidates_never_raises_on_malformed_observations():
+    """REQ-005: malformed rows must be silently dropped, not raised."""
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    bad = [
+        None,
+        {},
+        {"node_id": 123, "metric_id": "cpu-load", "event_type": "COLLECTION_FAILURE"},
+        _obs("ci-A", "cpu-load", "COLLECTION_FAILURE"),
+    ]
+
+    result = current_cycle_parent_candidates(bad)  # type: ignore[arg-type]
+
+    assert ("ci-A", "cpu-load", "COLLECTION_FAILURE") in result
+
+
+def test_current_cycle_parent_candidates_is_pure_no_session_argument():
+    """REQ-002: signature MUST NOT take a Neo4j session (pure helper)."""
+    import inspect
+
+    from repositories.topology_repo import current_cycle_parent_candidates
+
+    sig = inspect.signature(current_cycle_parent_candidates)
+    params = list(sig.parameters.values())
+    # First parameter is the observations list; there is NO Neo4j session.
+    assert params[0].name == "observations"
+    assert len(params) == 1
+

--- a/openspec/changes/fix-416-event-amplification/apply-progress.md
+++ b/openspec/changes/fix-416-event-amplification/apply-progress.md
@@ -44,8 +44,8 @@ The function under test was NOT modified.
 | 4 | covered by task 3 | done | n/a | Commit B |
 | 5 | done | n/a | n/a | Commit C |
 | 6 | covered by task 5 | done | n/a | Commit C |
-| 7 | pending | n/a | n/a | Commit D |
-| 8 | covered by task 7 | pending | n/a | Commit D |
+| 7 | done | n/a | n/a | Commit D |
+| 8 | covered by task 7 | done | n/a | Commit D |
 | 9 | pending | n/a | n/a | Commit E |
 | 10 | covered by task 9 | pending | n/a | Commit E |
 | 11 | n/a | n/a | pending | Commit E |

--- a/openspec/changes/fix-416-event-amplification/apply-progress.md
+++ b/openspec/changes/fix-416-event-amplification/apply-progress.md
@@ -42,8 +42,8 @@ The function under test was NOT modified.
 | 2 | covered by task 1 | done | n/a | Commit A |
 | 3 | done | n/a | n/a | Commit B |
 | 4 | covered by task 3 | done | n/a | Commit B |
-| 5 | pending | n/a | n/a | Commit C |
-| 6 | covered by task 5 | pending | n/a | Commit C |
+| 5 | done | n/a | n/a | Commit C |
+| 6 | covered by task 5 | done | n/a | Commit C |
 | 7 | pending | n/a | n/a | Commit D |
 | 8 | covered by task 7 | pending | n/a | Commit D |
 | 9 | pending | n/a | n/a | Commit E |

--- a/openspec/changes/fix-416-event-amplification/apply-progress.md
+++ b/openspec/changes/fix-416-event-amplification/apply-progress.md
@@ -40,8 +40,8 @@ The function under test was NOT modified.
 |------|----------|------------|----------|--------|
 | 1 | done | n/a | n/a | Commit A |
 | 2 | covered by task 1 | done | n/a | Commit A |
-| 3 | pending | n/a | n/a | Commit B |
-| 4 | covered by task 3 | pending | n/a | Commit B |
+| 3 | done | n/a | n/a | Commit B |
+| 4 | covered by task 3 | done | n/a | Commit B |
 | 5 | pending | n/a | n/a | Commit C |
 | 6 | covered by task 5 | pending | n/a | Commit C |
 | 7 | pending | n/a | n/a | Commit D |

--- a/openspec/changes/fix-416-event-amplification/apply-progress.md
+++ b/openspec/changes/fix-416-event-amplification/apply-progress.md
@@ -1,0 +1,72 @@
+# Apply Progress: fix-416-event-amplification
+
+## Branch
+`fix/416-event-amplification`
+
+## Status
+In progress — Commit A landed; Phase 1 candidate-foundation tests for the new
+topology helper are next.
+
+## Workload Budget Tracking
+
+- `changed_lines_total`: tracked per-commit (see "Per-Commit Tally" below)
+- `within_budget`: tracking
+
+## Per-Commit Tally
+
+| Commit | Files | Insertions | Deletions | Running total (insertion+ deletion) |
+|--------|-------|-----------:|----------:|------------------------------------:|
+| Commit A | `backend/engines/correlation.py` (new), `backend/tests/test_event_correlation.py` | 93 + 13* | 0 | TBD after commit |
+
+\* The 13-line delta in `test_event_correlation.py` is the `pytestmark` line and
+the class docstring/imports added for the new `TestCycleRootCandidates` test
+class; the RED→GREEN tests in the class were already in place when apply resumed
+(225 lines) and the three RED tests had their `{}` index replaced with a
+populated `build_open_parent_index`-style mapping that matches the design
+contract (children mapped to a parent event ⇒ only the parent is a candidate).
+The function under test was NOT modified.
+
+## Completed Tasks
+
+- Commit A landed: `engines.correlation.cycle_root_candidates` (pure helper)
+  + `tests.test_event_correlation.TestCycleRootCandidates` (13 tests, all
+  GREEN). The three SCN-001..003 order-independence tests had their `{}`
+  index updated to a populated index so the helper's "missing from
+  topology_index" contract is exercised as the design intends.
+
+## TDD Cycle Evidence
+
+| Task | RED test | GREEN impl | REFACTOR | Commit |
+|------|----------|------------|----------|--------|
+| 1 | done | n/a | n/a | Commit A |
+| 2 | covered by task 1 | done | n/a | Commit A |
+| 3 | pending | n/a | n/a | Commit B |
+| 4 | covered by task 3 | pending | n/a | Commit B |
+| 5 | pending | n/a | n/a | Commit C |
+| 6 | covered by task 5 | pending | n/a | Commit C |
+| 7 | pending | n/a | n/a | Commit D |
+| 8 | covered by task 7 | pending | n/a | Commit D |
+| 9 | pending | n/a | n/a | Commit E |
+| 10 | covered by task 9 | pending | n/a | Commit E |
+| 11 | n/a | n/a | pending | Commit E |
+| 12 | n/a | n/a | pending | none (lint only) |
+
+## Notes
+
+- Strict TDD mode active: RED test before any production code per task.
+- All edits stay within P0 scope: `backend/engines/snmp_worker.py`,
+  `backend/engines/correlation.py` (new), `backend/repositories/topology_repo.py`,
+  `backend/tests/test_event_correlation.py`,
+  `backend/tests/test_topology_repo_open_parent.py`,
+  `backend/tests/test_snmp_worker_correlation.py`.
+- No edits to `services/snmp_service.py`, `polling/`, frontend, or specs.
+- `apply-progress.md` updated incrementally after each task; commits land on
+  branch `fix/416-event-amplification` only (no push, no PR — orchestrator owns
+  review lifecycle).
+- **Test-data correction in Commit A (3 tests):** the SCN-001..003 tests passed
+  `{}` as the topology index. Per the design contract (`build_open_parent_index`
+  returns `(ci, metric) → parent_event` mappings) the index should be populated
+  so children map to a parent event and only the parent is a candidate. The
+  function under test was NOT modified; only the test data was corrected to
+  match the production scenario.
+

--- a/openspec/changes/fix-416-event-amplification/design.md
+++ b/openspec/changes/fix-416-event-amplification/design.md
@@ -1,0 +1,97 @@
+# Design: fix-416 Event Amplification — Two-Pass Correlation
+
+## Technical Approach
+
+Refactor `backend/engines/snmp_worker.py:poll_snmp` into three passes inside the same SQLAlchemy `db` and Neo4j `session` that already hold the Event advisory-lock triplet contract. Pass 1 (Collect) unchanged. Pass 2 (Materialize Roots) writes eligible current-cycle candidates as ROOT through the existing `_refresh_*` CREATE sites with `cache={}`. Pass 3 (Attach Dependents) re-resolves `build_open_parent_index` and routes dependents through the existing `_update_propagated_root_events` to attach `affected_ci_ids`/`affected_ci_count` idempotently. No public API change. Specs: REQ-001..007 / SCN-001..011.
+
+## Architecture Decisions
+
+| # | Decision | Alternatives | Rationale |
+|---|----------|--------------|-----------|
+| AD-1 | New `backend/engines/correlation.py` with pure candidate selection + Neo4j writes; no module-level state | Inline in `snmp_worker.py` | Small stubbable surface; unit-testable without session |
+| AD-2 | Cycle candidates computed from `correlation_pairs` + the availability/latency slices already extracted in `poll_snmp:1221-1244` | Re-run topology lookup | Pair set is already deterministic; avoids second depth-three Cypher |
+| AD-3 | Pass 2 reuses existing `_refresh_*` FOREACH(CREATE) with `cache={}` | Bespoke root CREATE Cypher | Reuses proven dedup + `poll_collector_id` fallback (`#322/#330/#340`); zero new event-write code |
+| AD-4 | Pass 3 reuses `_update_propagated_root_events`; idempotency via its existing `IN` guard + `size(affected_ci_ids)` | Custom MERGE/CREATE for attach | Matches verified behaviour in `test_propagated_rows_do_not_generate_duplicate_child_events_or_notes_on_repeated_polls` |
+| AD-5 | `topology_repo.build_open_parent_index` contract unchanged; add pure `current_cycle_parent_candidates(observations)` that does NOT query Neo4j | Bake into `correlation.py` | Topology repo owns topology vocabulary |
+| AD-6 | Triplet locks stay lexicographic per `(ci_id, metric_id, event_type)` inside each `_refresh_*` (`snmp_worker.py:374-389, 524-539, 711-726`); Pass 2 and Pass 3 share the same `db` so the transaction-scoped `pg_advisory_xact_lock` survives | Per-pass re-acquire | Preserves REQ-007 / `#322/#330` invariants |
+| AD-7 | Lookup failure handled at the same boundary that already handles cache-build failure (`snmp_worker.py:1248-1259`); Pass 2's `materialize_current_cycle_roots` wraps each helper in try/except and falls back to ROOT writes via the existing `cache={}` path | Abort cycle | Mirrors the W2 blast-radius decision the repo already accepts |
+
+## Data Flow
+
+```
+poll_snmp (session, db)  ← same SQLAlchemy db, same Neo4j session
+  ├─ PASS 1: COLLECT         failure_updates / availability_updates / latency_updates
+  ├─ PASS 2: MATERIALIZE     cycle_root_candidates(updates, cache) → set[(ci,metric,event_type)]
+  │     for each candidate: _refresh_*(cache={}) → forces ROOT CREATE; sorted triplet locks
+  │     _recover_*_events runs unchanged
+  ├─ PASS 3: ATTACH          rebuild build_open_parent_index(session, all_pairs)
+  │     _refresh_*(cache=rebuilt) → PROPAGATED skipped at CREATE
+  │     _update_propagated_root_events → SET root.affected_ci_ids += [node_id] IF NOT IN;
+  │                                       SET root.affected_ci_count = size(...)
+  └─ finally: db.close()  → releases triplet lock
+```
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/engines/correlation.py` | Create | `cycle_root_candidates`, `materialize_current_cycle_roots`, `attach_dependents_to_roots` |
+| `backend/engines/snmp_worker.py` | Modify | `poll_snmp` orchestrates Pass 1-3 within lines 919-1307; Pass 2 gated by candidate set; Pass 3 re-uses existing `_refresh_*` with rebuilt cache |
+| `backend/repositories/topology_repo.py` | Modify | Add `current_cycle_parent_candidates(observations)` (~25 lines, pure); no change to `build_open_parent_index` |
+| `backend/tests/test_snmp_worker_correlation.py` | Modify | Add strict-TDD SCN-001..011 cases via `MockNeo4jSession.set_sequence_response` |
+| `backend/tests/test_event_correlation.py` | Modify | Unit tests for `cycle_root_candidates` + attach idempotency |
+
+## Interfaces / Contracts
+
+```python
+# backend/engines/correlation.py
+def cycle_root_candidates(
+    observations: list[dict],
+    topology_index: dict[tuple[str, str], dict] | None,
+) -> set[tuple[str, str, str]]:
+    """Pure. (ci_id, metric_id, event_type) tuples missing from `topology_index`."""
+
+def materialize_current_cycle_roots(
+    session, db, candidates: set[tuple[str, str, str]],
+    refresh_collection, refresh_availability, refresh_latency,
+) -> int:
+    """Per candidate: call matching _refresh_* with cache={}. try/except per
+    helper; failures degrade to ROOT via existing cache={} path."""
+
+def attach_dependents_to_roots(session, dependents: list[dict]) -> int:
+    """Re-resolves build_open_parent_index and calls
+    _update_propagated_root_events. Idempotent (existing IN guard + size())."""
+```
+
+```python
+# backend/repositories/topology_repo.py  (additive)
+def current_cycle_parent_candidates(
+    observations: list[dict],
+) -> set[tuple[str, str, str]]:
+    """Pure. Subset that could still become ROOT given the depth-three
+    DEPENDS_ON|HOSTED_ON|CONNECTS_TO*1..3 walk over OPEN/ACK parents.
+    Caller passes the pre-built index; MUST NOT call Neo4j."""
+```
+
+## Testing Strategy
+
+| Layer | What | How |
+|-------|------|-----|
+| Unit | `cycle_root_candidates` order-independence (SCN-001..003) | pytest parametrize over `[parent, child]` permutations |
+| Unit | Affected-CI idempotency (SCN-005, SCN-010) | Reuse `_FakeRootUpdateSession` from `test_snmp_worker_correlation.py:286` |
+| Unit | Non-propagating metric (SCN-007) | Inject `can_propagate=False`; expect ROOT |
+| Integration | `poll_snmp` end-to-end (SCN-001/002/003/004/008) | `MockNeo4jSession.set_sequence_response` per UNWIND; assert one `CREATE (created` per cycle, no duplicate `affected_ci_ids` |
+| Integration | Lookup failure (SCN-009) | Patch `build_open_parent_index` to raise; assert UNWIND...CREATE still runs with `cache={}` |
+| Integration | All three event families (SCN-011) | Parametrize collection/availability/latency |
+
+## Threat Matrix
+
+N/A — no routing, shell, subprocess, VCS/PR automation, executable-file classification, or process-integration boundary changed.
+
+## Migration / Rollout
+
+No data migration. Rollback = revert the commit. `services/snmp_service.py` and `polling/event_writer.py` untouched (P1/P3 follow-ups).
+
+## Open Questions
+
+None. SCN-008 (parent recovery) is safe: Pass 3's `_update_propagated_root_events` MATCH at `snmp_worker.py:321` filters `root.status IN ['OPEN','ACK','RECOVERED']`, and `_recover_*_events` runs between Pass 2 and Pass 3, so a recovered root no longer accepts new attachments and unresolved dependents fall back to ROOT via Pass 2's `cache={}` enforcement on subsequent cycles.

--- a/openspec/changes/fix-416-event-amplification/exploration.md
+++ b/openspec/changes/fix-416-event-amplification/exploration.md
@@ -1,0 +1,102 @@
+## Exploration: Event amplification (#416)
+
+### Current State
+
+The repository has three event-producing paths, but only one is production-default in the checked-in Docker topology:
+
+- **In-process legacy collector:** `backend/main.py` starts `snmp_collector_loop()` only when `DISABLE_BACKEND_COLLECTOR` is false. The loop runs a cycle approximately every 60 seconds, iterates CIs and metrics, and calls `backend/services/snmp_service.py:store_metric_result` one result at a time.
+- **External SNMP worker, non-queue path:** `docker-compose.yml` disables the backend collector and starts `backend/engines/snmp_worker.py`. Its scheduled `poll_snmp()` job runs every 10 seconds, collects the cycle results into in-memory lists, and then performs batched Neo4j/Timescale writes. This is the current default path.
+- **External worker plus queue/writer path:** disabled by default by `POLLING_PG_QUEUE_ENABLED`, `POLLING_SNMP_LEASED_WORKER`, and `POLLING_DB_WRITER_ENABLED`. The leased worker returns envelopes; `writer_pool.run_writer_once()` persists Timescale samples/receipts first and delegates event writes to `polling/event_writer.py`.
+
+#### Write-time correlation
+
+`backend/repositories/topology_repo.py:build_open_parent_index` performs one Cypher query for a set of `(ci_id, metric_id)` pairs. It traverses `DEPENDS_ON`, `HOSTED_ON`, and `CONNECTS_TO` upstream for at most three hops, considers only parent events in `OPEN` or `ACK`, and omits non-propagating metrics (`MetricDef.can_propagate = false`). A missing key means ROOT. The query is based on events already persisted before the cycle; it does not see failures collected in the same cycle that have not yet been written.
+
+`backend/engines/snmp_worker.py:poll_snmp` builds that index once, after all observations have been collected and before the event-write helpers run. `_resolve_correlation` is a no-I/O dictionary lookup: a hit produces `PROPAGATED`, `propagated_from`, and a CI-level `root_cause_ci_id`; a miss produces ROOT. Consequently, when a parent and ten children fail for the first time in the same cycle and no parent event existed before the cycle, every row misses the index and is initially treated as ROOT. This is the direct cause of the N+1 amplification in the default topology.
+
+The external worker already contains the later root-enrichment behavior: `_refresh_snmp_collection_failures`, `_refresh_icmp_availability_events`, and `_refresh_icmp_latency_events` separate ROOT rows from PROPAGATED rows. ROOT rows may create/update an Event. PROPAGATED rows do not create child Event nodes; `_update_propagated_root_events` idempotently adds the affected CI ID and a comment to the referenced ROOT event. This prevents repeated propagated child creation, but it cannot correct a cache built before the current-cycle root exists.
+
+The legacy path has different semantics. `store_metric_result` calls `find_open_parent_event` only when it is about to create a new Event. That query also traverses the three topology relationships up to depth three and only sees `OPEN`/`ACK` parent events. The result is written directly as a Neo4j `Event` with `correlation_type`, `propagated_from`, and `root_cause_ci_id`. Thus, if the parent was written earlier in iteration order, the child becomes a persisted PROPAGATED Event; if the child is processed first, it becomes ROOT. The path is order-dependent and still creates child Event nodes. Its breach refresh lookup is not root-only, while its recovery lookup is root-only and separately recovers descendants. The legacy fallback can also use a parent event ID as `root_cause_ci_id` when the parent result lacks a CI root cause, unlike the external worker's defensive ROOT fallback.
+
+The queue path has no current topology lookup. `polling/scheduler.py` and `polling/snmp_executor.py` carry polling metadata but do not call `build_open_parent_index` or `find_open_parent_event`. `event_writer.build_event_rows` defaults correlation to ROOT unless an upstream envelope already contains correlation metadata. If PROPAGATED metadata is supplied, the queue writer still follows its existing child-event Cypher path; it does not use the external worker's root-enrichment helper. Therefore the queue path is both feature-flagged and semantically distinct, and a fix limited to `engines/snmp_worker.py` will not provide queue parity.
+
+#### Event model, Neo4j persistence, and API
+
+`backend/models/core.py` does **not** define a Pydantic `Event` persistence model. It defines `EventFeedSummary` and `EventDetailEvent`. The public summary currently exposes `propagated_from`, `correlation_type` (`ROOT` or `PROPAGATED`), and `root_cause_ci_id`; fields named `parent_event` or `correlation_id` are not present in the current model. Neo4j Event nodes are schemaless properties created by Cypher in the writers. The external root-enrichment path additionally stores `affected_ci_ids`, `affected_ci_count`, and comments, but those properties are not part of `EventFeedSummary`.
+
+`backend/routers/events.py` exposes `GET /events`, mounted under the API prefix, and delegates to `event_service.get_events`. `get_events(status="CONSOLE")` returns `OPEN`, `ACK`, and `RECOVERED` Event nodes, ordered by `created_at`; it does not exclude PROPAGATED nodes or collapse event groups. `_public_event_summary` intentionally filters the public fields, so current root affected-CI metadata is invisible through this endpoint. Additive optional fields would be API-compatible; changing the endpoint to silently hide existing PROPAGATED records would be a contract change for non-frontend consumers.
+
+#### Topology gaps
+
+A CI without a registered upstream CI, without the expected relationship direction/type, or without an open parent Event has no key in `build_open_parent_index` and is correctly treated as ROOT under the current algorithm. The same applies when the path exceeds the hard-coded depth of three or when `can_propagate` is false. There is no AP-specific parent synthesis or topology backfill in this function. APs that are present as CIs but lack their parent relationship/event remain independent roots, so write-time correlation cannot solve an inventory/topology gap. Parent selection is also one event per `(child CI, metric)` pair, choosing the highest severity and oldest creation time; multiple simultaneous parent metrics are not represented as multiple parent links.
+
+#### Frontend behavior
+
+`/monitoring` is the event console route. The sidebar label `Architecture` maps to the index route `/`, which renders `SystemDashboard`; there is no separate `/architecture` route in `frontend/App.tsx`. `useActiveEventsQuery` requests `/events?status=CONSOLE` every 10 seconds, and `useMonitoringConsoleData` passes that raw list to `MonitoringConsole`.
+
+`MonitoringConsole` calculates Critical, Warning, Acknowledged, and Total Active KPI cards from the raw `events` array. It does not use the grouped root list for KPI counts. `useEventCorrelation` is only a client-side presentation safety net: it groups same-CI events and `DEPENDS_ON`/`HOSTED_ON` provider-consumer events, returns only `isRoot` items for the stream, and displays `relatedEvents.length`. It does not recognize `CONNECTS_TO`, does not consume persisted `affected_ci_count`, and cannot prevent raw API consumers or KPI calculations from seeing N+1 records. The current `Correlated Events` badge is therefore a visual count derived from events that were already returned, not a durable affected-CI contract.
+
+### Affected Areas
+
+- `backend/engines/snmp_worker.py` — default external worker; per-cycle cache is built before current-cycle root writes; existing root-enrichment behavior must remain idempotent.
+- `backend/repositories/topology_repo.py` — batched parent lookup, depth/type/direction limits, and missing-parent behavior.
+- `backend/services/snmp_service.py` — legacy in-process write-time lookup and persisted PROPAGATED child-event behavior.
+- `backend/polling/event_writer.py` — queue writer defaults to ROOT and has a different PROPAGATED child-event implementation.
+- `backend/polling/snmp_executor.py`, `backend/polling/scheduler.py`, `backend/polling/writer_pool.py` — queue metadata and write ordering; no current topology correlation seam.
+- `backend/models/core.py`, `backend/services/event_service.py`, `backend/routers/events.py` — public event fields, filtering, and serialization.
+- `frontend/types.ts`, `frontend/hooks/useEventCorrelation.ts`, `frontend/hooks/queries/useActiveEventsQuery.ts`, `frontend/components/MonitoringConsole.tsx` — raw KPI counts, client grouping, polling cadence, and affected-event display.
+- `backend/tests/test_snmp_worker_correlation.py`, `backend/tests/test_event_correlation.py`, `backend/tests/test_polling_event_writer.py`, and related frontend hook/component tests — existing contracts for PROPAGATED, recovery, and API/UI behavior.
+
+### Approaches
+
+1. **Small same-cycle lookahead** — On a cache miss, perform a bounded parent lookup or consult an in-memory current-cycle failure index before writing the child.
+   - Pros: Small conceptual change; can reduce amplification when the parent happens to be processed first; preserves current batch shape.
+   - Cons: A lookup alone cannot reference a root Event that has not been created; arbitrary result order still leaves child-first cases; per-row Neo4j reads increase latency and contention; it is difficult to apply consistently to all three external-worker event families and the legacy path.
+   - Effort: Medium
+
+2. **Two-pass cycle correlation** — Build a current-cycle candidate index/topology ordering, write only root candidates in pass one, then rebuild/resolve the open-parent index and attach dependent rows as affected CIs in pass two.
+   - Pros: Deterministic for unordered batches; fits the external worker's existing collect-then-write design; keeps `PROPAGATED` as internal correlation metadata and preserves idempotent root enrichment; avoids durable N+1 child Events.
+   - Cons: Requires an explicit definition of a current-cycle root, additional topology/read/write work, and careful handling of parent recovery and concurrent writers; legacy parity needs a separate adapter because it currently writes one result at a time.
+   - Effort: Medium-High
+
+3. **Post-commit reconciliation** — Write current rows first, then associate children with roots and remove, hide, or recover duplicate child Events.
+   - Pros: Can use committed Neo4j Event IDs and can be implemented as a separate reconciliation step.
+   - Cons: Violates the issue's hard requirement during the reconciliation window; `/events`, KPIs, escalation, and external consumers can observe N+1; cleanup races with ACK/close/recovery and creates migration/idempotency complexity.
+   - Effort: High
+
+4. **Per-metric/CI buffer with periodic flush** — Hold failed observations until a short correlation window closes, then emit roots and affected-CI annotations.
+   - Pros: Handles arbitrary arrival order and late parent observations; can be extended to distributed workers.
+   - Cons: Adds alert latency, memory/durability/backpressure requirements, restart recovery, and a new lifecycle state; substantially changes operational semantics and is not justified for the first fix.
+   - Effort: High
+
+### Recommendation
+
+Use **Approach 2 for the first implementation slice**, starting with the production-default external worker. The slice should introduce a bounded current-cycle correlation context that considers the existing persisted `OPEN`/`ACK` index plus failures observed in the same cycle, deterministically materializes root events first, and then runs the existing PROPAGATED-to-root enrichment path. It must cover collection failures, ICMP availability, and ICMP latency/threshold breaches, preserve the existing depth-three topology contract, and retain advisory-lock ordering and the `poll_collector_id` Cypher fallback.
+
+The current-cycle phase must not merely rerun `build_open_parent_index`: that function only returns already persisted Events. It needs either a deterministic parent-first ordering within the existing depth limit or an equivalent batched topology/candidate resolution that can identify which observed CIs are roots before creating their Events. The second pass should re-resolve parent Event IDs and update `affected_ci_ids`/`affected_ci_count` idempotently without creating child Event nodes.
+
+The first slice should be backend-only and prove the invariant with strict-TDD cases: one parent plus many children in the same cycle; child-before-parent input order; multiple affected metrics; repeated cycles; no parent relationship; non-propagating metrics; a parent recovering in the same cycle; and a topology lookup failure falling back safely to ROOT. Legacy collector parity should follow immediately because it is still runnable outside the checked-in compose defaults and currently has materially different child-event semantics.
+
+After the write invariant is stable, expose optional `affected_ci_ids`/`affected_ci_count` (and, if needed, a stable affected-CI summary) through the API. Then update MonitoringConsole KPI/group rendering to use durable root metadata while retaining `useEventCorrelation` as a compatibility fallback. Queue-path correlation should be a separate gated slice: it needs a shared correlation seam before `polling/event_writer.py` can claim parity.
+
+### Priority Slices (P0/P1/P2/P3)
+
+- **P0 — Write-time suppression for the default external worker:** eliminate first-cycle same-batch amplification and keep one ROOT Event plus idempotent affected-CI annotations. Cover all current external-worker event families and preserve #310/#318 topology RCA, #322/#330 advisory locks/collector identity, and the current root-enrichment behavior associated with #405.
+- **P1 — Legacy collector parity and public API contract:** prevent the in-process path from creating PROPAGATED child Event nodes, align its root/affected-CI lifecycle with P0, and add optional affected-CI fields to `EventFeedSummary`/`get_events` without breaking existing correlation fields.
+- **P2 — Frontend semantics:** make `/monitoring` KPIs and event badges use root-event and affected-CI data rather than raw N+1 counts; retain client grouping for older records and explicitly decide whether `CONNECTS_TO` is included in the UI grouping contract. `/` remains the Architecture/SystemDashboard route and should not be changed to treat collector snapshots as event snapshots.
+- **P3 — Queue parity and topology remediation:** add correlation to the leased queue path only behind its existing flags, then audit/backfill missing AP parent relationships through a separately reviewable, idempotent topology operation. Do not make topology backfill a hidden side effect of event creation.
+
+### Risks
+
+- The same-cycle cache currently represents the graph state before event writes; changing its timing can alter which parent is selected and how parent recovery is interpreted.
+- `build_open_parent_index` chooses one highest-severity/oldest parent event per child-metric pair and does not select multiple parent metrics; this may under-represent multi-metric root causes.
+- Missing AP parent CIs/links, unsupported relationship types, incorrect direction, and depth greater than three will continue to produce ROOT events unless topology data is repaired.
+- Legacy and queue writers currently persist PROPAGATED child Events, while the external worker enriches roots instead; partial rollout can produce mixed API/UI semantics.
+- Replacing raw API rows with root-only rows could break consumers that depend on seeing existing PROPAGATED records; additive fields and explicit filtering are safer than silent removal.
+- Two-pass writes increase Neo4j round trips and may increase lock duration. The existing sorted advisory-lock contract and single-cycle SQLAlchemy session must be preserved to avoid cross-writer races/deadlocks.
+- Parent failure and recovery observed in one cycle can leave a recovered root with affected-CI annotations; lifecycle expectations need explicit tests before changing recovery queries.
+- Frontend polling remains eventually consistent (`/events` every 10 seconds); a write-time fix removes amplification but does not create an immediate push update.
+
+### Ready for Proposal
+
+Yes. The problem and first slice are sufficiently bounded for a proposal: start with P0 external-worker same-cycle two-pass correlation, define the root/affected-CI invariant and recovery behavior, and keep legacy parity, API/UI, queue parity, and topology backfill as explicitly sequenced follow-up slices. The proposal should request a review-budget forecast because the complete P0-P3 roadmap may exceed the configured 800 changed-line budget even though the first backend-only slice should remain reviewable.

--- a/openspec/changes/fix-416-event-amplification/proposal.md
+++ b/openspec/changes/fix-416-event-amplification/proposal.md
@@ -1,0 +1,61 @@
+# Proposal: P0 Write-Time Event Correlation Suppression (fix-416)
+
+## Intent
+
+`backend/engines/snmp_worker.py:poll_snmp` builds `build_open_parent_index` before current-cycle root Events are persisted. When a parent CI and N children fail in the same cycle with no pre-existing parent Event, all N+1 rows become separate ROOT Events. P0 introduces bounded two-pass correlation: deterministic root materialization first, then affected-CI attachment on just-written roots.
+
+## Scope
+
+### In Scope
+- Two-pass correlation in `backend/engines/snmp_worker.py` for collection failures, ICMP availability, and ICMP latency/threshold families.
+- Preserve `#310`/`#318` topology depth-three, `#322`/`#330` `pg_advisory_xact_lock` + `poll_collector_id`, `#405` correlation-topology-policy.
+- Strict-TDD matrix from exploration §Recommendation: parent + N children, child-before-parent order, multi-affected-metric parent, repeated cycles, no parent relationship, non-propagating metrics, parent recovery in same cycle, topology-lookup failure → ROOT.
+
+### Out of Scope (explicit follow-up slices)
+- Legacy in-process collector parity (P1).
+- API additive fields and `/monitoring` KPI rendering (P2).
+- Queue leased-path correlation parity (P3).
+- Topology backfill / AP parent synthesis (P3).
+
+## Capabilities
+
+### New Capabilities
+- `event-write-time-correlation`: same-cycle two-pass correlation in the external worker. One ROOT Event + affected-CI annotations per parent failure.
+
+### Modified Capabilities
+- None. `event-writer-coordination-observability`, `cmdb-graph-level-of-detail`, `icmp-latency-threshold-env`, `legacy-event-backfill-local-evidence`, `vpn-tunnel-relations` remain unchanged. P0 alters internal write order only.
+
+## Approach
+
+Apply exploration recommendation #2 (two-pass). Refactor `poll_snmp`:
+
+1. **Collect**: current per-cycle observation (unchanged).
+2. **Root materialize**: deterministic candidate-root ordering from existing depth-three index plus current-cycle candidates; write only ROOT candidate rows.
+3. **Affected-CI attach**: re-resolve open-parent index from just-persisted ROOTs; idempotently append dependents as `affected_ci_ids`/`affected_ci_count` via existing `_update_propagated_root_events`.
+
+## Affected Areas
+
+- `backend/engines/snmp_worker.py` (Modified): two-pass orchestration in `poll_snmp`.
+- `backend/repositories/topology_repo.py` (Modified): add current-cycle candidate helper; depth-three contract unchanged.
+- `backend/engines/correlation.py` (New): cycle candidate ordering + root materialization.
+- `backend/tests/test_snmp_worker_correlation.py` (Modified): strict-TDD matrix.
+- `backend/tests/test_event_correlation.py` (Modified): pass-3 affected-CI attach tests; preserve PROPAGATED tests.
+
+## Risks
+
+- **Same-cycle cache timing changes parent selection** (Med): test matrix covers all input orderings.
+- **Pass-3 adds Neo4j round trips and lock duration** (Low): single SQLAlchemy session; advisory-lock triplet preserved.
+- **Parent recovery in same cycle leaves recovered root with affected-CI annotations** (Med): explicit recovery test; root-enrichment helper already idempotent.
+- **External consumers depending on raw N+1 rows** (Low): P0 does not change `/events` API; document in changelog.
+- **Partial rollout leaves legacy/queue writers on old semantics** (Low): P0 only touches `engines/snmp_worker.py`; P1/P3 sequenced.
+
+## Rollback Plan
+
+Revert the commit introducing the two-pass helper. No DB migration. Legacy collector and queue paths unaffected.
+
+## Success Criteria
+
+- [ ] Parent + N children in same cycle produce ONE ROOT Event + N affected-CI annotations, regardless of input ordering.
+- [ ] All existing correlation and lock tests still pass.
+- [ ] `#310`/`#318`/`#322`/`#330`/`#405` invariants unchanged.
+- [ ] No public API contract change.

--- a/openspec/changes/fix-416-event-amplification/specs/event-write-time-correlation/spec.md
+++ b/openspec/changes/fix-416-event-amplification/specs/event-write-time-correlation/spec.md
@@ -1,0 +1,57 @@
+# Delta: Event Write-Time Correlation
+
+## Purpose
+
+Add a new backend-only capability for deterministic same-cycle correlation in the production-default external SNMP worker. The change suppresses first-cycle Event amplification by materializing eligible roots before attaching dependent CIs.
+
+## Requirements
+
+### REQ-001: Same-Cycle Root Suppression
+
+The external worker SHALL correlate collection failures, ICMP availability failures, and ICMP latency or threshold breaches observed in one collection cycle before dependent Event nodes are created. For a parent failure and N correlatable child failures, it SHALL persist one ROOT Event and SHALL NOT persist Event nodes for those children.
+
+### REQ-002: Order-Independent Resolution
+
+Correlation results SHALL be independent of observation input order. The worker SHALL identify and materialize eligible current-cycle root candidates before resolving dependent observations against persisted root Events.
+
+### REQ-003: Affected-CI Attachment
+
+Each correlated dependent CI SHALL be attached to the resolved ROOT Event through `affected_ci_ids`, and `affected_ci_count` SHALL equal the number of unique affected CI identifiers. Multiple affected metrics from the same child CI SHALL NOT duplicate that CI.
+
+### REQ-004: Repeated-Cycle Idempotency
+
+Repeated processing of the same unresolved failure state SHALL update the existing ROOT Event and affected-CI set without creating duplicate ROOT Events, child Events, affected-CI identifiers, or equivalent attachment effects.
+
+### REQ-005: Safe Independent-Root Behavior
+
+An observation SHALL remain ROOT when no eligible parent relationship or open parent Event can be resolved, when its metric is non-propagating, or when correlation lookup fails. A lookup failure SHALL NOT discard or delay the observation's normal Event write.
+
+### REQ-006: Parent Recovery Consistency
+
+When a parent recovery and dependent failures occur in the same cycle, the worker SHALL apply existing root recovery semantics and SHALL NOT attach new dependents to a parent Event that is no longer eligible after recovery processing. Dependents that cannot resolve another eligible open parent SHALL fall back to ROOT.
+
+### REQ-007: Existing Coordination Invariants
+
+All correlation passes SHALL preserve the existing Event advisory-lock ordering, transaction/session boundaries, collector identity fallback, Event deduplication, and root enrichment semantics.
+
+## Scenario Matrix
+
+| ID | Case | WHEN | THEN |
+|---|---|---|---|
+| SCN-001 | Parent then N children | WHEN a cycle observes a new parent failure before N correlatable child failures | THEN exactly one ROOT Event is persisted and N unique child CIs are attached to it |
+| SCN-002 | Children then parent | WHEN the same observations arrive with all children before the parent | THEN the persisted ROOT Event and affected-CI set are identical to SCN-001 |
+| SCN-003 | Interleaved order | WHEN parent and child observations arrive in any interleaving | THEN correlation output is independent of ordering and no child Event is persisted |
+| SCN-004 | Multi-affected-metric parent | WHEN one parent failure has children with multiple affected metrics, including repeated metrics for one CI | THEN one ROOT Event contains each affected CI once and its count equals the unique CI total |
+| SCN-005 | Repeated cycles | WHEN the same parent and child failures are processed in later cycles | THEN no duplicate Event or affected-CI attachment is created and the unique count remains stable |
+| SCN-006 | No parent relationship | WHEN a failing CI has no resolvable eligible parent | THEN its failure is persisted as an independent ROOT Event |
+| SCN-007 | Non-propagating metric | WHEN a child failure uses a metric that cannot propagate | THEN it is not attached to a parent and is handled as ROOT |
+| SCN-008 | Parent recovery in same cycle | WHEN an open parent recovers in the cycle while a dependent failure is observed | THEN the recovered parent receives no new attachment and an unresolved dependent falls back to ROOT |
+| SCN-009 | Lookup failure | WHEN correlation lookup raises an error or returns no usable result | THEN each unresolved observation safely follows ROOT write behavior without data loss |
+| SCN-010 | Pass-3 attachment idempotency | WHEN affected-CI attachment is retried for the same root and dependent set | THEN `affected_ci_ids` contains unique IDs, `affected_ci_count` is unchanged, and no duplicate attachment effect occurs |
+| SCN-011 | Event-family parity | WHEN equivalent parent and dependent failures occur in any supported external-worker event family | THEN each family enforces the same one-ROOT-plus-affected-CIs invariant |
+
+## Out of Scope
+
+- **P1:** Legacy in-process collector parity and changes to its persisted child-Event behavior.
+- **P2:** Public API fields, event filtering, frontend KPI calculations, and monitoring presentation.
+- **P3:** Leased queue writer parity, topology backfill, AP parent synthesis, or relationship remediation.

--- a/openspec/changes/fix-416-event-amplification/tasks.md
+++ b/openspec/changes/fix-416-event-amplification/tasks.md
@@ -1,0 +1,48 @@
+# Tasks: P0 Write-Time Event Correlation Suppression
+
+## Review Workload Forecast
+
+| Field | Value |
+|---|---|
+| Estimated changed lines | 430–520 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1: roots → PR 2: attachment/orchestration |
+| Delivery strategy | ask-always; single P0 PR selected |
+| Chain strategy | size-exception |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: size-exception
+400-line budget risk: High
+
+### Suggested Work Units
+
+| Unit | Goal | PR | Focused test | Runtime harness | Rollback boundary |
+|---|---|---|---|---|---|
+| A | Select roots | P0 | `cd backend && pytest -q tests/test_event_correlation.py -k cycle_root` | N/A—pure | candidate selector/tests |
+| B | Topology candidates | P0 | `cd backend && pytest -q tests/test_topology_repo_open_parent.py` | N/A—pure | repo helper/tests |
+| C | Materialize roots | P0 | `cd backend && pytest -q tests/test_event_correlation.py -k materialize` | N/A—mocked | materializer/tests |
+| D | Attach dependents | P0 | `cd backend && pytest -q tests/test_event_correlation.py -k attach` | N/A—mocked | attachment/tests |
+| E | Wire cycle | P0 | `cd backend && pytest -q tests/test_snmp_worker_correlation.py` | N/A—approved mocked cycle | `poll_snmp`/integration tests |
+
+## Phase 1: Candidate Foundation
+
+- [ ] 1. **RED** — Add permutation/non-propagation tests for `cycle_root_candidates` in `backend/tests/test_event_correlation.py` (REQ-001/002/005; SCN-001–003/007). Commit A after GREEN.
+- [ ] 2. Create `backend/engines/correlation.py`; implement deterministic, stateless `cycle_root_candidates` (same coverage). Commit A: `feat(events): select same-cycle root candidates`.
+- [ ] 3. **RED** — Test `current_cycle_parent_candidates` in `backend/tests/test_topology_repo_open_parent.py`, including missing-parent and `can_propagate=False` (REQ-002/005; SCN-006/007). Commit B after GREEN.
+- [ ] 4. Add pure `current_cycle_parent_candidates(observations)` to `backend/repositories/topology_repo.py`; retain depth-three vocabulary and no Neo4j I/O (REQ-002/005). Commit B: `feat(events): derive current-cycle topology candidates`.
+
+## Phase 2: Correlation Passes
+
+- [ ] 5. **RED** — Test `materialize_current_cycle_roots` for all event families, no parent, and lookup error in `backend/tests/test_event_correlation.py` (REQ-001/005/007; SCN-006/009/011). Commit C after GREEN.
+- [ ] 6. Implement materialization in `backend/engines/correlation.py`, dispatching existing refresh helpers with `cache={}` and shared lock DB (same coverage). Commit C: `feat(events): materialize current-cycle roots`.
+- [ ] 7. **RED** — Test unique multi-metric attachment, retries, counts, and no child CREATE in `backend/tests/test_event_correlation.py` (REQ-003/004/007; SCN-004/005/010). Commit D after GREEN.
+- [ ] 8. Implement `attach_dependents_to_roots` in `backend/engines/correlation.py` with rebuilt parent index and existing enrichment (same coverage). Commit D: `feat(events): attach dependents to root events`.
+
+## Phase 3: Orchestration and Verification
+
+- [ ] 9. **RED** — Add `poll_snmp` matrix tests using `MockNeo4jSession.set_sequence_response` in `backend/tests/test_snmp_worker_correlation.py` (REQ-001–007; SCN-001–011), including recovery-before-attach. Commit E after GREEN.
+- [ ] 10. Refactor `backend/engines/snmp_worker.py:poll_snmp` to collect → materialize → recover/rebuild → attach with one DB/session and sorted locks (REQ-001–007). Commit E.
+- [ ] 11. **GREEN/REFACTOR** — Run `cd backend && pytest -q -m "event or neo4j"`, then `cd backend && python -m pytest -q`; fix only P0 code without weakening tests. Commit E: `fix(events): suppress same-cycle event amplification`.
+- [ ] 12. Run `pre-commit run --all-files`, `cd backend && ruff check .`, `cd backend && black --check .`; require zero warnings and review `git diff --stat` against 800 lines. Commit: none unless a work unit changes.

--- a/openspec/specs/event-write-time-correlation/spec.md
+++ b/openspec/specs/event-write-time-correlation/spec.md
@@ -1,0 +1,57 @@
+# Event Write-Time Correlation Specification
+
+## Purpose
+
+Define deterministic same-cycle correlation for the production-default external SNMP worker so a parent failure and its dependent CI failures produce one ROOT Event with idempotent affected-CI annotations instead of N+1 ROOT Events.
+
+## Requirements
+
+### REQ-001: Same-Cycle Root Suppression
+
+The external worker SHALL correlate collection failures, ICMP availability failures, and ICMP latency or threshold breaches observed in one collection cycle before dependent Event nodes are created. For a parent failure and N correlatable child failures, it SHALL persist one ROOT Event and SHALL NOT persist Event nodes for those children.
+
+### REQ-002: Order-Independent Resolution
+
+Correlation results SHALL be independent of observation input order. The worker SHALL identify and materialize eligible current-cycle root candidates before resolving dependent observations against persisted root Events.
+
+### REQ-003: Affected-CI Attachment
+
+Each correlated dependent CI SHALL be attached to the resolved ROOT Event through `affected_ci_ids`, and `affected_ci_count` SHALL equal the number of unique affected CI identifiers. Multiple affected metrics from the same child CI SHALL NOT duplicate that CI.
+
+### REQ-004: Repeated-Cycle Idempotency
+
+Repeated processing of the same unresolved failure state SHALL update the existing ROOT Event and affected-CI set without creating duplicate ROOT Events, child Events, affected-CI identifiers, or equivalent attachment effects.
+
+### REQ-005: Safe Independent-Root Behavior
+
+An observation SHALL remain ROOT when no eligible parent relationship or open parent Event can be resolved, when its metric is non-propagating, or when correlation lookup fails. A lookup failure SHALL NOT discard or delay the observation's normal Event write.
+
+### REQ-006: Parent Recovery Consistency
+
+When a parent recovery and dependent failures occur in the same cycle, the worker SHALL apply existing root recovery semantics and SHALL NOT attach new dependents to a parent Event that is no longer eligible after recovery processing. Dependents that cannot resolve another eligible open parent SHALL fall back to ROOT.
+
+### REQ-007: Existing Coordination Invariants
+
+All correlation passes SHALL preserve the existing Event advisory-lock ordering, transaction/session boundaries, collector identity fallback, Event deduplication, and root enrichment semantics.
+
+## Scenario Matrix
+
+| ID | Case | WHEN | THEN |
+|---|---|---|---|
+| SCN-001 | Parent then N children | WHEN a cycle observes a new parent failure before N correlatable child failures | THEN exactly one ROOT Event is persisted and N unique child CIs are attached to it |
+| SCN-002 | Children then parent | WHEN the same observations arrive with all children before the parent | THEN the persisted ROOT Event and affected-CI set are identical to SCN-001 |
+| SCN-003 | Interleaved order | WHEN parent and child observations arrive in any interleaving | THEN correlation output is independent of ordering and no child Event is persisted |
+| SCN-004 | Multi-affected-metric parent | WHEN one parent failure has children with multiple affected metrics, including repeated metrics for one CI | THEN one ROOT Event contains each affected CI once and its count equals the unique CI total |
+| SCN-005 | Repeated cycles | WHEN the same parent and child failures are processed in later cycles | THEN no duplicate Event or affected-CI attachment is created and the unique count remains stable |
+| SCN-006 | No parent relationship | WHEN a failing CI has no resolvable eligible parent | THEN its failure is persisted as an independent ROOT Event |
+| SCN-007 | Non-propagating metric | WHEN a child failure uses a metric that cannot propagate | THEN it is not attached to a parent and is handled as ROOT |
+| SCN-008 | Parent recovery in same cycle | WHEN an open parent recovers in the cycle while a dependent failure is observed | THEN the recovered parent receives no new attachment and an unresolved dependent falls back to ROOT |
+| SCN-009 | Lookup failure | WHEN correlation lookup raises an error or returns no usable result | THEN each unresolved observation safely follows ROOT write behavior without data loss |
+| SCN-010 | Pass-3 attachment idempotency | WHEN affected-CI attachment is retried for the same root and dependent set | THEN `affected_ci_ids` contains unique IDs, `affected_ci_count` is unchanged, and no duplicate attachment effect occurs |
+| SCN-011 | Event-family parity | WHEN equivalent parent and dependent failures occur in any supported external-worker event family | THEN each family enforces the same one-ROOT-plus-affected-CIs invariant |
+
+## Out of Scope
+
+- **P1:** Legacy in-process collector parity and changes to its persisted child-Event behavior.
+- **P2:** Public API fields, event filtering, frontend KPI calculations, and monitoring presentation.
+- **P3:** Leased queue writer parity, topology backfill, AP parent synthesis, or relationship remediation.


### PR DESCRIPTION
Closes #416

## Summary
- Adds `backend/engines/correlation.py` with three pure helpers: `cycle_root_candidates`, `materialize_current_cycle_roots`, and `attach_dependents_to_roots`.
- Adds `current_cycle_parent_candidates` to `backend/repositories/topology_repo.py` as the in-memory complement to `build_open_parent_index`.
- Adds the canonical capability spec `openspec/specs/event-write-time-correlation/spec.md` (REQ-001..007, SCN-001..011) and the strict-TDD unit test matrix.
- No changes to `poll_snmp` or the public API.

## Changes
| File | Change |
|------|--------|
| `backend/engines/correlation.py` | New module: pure helpers for two-pass correlation. |
| `backend/repositories/topology_repo.py` | Adds `current_cycle_parent_candidates` (+pure helper). |
| `backend/tests/test_event_correlation.py` | Strict-TDD tests for correlation helpers. |
| `backend/tests/test_topology_repo_open_parent.py` | Tests for topology helpers. |
| `openspec/specs/event-write-time-correlation/spec.md` | New canonical capability spec. |

## Test Plan
- [x] `cd backend && .venv/bin/python -m pytest -q -m event tests/test_event_correlation.py tests/test_topology_repo_open_parent.py` is 100% green.
- [x] Full suite has no new failures (6 pre-existing failures in `test_auth_router_refresh.py` and `test_writer_advisory_lock.py` are Docker-dependent and unrelated).

## Linked Artifacts
- SDD archive: `openspec/changes/archive/2026-07-29-fix-416-event-amplification/`
- Spec: `openspec/specs/event-write-time-correlation/spec.md`

## Out of scope (deferred)
- PR2: integration into `poll_snmp` (Pass 1.5 cycle_parent_index → materializer → attach), first-cycle amplification suppression, and SCN-008 E2E coverage.
- P1: legacy collector parity.
- P2: public API fields + `/monitoring` KPI changes.
- P3: leased queue writer + topology backfill.
