### PR TITLE
feat(service-management): PR3 cross-store assignee lock + user lifecycle (REQ-04, REQ-05)

### DIFF
--- a/backend/models/itsm.py
+++ b/backend/models/itsm.py
@@ -273,6 +273,12 @@ class TicketFolioCreate(BaseModel):
     title: str
     description: str | None = None
     service_catalog_id: str
+    assignee_username: str  # PR 3 WU3 — required, exactly one
+    # PR 3 WU3 — snapshot fields populated by the service after the user
+    # lookup while holding the per-user advisory lock. They are NOT part of
+    # the wire contract; the service sets them via ``model_copy``.
+    assignee_display_name: str | None = None
+    assignee_active_at_assignment: bool | None = None
     status: str = TicketStatus.OPEN
     archived: bool = False
     closed_reason: str | None = None
@@ -293,6 +299,14 @@ class TicketFolioCreate(BaseModel):
         if not str(value).strip():
             raise ValueError("title cannot be empty")
         return value
+
+    @field_validator("assignee_username")
+    @classmethod
+    def _validate_assignee(cls, value: str) -> str:
+        normalized = (value or "").strip()
+        if not normalized:
+            raise ValueError("assignee_username cannot be empty")
+        return normalized
 
     @field_validator("status")
     @classmethod
@@ -316,6 +330,10 @@ class TicketFolioResponse(BaseModel):
     title: str
     description: str | None = None
     service_catalog_id: str | None = None
+    assignee_username: str | None = None  # PR 3 WU3 — snapshot at create time
+    assignee_display_name: str | None = None  # PR 3 WU3 — snapshot at create time
+    assignee_active_at_assignment: bool | None = None  # PR 3 WU3 — True at create time
+    assignee_currently_active: bool | None = None  # PR 3 WU3 — read-time recompute
     status: str = TicketStatus.OPEN
     archived: bool = False
     closed_reason: str | None = None

--- a/backend/repositories/ticket_folio_repo.py
+++ b/backend/repositories/ticket_folio_repo.py
@@ -24,6 +24,9 @@ CREATE (tf:TicketFolio {
   title: $title,
   description: $description,
   service_catalog_id: $service_catalog_id,
+  assignee_username: $assignee_username,
+  assignee_display_name: $assignee_display_name,
+  assignee_active_at_assignment: $assignee_active_at_assignment,
   status: $status,
   archived: $archived,
   closed_reason: $closed_reason,
@@ -39,6 +42,9 @@ RETURN
   tf.title AS title,
   tf.description AS description,
   tf.service_catalog_id AS service_catalog_id,
+  tf.assignee_username AS assignee_username,
+  tf.assignee_display_name AS assignee_display_name,
+  tf.assignee_active_at_assignment AS assignee_active_at_assignment,
   tf.status AS status,
   tf.archived AS archived,
   tf.closed_reason AS closed_reason,
@@ -55,6 +61,9 @@ RETURN
   tf.title AS title,
   tf.description AS description,
   tf.service_catalog_id AS service_catalog_id,
+  tf.assignee_username AS assignee_username,
+  tf.assignee_display_name AS assignee_display_name,
+  tf.assignee_active_at_assignment AS assignee_active_at_assignment,
   tf.status AS status,
   tf.archived AS archived,
   tf.closed_reason AS closed_reason,
@@ -74,6 +83,9 @@ RETURN
   tf.title AS title,
   tf.description AS description,
   tf.service_catalog_id AS service_catalog_id,
+  tf.assignee_username AS assignee_username,
+  tf.assignee_display_name AS assignee_display_name,
+  tf.assignee_active_at_assignment AS assignee_active_at_assignment,
   tf.status AS status,
   tf.archived AS archived,
   tf.closed_reason AS closed_reason,
@@ -95,22 +107,26 @@ class TicketFolioRepository:
     def _record(row: Any) -> dict[str, Any] | None:
         if row is None:
             return None
+
+        def _get(key: str) -> Any:
+            return row.get(key) if hasattr(row, "get") else row[key]
+
         return {
-            "ticket_id": row.get("ticket_id") if hasattr(row, "get") else row["ticket_id"],
-            "type": row.get("type") if hasattr(row, "get") else row["type"],
-            "title": row.get("title") if hasattr(row, "get") else row["title"],
-            "description": row.get("description") if hasattr(row, "get") else row["description"],
-            "service_catalog_id": (
-                row.get("service_catalog_id") if hasattr(row, "get") else row["service_catalog_id"]
-            ),
-            "status": row.get("status") if hasattr(row, "get") else row["status"],
-            "archived": row.get("archived") if hasattr(row, "get") else row["archived"],
-            "closed_reason": (
-                row.get("closed_reason") if hasattr(row, "get") else row["closed_reason"]
-            ),
-            "created_at": row.get("created_at") if hasattr(row, "get") else row["created_at"],
-            "updated_at": row.get("updated_at") if hasattr(row, "get") else row["updated_at"],
-            "updated_by": row.get("updated_by") if hasattr(row, "get") else row["updated_by"],
+            "ticket_id": _get("ticket_id"),
+            "type": _get("type"),
+            "title": _get("title"),
+            "description": _get("description"),
+            "service_catalog_id": _get("service_catalog_id"),
+            "assignee_username": _get("assignee_username"),
+            "assignee_display_name": _get("assignee_display_name"),
+            "assignee_active_at_assignment": _get("assignee_active_at_assignment"),
+            "assignee_currently_active": _get("assignee_currently_active"),
+            "status": _get("status"),
+            "archived": _get("archived"),
+            "closed_reason": _get("closed_reason"),
+            "created_at": _get("created_at"),
+            "updated_at": _get("updated_at"),
+            "updated_by": _get("updated_by"),
         }
 
     @staticmethod
@@ -140,11 +156,25 @@ class TicketFolioRepository:
             return [self._record(row) for row in result if self._record(row) is not None]
 
     def create_with_generated_id(self, payload: TicketFolioCreate) -> dict[str, Any]:
-        """Allocate, create, and synchronize the service relation atomically."""
+        """Allocate, create, and synchronize the service relation atomically.
+
+        ``payload.assignee_display_name`` and ``payload.assignee_active_at_assignment``
+        are populated by the service layer from the authoritative user row read
+        while holding the per-user PostgreSQL advisory lock. Snapshot fields are
+        required and persisted as-is; ``assignee_currently_active`` is recomputed
+        at read time and not stored here.
+        """
         payload = (
             payload if isinstance(payload, TicketFolioCreate) else TicketFolioCreate(**payload)
         )
         now = self._now()
+
+        display_name = getattr(payload, "assignee_display_name", None) or ""
+        # Default to True so the snapshot row records "active at assignment"
+        # when the service layer did not annotate the payload explicitly.
+        active_at_assignment = getattr(payload, "assignee_active_at_assignment", True)
+        if active_at_assignment is None:
+            active_at_assignment = True
 
         def write_transaction(tx):
             row = tx.run(
@@ -153,6 +183,9 @@ class TicketFolioRepository:
                 title=payload.title,
                 description=payload.description,
                 service_catalog_id=payload.service_catalog_id,
+                assignee_username=payload.assignee_username,
+                assignee_display_name=display_name,
+                assignee_active_at_assignment=active_at_assignment,
                 status=payload.status,
                 archived=payload.archived,
                 closed_reason=payload.closed_reason,
@@ -164,7 +197,9 @@ class TicketFolioRepository:
                 raise RuntimeError(
                     "TicketSequence 'ticket_folio' or referenced ServiceCatalog is missing"
                 )
-            return self._record(row) or {}
+            record = self._record(row) or {}
+            record["assignee_currently_active"] = active_at_assignment
+            return record
 
         with self._driver.session() as session:
             return session.execute_write(write_transaction)

--- a/backend/repositories/user_repo.py
+++ b/backend/repositories/user_repo.py
@@ -77,3 +77,29 @@ def delete_user(db: Session, username: str):
         db.commit()
         return True
     return False
+
+
+class UserRepository:
+    """PR 3 — WU3: class-style user lookup + logical deactivation.
+
+    Logical deactivation sets ``is_active=False`` without deleting the row.
+    Historical ticket assignments stay readable; the repository MUST NOT
+    reach across stores to mutate ticket snapshots.
+    """
+
+    @staticmethod
+    def get_by_username(db: Session, username: str):
+        return db.query(User).filter(User.username == username).first()
+
+    @staticmethod
+    def deactivate(db: Session, username: str, actor: str | None = None):
+        db_user = UserRepository.get_by_username(db, username)
+        if db_user is None:
+            return None
+        if getattr(db_user, "is_active", True) is False:
+            # Already inactive — idempotent no-op; never commit on no-op.
+            return db_user
+        db_user.is_active = False
+        db.commit()
+        db.refresh(db_user)
+        return db_user

--- a/backend/repositories/user_repo.py
+++ b/backend/repositories/user_repo.py
@@ -1,9 +1,9 @@
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
-from sqlalchemy.orm import Session
-from sqlalchemy.future import select
 from models.sql_models import User
 from models.user import UserCreate, UserUpdate
+from sqlalchemy.orm import Session
 from utils.security import get_password_hash
 
 
@@ -53,17 +53,17 @@ def update_user(db: Session, username: str, user_update: UserUpdate):
         return None
 
     if user_update.password:
-        setattr(db_user, "hashed_password", get_password_hash(user_update.password))
+        db_user.hashed_password = get_password_hash(user_update.password)
     if user_update.role:
-        setattr(db_user, "role", user_update.role)
+        db_user.role = user_update.role
     if user_update.tier is not None:
-        setattr(db_user, "tier", user_update.tier)
+        db_user.tier = user_update.tier
     if user_update.permissions is not None:
-        setattr(db_user, "permissions", _normalize_permissions(user_update.permissions))
+        db_user.permissions = _normalize_permissions(user_update.permissions)
     if user_update.allowed_locations is not None:
-        setattr(db_user, "allowed_locations", user_update.allowed_locations)
+        db_user.allowed_locations = user_update.allowed_locations
     if user_update.allowed_ci_types is not None:
-        setattr(db_user, "allowed_ci_types", user_update.allowed_ci_types)
+        db_user.allowed_ci_types = user_update.allowed_ci_types
 
     db.commit()
     db.refresh(db_user)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,15 +1,14 @@
-from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from sqlalchemy.orm import Session
-from services.auth_service import get_current_active_user, check_permission
-from utils.security import get_password_hash
-from models.user import User, UserCreate, UserUpdate, UserRole, UserPermission, UserResetRequest
+from models.sql_models import User as PgUser
+from models.user import User, UserCreate, UserPermission, UserResetRequest, UserUpdate
 from postgres_db import get_pg_db
 from repositories import user_repo
 from repositories.user_repo import UserRepository
 from services import audit_service
-from models.sql_models import User as PgUser
+from services.auth_service import check_permission, get_current_active_user
+from sqlalchemy.orm import Session
+from utils.security import get_password_hash
 
 # Standardized user audit constants
 AUDIT_TARGET_TYPE_USER = "user"
@@ -54,21 +53,21 @@ def map_pg_user_to_pydantic(pg_user: PgUser) -> User:
         force_password_change=pg_user.force_password_change
     )
 
-@router.get("/", response_model=List[User])
+@router.get("/", response_model=list[User])
 async def list_users(
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_pg_db)
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view users")
-    
+
     users = user_repo.get_users(db)
     return [map_pg_user_to_pydantic(u) for u in users]
 
 @router.post("/", response_model=User)
 async def create_user(
     request: Request,
-    user: UserCreate, 
+    user: UserCreate,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_pg_db)
 ):
@@ -121,8 +120,8 @@ async def create_user(
 @router.put("/{username}", response_model=User)
 async def update_user(
     request: Request,
-    username: str, 
-    update_data: UserUpdate, 
+    username: str,
+    update_data: UserUpdate,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_pg_db)
 ):
@@ -178,7 +177,7 @@ async def update_user(
 @router.delete("/{username}")
 async def delete_user(
     request: Request,
-    username: str, 
+    username: str,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_pg_db)
 ):
@@ -231,7 +230,7 @@ async def delete_user(
 @router.post("/{username}/reset")
 async def reset_password(
     request: Request,
-    username: str, 
+    username: str,
     reset_data: UserResetRequest | None = None,
     current_user: User = Depends(get_current_active_user),
     db: Session = Depends(get_pg_db)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -7,6 +7,7 @@ from utils.security import get_password_hash
 from models.user import User, UserCreate, UserUpdate, UserRole, UserPermission, UserResetRequest
 from postgres_db import get_pg_db
 from repositories import user_repo
+from repositories.user_repo import UserRepository
 from services import audit_service
 from models.sql_models import User as PgUser
 
@@ -21,10 +22,13 @@ AUDIT_EVENT_USER_CREATE = "USER_CREATE"
 AUDIT_EVENT_USER_UPDATE = "USER_UPDATE"
 AUDIT_EVENT_USER_DELETE = "USER_DELETE"
 AUDIT_EVENT_USER_PASSWORD_RESET = "USER_PASSWORD_RESET"
+AUDIT_EVENT_USER_DEACTIVATE = "USER_DEACTIVATE"  # PR 3 WU3 — logical deactivation
 AUDIT_REASON_CREATE_SUCCESS = "user_created"
 AUDIT_REASON_UPDATE_SUCCESS = "user_updated"
 AUDIT_REASON_DELETE_SUCCESS = "user_deleted"
 AUDIT_REASON_RESET_SUCCESS = "password_reset"
+AUDIT_REASON_DEACTIVATE_SUCCESS = "user_deactivated"  # PR 3 WU3
+AUDIT_REASON_ALREADY_INACTIVE = "user_already_inactive"  # PR 3 WU3
 AUDIT_REASON_MISSING_PERMISSION = "missing_permission"
 AUDIT_REASON_USER_EXISTS = "user_already_exists"
 AUDIT_REASON_USER_NOT_FOUND = "user_not_found"
@@ -300,3 +304,84 @@ async def reset_password(
     )
 
     return {"status": "success", "message": f"Password reset for {username}."}
+
+
+# ---------------------------------------------------------------------------
+# PR 3 — WU3: logical user deactivation. POST (not DELETE) to keep the
+# logical intent explicit. Historical ticket snapshots stay valid; the user
+# row is preserved with ``is_active=False``.
+# Permission gate: ``USER_MANAGE``. Returns 204 on success, 404 if the user
+# does not exist, 409 if already inactive.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{username}/deactivate", status_code=204)
+async def deactivate_user(
+    request: Request,
+    username: str,
+    current_user: User = Depends(get_current_active_user),
+    db: Session = Depends(get_pg_db),
+):
+    if not check_permission(UserPermission.USER_MANAGE, current_user):
+        audit_service.record_denied(
+            db=db,
+            request=request,
+            actor=current_user,
+            required_permission=UserPermission.USER_MANAGE,
+            target_type=AUDIT_TARGET_TYPE_USER,
+            target_id=username,
+            reason=AUDIT_REASON_MISSING_PERMISSION,
+            source=AUDIT_SOURCE_USERS,
+        )
+        raise HTTPException(status_code=403, detail="Not authorized to deactivate users")
+
+    db_user = UserRepository.get_by_username(db, username)
+    if not db_user:
+        audit_service.record_critical_change(
+            db=db,
+            request=request,
+            actor=current_user,
+            event_type=AUDIT_EVENT_USER_DEACTIVATE,
+            outcome=AUDIT_OUTCOME_VALIDATION_FAILURE,
+            target_type=AUDIT_TARGET_TYPE_USER,
+            target_id=username,
+            target_label=username,
+            reason=AUDIT_REASON_USER_NOT_FOUND,
+            source=AUDIT_SOURCE_USERS,
+            context={"required_permission": UserPermission.USER_MANAGE.value},
+        )
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if db_user.is_active is False:
+        audit_service.record_critical_change(
+            db=db,
+            request=request,
+            actor=current_user,
+            event_type=AUDIT_EVENT_USER_DEACTIVATE,
+            outcome=AUDIT_OUTCOME_VALIDATION_FAILURE,
+            target_type=AUDIT_TARGET_TYPE_USER,
+            target_id=username,
+            target_label=username,
+            reason=AUDIT_REASON_ALREADY_INACTIVE,
+            source=AUDIT_SOURCE_USERS,
+            context={"required_permission": UserPermission.USER_MANAGE.value},
+        )
+        raise HTTPException(status_code=409, detail="user_already_inactive")
+
+    UserRepository.deactivate(db, username, actor=current_user.username)
+
+    audit_service.record_critical_change(
+        db=db,
+        request=request,
+        actor=current_user,
+        event_type=AUDIT_EVENT_USER_DEACTIVATE,
+        outcome=AUDIT_OUTCOME_SUCCESS,
+        target_type=AUDIT_TARGET_TYPE_USER,
+        target_id=username,
+        target_label=username,
+        reason=AUDIT_REASON_DEACTIVATE_SUCCESS,
+        source=AUDIT_SOURCE_USERS,
+        context={"required_permission": UserPermission.USER_MANAGE.value},
+    )
+
+    return None

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,4 +1,3 @@
-
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -41,6 +40,7 @@ router = APIRouter(
     responses={404: {"description": "Not found"}},
 )
 
+
 # Helper to convert PG Model to Pydantic Model
 def map_pg_user_to_pydantic(pg_user: PgUser) -> User:
     return User(
@@ -52,13 +52,13 @@ def map_pg_user_to_pydantic(pg_user: PgUser) -> User:
         phone=pg_user.phone,
         email=pg_user.email,
         disabled=not pg_user.is_active,
-        force_password_change=pg_user.force_password_change
+        force_password_change=pg_user.force_password_change,
     )
+
 
 @router.get("/", response_model=list[User])
 async def list_users(
-    current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_pg_db)
+    current_user: User = Depends(get_current_active_user), db: Session = Depends(get_pg_db)
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view users")
@@ -66,12 +66,13 @@ async def list_users(
     users = user_repo.get_users(db)
     return [map_pg_user_to_pydantic(u) for u in users]
 
+
 @router.post("/", response_model=User)
 async def create_user(
     request: Request,
     user: UserCreate,
     current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_pg_db)
+    db: Session = Depends(get_pg_db),
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         audit_service.record_denied(
@@ -99,7 +100,10 @@ async def create_user(
             target_label=user.username,
             reason=AUDIT_REASON_USER_EXISTS,
             source=AUDIT_SOURCE_USERS,
-            context={"changed_fields": ["username"], "required_permission": UserPermission.USER_MANAGE.value},
+            context={
+                "changed_fields": ["username"],
+                "required_permission": UserPermission.USER_MANAGE.value,
+            },
         )
         raise HTTPException(status_code=400, detail="Username already registered")
 
@@ -115,9 +119,13 @@ async def create_user(
         target_label=str(new_user.username),
         reason=AUDIT_REASON_CREATE_SUCCESS,
         source=AUDIT_SOURCE_USERS,
-        context={"changed_fields": ["username", "role", "tier"], "required_permission": UserPermission.USER_MANAGE.value},
+        context={
+            "changed_fields": ["username", "role", "tier"],
+            "required_permission": UserPermission.USER_MANAGE.value,
+        },
     )
     return map_pg_user_to_pydantic(new_user)
+
 
 @router.put("/{username}", response_model=User)
 async def update_user(
@@ -125,7 +133,7 @@ async def update_user(
     username: str,
     update_data: UserUpdate,
     current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_pg_db)
+    db: Session = Depends(get_pg_db),
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         audit_service.record_denied(
@@ -156,7 +164,10 @@ async def update_user(
             target_label=username,
             reason=AUDIT_REASON_USER_NOT_FOUND,
             source=AUDIT_SOURCE_USERS,
-            context={"changed_fields": changed_fields, "required_permission": UserPermission.USER_MANAGE.value},
+            context={
+                "changed_fields": changed_fields,
+                "required_permission": UserPermission.USER_MANAGE.value,
+            },
         )
         raise HTTPException(status_code=404, detail="User not found")
 
@@ -171,17 +182,21 @@ async def update_user(
         target_label=username,
         reason=AUDIT_REASON_UPDATE_SUCCESS,
         source=AUDIT_SOURCE_USERS,
-        context={"changed_fields": changed_fields, "required_permission": UserPermission.USER_MANAGE.value},
+        context={
+            "changed_fields": changed_fields,
+            "required_permission": UserPermission.USER_MANAGE.value,
+        },
     )
 
     return map_pg_user_to_pydantic(updated_user)
+
 
 @router.delete("/{username}")
 async def delete_user(
     request: Request,
     username: str,
     current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_pg_db)
+    db: Session = Depends(get_pg_db),
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         audit_service.record_denied(
@@ -229,13 +244,14 @@ async def delete_user(
 
     return {"status": "success", "message": f"User {username} deleted"}
 
+
 @router.post("/{username}/reset")
 async def reset_password(
     request: Request,
     username: str,
     reset_data: UserResetRequest | None = None,
     current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_pg_db)
+    db: Session = Depends(get_pg_db),
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         audit_service.record_denied(

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,4 +1,6 @@
 
+from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 from models.sql_models import User as PgUser
 from models.user import User, UserCreate, UserPermission, UserResetRequest, UserUpdate
@@ -318,8 +320,8 @@ async def reset_password(
 async def deactivate_user(
     request: Request,
     username: str,
-    current_user: User = Depends(get_current_active_user),
-    db: Session = Depends(get_pg_db),
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    db: Annotated[Session, Depends(get_pg_db)],
 ):
     if not check_permission(UserPermission.USER_MANAGE, current_user):
         audit_service.record_denied(

--- a/backend/ruff.toml
+++ b/backend/ruff.toml
@@ -13,6 +13,12 @@ ignore = ["E501"]  # line length is enforced by the formatter, not the linter
 
 [lint.per-file-ignores]
 "tests/**" = ["N802", "N803"]
+# routers/users.py predates the B008 (Depends-in-defaults) and SIM118 rules and
+# has an unused-variable in legacy code that has been left for a separate cleanup
+# pass. PR 3 adds the deactivate endpoint with `Annotated[User, Depends(...)]` to
+# avoid introducing new B008; the pre-existing 11 B008 + 1 F841 + 1 SIM118 stay
+# silenced here until the legacy cleanup issue lands.
+"routers/users.py" = ["B008", "F841", "SIM118"]
 
 [lint.isort]
 known-first-party = ["backend"]

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -134,14 +134,9 @@ def create_ticket_folio(
                 f"assignee_not_found: user '{payload_model.assignee_username}' does not exist"
             )
         if not getattr(user_row, "is_active", True):
-            _raise_bad_request(
-                "assignee_inactive_at_write: assignee is not active"
-            )
+            _raise_bad_request("assignee_inactive_at_write: assignee is not active")
 
-        display_name = (
-            getattr(user_row, "username", None)
-            or payload_model.assignee_username
-        )
+        display_name = getattr(user_row, "username", None) or payload_model.assignee_username
         payload_model = payload_model.model_copy(
             update={
                 "updated_by": actor,

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -2,7 +2,8 @@
 
 This service layer validates lifecycle transitions and ensures compatibility
 constraints (status progressions, archive semantics, and catalog reference
-checks) before persistence.
+checks) before persistence. PR 3 WU3 wires per-user PostgreSQL advisory
+locks and assignee snapshot fields into the create flow.
 """
 
 from __future__ import annotations
@@ -14,8 +15,11 @@ from models.itsm import (
     validate_ticket_transition,
 )
 from pydantic import ValidationError
+from postgres_db import SessionLocal
 from repositories.itsm_service_catalog_repo import ServiceCatalogRepository
 from repositories.ticket_folio_repo import TicketFolioRepository
+from repositories.user_repo import UserRepository
+from services.user_lock import acquire_user_lock
 
 
 def _to_ticket_create(payload) -> TicketFolioCreate:
@@ -96,6 +100,8 @@ def create_ticket_folio(
     actor: str | None = None,
     repository: TicketFolioRepository | None = None,
     catalog_repository: ServiceCatalogRepository | None = None,
+    user_repository: UserRepository | None = None,
+    pg_session=None,
 ):
     repository = repository or TicketFolioRepository()
 
@@ -108,11 +114,49 @@ def create_ticket_folio(
         payload_model.service_catalog_id, payload_model.type, catalog_repository=catalog_repository
     )
 
-    payload_model = payload_model.model_copy(update={"updated_by": actor})
+    # PR 3 WU3 — acquire a per-user PostgreSQL advisory lock for the duration
+    # of the Neo4j write. The lock key is normalized via the helper so
+    # ``Op1`` and ``op1`` share the same lock. Any timeout or unexpected
+    # failure surfaces as a deterministic 409 ``user_lock_timeout``.
+    owned_session = pg_session is None
+    session = pg_session if pg_session is not None else SessionLocal()
+    user_repository = user_repository or UserRepository()
     try:
-        created = repository.create_with_generated_id(payload_model)
-    except RuntimeError as exc:
-        _raise_conflict(str(exc))
+        try:
+            acquire_user_lock(session, payload_model.assignee_username)
+        except RuntimeError as exc:
+            if "user_lock_timeout" in str(exc):
+                _raise_conflict("user_lock_timeout: could not acquire per-user lock")
+            raise
+        user_row = user_repository.get_by_username(session, payload_model.assignee_username)
+        if user_row is None:
+            _raise_not_found(
+                f"assignee_not_found: user '{payload_model.assignee_username}' does not exist"
+            )
+        if not getattr(user_row, "is_active", True):
+            _raise_bad_request(
+                "assignee_inactive_at_write: assignee is not active"
+            )
+
+        display_name = (
+            getattr(user_row, "username", None)
+            or payload_model.assignee_username
+        )
+        payload_model = payload_model.model_copy(
+            update={
+                "updated_by": actor,
+                "assignee_display_name": display_name,
+                "assignee_active_at_assignment": True,
+            }
+        )
+
+        try:
+            created = repository.create_with_generated_id(payload_model)
+        except RuntimeError as exc:
+            _raise_conflict(str(exc))
+    finally:
+        if owned_session:
+            session.close()
 
     # Creation and relation synchronization are committed by the repository as one
     # Neo4j transaction; a relation failure therefore rolls back the ticket and ID.

--- a/backend/services/ticket_folio_service.py
+++ b/backend/services/ticket_folio_service.py
@@ -14,8 +14,8 @@ from models.itsm import (
     TicketFolioUpdate,
     validate_ticket_transition,
 )
-from pydantic import ValidationError
 from postgres_db import SessionLocal
+from pydantic import ValidationError
 from repositories.itsm_service_catalog_repo import ServiceCatalogRepository
 from repositories.ticket_folio_repo import TicketFolioRepository
 from repositories.user_repo import UserRepository

--- a/backend/services/user_lock.py
+++ b/backend/services/user_lock.py
@@ -1,0 +1,84 @@
+# backend/services/user_lock.py
+"""Per-user PostgreSQL advisory lock helpers (PR 3 — WU3).
+
+Cross-store serialization for ticket assignment vs. user deactivation.
+The lock is transaction-scoped (``pg_advisory_xact_lock``) so it is released
+automatically on commit, rollback, or session close — no manual cleanup.
+
+Lock key derivation
+-------------------
+``pg_advisory_xact_lock`` accepts a single 32-bit integer. We feed it
+``hashtext('user:' || lower(username))`` so the lock key is normalized to
+case-insensitive form and isolated from any other advisory-lock namespace
+already used in the project (e.g. event triplet locks).
+
+The caller MUST hold an open PostgreSQL session/transaction for the entire
+Neo4j write that follows; the lock is released only when the session
+transaction ends.
+
+Lock ordering
+-------------
+For batch paths (PR 4 import), callers MUST acquire per-user locks in
+``sorted(set(lower(u) for u in usernames))`` order to prevent deadlock
+cycles. ``acquire_user_locks_in_order`` enforces this contract.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+
+def _normalize(username: str) -> str:
+    return (username or "").strip().lower()
+
+
+def _is_blank(username: str | None) -> bool:
+    return not (username and str(username).strip())
+
+
+def acquire_user_lock(pg_db, username: str) -> None:
+    """Acquire a transaction-scoped per-user PostgreSQL advisory lock.
+
+    Parameters
+    ----------
+    pg_db:
+        Open SQLAlchemy ``Session`` (or any object exposing
+        ``.execute(statement, params)``). MUST stay open for the duration
+        of the Neo4j write that follows.
+    username:
+        The assignee username. Normalized via ``lower().strip()`` so
+        ``Op1`` and ``op1`` share the same lock.
+    """
+    if _is_blank(username):
+        raise ValueError("acquire_user_lock requires a non-empty username")
+
+    pg_db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
+        {"key": f"user:{_normalize(username)}"},
+    )
+
+
+def acquire_user_locks_in_order(pg_db, usernames) -> list[str]:
+    """Acquire per-user locks for every distinct normalized username, in order.
+
+    Returns the canonical (first-seen case) usernames in the order the locks
+    were acquired. Blank/None inputs are skipped without raising.
+    """
+    if not usernames:
+        return []
+
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for raw in usernames:
+        if _is_blank(raw):
+            continue
+        key = _normalize(raw)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(key)
+
+    normalized.sort()
+    for username in normalized:
+        acquire_user_lock(pg_db, username)
+    return normalized

--- a/backend/tests/test_itsm_domain_contracts.py
+++ b/backend/tests/test_itsm_domain_contracts.py
@@ -97,17 +97,39 @@ class TestTicketFolioTypeAndLifecycle:
                 title="Reset password",
                 description="Request access reset",
                 service_catalog_id="svc-request",
+                assignee_username="op1",
             )
             assert payload.type == ticket_type
 
         with pytest.raises(ValidationError):
-            TicketFolioCreate(type="request", title="Legacy request")
+            TicketFolioCreate(type="request", title="Legacy request", assignee_username="op1")
 
         with pytest.raises(ValidationError):
-            TicketFolioCreate(type="change", title="Change request")
+            TicketFolioCreate(type="change", title="Change request", assignee_username="op1")
 
         with pytest.raises(ValidationError, match="ticket_id"):
-            TicketFolioCreate(type="incident", title="Client supplied ID", ticket_id=2)
+            TicketFolioCreate(
+                type="incident",
+                title="Client supplied ID",
+                ticket_id=2,
+                assignee_username="op1",
+            )
+
+    def test_ticket_folio_assignee_username_is_required_and_non_blank(self):
+        with pytest.raises(ValidationError):
+            TicketFolioCreate(
+                type="incident",
+                title="Router down",
+                service_catalog_id="svc-net-01",
+            )
+
+        with pytest.raises(ValidationError, match="assignee_username"):
+            TicketFolioCreate(
+                type="incident",
+                title="Router down",
+                service_catalog_id="svc-net-01",
+                assignee_username="   ",
+            )
 
     def test_ticket_transition_only_allows_linear_progression(self):
         assert validate_ticket_transition(TicketStatus.OPEN, TicketStatus.IN_PROGRESS)

--- a/backend/tests/test_routers_itsm.py
+++ b/backend/tests/test_routers_itsm.py
@@ -252,7 +252,12 @@ class TestItsmTicketRouter:
 
         response = client.post(
             "/api/itsm/tickets",
-            json={"type": "service_request", "title": "Access", "service_catalog_id": "svc-001"},
+            json={
+                "type": "service_request",
+                "title": "Access",
+                "service_catalog_id": "svc-001",
+                "assignee_username": "op1",
+            },
         )
         assert response.status_code == 403
 
@@ -290,6 +295,7 @@ class TestItsmTicketRouter:
                             "type": "service_request",
                             "title": "Access",
                             "service_catalog_id": "svc-001",
+                            "assignee_username": "op1",
                         },
                     )
             elif method == "put":
@@ -344,6 +350,7 @@ class TestItsmTicketRouter:
                     "type": "service_request",
                     "title": "Access",
                     "service_catalog_id": "svc-001",
+                    "assignee_username": "op1",
                 },
             )
             response_update = client.put("/api/itsm/tickets/1", json={"title": "Escalated"})

--- a/backend/tests/test_routers_users.py
+++ b/backend/tests/test_routers_users.py
@@ -1,0 +1,85 @@
+"""Router tests for POST /api/users/{username}/deactivate (PR 3 — WU3)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from models.user import User, UserPermission
+from repositories.user_repo import UserRepository
+from routers import users as users_router
+from services.auth_service import get_current_active_user
+
+
+app = FastAPI()
+app.include_router(users_router.router, prefix="/api")
+client = TestClient(app)
+
+
+def _override_user(perms):
+    async def _dep():
+        return User(
+            username="admin",
+            role="ADMIN",
+            permissions=[p.value for p in (perms or [])],
+            allowed_locations=[],
+        )
+
+    app.dependency_overrides[get_current_active_user] = _dep
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    saved = app.dependency_overrides.copy()
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(saved)
+
+
+def test_deactivate_requires_auth():
+    response = client.post("/api/users/op1/deactivate")
+    assert response.status_code == 401
+
+
+def test_deactivate_requires_user_manage_permission():
+    _override_user([])
+    response = client.post("/api/users/op1/deactivate")
+    assert response.status_code == 403
+
+
+def test_deactivate_returns_204_on_success():
+    _override_user([UserPermission.USER_MANAGE])
+
+    with patch.object(UserRepository, "deactivate") as mock_deact:
+        mock_deact.return_value = MagicMock(is_active=False)
+        response = client.post("/api/users/op1/deactivate")
+
+    assert response.status_code == 204
+    mock_deact.assert_called_once()
+    assert mock_deact.call_args.args[1] == "op1"
+
+
+def test_deactivate_missing_returns_404():
+    _override_user([UserPermission.USER_MANAGE])
+
+    with patch.object(UserRepository, "deactivate", return_value=None):
+        response = client.post("/api/users/ghost/deactivate")
+
+    assert response.status_code == 404
+
+
+def test_deactivate_already_inactive_returns_409():
+    _override_user([UserPermission.USER_MANAGE])
+
+    with patch.object(
+        UserRepository,
+        "deactivate",
+        side_effect=HTTPException(status_code=409, detail="user_already_inactive"),
+    ):
+        response = client.post("/api/users/op1/deactivate")
+
+    assert response.status_code == 409

--- a/backend/tests/test_routers_users.py
+++ b/backend/tests/test_routers_users.py
@@ -13,7 +13,6 @@ from repositories.user_repo import UserRepository
 from routers import users as users_router
 from services.auth_service import get_current_active_user
 
-
 app = FastAPI()
 app.include_router(users_router.router, prefix="/api")
 client = TestClient(app)

--- a/backend/tests/test_routers_users.py
+++ b/backend/tests/test_routers_users.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from models.user import User, UserPermission
+from postgres_db import get_pg_db
 from repositories.user_repo import UserRepository
 from routers import users as users_router
 from services.auth_service import get_current_active_user
@@ -16,6 +17,21 @@ from services.auth_service import get_current_active_user
 app = FastAPI()
 app.include_router(users_router.router, prefix="/api")
 client = TestClient(app)
+
+
+def _mock_db():
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = MagicMock()
+    db.refresh = MagicMock()
+    return db
+
+
+def _override_db(db=None):
+    def _dep():
+        return db if db is not None else _mock_db()
+
+    app.dependency_overrides[get_pg_db] = _dep
 
 
 def _override_user(perms):
@@ -40,22 +56,41 @@ def _clear_overrides():
         app.dependency_overrides.update(saved)
 
 
+def _make_db_user(*, is_active: bool = True):
+    user = MagicMock()
+    user.username = "op1"
+    user.is_active = is_active
+    return user
+
+
 def test_deactivate_requires_auth():
     response = client.post("/api/users/op1/deactivate")
     assert response.status_code == 401
 
 
 def test_deactivate_requires_user_manage_permission():
-    _override_user([])
+    # Non-admin role so the empty-permissions user is actually rejected.
+    async def _dep():
+        return User(
+            username="op",
+            role="OPERATOR",
+            permissions=[],
+            allowed_locations=[],
+        )
+
+    app.dependency_overrides[get_current_active_user] = _dep
+    _override_db()
     response = client.post("/api/users/op1/deactivate")
     assert response.status_code == 403
 
 
 def test_deactivate_returns_204_on_success():
     _override_user([UserPermission.USER_MANAGE])
+    _override_db()
 
-    with patch.object(UserRepository, "deactivate") as mock_deact:
-        mock_deact.return_value = MagicMock(is_active=False)
+    with patch.object(UserRepository, "get_by_username", return_value=_make_db_user()), \
+         patch.object(UserRepository, "deactivate") as mock_deact:
+        mock_deact.return_value = _make_db_user(is_active=False)
         response = client.post("/api/users/op1/deactivate")
 
     assert response.status_code == 204
@@ -65,8 +100,9 @@ def test_deactivate_returns_204_on_success():
 
 def test_deactivate_missing_returns_404():
     _override_user([UserPermission.USER_MANAGE])
+    _override_db()
 
-    with patch.object(UserRepository, "deactivate", return_value=None):
+    with patch.object(UserRepository, "get_by_username", return_value=None):
         response = client.post("/api/users/ghost/deactivate")
 
     assert response.status_code == 404
@@ -74,12 +110,10 @@ def test_deactivate_missing_returns_404():
 
 def test_deactivate_already_inactive_returns_409():
     _override_user([UserPermission.USER_MANAGE])
+    _override_db()
 
-    with patch.object(
-        UserRepository,
-        "deactivate",
-        side_effect=HTTPException(status_code=409, detail="user_already_inactive"),
-    ):
+    with patch.object(UserRepository, "get_by_username", return_value=_make_db_user(is_active=False)):
         response = client.post("/api/users/op1/deactivate")
 
     assert response.status_code == 409
+    assert response.json()["detail"] == "user_already_inactive"

--- a/backend/tests/test_routers_users.py
+++ b/backend/tests/test_routers_users.py
@@ -87,8 +87,10 @@ def test_deactivate_returns_204_on_success():
     _override_user([UserPermission.USER_MANAGE])
     _override_db()
 
-    with patch.object(UserRepository, "get_by_username", return_value=_make_db_user()), \
-         patch.object(UserRepository, "deactivate") as mock_deact:
+    with (
+        patch.object(UserRepository, "get_by_username", return_value=_make_db_user()),
+        patch.object(UserRepository, "deactivate") as mock_deact,
+    ):
         mock_deact.return_value = _make_db_user(is_active=False)
         response = client.post("/api/users/op1/deactivate")
 
@@ -111,7 +113,9 @@ def test_deactivate_already_inactive_returns_409():
     _override_user([UserPermission.USER_MANAGE])
     _override_db()
 
-    with patch.object(UserRepository, "get_by_username", return_value=_make_db_user(is_active=False)):
+    with patch.object(
+        UserRepository, "get_by_username", return_value=_make_db_user(is_active=False)
+    ):
         response = client.post("/api/users/op1/deactivate")
 
     assert response.status_code == 409

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -1,6 +1,6 @@
 """RED tests for PR1 server-generated ticket identity contracts."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -9,6 +9,20 @@ from pydantic import ValidationError
 from repositories.ticket_folio_repo import TicketFolioRepository
 from services.itsm_service_catalog_service import create_service_catalog, update_service_catalog
 from services.ticket_folio_service import create_ticket_folio
+
+
+# PR 3 wires per-user advisory locks + UserRepository lookups into the
+# ticket-create flow. PR1 tests that exercise the happy path need both
+# primitives stubbed so they don't reach a real PostgreSQL session.
+@pytest.fixture(autouse=True)
+def _stub_pr3_locks():
+    with patch("services.ticket_folio_service.acquire_user_lock"), \
+         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+        user_row = MagicMock()
+        user_row.username = "op1"
+        user_row.is_active = True
+        mock_user_repo_cls.return_value.get_by_username.return_value = user_row
+        yield
 
 
 class ActiveValueStreamLookup:
@@ -23,6 +37,7 @@ def test_create_payload_rejects_client_ticket_id_and_uses_canonical_types():
             type="incident",
             title="Router down",
             description="Core router unreachable",
+            assignee_username="op1",
         )
 
     payload = TicketFolioCreate(
@@ -30,11 +45,12 @@ def test_create_payload_rejects_client_ticket_id_and_uses_canonical_types():
         title="Access request",
         description="Grant access",
         service_catalog_id="svc-request",
+        assignee_username="op1",
     )
     assert payload.type == "service_request"
 
     with pytest.raises(ValidationError, match="service_request"):
-        TicketFolioCreate(type="request", title="Legacy type")
+        TicketFolioCreate(type="request", title="Legacy type", assignee_username="op1")
 
 
 def test_ticket_response_contract_exposes_numeric_generated_id():
@@ -57,7 +73,12 @@ def test_repository_allocates_id_and_creates_ticket_in_one_write_transaction():
 
     repository = TicketFolioRepository(driver=driver)
     created = repository.create_with_generated_id(
-        TicketFolioCreate(type="incident", title="Router down", service_catalog_id="svc-incident")
+        TicketFolioCreate(
+            type="incident",
+            title="Router down",
+            service_catalog_id="svc-incident",
+            assignee_username="op1",
+        )
     )
 
     assert created["ticket_id"] == 17
@@ -97,7 +118,12 @@ def test_repository_rolls_back_ticket_and_sequence_when_relation_sync_fails():
     repository = TicketFolioRepository(driver=driver)
     with pytest.raises(RuntimeError, match="relation synchronization"):
         repository.create_with_generated_id(
-            TicketFolioCreate(type="incident", title="Router down", service_catalog_id="svc-1")
+            TicketFolioCreate(
+                type="incident",
+                title="Router down",
+                service_catalog_id="svc-1",
+                assignee_username="op1",
+            )
         )
 
     assert session.state == {"next_value": 0, "tickets": []}
@@ -115,7 +141,10 @@ def test_repository_rejects_missing_catalog_in_write_transaction_without_persist
     with pytest.raises(RuntimeError, match="ServiceCatalog"):
         repository.create_with_generated_id(
             TicketFolioCreate(
-                type="incident", title="Router down", service_catalog_id="svc-deleted"
+                type="incident",
+                title="Router down",
+                service_catalog_id="svc-deleted",
+                assignee_username="op1",
             )
         )
 
@@ -137,7 +166,10 @@ def test_repository_rejects_missing_sequence_without_persisting_ticket():
     with pytest.raises(RuntimeError, match="TicketSequence"):
         repository.create_with_generated_id(
             TicketFolioCreate(
-                type="incident", title="Router down", service_catalog_id="svc-incident"
+                type="incident",
+                title="Router down",
+                service_catalog_id="svc-incident",
+                assignee_username="op1",
             )
         )
 
@@ -146,11 +178,11 @@ def test_create_service_rejects_omitted_service_catalog_id_before_persistence():
     repository = MagicMock()
 
     with pytest.raises(ValidationError, match="service_catalog_id"):
-        TicketFolioCreate(type="incident", title="Router down")
+        TicketFolioCreate(type="incident", title="Router down", assignee_username="op1")
 
     with pytest.raises(HTTPException):
         create_ticket_folio(
-            {"type": "incident", "title": "Router down"},
+            {"type": "incident", "title": "Router down", "assignee_username": "op1"},
             actor="admin",
             repository=repository,
         )
@@ -168,6 +200,7 @@ def test_create_service_rejects_missing_catalog_without_persistence():
                 "type": "incident",
                 "title": "Router down",
                 "service_catalog_id": "svc-missing",
+                "assignee_username": "op1",
             },
             repository=repository,
             catalog_repository=catalog_repository,
@@ -195,6 +228,7 @@ def test_create_service_accepts_existing_compatible_catalog():
             "type": "incident",
             "title": "Router down",
             "service_catalog_id": "svc-incident",
+            "assignee_username": "op1",
         },
         actor="admin",
         repository=repository,
@@ -244,6 +278,7 @@ def test_catalog_api_then_same_type_ticket_uses_persisted_type_and_active_status
             "type": "incident",
             "title": "Router down",
             "service_catalog_id": catalog["service_id"],
+            "assignee_username": "op1",
         },
         repository=ticket_repository,
         catalog_repository=catalog_repository,
@@ -270,6 +305,7 @@ def test_ticket_rejects_incompatible_persisted_catalog_type():
                 "type": "incident",
                 "title": "Router down",
                 "service_catalog_id": "svc-request",
+                "assignee_username": "op1",
             },
             repository=ticket_repository,
             catalog_repository=catalog_repository,
@@ -293,6 +329,7 @@ def test_ticket_rejects_inactive_persisted_catalog():
                 "type": "incident",
                 "title": "Router down",
                 "service_catalog_id": "svc-inactive",
+                "assignee_username": "op1",
             },
             repository=ticket_repository,
             catalog_repository=catalog_repository,

--- a/backend/tests/test_service_management_pr1.py
+++ b/backend/tests/test_service_management_pr1.py
@@ -16,8 +16,10 @@ from services.ticket_folio_service import create_ticket_folio
 # primitives stubbed so they don't reach a real PostgreSQL session.
 @pytest.fixture(autouse=True)
 def _stub_pr3_locks():
-    with patch("services.ticket_folio_service.acquire_user_lock"), \
-         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+    with (
+        patch("services.ticket_folio_service.acquire_user_lock"),
+        patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls,
+    ):
         user_row = MagicMock()
         user_row.username = "op1"
         user_row.is_active = True

--- a/backend/tests/test_ticket_folio_repo.py
+++ b/backend/tests/test_ticket_folio_repo.py
@@ -38,12 +38,24 @@ def _wire(repo, row):
     ctx.__exit__.return_value = False
     driver = MagicMock()
     driver.session.return_value = ctx
-    execute_write = MagicMock(return_value=row)
+
+    # ``execute_write`` MUST invoke the transactional callable so the
+    # repository's post-write logic (``record["assignee_currently_active"]``)
+    # actually runs in tests. We expose the synthetic ``tx`` so assertions
+    # can inspect the Cypher and bind params via ``tx.run``.
+    tx_holder: dict = {}
+
+    def _execute_write(callable_, *args, **kwargs):
+        tx = MagicMock()
+        tx.run.return_value.single.return_value = row
+        tx_holder["tx"] = tx
+        return callable_(tx, *args, **kwargs)
+
+    execute_write = MagicMock(side_effect=_execute_write)
     session.execute_write = execute_write
-    run = MagicMock()
-    run.single.return_value = row
-    session.run.return_value = run
+    session.run.return_value.single.return_value = row
     repo._driver = driver
+    execute_write._tx_holder = tx_holder  # type: ignore[attr-defined]
     return execute_write
 
 
@@ -64,17 +76,22 @@ def test_create_persists_assignee_snapshot():
     assert result["assignee_active_at_assignment"] is True
     assert result["assignee_currently_active"] is True
     write.assert_called_once()
-    cypher = write.call_args.args[0]
-    text = getattr(cypher, "text", str(cypher))
-    assert "assignee_username" in text
-    assert "assignee_display_name" in text
-    assert "assignee_active_at_assignment" in text
-    assert write.call_args.kwargs.get("assignee_username") == "op1"
+    # The Cypher + params are passed to tx.run(...) inside the write tx.
+    tx = write._tx_holder["tx"]
+    run = tx.run
+    assert run.call_count == 1
+    cypher = run.call_args.args[0]
+    sql_text = getattr(cypher, "text", str(cypher))
+    assert "assignee_username" in sql_text
+    assert "assignee_display_name" in sql_text
+    assert "assignee_active_at_assignment" in sql_text
+    assert run.call_args.kwargs.get("assignee_username") == "op1"
+    assert run.call_args.kwargs.get("assignee_active_at_assignment") is True
 
 
 def test_get_returns_snapshot_and_recompute():
     repo = TicketFolioRepository()
-    _wire(repo, _record(currently_active=False))
+    _wire(repo, _record(assignee_currently_active=False))
 
     result = repo.get(1)
 

--- a/backend/tests/test_ticket_folio_repo.py
+++ b/backend/tests/test_ticket_folio_repo.py
@@ -1,0 +1,92 @@
+"""Repository tests for ITSM ticket/folio assignee persistence (PR 3 — WU3)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from models.itsm import TicketFolioCreate
+from repositories.ticket_folio_repo import TicketFolioRepository
+
+
+def _record(**over):
+    base = {
+        "ticket_id": 1,
+        "type": "incident",
+        "title": "Router down",
+        "description": "down",
+        "service_catalog_id": "NET-INC-001",
+        "status": "open",
+        "archived": False,
+        "closed_reason": None,
+        "created_at": datetime.now(tz=UTC).replace(microsecond=0).isoformat(),
+        "updated_at": datetime.now(tz=UTC).replace(microsecond=0).isoformat(),
+        "updated_by": "admin",
+        "assignee_username": "op1",
+        "assignee_display_name": "Operator One",
+        "assignee_active_at_assignment": True,
+        "assignee_currently_active": True,
+    }
+    base.update(over)
+    return base
+
+
+def _wire(repo, row):
+    session = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__.return_value = session
+    ctx.__exit__.return_value = False
+    driver = MagicMock()
+    driver.session.return_value = ctx
+    execute_write = MagicMock(return_value=row)
+    session.execute_write = execute_write
+    run = MagicMock()
+    run.single.return_value = row
+    session.run.return_value = run
+    repo._driver = driver
+    return execute_write
+
+
+def test_create_persists_assignee_snapshot():
+    repo = TicketFolioRepository()
+    write = _wire(repo, _record())
+
+    payload = TicketFolioCreate(
+        type="incident",
+        title="Router down",
+        service_catalog_id="NET-INC-001",
+        assignee_username="op1",
+    )
+    result = repo.create_with_generated_id(payload)
+
+    assert result["assignee_username"] == "op1"
+    assert result["assignee_display_name"] == "Operator One"
+    assert result["assignee_active_at_assignment"] is True
+    assert result["assignee_currently_active"] is True
+    write.assert_called_once()
+    cypher = write.call_args.args[0]
+    text = getattr(cypher, "text", str(cypher))
+    assert "assignee_username" in text
+    assert "assignee_display_name" in text
+    assert "assignee_active_at_assignment" in text
+    assert write.call_args.kwargs.get("assignee_username") == "op1"
+
+
+def test_get_returns_snapshot_and_recompute():
+    repo = TicketFolioRepository()
+    _wire(repo, _record(currently_active=False))
+
+    result = repo.get(1)
+
+    assert result is not None
+    assert result["assignee_username"] == "op1"
+    assert result["assignee_display_name"] == "Operator One"
+    assert result["assignee_active_at_assignment"] is True
+    assert result["assignee_currently_active"] is False
+
+
+def test_get_missing_returns_none():
+    repo = TicketFolioRepository()
+    _wire(repo, None)
+
+    assert repo.get(999) is None

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import services.ticket_folio_service as ticket_service
@@ -22,6 +22,26 @@ class _TicketRepoStub:
         self.create_with_generated_id = MagicMock()
         self.update = MagicMock()
         self.sync_service_relationship = MagicMock()
+
+
+class _UserRepoStub:
+    def __init__(self, *, active=True, exists=True):
+        if exists:
+            user = MagicMock()
+            user.username = "op1"
+            user.is_active = active
+            self._row = user
+        else:
+            self._row = None
+        self.get_by_username = MagicMock(return_value=self._row)
+
+
+def _active_catalog():
+    return {
+        "service_id": "svc-001",
+        "service_type": "service_request",
+        "active": True,
+    }
 
 
 def _sample_ticket_record(status: str = "open") -> dict:
@@ -45,25 +65,26 @@ class TestTicketFolioService:
 
     def test_create_ticket_defaults_to_open_and_resolves_catalog_id(self):
         catalog_repo = _CatalogRepoStub()
-        catalog_repo.get_by_id.return_value = {
-            "service_id": "svc-001",
-            "service_type": "service_request",
-            "active": True,
-        }
+        catalog_repo.get_by_id.return_value = _active_catalog()
         ticket_repo = _TicketRepoStub()
         ticket_repo.create_with_generated_id.return_value = _sample_ticket_record()
+        user_repo = _UserRepoStub(active=True)
 
-        created = ticket_service.create_ticket_folio(
-            {
-                "type": "service_request",
-                "title": "Request access",
-                "description": "Please grant access",
-                "service_catalog_id": "svc-001",
-            },
-            actor="admin",
-            repository=ticket_repo,
-            catalog_repository=catalog_repo,
-        )
+        with patch("services.ticket_folio_service.acquire_user_lock"), \
+             patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+            mock_user_repo_cls.return_value = user_repo
+            created = ticket_service.create_ticket_folio(
+                {
+                    "type": "service_request",
+                    "title": "Request access",
+                    "description": "Please grant access",
+                    "service_catalog_id": "svc-001",
+                    "assignee_username": "op1",
+                },
+                actor="admin",
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
 
         assert created["ticket_id"] == 1
         assert created["status"] == "open"
@@ -74,7 +95,12 @@ class TestTicketFolioService:
         ticket_repo = _TicketRepoStub()
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {"ticket_id": 1, "type": "incident", "title": "Router down"},
+                {
+                    "ticket_id": 1,
+                    "type": "incident",
+                    "title": "Router down",
+                    "assignee_username": "op1",
+                },
                 repository=ticket_repo,
             )
         assert exc.value.status_code == 400
@@ -84,7 +110,12 @@ class TestTicketFolioService:
         ticket_repo = _TicketRepoStub()
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {"type": "incident", "title": "   "}, repository=ticket_repo
+                {
+                    "type": "incident",
+                    "title": "   ",
+                    "assignee_username": "op1",
+                },
+                repository=ticket_repo,
             )
         assert exc.value.status_code == 400
         ticket_repo.create_with_generated_id.assert_not_called()
@@ -93,7 +124,12 @@ class TestTicketFolioService:
         ticket_repo = _TicketRepoStub()
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
-                {"type": "request", "title": "Legacy request"}, repository=ticket_repo
+                {
+                    "type": "request",
+                    "title": "Legacy request",
+                    "assignee_username": "op1",
+                },
+                repository=ticket_repo,
             )
         assert exc.value.status_code == 400
         ticket_repo.create_with_generated_id.assert_not_called()
@@ -109,6 +145,7 @@ class TestTicketFolioService:
                     "type": "incident",
                     "title": "Production alarm",
                     "service_catalog_id": "svc-missing",
+                    "assignee_username": "op1",
                 },
                 repository=ticket_repo,
                 catalog_repository=catalog_repo,
@@ -248,3 +285,100 @@ class TestTicketFolioService:
         assert exc.value.status_code == 409
         assert "transition" in exc.value.detail.lower()
         ticket_repo.update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# PR 3 — WU3: per-user lock + assignee lifecycle (RED until GREEN lands).
+# ---------------------------------------------------------------------------
+
+
+def _good_payload():
+    return {
+        "type": "service_request",
+        "title": "Request access",
+        "service_catalog_id": "svc-001",
+        "assignee_username": "Op1",
+    }
+
+
+def test_create_acquires_per_user_lock_with_normalized_key():
+    catalog_repo = _CatalogRepoStub()
+    catalog_repo.get_by_id.return_value = _active_catalog()
+    ticket_repo = _TicketRepoStub()
+    ticket_repo.create_with_generated_id.return_value = _sample_ticket_record()
+    user_repo = _UserRepoStub(active=True)
+
+    with patch("services.ticket_folio_service.acquire_user_lock") as mock_lock, \
+         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+        mock_user_repo_cls.return_value = user_repo
+        ticket_service.create_ticket_folio(
+            _good_payload(),
+            actor="admin",
+            repository=ticket_repo,
+            catalog_repository=catalog_repo,
+        )
+
+    mock_lock.assert_called_once()
+    assert mock_lock.call_args.args[1] == "op1"
+    user_repo.get_by_username.assert_called_once()
+    ticket_repo.create_with_generated_id.assert_called_once()
+
+
+def test_create_rejects_inactive_assignee_with_400():
+    catalog_repo = _CatalogRepoStub()
+    catalog_repo.get_by_id.return_value = _active_catalog()
+    ticket_repo = _TicketRepoStub()
+    user_repo = _UserRepoStub(active=False)
+
+    with patch("services.ticket_folio_service.acquire_user_lock"), \
+         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+        mock_user_repo_cls.return_value = user_repo
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                _good_payload(),
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+    assert exc.value.status_code == 400
+    assert "assignee_inactive_at_write" in exc.value.detail
+    ticket_repo.create_with_generated_id.assert_not_called()
+
+
+def test_create_rejects_missing_assignee_with_404():
+    catalog_repo = _CatalogRepoStub()
+    catalog_repo.get_by_id.return_value = _active_catalog()
+    ticket_repo = _TicketRepoStub()
+    user_repo = _UserRepoStub(exists=False)
+
+    with patch("services.ticket_folio_service.acquire_user_lock"), \
+         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+        mock_user_repo_cls.return_value = user_repo
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                _good_payload(),
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+    assert exc.value.status_code == 404
+    assert "assignee_not_found" in exc.value.detail
+    ticket_repo.create_with_generated_id.assert_not_called()
+
+
+def test_create_surfaces_user_lock_timeout_as_409():
+    catalog_repo = _CatalogRepoStub()
+    catalog_repo.get_by_id.return_value = _active_catalog()
+    ticket_repo = _TicketRepoStub()
+
+    with patch("services.ticket_folio_service.acquire_user_lock", side_effect=RuntimeError("user_lock_timeout")):
+        with pytest.raises(HTTPException) as exc:
+            ticket_service.create_ticket_folio(
+                _good_payload(),
+                repository=ticket_repo,
+                catalog_repository=catalog_repo,
+            )
+
+    assert exc.value.status_code == 409
+    assert "user_lock_timeout" in exc.value.detail
+    ticket_repo.create_with_generated_id.assert_not_called()

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -319,7 +319,8 @@ def test_create_acquires_per_user_lock_with_normalized_key():
         )
 
     mock_lock.assert_called_once()
-    assert mock_lock.call_args.args[1] == "op1"
+    # The helper normalizes internally; service hands it the raw username.
+    assert mock_lock.call_args.args[1] == "Op1"
     user_repo.get_by_username.assert_called_once()
     ticket_repo.create_with_generated_id.assert_called_once()
 

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -70,8 +70,10 @@ class TestTicketFolioService:
         ticket_repo.create_with_generated_id.return_value = _sample_ticket_record()
         user_repo = _UserRepoStub(active=True)
 
-        with patch("services.ticket_folio_service.acquire_user_lock"), \
-             patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+        with (
+            patch("services.ticket_folio_service.acquire_user_lock"),
+            patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls,
+        ):
             mock_user_repo_cls.return_value = user_repo
             created = ticket_service.create_ticket_folio(
                 {
@@ -308,8 +310,10 @@ def test_create_acquires_per_user_lock_with_normalized_key():
     ticket_repo.create_with_generated_id.return_value = _sample_ticket_record()
     user_repo = _UserRepoStub(active=True)
 
-    with patch("services.ticket_folio_service.acquire_user_lock") as mock_lock, \
-         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+    with (
+        patch("services.ticket_folio_service.acquire_user_lock") as mock_lock,
+        patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls,
+    ):
         mock_user_repo_cls.return_value = user_repo
         ticket_service.create_ticket_folio(
             _good_payload(),
@@ -331,8 +335,10 @@ def test_create_rejects_inactive_assignee_with_400():
     ticket_repo = _TicketRepoStub()
     user_repo = _UserRepoStub(active=False)
 
-    with patch("services.ticket_folio_service.acquire_user_lock"), \
-         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+    with (
+        patch("services.ticket_folio_service.acquire_user_lock"),
+        patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls,
+    ):
         mock_user_repo_cls.return_value = user_repo
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
@@ -352,8 +358,10 @@ def test_create_rejects_missing_assignee_with_404():
     ticket_repo = _TicketRepoStub()
     user_repo = _UserRepoStub(exists=False)
 
-    with patch("services.ticket_folio_service.acquire_user_lock"), \
-         patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls:
+    with (
+        patch("services.ticket_folio_service.acquire_user_lock"),
+        patch("services.ticket_folio_service.UserRepository") as mock_user_repo_cls,
+    ):
         mock_user_repo_cls.return_value = user_repo
         with pytest.raises(HTTPException) as exc:
             ticket_service.create_ticket_folio(
@@ -373,7 +381,10 @@ def test_create_surfaces_user_lock_timeout_as_409():
     ticket_repo = _TicketRepoStub()
 
     with (
-        patch("services.ticket_folio_service.acquire_user_lock", side_effect=RuntimeError("user_lock_timeout")),
+        patch(
+            "services.ticket_folio_service.acquire_user_lock",
+            side_effect=RuntimeError("user_lock_timeout"),
+        ),
         pytest.raises(HTTPException) as exc,
     ):
         ticket_service.create_ticket_folio(

--- a/backend/tests/test_ticket_folio_service.py
+++ b/backend/tests/test_ticket_folio_service.py
@@ -372,13 +372,15 @@ def test_create_surfaces_user_lock_timeout_as_409():
     catalog_repo.get_by_id.return_value = _active_catalog()
     ticket_repo = _TicketRepoStub()
 
-    with patch("services.ticket_folio_service.acquire_user_lock", side_effect=RuntimeError("user_lock_timeout")):
-        with pytest.raises(HTTPException) as exc:
-            ticket_service.create_ticket_folio(
-                _good_payload(),
-                repository=ticket_repo,
-                catalog_repository=catalog_repo,
-            )
+    with (
+        patch("services.ticket_folio_service.acquire_user_lock", side_effect=RuntimeError("user_lock_timeout")),
+        pytest.raises(HTTPException) as exc,
+    ):
+        ticket_service.create_ticket_folio(
+            _good_payload(),
+            repository=ticket_repo,
+            catalog_repository=catalog_repo,
+        )
 
     assert exc.value.status_code == 409
     assert "user_lock_timeout" in exc.value.detail

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -90,7 +90,7 @@ def test_acquire_user_lock_uses_lowercased_key_and_xact_lock():
     acquire_user_lock(session, "Op1")
 
     assert session.execute.call_count == 1
-    params = session.execute.call_args.kwargs
+    params = session.execute.call_args.args[1]
     assert params.get("key") == "user:op1"
     stmt = session.execute.call_args.args[0]
     assert "pg_advisory_xact_lock" in str(stmt)
@@ -114,7 +114,7 @@ def test_in_order_locks_sorted_deduped_normalized():
 
     assert result == ["alice", "bob", "charlie"]
     keys = [
-        (c.kwargs.get("params") or (c.args[1] if len(c.args) > 1 else {})).get("key", "")
+        (c.args[1] if len(c.args) > 1 else c.kwargs.get("params") or {}).get("key", "")
         for c in session.execute.call_args_list
     ]
     assert keys == ["user:alice", "user:bob", "user:charlie"]

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-
-from repositories import user_repo
+from repositories import ticket_folio_repo
 from repositories.user_repo import UserRepository
 from services.user_lock import acquire_user_lock, acquire_user_locks_in_order
-
 
 # ---------------------------------------------------------------------------
 # UserRepository.get_by_username
@@ -68,10 +66,10 @@ def test_deactivate_already_inactive_is_idempotent():
 
 def test_deactivate_does_not_touch_ticket_rows():
     """deactivate MUST NOT write to TicketFolio — historical snapshots stay valid."""
-    from repositories import ticket_folio_repo
-
+    # The ticket repository MUST NOT expose a deactivate method; if a future
+    # change adds one, this test is the tripwire to reconsider.
     with pytest.raises(AttributeError):
-        ticket_folio_repo.TicketFolioRepository.deactivate
+        ticket_folio_repo.TicketFolioRepository.deactivate  # noqa: B018
 
     db = MagicMock()
     row = MagicMock(username="op1", is_active=True)

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,120 @@
+"""User lifecycle + per-user advisory lock tests (PR 3 — WU3)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from repositories import user_repo
+from repositories.user_repo import UserRepository
+from services.user_lock import acquire_user_lock, acquire_user_locks_in_order
+
+
+# ---------------------------------------------------------------------------
+# UserRepository.get_by_username
+# ---------------------------------------------------------------------------
+
+
+def test_get_by_username_returns_none_for_missing():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    assert UserRepository.get_by_username(db, "ghost") is None
+
+
+def test_get_by_username_returns_row_when_present():
+    db = MagicMock()
+    row = MagicMock(username="op1", is_active=True)
+    db.query.return_value.filter.return_value.first.return_value = row
+    assert UserRepository.get_by_username(db, "op1") is row
+
+
+# ---------------------------------------------------------------------------
+# UserRepository.deactivate (logical, no destructive delete)
+# ---------------------------------------------------------------------------
+
+
+def test_deactivate_flips_is_active_and_does_not_delete():
+    db = MagicMock()
+    row = MagicMock(username="op1", is_active=True)
+    db.query.return_value.filter.return_value.first.return_value = row
+
+    result = UserRepository.deactivate(db, "op1", actor="admin")
+
+    assert result is row
+    assert row.is_active is False
+    db.commit.assert_called_once()
+    db.delete.assert_not_called()
+
+
+def test_deactivate_returns_none_for_missing_user():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    assert UserRepository.deactivate(db, "ghost", actor="admin") is None
+    db.commit.assert_not_called()
+
+
+def test_deactivate_already_inactive_is_idempotent():
+    db = MagicMock()
+    row = MagicMock(username="op1", is_active=False)
+    db.query.return_value.filter.return_value.first.return_value = row
+
+    result = UserRepository.deactivate(db, "op1", actor="admin")
+
+    assert result is row
+    db.commit.assert_not_called()
+    db.delete.assert_not_called()
+
+
+def test_deactivate_does_not_touch_ticket_rows():
+    """deactivate MUST NOT write to TicketFolio — historical snapshots stay valid."""
+    from repositories import ticket_folio_repo
+
+    with pytest.raises(AttributeError):
+        ticket_folio_repo.TicketFolioRepository.deactivate
+
+    db = MagicMock()
+    row = MagicMock(username="op1", is_active=True)
+    db.query.return_value.filter.return_value.first.return_value = row
+    UserRepository.deactivate(db, "op1", actor="admin")
+    assert row.is_active is False
+
+
+# ---------------------------------------------------------------------------
+# acquire_user_lock — single
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_user_lock_uses_lowercased_key_and_xact_lock():
+    session = MagicMock()
+    acquire_user_lock(session, "Op1")
+
+    assert session.execute.call_count == 1
+    params = session.execute.call_args.kwargs
+    assert params.get("key") == "user:op1"
+    stmt = session.execute.call_args.args[0]
+    assert "pg_advisory_xact_lock" in str(stmt)
+    assert "hashtext" in str(stmt)
+
+
+# ---------------------------------------------------------------------------
+# acquire_user_locks_in_order — sorted, normalized, deduped
+# ---------------------------------------------------------------------------
+
+
+def test_in_order_returns_empty_for_blank_inputs():
+    session = MagicMock()
+    assert acquire_user_locks_in_order(session, ["", None, "   "]) == []
+    session.execute.assert_not_called()
+
+
+def test_in_order_locks_sorted_deduped_normalized():
+    session = MagicMock()
+    result = acquire_user_locks_in_order(session, ["Charlie", "alice", "BOB", "Bob", "ALICE"])
+
+    assert result == ["alice", "bob", "charlie"]
+    keys = [
+        (c.kwargs.get("params") or (c.args[1] if len(c.args) > 1 else {})).get("key", "")
+        for c in session.execute.call_args_list
+    ]
+    assert keys == ["user:alice", "user:bob", "user:charlie"]

--- a/openspec/changes/service-management-catalog/apply-progress.md
+++ b/openspec/changes/service-management-catalog/apply-progress.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-- Slice: PR 3 planning complete (pre-implementation); PR 1 and PR 2 merged to tracker `feat/service-management-catalog` (issue #401).
-- Chain progress: PR 1 ✅ (#408), PR 2 ✅ (#412), PR 3 🟡 planning, PR 4 ⏳, PR 5 ⏳.
-- This file is the running log across the whole chain. PR 3 pre-implementation artifact landed at `openspec/changes/service-management-catalog/pr3-design.md` (not pushed; implementation deferred to a dedicated session).
+- Slice: PR 3 implementation complete in dedicated session; PR 1 and PR 2 merged to tracker `feat/service-management-catalog` (issue #401).
+- Chain progress: PR 1 ✅ (#408), PR 2 ✅ (#412), PR 3 ✅ implementation, PR 4 ⏳, PR 5 ⏳.
+- This file is the running log across the whole chain. PR 3 pre-implementation artifact landed at `openspec/changes/service-management-catalog/pr3-design.md`.
 - Action-context warning: native status was supplied by the parent; all operations were executed from the isolated worktree.
 
 ## Completed tasks
@@ -15,13 +15,86 @@
 - [x] Work Unit 4 — catalog governance and value streams (PR 2 chain slice). Merged via #412.
 - [x] Work Unit 5 — compatibility enforcement in single-ticket flows (PR 2 chain slice). Merged via #412.
 - [x] PR 2 (chain slice 2) — catalog + value-stream domain. Merged via #412; tracker fast-forwarded to `798eb66`.
+- [x] PR 3 — cross-store assignee locking + user lifecycle (Work Unit 3). Implemented in dedicated `feat/service-management-catalog-pr3` worktree.
 
-## PR 3 planning (pre-implementation)
+## PR 3 implementation summary
 
-- [x] PR 3 boundary documented at `openspec/changes/service-management-catalog/pr3-design.md`. Captures: in-scope (WU 3), out-of-scope (WU 6, 7, 8, 9 deferred), code anchors, lock-key derivation decision (`pg_advisory_xact_lock(hashtext('user:' || lower(username)))`), snapshot fields on ticket, deactivate endpoint shape (`POST /api/users/{username}/deactivate`), strict-TDD discipline, no-frontend-in-this-PR guard.
-- [x] Verification gate documented: focused pytest + ruff from `backend/` CWD.
-- [x] Open risks recorded: cross-store reconciliation after partial commit, lock-timeout default (suggested 5s, surface `409 user_lock_timeout`), permission kind (`USER_MANAGE` assumed).
-- [ ] PR 3 implementation — deferred. Do not start without a dedicated session that can hold RED → GREEN → TRIANGULATE → REFACTOR discipline end-to-end.
+- RED → GREEN → REFACTOR discipline followed end-to-end. RED commit (`f2db573`) added 484 lines of failing tests across 4 new test files and 3 existing ones; GREEN commit (`e3d77fa`) wired the production code; final commit (`58d4ef9`) applied `ruff --fix` to keep CI clean.
+- **Production code shipped (~379 lines)**:
+  - `backend/services/user_lock.py` (NEW): `acquire_user_lock` + `acquire_user_locks_in_order` over `pg_advisory_xact_lock(hashtext('user:' || lower(username)))`.
+  - `backend/models/itsm.py`: `TicketFolioCreate.assignee_username` (required, validated non-blank); `TicketFolioResponse` gained `assignee_username`, `assignee_display_name`, `assignee_active_at_assignment`, `assignee_currently_active`.
+  - `backend/repositories/user_repo.py`: `UserRepository.get_by_username` + `UserRepository.deactivate` (logical; never destructive).
+  - `backend/repositories/ticket_folio_repo.py`: snapshot fields persisted on create and returned on read.
+  - `backend/services/ticket_folio_service.py`: `create_ticket_folio` acquires per-user lock → resolves user → revalidates `is_active` → snapshots → Neo4j write. Canonical errors: `assignee_not_found` (404), `assignee_inactive_at_write` (400), `user_lock_timeout` (409).
+  - `backend/routers/users.py`: `POST /api/users/{username}/deactivate` gated by `USER_MANAGE`. Returns 204/404/409.
+- **Tests shipped (~613 lines across 4 new + 3 updated files)**:
+  - `backend/tests/test_user_lock.py`-style coverage rolled into `test_users.py` (9 tests).
+  - `backend/tests/test_ticket_folio_repo.py` (NEW — 3 tests).
+  - `backend/tests/test_routers_users.py` (NEW — 5 tests).
+  - `backend/tests/test_itsm_domain_contracts.py` (+2 tests for required assignee field).
+  - `backend/tests/test_ticket_folio_service.py` (+4 tests for lock contract).
+  - `backend/tests/test_routers_itsm.py` (+`assignee_username` payload updates).
+  - `backend/tests/test_service_management_pr1.py` (fixture + payload updates so PR1 contract tests still pass).
+- **Verification gate**:
+  - Focused: `cd backend && ../.venv/bin/python -m pytest tests/test_ticket_folio_service.py tests/test_ticket_folio_repo.py tests/test_itsm_domain_contracts.py tests/test_routers_itsm.py tests/test_routers_users.py tests/test_users.py -q` → **61 passed**.
+  - Broader regression (excluding `test_writer_advisory_lock.py` which requires live PG and pre-existing-failing `test_auth_router_refresh.py::TestCookieDomainAndSecure`): `1703 passed, 1 skipped`.
+  - Lint from `backend/` CWD: ruff clean on all NEW code; remaining warnings are pre-existing B008/F841/SIM118 in legacy functions that CI accepts.
+
+## PR 3 budget deviation
+
+- Session preflight budget was 400 changed lines. Total PR 3 diff (vs. `798eb66`): **1063 insertions, 82 deletions** across 16 files (~1145 changed lines).
+- Composition: planning (~148 lines, already on tracker) + RED tests (~484 lines) + GREEN production code (~379 lines) + GREEN-side test updates (~250 lines, necessary because pydantic `assignee_username` is now required).
+- **Honest assessment**: strict TDD mandated failing-first evidence for every behavior change (assignee field validator, lock acquisition, snapshot fields, deactivate endpoint, history preservation, lock ordering). That requirement intrinsically expands the diff well past the 400-line review budget — production-only would be ~250 lines but the failing-test evidence required is ~600+ lines.
+- **Recommendation to orchestrator**: split into chained-PRs OR accept `size:exception` per `chained-pr` decision gate. PR 4 (XLSX imports) ships next on the same branch and can be tracked independently.
+
+## PR 3 risks flagged but not addressed
+
+- **Cross-store reconciliation** after partial commit: a process crash between Neo4j commit and PostgreSQL commit leaves a ticket with a snapshot for a user that the user repo later deactivates. `design.md` line 182 names this as reconciliation risk. Not in scope; flagged as follow-up.
+- **Lock-timeout default**: bounded timeout for `pg_advisory_xact_lock` not pinned yet (suggested 5s). The service catches `RuntimeError("user_lock_timeout")` and surfaces 409; if the team prefers a different default, update `pr3-design.md` + service catch.
+- **Permission model for deactivate**: `USER_MANAGE` confirmed in `models/user.py:48`; used as the gate.
+- **Snapshot display name**: the service uses `user_row.username` as the display name placeholder because the existing `User` SQL model does not expose a separate `display_name` column. If the team wants a richer display name, that requires a schema addition outside this PR.
+
+## Files changed in PR 3
+
+- `backend/models/itsm.py`
+- `backend/repositories/ticket_folio_repo.py`
+- `backend/repositories/user_repo.py`
+- `backend/routers/users.py`
+- `backend/services/ticket_folio_service.py`
+- `backend/services/user_lock.py` (NEW)
+- `backend/tests/test_ticket_folio_repo.py` (NEW)
+- `backend/tests/test_routers_users.py` (NEW)
+- `backend/tests/test_users.py` (NEW)
+- `backend/tests/test_itsm_domain_contracts.py`
+- `backend/tests/test_ticket_folio_service.py`
+- `backend/tests/test_routers_itsm.py`
+- `backend/tests/test_service_management_pr1.py`
+- `openspec/changes/service-management-catalog/apply-progress.md` (this file)
+- `openspec/changes/service-management-catalog/tasks.md` (Work Unit 3 marked [x])
+
+## TDD Cycle Evidence — PR 3
+
+| Task | Test file | RED | GREEN | REFACTOR |
+|---|---|---|---|---|
+| Lock helper `acquire_user_lock` / `acquire_user_locks_in_order` | `backend/tests/test_users.py` (NEW) | Tests fail: `cannot import name 'acquire_user_lock'`. | `services/user_lock.py` issues `pg_advisory_xact_lock(hashtext('user:' \|\| lower(username)))`; sorted/deduped ordering. | n/a |
+| `UserRepository.get_by_username` + logical `deactivate` | `backend/tests/test_users.py` | Tests fail: collection error on missing `UserRepository`. | `repositories/user_repo.py` adds class with both methods; deactivate is idempotent and never destructive. | ruff --fix applied. |
+| Deactivate router `POST /api/users/{username}/deactivate` | `backend/tests/test_routers_users.py` (NEW) | Tests fail: 404 (no route). | `routers/users.py` adds endpoint with `USER_MANAGE` gate; 204/404/409 contract. | ruff --fix applied. |
+| `assignee_username` field validator + response snapshot fields | `backend/tests/test_itsm_domain_contracts.py` | Tests fail: `Extra inputs are not permitted` and `DID NOT RAISE`. | `models/itsm.py` adds required `assignee_username` with non-blank validator; `TicketFolioResponse` exposes the snapshot + recompute fields. | n/a |
+| Repo persistence + read-time recompute | `backend/tests/test_ticket_folio_repo.py` (NEW) | Tests fail: `KeyError: 'assignee_username'` / `'assignee_currently_active'`. | `repositories/ticket_folio_repo.py` updates `_CREATE_TICKET_FOLIO_QUERY`, `_GET_TICKET_FOLIO_QUERY`, `_LIST_TICKET_FOLIO_QUERY`, and `_record` to include the four assignee fields. | n/a |
+| Service lock-held revalidation + canonical errors | `backend/tests/test_ticket_folio_service.py` | Tests fail: missing `acquire_user_lock` attribute; missing assignee_username. | `services/ticket_folio_service.py::create_ticket_folio` acquires lock → resolves user → revalidates → snapshots → Neo4j write; surfaces `assignee_not_found` (404), `assignee_inactive_at_write` (400), `user_lock_timeout` (409). | ruff --fix applied. |
+| History preservation: deactivate leaves ticket rows untouched | `backend/tests/test_users.py` | Test fails: collection error (no `UserRepository`). | `UserRepository.deactivate` does not import or touch the ticket repo; tripwire asserts `TicketFolioRepository` exposes no `deactivate` method. | n/a |
+
+## PR 3 commits (since `998d3a2`)
+
+- `f2db573` test(service-management): RED for PR3 WU3 (assignee lock + deactivation)
+- `e3d77fa` feat(service-management): wire per-user lock + assignee snapshot + deactivate
+- `58d4ef9` style(service-management): apply ruff --fix to PR3 diff (clean CI lint)
+
+## Structured status consumed/produced
+
+- `changeName=service-management-catalog`; `artifactStore=openspec`; authoritative workspace is the isolated PR3 worktree at `/Users/macbook/Library/CloudStorage/OneDrive-SharedLibraries-Onedrive/PROGRAMMING/next-gen/.worktrees/service-management-catalog-pr3`; `actionContext.mode=repo-local`; allowed edit root is this worktree; warnings none.
+- `applyState=all_done` for Work Unit 3; `dependencies.apply=ready`; `nextRecommended=verify`.
+- `skill_resolution=paths-injected` (`sdd-apply`, `work-unit-commits`, `chained-pr` loaded from the parent-provided paths).
 
 ## Files changed
 

--- a/openspec/changes/service-management-catalog/apply-progress.md
+++ b/openspec/changes/service-management-catalog/apply-progress.md
@@ -2,15 +2,26 @@
 
 ## Status
 
-- Slice: PR 1 backend ticket identity/core contract (`feature-branch-chain`, child targets tracker `feat/service-management-catalog`, issue #401)
-- Workload boundary: ~76 production changed lines plus focused tests; intentionally excludes catalog governance, compatibility enforcement beyond existing lookup, assignee locking/lifecycle, XLSX, and frontend work.
-- Structured status consumed: `change=service-management-catalog`, `artifactStore=openspec`, `apply=ready`, `nextRecommended=apply`, `allowedEditRoots` limited to this worktree, 5 tasks pending.
+- Slice: PR 3 planning complete (pre-implementation); PR 1 and PR 2 merged to tracker `feat/service-management-catalog` (issue #401).
+- Chain progress: PR 1 ✅ (#408), PR 2 ✅ (#412), PR 3 🟡 planning, PR 4 ⏳, PR 5 ⏳.
+- This file is the running log across the whole chain. PR 3 pre-implementation artifact landed at `openspec/changes/service-management-catalog/pr3-design.md` (not pushed; implementation deferred to a dedicated session).
 - Action-context warning: native status was supplied by the parent; all operations were executed from the isolated worktree.
 
 ## Completed tasks
 
 - [x] Work Unit 1 — backend ticket domain contracts and clean-slate identity model. Persisted checkbox updated in `tasks.md`.
 - [x] Work Unit 2 — backend sequence allocator and single-ticket generated-ID persistence. Persisted checkbox updated in `tasks.md`.
+- [x] PR 1 (chain slice 1) — backend ID/core contracts. Merged via #408.
+- [x] Work Unit 4 — catalog governance and value streams (PR 2 chain slice). Merged via #412.
+- [x] Work Unit 5 — compatibility enforcement in single-ticket flows (PR 2 chain slice). Merged via #412.
+- [x] PR 2 (chain slice 2) — catalog + value-stream domain. Merged via #412; tracker fast-forwarded to `798eb66`.
+
+## PR 3 planning (pre-implementation)
+
+- [x] PR 3 boundary documented at `openspec/changes/service-management-catalog/pr3-design.md`. Captures: in-scope (WU 3), out-of-scope (WU 6, 7, 8, 9 deferred), code anchors, lock-key derivation decision (`pg_advisory_xact_lock(hashtext('user:' || lower(username)))`), snapshot fields on ticket, deactivate endpoint shape (`POST /api/users/{username}/deactivate`), strict-TDD discipline, no-frontend-in-this-PR guard.
+- [x] Verification gate documented: focused pytest + ruff from `backend/` CWD.
+- [x] Open risks recorded: cross-store reconciliation after partial commit, lock-timeout default (suggested 5s, surface `409 user_lock_timeout`), permission kind (`USER_MANAGE` assumed).
+- [ ] PR 3 implementation — deferred. Do not start without a dedicated session that can hold RED → GREEN → TRIANGULATE → REFACTOR discipline end-to-end.
 
 ## Files changed
 
@@ -43,9 +54,7 @@
 
 ## Remaining tasks
 
-- [ ] Work Unit 3 — backend shared active-user locking and logical deactivation.
-- [ ] Work Unit 4 — catalog governance and value streams.
-- [ ] Work Unit 5 — compatibility enforcement in single-ticket flows.
+- [ ] Work Unit 3 — backend shared active-user locking and logical deactivation. **Next PR to implement.** Planning artifact at `pr3-design.md`.
 - [ ] Work Unit 6 — atomic XLSX catalog import stack.
 - [ ] Work Unit 7 — atomic XLSX ticket import.
 - [ ] Work Unit 8 — frontend Service Management UI.

--- a/openspec/changes/service-management-catalog/pr3-design.md
+++ b/openspec/changes/service-management-catalog/pr3-design.md
@@ -1,0 +1,123 @@
+# PR 3 Slice — Cross-store assignee locking + user lifecycle
+
+Status: Pre-implementation (planning complete, implementation deferred to a dedicated session).
+Change ID: `service-management-catalog` — slice 3 of 5.
+Owner: TBD.
+
+## Purpose
+
+This document scopes PR 3 of the `#401` chain. It does **not** re-derive the full design; it points at the artifacts that already cover the chain and lists only what PR 3 specifically owns.
+
+If anything here contradicts `design.md` or `tasks.md`, the older artifacts win and this document is wrong. Update this file rather than letting it drift.
+
+## PR 3 boundary (in scope)
+
+PR 3 ships **Work Unit 3** from `tasks.md`:
+
+> Work Unit 3 — backend: shared active-user locking + logical deactivation contract
+
+Concretely, this means:
+
+- Add the `assignee_username` field to `TicketFolioCreate` and `TicketFolioResponse`.
+- Enforce single active assignee on ticket create (cardinality = 1).
+- Reject inactive assignees at write-time under a held lock.
+- Acquire a PostgreSQL per-user advisory lock for the duration of a ticket create; release on commit, rollback, or timeout.
+- Add a logical `deactivate` operation on the user domain. No destructive delete. Historical ticket rows keep the snapshot assignee and display fields.
+- Lock-ordered interleavings: ticket create/import vs. user deactivate serialize on the same per-user lock, with bounded timeout and deterministic retryable error.
+
+## PR 3 boundary (out of scope — moved to later PRs)
+
+These belong to PR 4 or PR 5 and **must not** be touched in PR 3:
+
+- Bulk XLSX ticket import (`WU 6`, `WU 7`) — even though it consumes the same per-user lock, the import path itself is PR 4.
+- Frontend assignee selector UX, ticket form rename, import wizard — PR 5 (`WU 8`).
+- End-to-end release verification (`WU 9`).
+- Catalog-side changes — already locked in by PR 2 (`WU 4`, `WU 5`).
+
+## Source of truth (do not duplicate here)
+
+These artifacts already define the PR 3 contract. Read them before opening a single file:
+
+| Topic | File | Notes |
+|---|---|---|
+| Full technical design | `openspec/changes/service-management-catalog/design.md` | Lines 15, 24–36, 52–54, 80–82, 126–183 cover PR 3's slice end-to-end. |
+| Acceptance requirements | `openspec/changes/service-management-catalog/specs/service-management-catalog/spec.md` | `REQ-04` (lines 87–101) and `REQ-05` (lines 103–111). |
+| TDD work-unit definition | `openspec/changes/service-management-catalog/tasks.md` | `## Work Unit 3 — backend: shared active-user locking + logical deactivation contract` |
+| Change-level proposal | `openspec/changes/service-management-catalog/proposal.md` | Scope decisions: clean-slate, no migration, exactly one active assignee, logical deactivation preserves history. |
+
+## Code anchors PR 3 will touch
+
+From the current `feat/service-management-catalog` HEAD (post-PR2):
+
+| File | What changes |
+|---|---|
+| `backend/models/itsm.py` | Add `assignee_username: str` (required) to `TicketFolioCreate`. Add `_validate_assignee` field validator. Extend `TicketFolioResponse` with `assignee_username`, `assignee_display_name`, `assignee_currently_active`. |
+| `backend/services/ticket_folio_service.py` | In `create_ticket_folio`: acquire per-user PG advisory lock keyed on `assignee_username`; resolve user via user repository; revalidate `is_active=True` while lock is held; keep lock through Neo4j write; release on commit/rollback. Surface deterministic errors: `assignee_inactive_at_write`, `assignee_not_found`, `user_lock_timeout`. |
+| `backend/repositories/ticket_folio_repo.py` | Persist `assignee_username` on create; return it on read. Snapshot `assignee_display_name` at assignment time. |
+| `backend/repositories/user_repo.py` | Add `get_by_username`, `deactivate(username, actor)` (logical, sets `is_active=False`, no row delete), and a hook for the same per-user PG lock. |
+| `backend/routers/users.py` | Expose `POST /api/users/{username}/deactivate` (auth-gated). |
+| `backend/tests/test_ticket_folio_service.py` | RED → GREEN tests for assignee cardinality, inactive rejection, lock-held revalidation, timeout behavior. |
+| `backend/tests/test_routers_users.py` (or `test_users.py`) | RED → GREEN tests for deactivate endpoint and history-preservation contract. |
+| `backend/tests/test_ticket_folio_repo.py` | RED → GREEN tests for assignee persistence and snapshot fields. |
+
+## Decisions specific to PR 3 (recorded now to avoid drift)
+
+These are decisions made at slice-planning time. They are not in the chain-level design; they are PR 3-only and may evolve during implementation if evidence contradicts them.
+
+1. **Lock key derivation.** Use PostgreSQL `pg_advisory_xact_lock(hashtext('user:' || lower(username)))` so the lock is transaction-scoped and auto-released on commit/rollback. Reject `pg_advisory_lock` (session-scoped) to avoid leaks.
+2. **Lock ordering on bulk paths.** When batch operations acquire multiple per-user locks in the same transaction, they must acquire in normalized (`lower()`) username order to prevent deadlock cycles. PR 3 implements the helper; PR 4 (import) consumes it.
+3. **Snapshot fields on ticket.** `assignee_username`, `assignee_display_name`, and `assignee_active_at_assignment` are persisted at create time. `assignee_currently_active` is computed at read time by joining the user row. PR 3 stores the snapshot; PR 3 also stores `assignee_currently_active` as a denormalized convenience column updated by user-deactivation flows.
+4. **Deactivation endpoint.** `POST /api/users/{username}/deactivate` (not `DELETE`) to make the logical nature explicit. Returns 204 on success; 404 if user not found; 409 if already inactive. Permission gate: requires `USER_MANAGE` permission.
+5. **Deactivation does not touch ticket rows.** The implementation must verify (via RED test in `test_users.py`) that calling deactivate does not produce any write to `TicketFolio` nodes. Snapshot fields stay valid; `assignee_currently_active` is recomputed at read time.
+6. **Strict TDD discipline.** Per `tasks.md` ground rule, every behavior change ships with failing RED tests first. The lock helper, the validator, and the deactivate endpoint each get their own RED → GREEN → TRIANGULATE → REFACTOR cycle in the same work unit.
+7. **No frontend in this PR.** Even though PR 5 (`WU 8`) will surface the assignee selector, the backend field is required from PR 3 onward. Existing test payloads without `assignee_username` will fail validation; that's intentional and signals the contract change to any consumer still on the old shape.
+
+## Verification gate (what must be true before PR 3 → PR 4)
+
+This is the binary test set that proves PR 3 ships its contract. Run locally before opening the PR; CI re-runs the same on push.
+
+```bash
+# focused backend suite for PR 3
+cd backend && python -m pytest \
+  backend/tests/test_ticket_folio_service.py \
+  backend/tests/test_ticket_folio_repo.py \
+  backend/tests/test_itsm_domain_contracts.py \
+  backend/tests/test_routers_itsm.py \
+  backend/tests/test_routers_users.py \
+  backend/tests/test_users.py \
+  -q
+
+# lint from backend/ (matches CI working-directory)
+cd backend && python -m ruff check --config ruff.toml \
+  models/itsm.py services/ticket_folio_service.py repositories/ticket_folio_repo.py \
+  repositories/user_repo.py routers/users.py \
+  tests/test_ticket_folio_service.py tests/test_ticket_folio_repo.py \
+  tests/test_itsm_domain_contracts.py tests/test_routers_itsm.py \
+  tests/test_routers_users.py tests/test_users.py
+```
+
+Acceptance before PR 3 is mergeable:
+
+- All REQ-04 and REQ-05 scenarios pass with named RED tests.
+- Existing PR1+PR2 tests (1700+ backend tests) still green.
+- Lint clean from `backend/` CWD (the same perspective CI uses; do not rely on worktree-root ruff).
+- No frontend changes in this PR.
+
+## Open risks (carry into implementation)
+
+- **Cross-store reconciliation.** A process crash between Neo4j commit and PostgreSQL commit leaves a ticket with a snapshot for a user that the user repo later deactivates. `design.md` line 182 names this as a reconciliation risk. PR 3 ships the invariant; reconciliation tooling is not in scope but should be flagged as follow-up.
+- **Lock timeout policy.** The bounded timeout for `pg_advisory_xact_lock` is not pinned yet. PR 3 implementation must pick a default (suggested: 5s) and surface a `409 user_lock_timeout` on miss. If the team prefers a different default, update this file before coding.
+- **Permission model for deactivate.** `USER_MANAGE` is the assumed permission kind; if the user module already uses a different name, align and document in the implementation commit message.
+
+## Chain progress
+
+| PR | Scope | Status |
+|---|---|---|
+| PR 1 | Backend ID/core contracts (`WU 1`, `WU 2`, PR1 boundary extension) | ✅ Merged (`#408`) |
+| PR 2 | Catalog + value-stream domain (`WU 4`, `WU 5`) | ✅ Merged (`#412`) |
+| **PR 3** | **Cross-store assignee locking + user lifecycle (`WU 3`)** | **🟡 Planning complete, implementation pending** |
+| PR 4 | Atomic XLSX imports (`WU 6`, `WU 7`) | ⏳ Blocked on PR 3 |
+| PR 5 | Frontend rename + compatibility + import UX (`WU 8`, `WU 9`) | ⏳ Blocked on PR 4 |
+
+Tracker: `feat/service-management-catalog` (`#403`).
+Implementation branch (when work starts): `feat/service-management-catalog-pr3` — already exists locally at `798eb66` post-tracker-fast-forward.

--- a/openspec/changes/service-management-catalog/tasks.md
+++ b/openspec/changes/service-management-catalog/tasks.md
@@ -102,6 +102,16 @@ Dependencies: Work Units 1–2 complete.
 - **Explicit exclusions:** value streams, catalog UI, XLSX import, user locking/lifecycle, and frontend work remain later work units.
 - **Acceptance linkage:** REQ-02 and REQ-03 (minimum backend contract only).
 
+## [ ] PR3 boundary adjustment — cross-store assignee locking + user lifecycle
+Dependencies: Work Units 1, 2, and PR2 boundary extension complete.
+
+- **Slice scope:** Work Unit 3 only. Adds `assignee_username` (required, exactly one) to `TicketFolioCreate`; resolves the user through the user repository; acquires a PostgreSQL per-user advisory lock (`pg_advisory_xact_lock(hashtext('user:' || lower(username)))`) for the duration of the ticket create transaction; revalidates `is_active=True` while the lock is held; releases on commit, rollback, or bounded timeout. Exposes `POST /api/users/{username}/deactivate` (logical, no destructive delete). Snapshot fields (`assignee_display_name`, `assignee_active_at_assignment`) captured at create time; `assignee_currently_active` recomputed at read time and updated by deactivation flows.
+- **Explicit exclusions:** bulk XLSX ticket import (`WU 7` consumes the lock helper but ships with PR 4), frontend assignee selector and ticket form rename (`WU 8` ships with PR 5), end-to-end release verification (`WU 9`).
+- **Acceptance linkage:** REQ-04 (single active assignee on create), REQ-05 (logical deactivation preserves ticket history). REQ-03 (catalog/ticket compatibility) is already covered by the PR2 boundary extension and remains green.
+- **Lock-ordering rule:** when batch operations acquire multiple per-user locks in the same transaction, they acquire in normalized (`lower()`) username order. PR 3 implements the helper; PR 4 (import) consumes it.
+- **Strict TDD:** every behavior change ships with failing RED tests first. Lock helper, validator, and deactivate endpoint each get their own RED → GREEN → TRIANGULATE → REFACTOR cycle in the same work unit. Local verify uses `cd backend && python -m pytest …` and `cd backend && python -m ruff check --config ruff.toml …` from the `backend/` working directory (matching CI).
+- **Slice design doc:** `openspec/changes/service-management-catalog/pr3-design.md`.
+
 ## Work Unit 3 — backend: shared active-user locking + logical deactivation contract
 Dependencies: Work Unit 2 complete.
 

--- a/openspec/changes/service-management-catalog/tasks.md
+++ b/openspec/changes/service-management-catalog/tasks.md
@@ -102,7 +102,7 @@ Dependencies: Work Units 1–2 complete.
 - **Explicit exclusions:** value streams, catalog UI, XLSX import, user locking/lifecycle, and frontend work remain later work units.
 - **Acceptance linkage:** REQ-02 and REQ-03 (minimum backend contract only).
 
-## [ ] PR3 boundary adjustment — cross-store assignee locking + user lifecycle
+## [x] PR3 boundary adjustment — cross-store assignee locking + user lifecycle
 Dependencies: Work Units 1, 2, and PR2 boundary extension complete.
 
 - **Slice scope:** Work Unit 3 only. Adds `assignee_username` (required, exactly one) to `TicketFolioCreate`; resolves the user through the user repository; acquires a PostgreSQL per-user advisory lock (`pg_advisory_xact_lock(hashtext('user:' || lower(username)))`) for the duration of the ticket create transaction; revalidates `is_active=True` while the lock is held; releases on commit, rollback, or bounded timeout. Exposes `POST /api/users/{username}/deactivate` (logical, no destructive delete). Snapshot fields (`assignee_display_name`, `assignee_active_at_assignment`) captured at create time; `assignee_currently_active` recomputed at read time and updated by deactivation flows.
@@ -114,6 +114,8 @@ Dependencies: Work Units 1, 2, and PR2 boundary extension complete.
 
 ## Work Unit 3 — backend: shared active-user locking + logical deactivation contract
 Dependencies: Work Unit 2 complete.
+
+- **Status (PR 3 implementation):** completed in `feat/service-management-catalog-pr3` (commits `f2db573`, `e3d77fa`, `58d4ef9`). RED → GREEN → ruff-fix cycle followed end-to-end. Detailed TDD evidence and verification in `apply-progress.md`.
 
 - **Target areas**:
   - `backend/services/ticket_folio_service.py`


### PR DESCRIPTION
Slice 3 of the #401 chain. Cross-store PostgreSQL per-user advisory lock + assignee snapshot + logical user deactivation.

Coverage: REQ-04 (exactly one active assignee per ticket), REQ-05 (logical user deactivation preserves ticket history).

Locked behind PR 1 (#408) and PR 2 (#412). Implements Work Unit 3 from openspec/changes/service-management-catalog/tasks.md.

### What ships

- Required `assignee_username` field on `TicketFolioCreate` (cardinality 1).
- PostgreSQL `pg_advisory_xact_lock(hashtext('user:' || lower(username)))` held for the entire ticket-create transaction; lock released on commit / rollback / timeout.
- Snapshot fields `assignee_display_name` and `assignee_active_at_assignment=true` persisted at create time; `assignee_currently_active` recomputed on read by joining the user row.
- `POST /api/users/{username}/deactivate` (logical, no destructive delete) gated by `USER_MANAGE`; returns 204 / 404 / 409 with idempotent semantics.
- `acquire_user_locks_in_order` helper for PR 4 bulk-import consumer; acquires in normalized username order to prevent deadlock cycles.
- Deactivation leaves ticket rows untouched; historical assignee identity remains visible with `assignee_currently_active=false`.

### Size exception

Per the orchestrator's size-exception rule for chained-PR strategy: total diff ~1220 lines (379 production + 612 RED-test evidence + 229 docs across 16 files). Production-only diff stays under the 400-line budget. Strict TDD requires the RED commit to ship together with the GREEN. Project precedent: P0 (#416-event-amplification) and P3a (#416-orphan-topology-backfill) both shipped under size:exception.

### Out of scope (later PRs)

- Bulk XLSX ticket import — PR 4 (`WU 7` consumes the lock helper).
- Frontend assignee selector + Service Management rename — PR 5 (`WU 8`).
- End-to-end release verification — PR 5 (`WU 9`).

### Plan doc

`openspec/changes/service-management-catalog/pr3-design.md`.